### PR TITLE
Detect SQL DDL password clauses

### DIFF
--- a/crates/pentect-core/src/detect/rule.rs
+++ b/crates/pentect-core/src/detect/rule.rs
@@ -414,6 +414,12 @@ impl RuleDetector {
             // lines in OpenAPI/YAML examples. The validator rejects prose and
             // placeholder token names.
             (r#"(?i)(?:^|[^A-Za-z0-9_-])bearer[ \t]+([A-Za-z0-9._~+/=-]{20,})(?:$|[\s"',;)])"#, Secret, "BEARER_TOKEN", Medium, 1, V::BearerToken),
+            // SQL DDL password clauses are grammar-level credential material
+            // across PostgreSQL/MySQL/Oracle/SQL Server style statements. Split
+            // quoted/bare values so only the password bytes are masked.
+            (r#"(?i)\b(?:create|alter)\s+(?:user|role|login)\b[^\r\n;]{0,180}?\b(?:identified\s+(?:with\s+(?:'[^'\r\n]{1,64}'|[A-Za-z0-9_]+)\s+)?(?:by|as)|password)\s*=?\s*'([^'\r\n]{1,160})'"#, Secret, "SQL_PASSWORD", Medium, 1, V::SqlPasswordValue),
+            (r#"(?i)\b(?:create|alter)\s+(?:user|role|login)\b[^\r\n;]{0,180}?\b(?:identified\s+(?:with\s+(?:"[^"\r\n]{1,64}"|[A-Za-z0-9_]+)\s+)?(?:by|as)|password)\s*=?\s*"([^"\r\n]{1,160})""#, Secret, "SQL_PASSWORD", Medium, 1, V::SqlPasswordValue),
+            (r#"(?i)\b(?:create|alter)\s+(?:user|role|login)\b[^\r\n;]{0,180}?\b(?:identified\s+(?:with\s+[A-Za-z0-9_]+\s+)?(?:by|as)|password)\s*=?\s*([^\s;,)'"`]{1,160})(?:$|[\s;,)])"#, Secret, "SQL_PASSWORD", Medium, 1, V::SqlPasswordValue),
             // Preserve path structure for debugging, but hide the local account
             // segment that frequently leaks in stack traces and tool output.
             (r#"(?i)\bAccountKey\b[ \t]*=[ \t]*([A-Za-z0-9+/=]{40,})(?:;|$|[\s"',)])"#, Secret, "AZURE_STORAGE_ACCOUNT_KEY", High, 1, V::None),
@@ -826,6 +832,22 @@ mod tests {
             "- Bearer 0a000aa0a0a0000000a000a0a0a00000a0a000aaaa0a000aa0aaa000a0a0a000",
             "BEARER_TOKEN"
         ));
+        assert!(has(
+            "CREATE ROLE app WITH LOGIN PASSWORD 's3cret';",
+            "SQL_PASSWORD"
+        ));
+        assert!(has(
+            "CREATE USER root@'host' IDENTIFIED BY \"p4ssw0rd\";",
+            "SQL_PASSWORD"
+        ));
+        assert!(has(
+            "ALTER USER root IDENTIFIED WITH mysql_native_password BY hunter2;",
+            "SQL_PASSWORD"
+        ));
+        assert!(has(
+            "ALTER LOGIN bob WITH PASSWORD = 'Adm1nPass';",
+            "SQL_PASSWORD"
+        ));
         assert!(!has(
             "Authorization: Bearer YOUR_ACCESS_TOKEN_VALUE",
             "BEARER_TOKEN"
@@ -852,6 +874,11 @@ mod tests {
         assert!(!has("documentation says Basic docs", "BASIC_AUTH"));
         assert!(!has(r#"header: "Basic something""#, "BASIC_AUTH"));
         assert!(!has(r#"header: "Basic dXNlcm9ubHk=""#, "BASIC_AUTH"));
+        assert!(!has("password field docs", "SQL_PASSWORD"));
+        assert!(!has(
+            "CREATE ROLE app WITH LOGIN PASSWORD NULL;",
+            "SQL_PASSWORD"
+        ));
     }
 
     #[test]

--- a/crates/pentect-core/src/detect/validate.rs
+++ b/crates/pentect-core/src/detect/validate.rs
@@ -910,6 +910,7 @@ pub enum Validator {
     BasicAuthToken68,
     DbConnectionString,
     BearerToken,
+    SqlPasswordValue,
 }
 
 impl Validator {
@@ -958,6 +959,7 @@ impl Validator {
             "basic_auth_token68" => Validator::BasicAuthToken68,
             "db_connection_string" => Validator::DbConnectionString,
             "bearer_token" => Validator::BearerToken,
+            "sql_password_value" => Validator::SqlPasswordValue,
             _ => return None,
         })
     }
@@ -1004,8 +1006,54 @@ impl Validator {
             Validator::BasicAuthToken68 => basic_auth_token68(s),
             Validator::DbConnectionString => db_connection_string(s),
             Validator::BearerToken => bearer_token(s),
+            Validator::SqlPasswordValue => sql_password_value(s),
         }
     }
+}
+
+pub fn sql_password_value(s: &str) -> bool {
+    // SQL DDL `PASSWORD` / `IDENTIFIED BY` clauses can legitimately contain
+    // weak default-looking passwords. Only reject syntax placeholders and
+    // clause keywords that are not password material.
+    let value = s.trim();
+    if !(1..=512).contains(&value.len()) || value.bytes().any(|b| matches!(b, b'\r' | b'\n')) {
+        return false;
+    }
+    let normalized = value
+        .trim_matches(|ch: char| matches!(ch, '\'' | '"' | '`'))
+        .trim();
+    if normalized.is_empty()
+        || normalized
+            .bytes()
+            .any(|b| matches!(b, b'<' | b'>' | b'{' | b'}' | b'[' | b']' | b'*'))
+        || !normalized.bytes().any(|b| b.is_ascii_alphanumeric())
+        || normalized.contains('`')
+        || normalized.contains(" + ")
+        || normalized.starts_with('+')
+        || normalized.ends_with('+')
+        || matches!(normalized, "%s" | "%v" | "%q" | "%d")
+        || (normalized.starts_with("%%") && normalized.ends_with("%%"))
+    {
+        return false;
+    }
+    !matches!(
+        normalized.to_ascii_lowercase().as_str(),
+        "null"
+            | "none"
+            | "default"
+            | "password"
+            | "expire"
+            | "expired"
+            | "lock"
+            | "locked"
+            | "unlock"
+            | "unlocked"
+            | "required"
+            | "optional"
+            | "temporary"
+            | "tablespace"
+            | "users"
+    )
 }
 
 pub fn bearer_token(s: &str) -> bool {
@@ -1165,6 +1213,18 @@ mod tests {
             "example-bearer-token-value" => false,
             "abcdefghijklmnopqrstuv" => false,
             "short123" => false);
+    }
+
+    #[test]
+    fn sql_password_value_rejects_clause_keywords_and_placeholders() {
+        vectors!(sql_password_value,
+            "hunter2" => true,
+            "p4ss" => true,
+            "password" => false,
+            "NULL" => false,
+            "<password>" => false,
+            "***" => false,
+            "temporary" => false);
     }
 
     #[test]


### PR DESCRIPTION
Scope:\n- Detect SQL DDL password values from CREATE/ALTER USER/ROLE/LOGIN clauses.\n- Keep weak real SQL passwords detectable, but reject syntax placeholders and source-template fragments.\n\nCredData delta versus #2 baseline:\n- TP: 10450 -> 10480\n- FP: 6726 -> 6729\n- FN: 4654 -> 4624\n- Precision: 0.608407 -> 0.608984\n- Recall: 0.691870 -> 0.693856\n- F1: 0.647460 -> 0.648655\n\nLocal checks:\n- cargo fmt --all -- --check\n- cargo test --workspace --all-features\n- cargo clippy --all-targets --all-features -- -D warnings