### PR TITLE
[codex] add semantic sidecar providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,26 @@ MVP: secret-aware tool boundary for AI agents.
   - https://geminicli.com/docs/hooks/reference
 
 Prompt/TUI masking is TODO.
+
+Hostile gap corpus:
+
+```powershell
+cargo build -p pentect-cli --release
+python tools/eval_hostile_realworld.py --bin target\release\pentect.exe
+```
+
+This corpus is intentionally mean: encoded/fractured secrets, low-entropy keyed
+values, semantic PII, real-looking logs, and benign near misses. It is for gap
+tracking, not a CI pass/fail gate.
+
+For the semantic layer:
+
+```powershell
+cargo build -p pentect-cli --release --features semantic
+python tools/eval_hostile_realworld.py --bin target\release\pentect.exe --pentect-arg=--semantic
+```
+
+Semantic detection is provider-backed and optional. The default provider is
+spaCy; use `--semantic-provider gliner` or `--semantic-provider presidio` when
+those Python packages/models are installed. `--ner` remains as a legacy alias for
+`--semantic --semantic-provider spacy`.

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -15,7 +15,10 @@ default = ["pdf"]
 # PDF input is an adapter concern: extract text locally, then feed the normal
 # masking kernel. Disable default features for a slimmer text-only CLI.
 pdf = ["dep:pdf-extract"]
-# Enable the semantic NER sidecar (--ner). Requires Python + spaCy at runtime.
+# Enable the semantic sidecar (--semantic). Requires Python and a provider
+# runtime such as spaCy, GLiNER, or Presidio.
+semantic = ["ner"]
+# Backward-compatible feature name. Prefer `semantic` in user-facing docs.
 ner = ["pentect-core/ner"]
 
 [dependencies]

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -51,7 +51,10 @@ fn usage() {
          \x20 --pack-dir DIR   load every *.toml pack in a directory (repeatable)\n\
          \x20 --disable LABEL  turn off a built-in detector by label (repeatable)\n\
          \x20 --enable LABEL   turn on an off-by-default built-in (e.g. DATE_TIME)\n\
-         \x20 --ner            also mask person/location/org via the NER sidecar (needs --features ner)"
+         \x20 --semantic       also mask person/location/org/address via a semantic sidecar\n\
+         \x20 --semantic-provider spacy|gliner|presidio  choose the semantic provider\n\
+         \x20 --semantic-script FILE  choose the semantic sidecar script\n\
+         \x20 --ner            legacy alias for --semantic --semantic-provider spacy"
     );
 }
 
@@ -1094,24 +1097,50 @@ fn build_engine(profile: Profile, aggressive: bool, packs: Vec<Pack>, args: &[St
     if aggressive {
         eprintln!("[pentect] WARNING: --aggressive disables benign-shape guards; output likely unusable for reasoning.");
     }
-    Engine::with_profile_packs_detectors(profile, packs, ner_detectors(args), aggressive)
+    Engine::with_profile_packs_detectors(profile, packs, semantic_detectors(args), aggressive)
 }
 
-/// `--ner` adds the semantic NER sidecar (person/location/org/nationality).
-/// Built only with `--features ner`; the script defaults to PENTECT_NER_SCRIPT
-/// or tools/ner_sidecar.py.
-#[cfg(feature = "ner")]
-fn ner_detectors(args: &[String]) -> Vec<Box<dyn pentect_core::Detector>> {
-    if !has_flag(args, "--ner") {
-        return Vec::new();
+#[derive(Debug, PartialEq, Eq)]
+struct SemanticOpts {
+    provider: String,
+    script: String,
+}
+
+fn semantic_requested(args: &[String]) -> bool {
+    has_flag(args, "--semantic")
+        || has_flag(args, "--ner")
+        || arg_value(args, "--semantic-provider").is_some()
+        || arg_value(args, "--semantic-script").is_some()
+}
+
+fn semantic_opts(args: &[String]) -> Option<SemanticOpts> {
+    if !semantic_requested(args) {
+        return None;
     }
-    let script =
-        std::env::var("PENTECT_NER_SCRIPT").unwrap_or_else(|_| "tools/ner_sidecar.py".into());
-    match pentect_core::NerDetector::spawn(&script) {
+    let provider = arg_value(args, "--semantic-provider")
+        .or_else(|| std::env::var("PENTECT_SEMANTIC_PROVIDER").ok())
+        .unwrap_or_else(|| "spacy".into());
+    let script = arg_value(args, "--semantic-script")
+        .or_else(|| std::env::var("PENTECT_SEMANTIC_SCRIPT").ok())
+        .or_else(|| std::env::var("PENTECT_NER_SCRIPT").ok())
+        .unwrap_or_else(|| "tools/ner_sidecar.py".into());
+    Some(SemanticOpts { provider, script })
+}
+
+/// `--semantic` adds the semantic sidecar (person/location/org/address).
+/// Built only with `--features semantic`/`ner`; the script defaults to
+/// PENTECT_SEMANTIC_SCRIPT, PENTECT_NER_SCRIPT, or tools/ner_sidecar.py.
+#[cfg(feature = "ner")]
+fn semantic_detectors(args: &[String]) -> Vec<Box<dyn pentect_core::Detector>> {
+    let Some(opts) = semantic_opts(args) else {
+        return Vec::new();
+    };
+    match pentect_core::SemanticDetector::spawn_with_provider(&opts.script, &opts.provider) {
         Ok(d) => vec![Box::new(d)],
         Err(e) => {
             eprintln!(
-                "[pentect] --ner: could not start NER sidecar ({e}); continuing without NER."
+                "[pentect] --semantic provider='{}': could not start semantic sidecar ({e}); continuing without semantic detection.",
+                opts.provider
             );
             Vec::new()
         }
@@ -1119,9 +1148,9 @@ fn ner_detectors(args: &[String]) -> Vec<Box<dyn pentect_core::Detector>> {
 }
 
 #[cfg(not(feature = "ner"))]
-fn ner_detectors(args: &[String]) -> Vec<Box<dyn pentect_core::Detector>> {
-    if has_flag(args, "--ner") {
-        eprintln!("[pentect] --ner requires a build with `--features ner`; ignoring.");
+fn semantic_detectors(args: &[String]) -> Vec<Box<dyn pentect_core::Detector>> {
+    if semantic_requested(args) {
+        eprintln!("[pentect] --semantic requires a build with `--features semantic`; ignoring.");
     }
     Vec::new()
 }
@@ -1229,6 +1258,32 @@ mod tests {
         let opts = ReadOpts::parse(&args).unwrap();
         assert_eq!(opts.kind, Some(Kind::Env));
         assert!(opts.emit_meta);
+    }
+
+    #[test]
+    fn semantic_provider_flag_implies_semantic_sidecar() {
+        let args = vec![
+            "pentect".into(),
+            "mask".into(),
+            "--semantic-provider".into(),
+            "gliner".into(),
+            "--semantic-script".into(),
+            "tools/custom_sidecar.py".into(),
+        ];
+        assert!(semantic_requested(&args));
+        assert_eq!(
+            semantic_opts(&args),
+            Some(SemanticOpts {
+                provider: "gliner".into(),
+                script: "tools/custom_sidecar.py".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn legacy_ner_flag_requests_semantic_sidecar() {
+        let args = vec!["pentect".into(), "mask".into(), "--ner".into()];
+        assert!(semantic_requested(&args));
     }
 
     #[test]

--- a/crates/pentect-core/Cargo.toml
+++ b/crates/pentect-core/Cargo.toml
@@ -10,9 +10,11 @@ repository.workspace = true
 default = ["rand-key"]
 # CSPRNG key generation; disable for WASM/rules-only builds that supply the key.
 rand-key = ["dep:getrandom"]
-# Semantic NER via a persistent Python sidecar (spaCy / ai4privacy). No extra
-# Rust deps — just std::process. Off by default (the deterministic core needs
-# no model); opt in for person/location/org/nationality coverage.
+# Semantic PII via a persistent Python sidecar (spaCy / GLiNER / Presidio). No
+# extra Rust deps — just std::process. Off by default (the deterministic core
+# needs no model); opt in for person/location/org/address coverage.
+semantic = ["ner"]
+# Backward-compatible feature name. Prefer `semantic` in user-facing docs.
 ner = []
 
 [dependencies]

--- a/crates/pentect-core/src/detect/mod.rs
+++ b/crates/pentect-core/src/detect/mod.rs
@@ -18,7 +18,7 @@ pub use card::CardDetector;
 pub use decode::{DecodeDetector, DEFAULT_DECODE_DEPTH, DEFAULT_MIN_OPAQUE_RUN};
 pub use entropy::{EntropyDetector, DEFAULT_ENTROPY_MIN_LEN, DEFAULT_ENTROPY_THRESHOLD};
 #[cfg(feature = "ner")]
-pub use ner::NerDetector;
+pub use ner::{NerDetector, SemanticDetector};
 pub use pem::PemDetector;
 pub use phone::PhoneDetector;
 pub use rule::{RuleDetector, RuleSpec};

--- a/crates/pentect-core/src/detect/ner.rs
+++ b/crates/pentect-core/src/detect/ner.rs
@@ -1,7 +1,7 @@
-//! Semantic NER via a persistent Python sidecar (see tools/ner_sidecar.py).
+//! Semantic PII via a persistent Python sidecar (see tools/ner_sidecar.py).
 //! Catches the entities a deterministic core cannot — person, location,
-//! organization, nationality — by talking to a model loaded once in a child
-//! process. Off unless built with the `ner` feature.
+//! organization, address — by talking to a provider loaded once in a child
+//! process. Off unless built with the `semantic`/`ner` feature.
 
 use super::Detector;
 use crate::model::*;
@@ -10,9 +10,12 @@ use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::Mutex;
 
-pub struct NerDetector {
+pub struct SemanticDetector {
     proc: Mutex<NerProc>,
 }
+
+/// Backward-compatible name for older callers. Prefer `SemanticDetector`.
+pub type NerDetector = SemanticDetector;
 
 struct NerProc {
     child: Child,
@@ -20,14 +23,20 @@ struct NerProc {
     stdout: BufReader<ChildStdout>,
 }
 
-impl NerDetector {
-    /// Spawn the sidecar (`<python> <script>`) and block until its model is
+impl SemanticDetector {
+    /// Spawn the default spaCy sidecar provider.
+    pub fn spawn(script: &str) -> std::io::Result<Self> {
+        Self::spawn_with_provider(script, "spacy")
+    }
+
+    /// Spawn the sidecar (`<python> <script>`) and block until its provider is
     /// loaded (it prints `READY`). `python` defaults to PENTECT_PYTHON or
     /// "python". Errors if the process can't start or never signals ready.
-    pub fn spawn(script: &str) -> std::io::Result<Self> {
+    pub fn spawn_with_provider(script: &str, provider: &str) -> std::io::Result<Self> {
         let python = std::env::var("PENTECT_PYTHON").unwrap_or_else(|_| "python".into());
         let mut child = Command::new(python)
             .arg(script)
+            .env("PENTECT_SEMANTIC_PROVIDER", provider)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -36,8 +45,11 @@ impl NerDetector {
         let mut stdout = BufReader::new(child.stdout.take().expect("piped stdout"));
         let mut ready = String::new();
         stdout.read_line(&mut ready)?;
-        if ready.trim() != "READY" {
-            return Err(std::io::Error::other("ner sidecar did not signal READY"));
+        let ready = ready.trim();
+        if ready != "READY" && !ready.starts_with("READY ") {
+            return Err(std::io::Error::other(
+                "semantic sidecar did not signal READY",
+            ));
         }
         Ok(Self {
             proc: Mutex::new(NerProc {
@@ -49,7 +61,7 @@ impl NerDetector {
     }
 }
 
-impl Drop for NerDetector {
+impl Drop for SemanticDetector {
     fn drop(&mut self) {
         if let Ok(mut p) = self.proc.lock() {
             let _ = p.child.kill();
@@ -57,7 +69,7 @@ impl Drop for NerDetector {
     }
 }
 
-impl Detector for NerDetector {
+impl Detector for SemanticDetector {
     fn detect(&self, view: &NormalizedView) -> Vec<Span> {
         let text = view.text();
         let Ok(req) = serde_json::to_string(text) else {
@@ -86,7 +98,7 @@ impl Detector for NerDetector {
                 category: Category::Pii,
                 label,
                 // Probabilistic, so Medium: a vendor rule on the same span keeps
-                // its label, but NER still beats nothing.
+                // its label, but semantic detection still beats nothing.
                 confidence: Confidence::Medium,
                 source: DetectorId::Ner,
             })
@@ -100,9 +112,9 @@ mod tests {
     use crate::detect::region;
 
     #[test]
-    fn ner_detects_person_org_location() {
+    fn semantic_detects_person_org_location() {
         let script = concat!(env!("CARGO_MANIFEST_DIR"), "/../../tools/ner_sidecar.py");
-        let det = match NerDetector::spawn(script) {
+        let det = match SemanticDetector::spawn_with_provider(script, "spacy") {
             Ok(d) => d,
             Err(_) => return, // python/spaCy unavailable here — skip, don't fail
         };

--- a/crates/pentect-core/src/detect/rule.rs
+++ b/crates/pentect-core/src/detect/rule.rs
@@ -139,6 +139,15 @@ impl RuleDetector {
             ),
             (r"AKIA[A-Z0-9]{16}", Secret, "AWS_AKID", High),
             (r"sk-[A-Za-z0-9_-]{20,}", Secret, "OPENAI_API_KEY", High),
+            // Copy/paste, log wrapping, and markdown often insert whitespace
+            // around the vendor delimiter. Keep this specific to the distinctive
+            // OpenAI prefix rather than deleting arbitrary whitespace in tokens.
+            (
+                r"sk[ \t]+-[ \t]*[A-Za-z0-9_-]{20,}",
+                Secret,
+                "OPENAI_API_KEY",
+                High,
+            ),
             (r"rpa_[A-Za-z0-9]{24,}", Secret, "RUNPOD_API_KEY", High),
             (r"xox[baprs]-[A-Za-z0-9-]{10,}", Secret, "SLACK_TOKEN", High),
             (
@@ -458,6 +467,21 @@ impl RuleDetector {
         ];
         #[rustfmt::skip]
         let captured: &[(&str, Category, &str, Confidence, usize, Validator)] = &[
+            // Context-keyed values in free text / shell logs. This is deliberately
+            // not a raw "any key=value" detector: it fires only on a closed set of
+            // credential-bearing nouns, and captures the value rather than the
+            // surrounding sentence. That catches low-entropy secrets ("password
+            // is summer-2026!") without masking ports, counters, or status codes.
+            (r#"(?i)\b(?:password|passwd|pwd|passphrase|secret|shared[-_ ]?secret|client[-_ ]?secret|api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|id[-_ ]?token|auth[-_ ]?token|otp|recovery[-_ ]?phrase)\b[^\r\n]{0,24}?(?:=|:|=>|\bis\b)?[ \t'"]{0,3}([A-Za-z0-9][A-Za-z0-9._~+/=!@#$%^&*()-]{3,160})(?:$|[\s"',;)])"#, Secret, "KEYED_SECRET", Medium, 1, V::None),
+            // Session/JWT-like values need context. A bare aaa.bbb.ccc is common
+            // test/noise; a long three-segment token after session/jwt/cookie is
+            // credential-bearing even if the header is opaque or not JSON.
+            (r#"(?i)\b(?:session|sid|jwt|cookie|auth[-_ ]?token|access[-_ ]?token|refresh[-_ ]?token)\b[^\r\n]{0,16}?(?:=|:)[ \t'"]{0,3}([A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,})(?:$|[\s"',;)])"#, Secret, "SESSION_TOKEN", Medium, 1, V::None),
+            // Support/health/customer case IDs are sensitive when keyed by
+            // patient/case/customer language. This does not mask ordinary JIRA
+            // stories or invoice numbers because the year-like middle segment is
+            // required and the keyword is required.
+            (r#"(?i)\b(?:case|patient|customer|member|mrn|medical record|health record)[^\r\n]{0,16}?\b([A-Z]{2,6}-[0-9]{4}-[0-9]{6,})\b"#, Identifier, "CASE_IDENTIFIER", Medium, 1, V::None),
             // Preserve path structure for debugging, but hide the local account
             // segment that frequently leaks in stack traces and tool output.
             (r#"(?i)\b[A-Z]:[\\/]+Users[\\/]+([^\\/\s:\r\n"<>|?*]{1,64})(?:[\\/]|$|[\s"',;)])"#, Pii, "LOCAL_USERNAME", Medium, 1, V::LocalUsername),
@@ -583,6 +607,10 @@ mod tests {
             ("AKIAIOSFODNN7EXAMPLE", "AWS_AKID"),
             (concat!("sk", "-ABCDEFGHIJKLMNOPQRSTUVWX"), "OPENAI_API_KEY"),
             (
+                concat!("sk", " -ABCDEFGHIJKLMNOPQRSTUVWX"),
+                "OPENAI_API_KEY",
+            ),
+            (
                 concat!("rpa", "_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"),
                 "RUNPOD_API_KEY",
             ),
@@ -695,6 +723,38 @@ mod tests {
         assert!(hits("a@b.co.uk"));
         assert!(!hits("alice@.com"));
         assert!(!hits("alice@example."));
+    }
+
+    #[test]
+    fn keyed_value_context_masks_low_entropy_values_without_masking_counters() {
+        let det = RuleDetector::builtin();
+        let labels = |s: &str| {
+            let reg = region(s);
+            let v = NormalizedView::build(&reg, s);
+            det.detect(&v)
+                .iter()
+                .map(|sp| sp.label.clone())
+                .collect::<Vec<_>>()
+        };
+        let has = |text: &str, label: &str| labels(text).iter().any(|got| got == label);
+        assert!(has("password is summer-2026! for the demo", "KEYED_SECRET"));
+        assert!(has("client_secret: tenant-7-trial", "KEYED_SECRET"));
+        assert!(has("otp=100482 expires soon", "KEYED_SECRET"));
+        assert!(has(
+            "k8s secret data api-key: abcDEF123456+/==",
+            "KEYED_SECRET"
+        ));
+        assert!(has(
+            "cookie session=abcdefghijkl.mnopqrstuvwxyz.ABCDEFGHIJKLMN",
+            "SESSION_TOKEN"
+        ));
+        assert!(has("Case PT-2026-100482 follows up", "CASE_IDENTIFIER"));
+        assert!(!has(
+            "port=5432 workers=4 timeout_ms=30000 status=200",
+            "KEYED_SECRET"
+        ));
+        assert!(!has("jwt_like=aaa.bbb.ccc css=#aabbcc", "SESSION_TOKEN"));
+        assert!(!has("story=SEC-100482 estimate=8", "CASE_IDENTIFIER"));
     }
 
     #[test]

--- a/crates/pentect-core/src/lib.rs
+++ b/crates/pentect-core/src/lib.rs
@@ -31,12 +31,12 @@ pub mod policy;
 pub mod recovery;
 
 pub use codec::Codec;
-#[cfg(feature = "ner")]
-pub use detect::NerDetector;
 pub use detect::{
     CardDetector, DecodeDetector, Detector, EntropyDetector, PemDetector, RuleDetector, RuleSpec,
     StructuralDetector,
 };
+#[cfg(feature = "ner")]
+pub use detect::{NerDetector, SemanticDetector};
 pub use model::{ByteRange, Category, Confidence, Input, Kind, Span};
 pub use pack::{load_pack, Pack};
 pub use parse::{EnvParser, HarParser, JsonParser, Parser, TextParser};

--- a/crates/pentect-core/src/normalize.rs
+++ b/crates/pentect-core/src/normalize.rs
@@ -10,13 +10,11 @@
 use crate::model::{ByteRange, Region};
 use unicode_normalization::UnicodeNormalization;
 
-/// Identity normalization: NFC (deliberately not NFKC) plus zero-width/bidi
-/// stripping. Conservative so distinct values are never merged (full-width vs
-/// ASCII digits stay distinct). Used for placeholder hashing and the sweep.
+/// Identity normalization: NFC only (deliberately not NFKC, and deliberately
+/// not dropping zero-width/bidi controls). Used for placeholder hashing and the
+/// sweep, where merging distinct source bytes would make restore ambiguous.
 pub fn n_id(s: &str) -> String {
-    s.nfc()
-        .filter(|c| !is_zero_width(*c) && !is_bidi(*c))
-        .collect()
+    s.nfc().collect()
 }
 
 fn is_zero_width(c: char) -> bool {
@@ -36,10 +34,20 @@ fn hex_val(b: u8) -> Option<u8> {
     }
 }
 
+fn push_ascii_escape(norm: &mut String, segs: &mut Vec<Seg>, byte: u8, raw: ByteRange) {
+    let norm_start = norm.len();
+    norm.push(byte as char);
+    segs.push(Seg {
+        norm: ByteRange::new(norm_start, norm.len()),
+        raw,
+    });
+}
+
 /// A region's text after aggressive normalization for detection (NFKC, zero-width
-/// /bidi stripping, and percent-decoding of `%XX` ASCII), with a map back to raw
-/// byte ranges. Detectors run on the normalized text so these tricks can't break
-/// a match; the resulting spans are always reported in raw coordinates.
+/// /bidi stripping, percent-decoding of `%XX` ASCII, and source-literal decoding
+/// of ASCII `\u00XX` / `\xXX` escapes), with a map back to raw byte ranges.
+/// Detectors run on the normalized text so these tricks can't break a match; the
+/// resulting spans are always reported in raw coordinates.
 pub struct NormalizedView<'a> {
     pub region: &'a Region,
     norm: String,
@@ -70,14 +78,39 @@ impl<'a> NormalizedView<'a> {
                     let byte = (hi << 4) | lo;
                     if byte.is_ascii() {
                         let raw = ByteRange::new(base + i, base + i + 3);
-                        let norm_start = norm.len();
-                        norm.push(byte as char);
-                        segs.push(Seg {
-                            norm: ByteRange::new(norm_start, norm.len()),
-                            raw,
-                        });
+                        push_ascii_escape(&mut norm, &mut segs, byte, raw);
                         i += 3;
                         continue;
+                    }
+                }
+            }
+            // Source-code / JSON-style ASCII escapes (`\u002d`, `\x2d`) are a
+            // common way for logs and tool output to split a recognizable token.
+            if bytes[i] == b'\\' {
+                if i + 5 < bytes.len()
+                    && bytes[i + 1] == b'u'
+                    && bytes[i + 2] == b'0'
+                    && bytes[i + 3] == b'0'
+                {
+                    if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 4]), hex_val(bytes[i + 5])) {
+                        let byte = (hi << 4) | lo;
+                        if byte.is_ascii() {
+                            let raw = ByteRange::new(base + i, base + i + 6);
+                            push_ascii_escape(&mut norm, &mut segs, byte, raw);
+                            i += 6;
+                            continue;
+                        }
+                    }
+                }
+                if i + 3 < bytes.len() && matches!(bytes[i + 1], b'x' | b'X') {
+                    if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 2]), hex_val(bytes[i + 3])) {
+                        let byte = (hi << 4) | lo;
+                        if byte.is_ascii() {
+                            let raw = ByteRange::new(base + i, base + i + 4);
+                            push_ascii_escape(&mut norm, &mut segs, byte, raw);
+                            i += 4;
+                            continue;
+                        }
                     }
                 }
             }
@@ -174,6 +207,25 @@ mod tests {
         let v = NormalizedView::build(&r, raw);
         assert_eq!(v.text(), "a-b");
         assert_eq!(v.to_raw(ByteRange::new(1, 2)), ByteRange::new(1, 4));
+    }
+
+    #[test]
+    fn decodes_ascii_source_escapes() {
+        let raw = r"a\u002db\x2ec";
+        let r = region(raw);
+        let v = NormalizedView::build(&r, raw);
+        assert_eq!(v.text(), "a-b.c");
+        assert_eq!(v.to_raw(ByteRange::new(1, 2)), ByteRange::new(1, 7));
+        assert_eq!(v.to_raw(ByteRange::new(3, 4)), ByteRange::new(8, 12));
+    }
+
+    #[test]
+    fn identity_keeps_controls_that_detection_drops() {
+        assert_ne!(
+            n_id("AKIAIOSFODNN7EXAMPLE"),
+            n_id("AKIA\u{200b}IOSFODNN7EXAMPLE")
+        );
+        assert_ne!(n_id("abc"), n_id("a\u{202e}bc"));
     }
 
     proptest::proptest! {

--- a/tools/eval_hostile_realworld.py
+++ b/tools/eval_hostile_realworld.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+"""Evaluate Pentect on a hostile, real-world-ish masking corpus.
+
+This is intentionally not a "make the current engine look good" benchmark.
+It mixes structural secrets, shell/config/log contexts, encoded/fractured
+values, low-entropy keyed values, and semantic PII that a deterministic core
+should not pretend to understand. The goal is not a pass/fail target; it is a
+gap corpus that makes today's misses obvious enough to prioritize.
+
+No-cheat rule for using this corpus:
+- Do not remove or weaken cases to improve the number.
+- Do not hard-code generated values, names, addresses, counts, or case IDs.
+- Only add detectors that generalize to a documented syntax, protocol, or
+  defensible context pattern.
+- Semantic PII should be handled by a general NER layer, not by copying names
+  from this file into regexes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Iterable
+
+
+DEFAULT_BIN = (
+    "target/release/pentect.exe"
+    if sys.platform == "win32"
+    else "target/release/pentect"
+)
+
+
+@dataclass(frozen=True)
+class Target:
+    value: str
+    category: str
+    note: str
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    text: str
+    sensitive: tuple[Target, ...]
+    benign: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EvalResult:
+    coverage: float
+    utility: float
+    sensitive_total: int
+    sensitive_caught: int
+    benign_total: int
+    benign_preserved: int
+    seconds: float
+    bytes_in: int
+    masked_stdout: str
+    stderr: str
+    by_category: dict[str, dict[str, int]]
+    misses: list[dict[str, str]]
+    overmasks: list[str]
+
+
+def main() -> int:
+    args = parse_args()
+    cases = build_cases(args.scale)
+    result = run_eval(args, cases)
+    report = to_report(args, cases, result)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print_report(report)
+    if args.fail_under_coverage is not None and result.coverage < args.fail_under_coverage:
+        return 1
+    if args.fail_under_utility is not None and result.utility < args.fail_under_utility:
+        return 1
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--bin", default=DEFAULT_BIN, help="pentect binary path")
+    p.add_argument("--profile", default="balanced")
+    p.add_argument("--kind", default="text", choices=["text", "json", "env", "har"])
+    p.add_argument("--scale", type=int, default=1, help="repeat corpus families N times")
+    p.add_argument(
+        "--pentect-arg",
+        action="append",
+        default=[],
+        help="extra argument passed after `pentect mask` (repeatable), e.g. --pentect-arg=--semantic",
+    )
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--fail-under-coverage", type=float)
+    p.add_argument("--fail-under-utility", type=float)
+    p.add_argument("--sample-limit", type=int, default=25)
+    return p.parse_args()
+
+
+def build_cases(scale: int) -> list[Case]:
+    scale = max(1, scale)
+    cases: list[Case] = []
+    for round_no in range(scale):
+        cases.extend(structured_secret_cases(round_no))
+        cases.extend(ops_log_cases(round_no))
+        cases.extend(encoded_and_fragmented_cases(round_no))
+        cases.extend(low_entropy_keyed_cases(round_no))
+        cases.extend(semantic_pii_cases(round_no))
+        cases.extend(benign_near_miss_cases(round_no))
+    return cases
+
+
+def structured_secret_cases(round_no: int) -> list[Case]:
+    cases: list[Case] = []
+    for i in range(80):
+        n = round_no * 1000 + i
+        openai = openai_key(n)
+        github = github_token(n)
+        runpod = runpod_key(n)
+        aws = aws_access_key(n)
+        stripe = stripe_key(n)
+        card = card_number(i)
+        iban = iban_number(i)
+        email = f"ops.{n}@example-company.test"
+        url = f"postgresql://svc_{n}:pAss-{n}-rotated@db-{i % 7}.internal:5432/app"
+        text = "\n".join(
+            [
+                f"deploy[{n}] OPENAI_API_KEY={openai} GITHUB_TOKEN={github}",
+                f"runner env RUNPOD_API_KEY={runpod} AWS_ACCESS_KEY_ID={aws}",
+                f"billing stripe={stripe} card={card} iban={iban}",
+                f"contact={email} dsn={url} retry={i % 5} build=8da1fcd",
+            ]
+        )
+        cases.append(
+            Case(
+                f"structured_secret_{n}",
+                text,
+                (
+                    target(openai, "vendor_secret", "OpenAI-style key"),
+                    target(github, "vendor_secret", "GitHub token"),
+                    target(runpod, "vendor_secret", "RunPod token"),
+                    target(aws, "cloud_key", "AWS access key id"),
+                    target(stripe, "vendor_secret", "Stripe key"),
+                    target(card, "financial_id", "payment card"),
+                    target(iban, "financial_id", "IBAN"),
+                    target(email, "identity", "email address"),
+                    target(url, "connection_secret", "database URL with credentials"),
+                ),
+                (
+                    f"deploy[{n}]",
+                    "retry=",
+                    "build=8da1fcd",
+                ),
+            )
+        )
+    return cases
+
+
+def ops_log_cases(round_no: int) -> list[Case]:
+    cases: list[Case] = []
+    for i in range(80):
+        n = round_no * 1000 + i
+        path_user = f"user{n:04d}"
+        win_path = rf"C:\Users\{path_user}\Desktop\client-{i}\.env"
+        unix_path = f"/home/{path_user}/.ssh/config"
+        phone = phone_number(i)
+        btc = btc_address(i)
+        pem_body = f"MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT{n:04d}"
+        pem = f"-----BEGIN RSA PRIVATE KEY-----\n{pem_body}\n-----END RSA PRIVATE KEY-----"
+        text = "\n".join(
+            [
+                f"ERROR failed loading {win_path}; fallback={unix_path}",
+                f"support phone {phone} wallet {btc}",
+                pem,
+                f"request_id=550e8400-e29b-41d4-a716-{n:012d} status=500 bytes=1048576",
+            ]
+        )
+        cases.append(
+            Case(
+                f"ops_log_{n}",
+                text,
+                (
+                    target(path_user, "local_context", "username in local path"),
+                    target(phone, "phone", "phone number"),
+                    target(btc, "crypto_address", "crypto wallet"),
+                    target(pem_body, "private_key", "PEM body"),
+                ),
+                (
+                    "status=500",
+                    "bytes=1048576",
+                    f"client-{i}",
+                ),
+            )
+        )
+    return cases
+
+
+def encoded_and_fragmented_cases(round_no: int) -> list[Case]:
+    cases: list[Case] = []
+    for i in range(70):
+        n = round_no * 1000 + i
+        raw = openai_key(n)
+        percent = raw.replace("-", "%2D")
+        zero_width = raw[:3] + "\u200b" + raw[3:]
+        spaced = raw[:2] + " " + raw[2:]
+        quoted = raw.replace("-", "\\u002d")
+        b64ish = b64_token(n)
+        jwt = jwt_like(n)
+        text = "\n".join(
+            [
+                f"proxy saw Authorization: Bearer {percent}",
+                f"copy/paste artifact token={zero_width}",
+                f"ticket says token maybe `{spaced}`",
+                f"json escaped key=\"{quoted}\"",
+                f"k8s secret data api-key: {b64ish}",
+                f"cookie session={jwt}; SameSite=Lax",
+            ]
+        )
+        cases.append(
+            Case(
+                f"encoded_fragmented_{n}",
+                text,
+                (
+                    target(percent, "encoded_secret", "percent-encoded key"),
+                    target(zero_width, "encoded_secret", "zero-width key"),
+                    target(spaced, "fragmented_secret", "space-fragmented key"),
+                    target(quoted, "encoded_secret", "JSON-escaped hyphen"),
+                    target(b64ish, "encoded_secret", "base64-ish secret payload"),
+                    target(jwt, "session_token", "JWT-like cookie"),
+                ),
+                (
+                    "SameSite=Lax",
+                    "copy/paste",
+                ),
+            )
+        )
+    return cases
+
+
+def low_entropy_keyed_cases(round_no: int) -> list[Case]:
+    cases: list[Case] = []
+    for i in range(90):
+        n = round_no * 1000 + i
+        values = [
+            f"summer-{2020 + (i % 9)}!",
+            f"{100000 + n}",
+            f"blue-team-{i % 13}",
+            f"tenant-{i % 17}-trial",
+            f"correct-horse-{i % 31}",
+        ]
+        labels = [
+            "password",
+            "otp",
+            "shared_secret",
+            "client_secret",
+            "recovery_phrase",
+        ]
+        text = "\n".join(
+            [
+                f"Slack paste: {labels[0]} is {values[0]} for the demo box.",
+                f"Helpdesk note: {labels[1]}={values[1]}, expires in 30s.",
+                f"Legacy config has {labels[2]}: {values[2]}",
+                f"OAuth app {labels[3]} '{values[3]}' rotated later.",
+                f"Operator wrote {labels[4]} => {values[4]} in the runbook.",
+                "benign: port=5432 workers=4 timeout_ms=30000 status=200",
+            ]
+        )
+        cases.append(
+            Case(
+                f"low_entropy_keyed_{n}",
+                text,
+                tuple(
+                    target(v, "low_entropy_keyed", f"{label} value")
+                    for label, v in zip(labels, values)
+                ),
+                (
+                    "port=5432",
+                    "workers=4",
+                    "timeout_ms=30000",
+                    "status=200",
+                ),
+            )
+        )
+    return cases
+
+
+def semantic_pii_cases(round_no: int) -> list[Case]:
+    cases: list[Case] = []
+    names = [
+        "Alice Tanaka",
+        "Bob Smith",
+        "Carla Gomez",
+        "Daisuke Sato",
+        "Evelyn Chen",
+        "Fatima Khan",
+        "George Novak",
+        "Hana Suzuki",
+        "Ivan Petrov",
+        "Julia Rossi",
+    ]
+    orgs = [
+        "Northwind Security",
+        "Aperture Labs",
+        "Contoso Retail",
+        "Kisaragi Clinic",
+        "Bluefin Robotics",
+    ]
+    streets = [
+        "1600 Amphitheatre Parkway, Mountain View CA",
+        "1-1-2 Otemachi, Chiyoda-ku, Tokyo",
+        "221B Baker Street, London",
+        "350 Fifth Avenue, New York NY",
+        "Unter den Linden 77, Berlin",
+    ]
+    japanese_name = "\u5c71\u7530\u592a\u90ce"
+    japanese_addr = "\u6771\u4eac\u90fd\u6e0b\u8c37\u533a\u9053\u7384\u57421-2-3"
+    for i in range(110):
+        n = round_no * 1000 + i
+        name = names[i % len(names)]
+        org = orgs[i % len(orgs)]
+        street = streets[i % len(streets)]
+        patient_id = f"PT-{2026 + (i % 3)}-{100000 + n}"
+        text = "\n".join(
+            [
+                f"Meeting note: {name} from {org} approved the pentest scope.",
+                f"Ship the signed NDA to {street}; concierge has the badge.",
+                f"Case {patient_id}: caller says their manager is {names[(i + 3) % len(names)]}.",
+                f"JP note: owner={japanese_name} address={japanese_addr}",
+                "benign: sprint=42 story=SEC-100482 estimate=8",
+            ]
+        )
+        cases.append(
+            Case(
+                f"semantic_pii_{n}",
+                text,
+                (
+                    target(name, "semantic_pii", "person name"),
+                    target(org, "semantic_pii", "organization"),
+                    target(street, "semantic_pii", "street address"),
+                    target(patient_id, "case_identifier", "patient/customer case id"),
+                    target(japanese_name, "semantic_pii", "Japanese person name"),
+                    target(japanese_addr, "semantic_pii", "Japanese address"),
+                ),
+                (
+                    "sprint=42",
+                    "story=SEC-100482",
+                    "estimate=8",
+                ),
+            )
+        )
+    return cases
+
+
+def benign_near_miss_cases(round_no: int) -> list[Case]:
+    cases: list[Case] = []
+    for i in range(120):
+        n = round_no * 1000 + i
+        text = "\n".join(
+            [
+                f"build={n} sha=356a192b7913b04c54574d18c28d46e6395428ab",
+                f"uuid=550e8400-e29b-41d4-a716-{n:012d} trace=00f067aa0ba902b7",
+                "card_like=4242424242424241 iban_like=DE15804319371058294618",
+                "jwt_like=aaa.bbb.ccc css=#aabbcc asset=app.8da1fcd.js",
+                "invoice=INV90070183 amount_cents=1999 retry_after=30",
+            ]
+        )
+        cases.append(
+            Case(
+                f"benign_near_miss_{n}",
+                text,
+                (),
+                (
+                    "356a192b7913b04c54574d18c28d46e6395428ab",
+                    f"550e8400-e29b-41d4-a716-{n:012d}",
+                    "4242424242424241",
+                    "DE15804319371058294618",
+                    "aaa.bbb.ccc",
+                    "#aabbcc",
+                    "INV90070183",
+                ),
+            )
+        )
+    return cases
+
+
+def run_eval(args: argparse.Namespace, cases: list[Case]) -> EvalResult:
+    text = render_corpus(cases)
+    cmd = [
+        args.bin,
+        "mask",
+        "--kind",
+        args.kind,
+        "--profile",
+        args.profile,
+        *args.pentect_arg,
+    ]
+    start = time.perf_counter()
+    proc = subprocess.run(
+        cmd,
+        input=text,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    seconds = time.perf_counter() - start
+    if proc.returncode != 0:
+        print(proc.stderr, file=sys.stderr)
+        raise SystemExit(proc.returncode)
+    masked_cases = split_case_outputs(proc.stdout, cases)
+
+    by_category: dict[str, dict[str, int]] = {}
+    misses: list[dict[str, str]] = []
+    overmasks: list[str] = []
+    sensitive_total = 0
+    sensitive_caught = 0
+    benign_total = 0
+    benign_preserved = 0
+
+    for case in cases:
+        case_out = masked_cases.get(case.name, proc.stdout)
+        for item in case.sensitive:
+            sensitive_total += 1
+            row = by_category.setdefault(item.category, {"total": 0, "caught": 0})
+            row["total"] += 1
+            if item.value in case_out:
+                misses.append(
+                    {
+                        "case": case.name,
+                        "category": item.category,
+                        "note": item.note,
+                        "value": display_value(item.value),
+                    }
+                )
+            else:
+                sensitive_caught += 1
+                row["caught"] += 1
+        for value in case.benign:
+            benign_total += 1
+            if value in case_out:
+                benign_preserved += 1
+            else:
+                overmasks.append(f"{case.name}: {display_value(value)}")
+
+    coverage = sensitive_caught / max(1, sensitive_total)
+    utility = benign_preserved / max(1, benign_total)
+    return EvalResult(
+        coverage=coverage,
+        utility=utility,
+        sensitive_total=sensitive_total,
+        sensitive_caught=sensitive_caught,
+        benign_total=benign_total,
+        benign_preserved=benign_preserved,
+        seconds=seconds,
+        bytes_in=len(text.encode("utf-8")),
+        masked_stdout=proc.stdout,
+        stderr=proc.stderr,
+        by_category=by_category,
+        misses=misses,
+        overmasks=overmasks,
+    )
+
+
+def to_report(args: argparse.Namespace, cases: list[Case], result: EvalResult) -> dict[str, object]:
+    by_category = []
+    for category, row in sorted(result.by_category.items()):
+        total = row["total"]
+        caught = row["caught"]
+        by_category.append(
+            {
+                "category": category,
+                "caught": caught,
+                "total": total,
+                "coverage": caught / max(1, total),
+            }
+        )
+    return {
+        "profile": args.profile,
+        "kind": args.kind,
+        "pentect_args": args.pentect_arg,
+        "cases": len(cases),
+        "bytes": result.bytes_in,
+        "seconds": result.seconds,
+        "mib_per_s": result.bytes_in / (1024 * 1024) / max(result.seconds, 1e-9),
+        "coverage": result.coverage,
+        "sensitive": {
+            "caught": result.sensitive_caught,
+            "total": result.sensitive_total,
+        },
+        "utility": result.utility,
+        "benign": {
+            "preserved": result.benign_preserved,
+            "total": result.benign_total,
+        },
+        "by_category": by_category,
+        "miss_samples": result.misses[: args.sample_limit],
+        "overmask_samples": result.overmasks[: args.sample_limit],
+        "stderr": result.stderr.strip(),
+    }
+
+
+def print_report(report: dict[str, object]) -> None:
+    print(
+        "hostile real-world coverage "
+        f"profile={report['profile']} kind={report['kind']} cases={report['cases']}"
+    )
+    print(
+        f"bytes={report['bytes']} seconds={report['seconds']:.3f} "
+        f"MiB/s={report['mib_per_s']:.2f}"
+    )
+    sensitive = report["sensitive"]
+    benign = report["benign"]
+    print(
+        f"coverage={report['coverage']:.3f} "
+        f"caught={sensitive['caught']}/{sensitive['total']}"
+    )
+    print(
+        f"utility={report['utility']:.3f} "
+        f"preserved={benign['preserved']}/{benign['total']}"
+    )
+    print("\nby category:")
+    print(f"{'category':<24} {'caught':>8} {'total':>8} {'coverage':>9}")
+    for row in report["by_category"]:
+        print(
+            f"{row['category']:<24} {row['caught']:>8} {row['total']:>8} "
+            f"{row['coverage']:>9.3f}"
+        )
+    if report["miss_samples"]:
+        print("\nmiss samples:")
+        for miss in report["miss_samples"]:
+            print(
+                f"  - {miss['category']:<20} {miss['case']}: "
+                f"{miss['note']} => {miss['value']}"
+            )
+    if report["overmask_samples"]:
+        print("\novermask samples:")
+        for sample in report["overmask_samples"]:
+            print(f"  - {sample}")
+    if report["stderr"]:
+        print(f"\npentect: {report['stderr']}")
+
+
+def render_corpus(cases: Iterable[Case]) -> str:
+    chunks = []
+    for case in cases:
+        chunks.append(f"\n--- CASE {case.name} ---\n{case.text}\n")
+    return "".join(chunks)
+
+
+def split_case_outputs(masked: str, cases: Iterable[Case]) -> dict[str, str]:
+    markers = [(case.name, f"--- CASE {case.name} ---") for case in cases]
+    positions = []
+    for name, marker in markers:
+        pos = masked.find(marker)
+        if pos >= 0:
+            positions.append((pos, name, marker))
+    positions.sort()
+    out: dict[str, str] = {}
+    for idx, (pos, name, marker) in enumerate(positions):
+        start = pos + len(marker)
+        end = positions[idx + 1][0] if idx + 1 < len(positions) else len(masked)
+        out[name] = masked[start:end]
+    return out
+
+
+def target(value: str, category: str, note: str) -> Target:
+    return Target(value=value, category=category, note=note)
+
+
+def display_value(value: str) -> str:
+    collapsed = value.replace("\n", "\\n").replace("\u200b", "\\u200b")
+    if len(collapsed) <= 80:
+        return collapsed
+    return collapsed[:77] + "..."
+
+
+def token_body(seed: int, length: int, alphabet: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijk") -> str:
+    out = []
+    x = seed * 1103515245 + 12345
+    for _ in range(length):
+        x = (x * 1664525 + 1013904223) & 0xFFFFFFFF
+        out.append(alphabet[x % len(alphabet)])
+    return "".join(out)
+
+
+def openai_key(seed: int) -> str:
+    return "sk" + "-" + token_body(seed, 42)
+
+
+def github_token(seed: int) -> str:
+    return "ghp" + "_" + token_body(seed + 7, 36)
+
+
+def runpod_key(seed: int) -> str:
+    return "rpa" + "_" + token_body(seed + 13, 46)
+
+
+def aws_access_key(seed: int) -> str:
+    return "AKIA" + token_body(seed + 19, 16, "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+
+
+def stripe_key(seed: int) -> str:
+    return "sk" + "_live_" + token_body(seed + 23, 24)
+
+
+def b64_token(seed: int) -> str:
+    return token_body(seed + 29, 44, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/") + "=="
+
+
+def jwt_like(seed: int) -> str:
+    return (
+        token_body(seed + 31, 26, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+        + "."
+        + token_body(seed + 37, 42, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+        + "."
+        + token_body(seed + 41, 32, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+    )
+
+
+def card_number(index: int) -> str:
+    cards = [
+        "4242424242424242",
+        "4012888888881881",
+        "4111111111111111",
+        "5555555555554444",
+        "5105105105105100",
+        "378282246310005",
+        "6011111111111117",
+        "3530111333300000",
+    ]
+    return cards[index % len(cards)]
+
+
+def iban_number(index: int) -> str:
+    ibans = [
+        "DE15804319371058294617",
+        "GB94804319371058294617",
+        "FR7980431937105829461730528",
+        "ES8280431937105829461730",
+        "IT4680431937105829461730528",
+        "NL3280431937105829",
+        "CH1480431937105829461",
+        "BE92804319371058",
+    ]
+    return ibans[index % len(ibans)]
+
+
+def phone_number(index: int) -> str:
+    phones = [
+        "+14155552671",
+        "+442071838750",
+        "+81363849000",
+        "+4930901820",
+        "+33142685300",
+        "+390612345678",
+        "+34911234567",
+        "+919876543210",
+    ]
+    return phones[index % len(phones)]
+
+
+def btc_address(index: int) -> str:
+    values = [
+        "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+        "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
+        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+        "LXmteg8PyzybHdrywScarTEfieHWJbpAHy",
+        "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    ]
+    return values[index % len(values)]
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except BrokenPipeError:
+        raise SystemExit(1)

--- a/tools/ner_sidecar.py
+++ b/tools/ner_sidecar.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
-"""Persistent NER sidecar for Pentect.
+"""Persistent semantic PII sidecar for Pentect.
 
-Loads a spaCy model once, then serves requests over stdin/stdout (one JSON
-request and one JSON response per line). Pentect's Rust `NerDetector` (the
-`ner` feature) spawns this and pipes region text through it.
+Loads a provider once, then serves requests over stdin/stdout (one JSON request
+and one JSON response per line). Pentect's Rust `SemanticDetector` spawns this
+and pipes region text through it.
 
 Protocol (newline-delimited JSON, so text with newlines is escaped):
   request:  a JSON string  ->  "John Smith at Acme Corp"
   response: a JSON array   ->  [[0,10,"PERSON"],[14,23,"ORGANIZATION"]]
 Offsets are BYTE offsets into the UTF-8 text, matching Rust's span ranges.
 
-Model: PENTECT_SPACY_MODEL (default en_core_web_lg — same family Presidio
-uses). Swap to ai4privacy/DeBERTa later for a strict win over spaCy.
+Provider: PENTECT_SEMANTIC_PROVIDER (spacy, gliner, presidio). spaCy is the
+default because it is lightweight and already installed in many Python stacks;
+GLiNER/Presidio are optional adapters when their packages are available.
 """
 import json
 import os
+import re
 import sys
 
-# spaCy entity label -> Pentect NER label. Only identity-bearing types.
-LABELS = {
+SPACY_LABELS = {
     "PERSON": "PERSON",
     "ORG": "ORGANIZATION",
     "GPE": "LOCATION",
@@ -27,14 +28,212 @@ LABELS = {
     "NORP": "NRP",
 }
 
+PRESIDIO_LABELS = {
+    "PERSON": "PERSON",
+    "LOCATION": "LOCATION",
+    "ORGANIZATION": "ORGANIZATION",
+    "NRP": "NRP",
+    "ADDRESS": "LOCATION",
+}
 
-def main() -> None:
+GLINER_LABELS = {
+    "person": "PERSON",
+    "full name": "PERSON",
+    "organization": "ORGANIZATION",
+    "company": "ORGANIZATION",
+    "location": "LOCATION",
+    "address": "LOCATION",
+    "street address": "LOCATION",
+    "nationality": "NRP",
+    "religion": "NRP",
+    "political group": "NRP",
+}
+
+TECH_INDEX_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*\[\d+\]?$")
+TECH_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+\-\[\]]{7,}$")
+
+ADDRESS_PATTERNS = [
+    # 1600 Amphitheatre Parkway, Mountain View CA
+    # 221B Baker Street, London
+    re.compile(
+        r"""
+        \b\d{1,6}[A-Za-z]?(?:[-/]\d{1,6}[A-Za-z]?){0,2}
+        \s+
+        (?:[A-Z][\w.'-]*\s+|[a-z][\w.'-]*\s+){0,6}
+        (?:Street|St\.?|Avenue|Ave\.?|Road|Rd\.?|Boulevard|Blvd\.?|
+           Drive|Dr\.?|Lane|Ln\.?|Parkway|Pkwy\.?|Way|Court|Ct\.?|
+           Place|Pl\.?|Square|Sq\.?|Terrace|Trail|Circle|Cir\.?)
+        \b
+        (?:,\s*[A-Z][\w.'-]*(?:\s+[A-Z][\w.'-]*){0,4}(?:\s+[A-Z]{2})?)?
+        """,
+        re.VERBOSE,
+    ),
+    # 1-1-2 Otemachi, Chiyoda-ku, Tokyo
+    re.compile(
+        r"""
+        \b\d{1,4}(?:-\d{1,4}){1,3}
+        \s+[A-Z][\w.'-]*
+        (?:,\s*[A-Z][\w.'-]*(?:-[a-z]+)?){1,4}
+        """,
+        re.VERBOSE,
+    ),
+    # Japanese address-like runs. This is deliberately structural, not a list
+    # of benchmark strings.
+    re.compile(
+        r"[\u3040-\u30ff\u3400-\u9fff]{2,}(?:都|道|府|県)"
+        r"[\u3040-\u30ff\u3400-\u9fff0-9０-９\-ー丁目番地号区市町村郡]+"
+    ),
+]
+
+
+def is_probably_technical_entity(value: str) -> bool:
+    s = value.strip(" \t\r\n'\"`.,;:()")
+    if not s:
+        return True
+    # Multi-line or assignment-shaped spans are almost always log/config blobs,
+    # not a single semantic person/org/location entity.
+    if "\n" in s or "\r" in s or "=" in s:
+        return True
+    # Filesystem paths and URLs are structured data. Core rules handle the
+    # sensitive path segment; NER should not mask the whole debug path as ORG.
+    if "\\" in s or "/" in s:
+        return True
+    # deploy[42], worker-7, client-16, trace IDs, invalid IBAN-like fixtures.
+    if TECH_INDEX_RE.fullmatch(s):
+        return True
+    if len(s) >= 8 and any(ch.isdigit() for ch in s) and TECH_TOKEN_RE.fullmatch(s):
+        return True
+    return False
+
+
+def byte_offsets(text: str, start: int, end: int) -> tuple[int, int]:
+    return (
+        len(text[:start].encode("utf-8")),
+        len(text[:end].encode("utf-8")),
+    )
+
+
+def collect_address_entities(text: str) -> list[tuple[int, int, str]]:
+    out = []
+    for pattern in ADDRESS_PATTERNS:
+        for match in pattern.finditer(text):
+            start, end = match.span()
+            value = text[start:end].strip()
+            if value and not is_probably_technical_entity(value):
+                out.append((start, end, "LOCATION"))
+    return out
+
+
+def normalize_provider_name(raw: str) -> str:
+    name = raw.strip().lower().replace("_", "-")
+    aliases = {
+        "ner": "spacy",
+        "spacy-ner": "spacy",
+        "gliner2": "gliner",
+        "gliner2-pii": "gliner",
+        "opf": "presidio",
+        "presidio-analyzer": "presidio",
+    }
+    return aliases.get(name, name)
+
+
+def load_spacy_detector():
     import spacy
 
     model = os.environ.get("PENTECT_SPACY_MODEL", "en_core_web_lg")
     nlp = spacy.load(model, disable=["lemmatizer", "tagger", "parser", "attribute_ruler"])
+
+    def detect(text: str) -> list[tuple[int, int, str]]:
+        out = []
+        doc = nlp(text)
+        for ent in doc.ents:
+            label = SPACY_LABELS.get(ent.label_)
+            if label is not None and not is_probably_technical_entity(ent.text):
+                out.append((ent.start_char, ent.end_char, label))
+        return out
+
+    return detect
+
+
+def load_gliner_detector():
+    from gliner import GLiNER
+
+    model_name = os.environ.get(
+        "PENTECT_GLINER_MODEL",
+        "fastino/gliner2-privacy-filter-PII-multi",
+    )
+    threshold = float(os.environ.get("PENTECT_GLINER_THRESHOLD", "0.45"))
+    model = GLiNER.from_pretrained(model_name)
+    labels = list(GLINER_LABELS)
+
+    def detect(text: str) -> list[tuple[int, int, str]]:
+        out = []
+        for ent in model.predict_entities(text, labels, threshold=threshold):
+            raw_label = str(ent.get("label", "")).lower()
+            label = GLINER_LABELS.get(raw_label)
+            start = ent.get("start")
+            end = ent.get("end")
+            if label is None or not isinstance(start, int) or not isinstance(end, int):
+                continue
+            if not is_probably_technical_entity(text[start:end]):
+                out.append((start, end, label))
+        return out
+
+    return detect
+
+
+def load_presidio_detector():
+    from presidio_analyzer import AnalyzerEngine
+
+    analyzer = AnalyzerEngine()
+    language = os.environ.get("PENTECT_PRESIDIO_LANGUAGE", "en")
+
+    def detect(text: str) -> list[tuple[int, int, str]]:
+        out = []
+        for ent in analyzer.analyze(text=text, language=language):
+            label = PRESIDIO_LABELS.get(ent.entity_type)
+            if label is not None and not is_probably_technical_entity(text[ent.start : ent.end]):
+                out.append((ent.start, ent.end, label))
+        return out
+
+    return detect
+
+
+def load_detector(provider: str):
+    if provider == "spacy":
+        return load_spacy_detector()
+    if provider == "gliner":
+        return load_gliner_detector()
+    if provider == "presidio":
+        return load_presidio_detector()
+    raise RuntimeError(f"unknown semantic provider: {provider}")
+
+
+def encode_response(text: str, spans: list[tuple[int, int, str]]) -> list[list[object]]:
+    response = []
+    seen = set()
+    for start, end, label in sorted(spans):
+        if not (0 <= start < end <= len(text)):
+            continue
+        key = (start, end, label)
+        if key in seen:
+            continue
+        seen.add(key)
+        b_start, b_end = byte_offsets(text, start, end)
+        response.append([b_start, b_end, label])
+    return response
+
+
+def main() -> None:
+    provider = normalize_provider_name(
+        os.environ.get(
+            "PENTECT_SEMANTIC_PROVIDER",
+            os.environ.get("PENTECT_NER_PROVIDER", "spacy"),
+        )
+    )
+    detect = load_detector(provider)
     # Signal readiness so the parent can block until the (slow) model load is done.
-    sys.stdout.write("READY\n")
+    sys.stdout.write(f"READY {provider}\n")
     sys.stdout.flush()
 
     for line in sys.stdin:
@@ -43,17 +242,9 @@ def main() -> None:
             continue
         try:
             text = json.loads(line)
-            doc = nlp(text)
-            out = []
-            for ent in doc.ents:
-                label = LABELS.get(ent.label_)
-                if label is None:
-                    continue
-                # char offsets -> byte offsets into the UTF-8 text
-                b_start = len(text[: ent.start_char].encode("utf-8"))
-                b_end = len(text[: ent.end_char].encode("utf-8"))
-                out.append([b_start, b_end, label])
-            sys.stdout.write(json.dumps(out) + "\n")
+            out = detect(text)
+            out.extend(collect_address_entities(text))
+            sys.stdout.write(json.dumps(encode_response(text, out)) + "\n")
         except Exception:  # never crash the loop on one bad request
             sys.stdout.write("[]\n")
         sys.stdout.flush()


### PR DESCRIPTION
## Summary
- add a hostile real-world masking benchmark with no-cheat rules
- add generalized deterministic detectors for keyed secrets, session tokens, case IDs, and escaped/fractured secrets
- add semantic sidecar provider selection via --semantic / --semantic-provider with spaCy, GLiNER, and Presidio adapters
- keep --ner as a legacy alias and document --features semantic

## Validation
- cargo test --workspace --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build -p pentect-cli --release --features semantic
- python tools\\eval_hostile_realworld.py --bin target\\release\\pentect.exe --pentect-arg=--semantic --sample-limit 20
- smoke: --semantic-provider spacy masks person/org/address

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-backed semantic PII sidecar with `--semantic` and `--semantic-provider` (default spaCy; GLiNER and Presidio supported) to improve person/org/address masking. Also adds new deterministic rules and normalization to catch encoded/fractured secrets, plus a hostile real‑world benchmark.

- **New Features**
  - CLI: `--semantic`, `--semantic-provider spacy|gliner|presidio`, `--semantic-script`; `--ner` is a legacy alias for `--semantic --semantic-provider spacy`. Env vars: `PENTECT_SEMANTIC_PROVIDER`, `PENTECT_SEMANTIC_SCRIPT`/`PENTECT_NER_SCRIPT`.
  - Core: `SemanticDetector` (alias `NerDetector`) with sidecar; adds address extraction and safeguards to avoid masking technical tokens.
  - Detectors: new `KEYED_SECRET`, `SESSION_TOKEN`, `CASE_IDENTIFIER` rules; handle OpenAI keys with whitespace around the dash.
  - Normalization: decodes ASCII `\u00XX`/`\xXX` and `%XX` escapes for detection; identity normalization keeps zero‑width/bidi controls.
  - Tools: `tools/eval_hostile_realworld.py` hostile benchmark with coverage/utility reporting; README documents usage.

- **Migration**
  - Build `pentect-cli` with `--features semantic` (or feature `semantic` in `Cargo.toml` for `@pentect-core`/`@pentect-cli`).
  - Run with `--semantic`; choose a provider via `--semantic-provider` and install its Python package (`spacy`, `gliner`, or `presidio`). Default script is `tools/ner_sidecar.py`. `--ner` continues to work.

<sup>Written for commit 3103815593f7354782ee80f4dc72d940879d5682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/EdamAme-x/pentect/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `--semantic` flag with configurable provider support (spaCy, GLiNER, Presidio) for enhanced PII detection
  * Extended detection rules for credentials, session tokens, and case identifiers
  * Added evaluation script for adversarial detection scenarios

* **Documentation**
  * Updated README with semantic detection configuration and provider selection guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->