### PR TITLE
Improve structured secret false positive filters

### DIFF
--- a/crates/pentect-core/src/detect/auth_code.rs
+++ b/crates/pentect-core/src/detect/auth_code.rs
@@ -67,6 +67,9 @@ fn is_git_file_mode_context(text: &str, value_start: usize) -> bool {
     let Some(colon) = prefix.rfind(':') else {
         return false;
     };
+    if !prefix[colon + 1..].chars().all(char::is_whitespace) {
+        return false;
+    }
     let before = prefix[..colon].trim_end();
     before.ends_with("\"mode\"") || before.ends_with("'mode'") || before.ends_with("\\\"mode\\\"")
 }
@@ -231,6 +234,10 @@ mod tests {
             r#"{"title":"login code help","comments":42754194,"total_count":813448}"#
         )
         .is_empty());
+        assert!(has_value(
+            r#"{"headers":"X-GitHub-OTP","id":123,"otp":327146}"#,
+            "327146"
+        ));
         assert!(!has_value(
             "Enter 7QK4P on the login page. Order code AB12-CD ships tomorrow.",
             "AB12-CD"

--- a/crates/pentect-core/src/detect/auth_code.rs
+++ b/crates/pentect-core/src/detect/auth_code.rs
@@ -20,6 +20,7 @@ impl Detector for AuthCodeDetector {
             .filter(|span| {
                 !is_header_name_only_otp_context(view.text(), span.range.start)
                     && !is_git_file_mode_context(view.text(), span.range.start)
+                    && !is_json_numeric_metadata_context(view.text(), span.range.start)
             })
             .collect()
     }
@@ -68,6 +69,66 @@ fn is_git_file_mode_context(text: &str, value_start: usize) -> bool {
     };
     let before = prefix[..colon].trim_end();
     before.ends_with("\"mode\"") || before.ends_with("'mode'") || before.ends_with("\\\"mode\\\"")
+}
+
+fn is_json_numeric_metadata_context(text: &str, value_start: usize) -> bool {
+    // Saved API responses put many numeric ids/counts on the same long line as
+    // auth-related field names (`login`, `X-GitHub-OTP`). A local JSON key such
+    // as `"id": 327146` proves the number is metadata, not an OTP.
+    if value_start > text.len() {
+        return false;
+    }
+    let line_start = text[..value_start]
+        .rfind('\n')
+        .map_or(0, |offset| offset + 1);
+    let prefix = &text[line_start..value_start];
+    let Some(colon) = prefix.rfind(':') else {
+        return false;
+    };
+    let before = prefix[..colon].trim_end();
+    let Some(key) = quoted_key_suffix(before) else {
+        return false;
+    };
+    let normalized = normalize_key_name(key);
+    matches!(
+        normalized.as_str(),
+        "id" | "node_id"
+            | "size"
+            | "count"
+            | "total_count"
+            | "watchers_count"
+            | "forks_count"
+            | "open_issues_count"
+            | "network_count"
+            | "comments"
+            | "additions"
+            | "deletions"
+            | "changes"
+    ) || normalized.ends_with("_id")
+        || normalized.ends_with("_count")
+}
+
+fn quoted_key_suffix(value: &str) -> Option<&str> {
+    let quote = value.as_bytes().last().copied()?;
+    if !matches!(quote, b'"' | b'\'') {
+        return None;
+    }
+    let key_end = value.len() - 1;
+    let key_start = value[..key_end].rfind(quote as char)? + 1;
+    let key = &value[key_start..key_end];
+    (!key.is_empty()).then_some(key)
+}
+
+fn normalize_key_name(value: &str) -> String {
+    let mut out = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if !out.ends_with('_') {
+            out.push('_');
+        }
+    }
+    out.trim_matches('_').to_string()
 }
 
 fn specs() -> Vec<PatternSpec> {
@@ -160,6 +221,14 @@ mod tests {
         );
         assert!(values_for(
             r#"Create code object with {\"mode\": \"100644\", \"path\": \"foo.py\"}"#
+        )
+        .is_empty());
+        assert!(values_for(
+            r#"{"headers":"X-GitHub-OTP, Accept-Encoding","actor":{"id":327146,"login":"octo"}}"#
+        )
+        .is_empty());
+        assert!(values_for(
+            r#"{"title":"login code help","comments":42754194,"total_count":813448}"#
         )
         .is_empty());
         assert!(!has_value(

--- a/crates/pentect-core/src/detect/key_value.rs
+++ b/crates/pentect-core/src/detect/key_value.rs
@@ -1924,21 +1924,29 @@ fn is_escaped_source_payload_fragment_literal(value: &str, source_key: &str) -> 
         return false;
     }
     let value = value.trim().trim_matches('"');
-    if value.starts_with("\\\"") && value.len() <= 96 {
-        return true;
+    if let Some(head) = escaped_quoted_payload_head(value) {
+        return is_payload_fragment_head(head);
     }
     if !(value.contains("\\n") || value.contains("\\t")) {
         return false;
     }
-    let head = value
+    let head = payload_fragment_head(value);
+    is_payload_fragment_head(head)
+}
+
+fn escaped_quoted_payload_head(value: &str) -> Option<&str> {
+    value.strip_prefix("\\\"").map(payload_fragment_head)
+}
+
+fn payload_fragment_head(value: &str) -> &str {
+    value
         .split("\\n")
         .next()
         .unwrap_or(value)
         .split("\\t")
         .next()
         .unwrap_or(value)
-        .trim_matches(|ch: char| matches!(ch, '+' | '\\' | '"' | '\'' | '`' | ' '));
-    is_payload_fragment_head(head)
+        .trim_matches(|ch: char| matches!(ch, '+' | '\\' | '"' | '\'' | '`' | ' '))
 }
 
 fn source_key_has_escaped_payload_shape(source_key: &str) -> bool {
@@ -3124,6 +3132,15 @@ mod tests {
         ] {
             assert!(hits(raw).is_empty(), "{raw}: {:?}", hits(raw));
         }
+        let source_payload = r#"{"files":{"app.rs":{"content":"password: \"sk-live-123\""}}}"#;
+        assert!(is_escaped_source_payload_fragment_literal(
+            r#"\"Basic"#,
+            source_payload
+        ));
+        assert!(!is_escaped_source_payload_fragment_literal(
+            r#"\"sk-live-123"#,
+            source_payload
+        ));
     }
 
     #[test]

--- a/crates/pentect-core/src/detect/key_value.rs
+++ b/crates/pentect-core/src/detect/key_value.rs
@@ -623,7 +623,9 @@ fn looks_like_secret_value(
         || is_html_documentation_fragment_literal(value, key_name, source_key)
         || is_escaped_html_source_fragment_literal(value, source_key)
         || is_fingerprint_literal(value, key_name)
-        || is_source_constant_reference_literal(value, source_key)
+        || is_escaped_control_placeholder_literal(value, key_name)
+        || is_escaped_source_payload_fragment_literal(value, source_key)
+        || is_source_constant_reference_literal(value, key_name, source_key)
         || is_source_declared_name_literal(value, key_name, source_key)
         || is_source_config_name_literal(value, source_key)
         || is_source_sensitive_name_reference_literal(value, source_key)
@@ -1854,7 +1856,118 @@ fn is_fingerprint_literal(value: &str, key_name: &str) -> bool {
             .all(|part| part.len() == 2 && part.bytes().all(|b| b.is_ascii_hexdigit()))
 }
 
-fn is_source_constant_reference_literal(value: &str, source_key: &str) -> bool {
+fn is_escaped_control_placeholder_literal(value: &str, key_name: &str) -> bool {
+    // Test fixtures often keep table-shaped placeholder values in escaped
+    // string form, e.g. `LINE_1\nLINE_2` for a private key column or
+    // `password_1\t\t` for a decrypted sample. Require literal escaped
+    // control characters plus placeholder grammar; real escaped binary or
+    // base64 material is not affected.
+    let value = value.trim();
+    if !(value.contains("\\n") || value.contains("\\t")) {
+        return false;
+    }
+    is_numbered_line_placeholder_literal(value)
+        || is_key_named_tab_placeholder_literal(value, key_name)
+        || is_escaped_sensitive_key_name_fragment(value)
+}
+
+fn is_numbered_line_placeholder_literal(value: &str) -> bool {
+    let parts = value.split("\\n").collect::<Vec<_>>();
+    (2..=32).contains(&parts.len())
+        && parts
+            .iter()
+            .all(|part| is_numbered_placeholder(part, "line"))
+}
+
+fn is_numbered_placeholder(value: &str, prefix: &str) -> bool {
+    let normalized = normalize_key(value);
+    normalized
+        .strip_prefix(prefix)
+        .and_then(|rest| rest.strip_prefix('_'))
+        .is_some_and(|number| !number.is_empty() && number.bytes().all(|b| b.is_ascii_digit()))
+}
+
+fn is_key_named_tab_placeholder_literal(value: &str, key_name: &str) -> bool {
+    let mut body = value;
+    let mut tabs = 0usize;
+    while let Some(rest) = body.strip_suffix("\\t") {
+        body = rest;
+        tabs += 1;
+    }
+    if tabs < 2 {
+        return false;
+    }
+    let body = normalize_key(body);
+    let key = normalize_key(key_name);
+    body == key || is_numbered_placeholder(&body, &key)
+}
+
+fn is_escaped_sensitive_key_name_fragment(value: &str) -> bool {
+    let Some((head, tail)) = value.split_once("\\n") else {
+        return false;
+    };
+    let head = normalize_key(head);
+    !head.is_empty()
+        && head.split('_').any(is_sensitive_setting_name_component)
+        && tail
+            .split("\\t")
+            .all(|part| part.is_empty() || matches!(part, "+" | "if"))
+}
+
+fn is_escaped_source_payload_fragment_literal(value: &str, source_key: &str) -> bool {
+    // Saved API responses and replay files can embed source code inside JSON
+    // strings. A colon inside that escaped code may make the scanner split a
+    // code fragment as `password: \"Basic` or `token: client_secret\n\t`.
+    // Suppress only when the left side already proves escaped payload context
+    // and the captured value carries escaped string/control syntax.
+    if !source_key_has_escaped_payload_shape(source_key) {
+        return false;
+    }
+    let value = value.trim().trim_matches('"');
+    if value.starts_with("\\\"") && value.len() <= 96 {
+        return true;
+    }
+    if !(value.contains("\\n") || value.contains("\\t")) {
+        return false;
+    }
+    let head = value
+        .split("\\n")
+        .next()
+        .unwrap_or(value)
+        .split("\\t")
+        .next()
+        .unwrap_or(value)
+        .trim_matches(|ch: char| matches!(ch, '+' | '\\' | '"' | '\'' | '`' | ' '));
+    is_payload_fragment_head(head)
+}
+
+fn source_key_has_escaped_payload_shape(source_key: &str) -> bool {
+    let lower = source_key.to_ascii_lowercase();
+    contains_any(
+        &lower,
+        &[
+            "\\n",
+            "\\t",
+            "\\\"",
+            "\"content\"",
+            "\"patch\"",
+            "\"files\"",
+        ],
+    )
+}
+
+fn is_payload_fragment_head(head: &str) -> bool {
+    let normalized = normalize_key(head);
+    normalized.is_empty()
+        || matches!(
+            normalized.as_str(),
+            "basic" | "bearer" | "class" | "instance"
+        )
+        || is_source_secret_name_reference_value(&normalized)
+        || is_uppercase_identifier_constant(head)
+}
+
+fn is_source_constant_reference_literal(value: &str, key_name: &str, source_key: &str) -> bool {
     // C-family/Rust/C# assignments often put enum constants or environment
     // variable names in sensitive-looking fields:
     // `gss_buffer_desc token = GSS_C_EMPTY_BUFFER` or
@@ -1867,7 +1980,58 @@ fn is_source_constant_reference_literal(value: &str, source_key: &str) -> bool {
     if !is_uppercase_identifier_constant(value) || !source_key_has_code_shape(source_key) {
         return false;
     }
-    is_non_secret_source_constant_value(value)
+    is_non_secret_source_constant_value(value) || is_source_sensitive_setting_name(value, key_name)
+}
+
+fn is_source_sensitive_setting_name(value: &str, key_name: &str) -> bool {
+    // Source declarations also store the public *name* of a credential setting,
+    // e.g. `expectedTokenValue = "GITHUB_TOKEN_VALUE"` or
+    // `OAuthClientSecret = "GCM_BITBUCKET_CLOUD_CLIENTSECRET"`. This is not
+    // value-list based: require an ALL_CAPS identifier, a sensitive suffix, and
+    // a suffix that matches the declared identifier once case/separators are
+    // normalized. Short one-word suffixes like `_SECRET` are deliberately not
+    // enough, because `PROD_SECRET_VALUE` can still be real config material.
+    let key_compact = normalize_key(key_name).replace('_', "");
+    if key_compact.len() < 8 {
+        return false;
+    }
+    let parts = normalize_key(value)
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if parts.len() < 2
+        || !parts
+            .iter()
+            .any(|part| is_sensitive_setting_name_component(part))
+    {
+        return false;
+    }
+    (0..parts.len()).any(|idx| {
+        let suffix = parts[idx..].join("");
+        suffix.len() >= 8
+            && key_compact.ends_with(&suffix)
+            && parts[idx..]
+                .iter()
+                .any(|part| is_sensitive_setting_name_component(part))
+    })
+}
+
+fn is_sensitive_setting_name_component(part: &str) -> bool {
+    matches!(
+        part,
+        "secret"
+            | "secrets"
+            | "clientsecret"
+            | "token"
+            | "tokens"
+            | "password"
+            | "passwd"
+            | "credential"
+            | "credentials"
+            | "auth"
+            | "key"
+    )
 }
 
 fn is_source_declared_name_literal(value: &str, key_name: &str, source_key: &str) -> bool {
@@ -2488,6 +2652,7 @@ fn key_name_indicates_sensitive_material(key_name: &str) -> bool {
                 | "pwd"
                 | "pass"
                 | "secret"
+                | "secrets"
                 | "token"
                 | "credential"
                 | "credentials"
@@ -2919,6 +3084,15 @@ mod tests {
             r#"var response = "id_token=my_id_token&state=protected_state&code=my_code";"#,
             r#"access_token = "Test Access Token","#,
             r#"refresh_token = "Test Refresh Token""#,
+            r#"const string expectedTokenValue = "GITHUB_TOKEN_VALUE";"#,
+            r#"public const string OAuthClientSecret = "GCM_BITBUCKET_CLOUD_CLIENTSECRET";"#,
+            r#""privateKey": "LINE_1\nLINE_2\nLINE_2","#,
+            r#""password": "password_1\t\t\t\t","#,
+            r#""passphrase": "passphrase\t\t\t\t","#,
+            r#"{"files":{"fail.py":{"content":"login = \"\"\npassword = \"\"\norgName = \"\""}}}"#,
+            r#"{"patch":"@@ -0,0 +1,2 @@\n+client_secret\n\t\t"}"#,
+            r#"{"patch":"@@ -0,0 +1 @@\n+Authorization: BEARER\n\tif token"}"#,
+            r#"// User-Secrets: https://docs.asp.net/en/latest/security/app-secrets.html"#,
             r#"val FAILED_TO_RETRIEVE_GENERATED_KEY = "Failed to retrieve the generated key.""#,
             r#"POSTGRES_HOST_AUTH_METHOD: scram-sha-256"#,
             r#"c.key = "__vlist__" + nestedIndex;"#,
@@ -2988,6 +3162,11 @@ mod tests {
             "Correct horse battery staple!"
         ));
         assert!(has(r#"passwordLabel = "tenant-7-trial""#, "tenant-7-trial"));
+        assert!(has(r#"password = "abc\tdef123""#, "abc\\tdef123"));
+        assert!(has(
+            r#"private_key = "LINE_1\nA2secret""#,
+            "LINE_1\\nA2secret"
+        ));
     }
 
     #[test]

--- a/crates/pentect-core/src/detect/structural.rs
+++ b/crates/pentect-core/src/detect/structural.rs
@@ -104,6 +104,9 @@ impl Detector for SensitiveKeyDetector {
         if region.ctx.key.as_deref().is_some_and(|key| {
             is_ui_copy_sensitive_key(key, view.text())
                 || is_structured_token_prose(key, view.text())
+                || is_structured_placeholder_value(key, view.text())
+                || is_structured_secret_identifier_name(key, view.text())
+                || is_structured_generic_key_weak_value(key, view.text())
                 || is_structured_generic_key_name_reference(key, view.text())
         }) {
             return vec![];
@@ -137,7 +140,7 @@ fn sensitive_context_label(ctx: &Context) -> Option<String> {
 
 fn is_sensitive_key_name(key: &str) -> bool {
     let name = normalize_identifier(key);
-    if is_explicitly_non_sensitive_key(&name) {
+    if is_explicitly_non_sensitive_key(&name) || is_non_credential_sensitive_word_name(&name) {
         return false;
     }
     name == "key"
@@ -178,6 +181,104 @@ fn is_sensitive_key_name(key: &str) -> bool {
         ]
         .iter()
         .any(|needle| name.contains(needle))
+}
+
+fn is_non_credential_sensitive_word_name(name: &str) -> bool {
+    // Some technical names contain sensitive substrings but identify public
+    // concepts: parsers/tokenizers, UI labels/tooltips, or API operation names.
+    // Reject them before broad key-name matching so `tokenizer` does not become
+    // `token`, while actual fields such as `access_token` still pass.
+    let parts = name
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        return false;
+    }
+    if parts
+        .iter()
+        .any(|part| matches!(*part, "tokenizer" | "tokenizers"))
+        || has_structural_phrase(&parts, &["token", "sale"])
+        || parts.last().is_some_and(|part| *part == "arn")
+        || is_last_used_metadata_name(&parts)
+        || has_structural_phrase(&parts, &["password", "cannot", "be", "empty"])
+        || parts
+            .iter()
+            .any(|part| matches!(*part, "tooltip" | "label" | "title"))
+    {
+        return true;
+    }
+    is_sentence_like_key_name(&parts) || is_api_operation_name(&parts)
+}
+
+fn is_sentence_like_key_name(parts: &[&str]) -> bool {
+    // Translation/test names can be whole sentences:
+    // `log_in_with_the_admin_user_credentials_without...`. Long prose-like keys
+    // are not storage fields, even if they contain `password` or `credentials`.
+    parts.len() >= 8
+        && parts.iter().any(|part| {
+            matches!(
+                *part,
+                "with"
+                    | "without"
+                    | "the"
+                    | "this"
+                    | "about"
+                    | "via"
+                    | "before"
+                    | "after"
+                    | "should"
+                    | "challenge"
+            )
+        })
+}
+
+fn is_api_operation_name(parts: &[&str]) -> bool {
+    // AWS/OpenAPI model names such as `GetSecretValue`,
+    // `AdminResetUserPassword`, and `ListSecrets` name operations. A concrete
+    // response field under those operations can still be caught by its own key.
+    let Some(first) = parts.first().copied() else {
+        return false;
+    };
+    let verb = if first == "admin" && parts.len() >= 2 {
+        parts[1]
+    } else {
+        first
+    };
+    matches!(
+        verb,
+        "get"
+            | "list"
+            | "create"
+            | "delete"
+            | "describe"
+            | "put"
+            | "update"
+            | "set"
+            | "reset"
+            | "restore"
+            | "rotate"
+            | "cancel"
+            | "initiate"
+            | "respond"
+    ) && parts
+        .iter()
+        .any(|part| matches!(*part, "secret" | "secrets" | "password" | "auth" | "token"))
+}
+
+fn is_last_used_metadata_name(parts: &[&str]) -> bool {
+    parts.iter().any(|part| matches!(*part, "last"))
+        && parts
+            .iter()
+            .any(|part| matches!(*part, "used" | "authenticated" | "time"))
+}
+
+fn has_structural_phrase(parts: &[&str], phrase: &[&str]) -> bool {
+    !phrase.is_empty()
+        && parts.len() >= phrase.len()
+        && parts
+            .windows(phrase.len())
+            .any(|window| window.iter().zip(phrase).all(|(part, word)| part == word))
 }
 
 fn is_ui_copy_sensitive_key(key: &str, value: &str) -> bool {
@@ -274,6 +375,125 @@ fn is_structured_token_prose(key: &str, value: &str) -> bool {
         || name == "refresh_token"
         || name == "id_token";
     is_token_key && value.chars().any(char::is_whitespace)
+}
+
+fn is_structured_placeholder_value(key: &str, value: &str) -> bool {
+    // JSON/YAML schemas and fixtures commonly put type names or weak examples
+    // under sensitive-looking fields (`token: string`, `token: abcde`). Those
+    // are not usable credentials. Keep this mostly token-scoped; `password:
+    // correct horse battery staple` remains detectable.
+    let name = normalize_identifier(key);
+    if is_schema_type_placeholder(value) {
+        return true;
+    }
+    is_token_key_name(&name) && !token_value_has_secret_shape(value)
+}
+
+fn is_structured_secret_identifier_name(key: &str, value: &str) -> bool {
+    // `SecretId`/`secret_id` in cloud APIs identifies a secret resource. The
+    // resource name (`MyTestDatabaseSecret`) is sensitive metadata at most, not
+    // the secret bytes. Concrete secret values still fire under `secret`,
+    // `secret_key`, or keyed detectors.
+    let name = normalize_identifier(key);
+    matches!(name.as_str(), "secret_id" | "secretid") && is_public_resource_identifier_value(value)
+}
+
+fn is_public_resource_identifier_value(value: &str) -> bool {
+    let value = value.trim();
+    (3..=128).contains(&value.len())
+        && !value.contains("://")
+        && !value.chars().any(char::is_whitespace)
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'/' | b':'))
+        && value.bytes().any(|b| b.is_ascii_alphabetic())
+}
+
+fn is_structured_generic_key_weak_value(key: &str, value: &str) -> bool {
+    // A literal JSON `"key"` often means "field name" or "keyboard shortcut".
+    // Do not let the generic word alone mask low-shape names; values with token
+    // punctuation, digits plus mixed case, or sufficient length remain visible.
+    if normalize_identifier(key) != "key" {
+        return false;
+    }
+    let value = value.trim();
+    is_keyboard_shortcut_value(value) || !generic_key_value_has_secret_shape(value)
+}
+
+fn is_keyboard_shortcut_value(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    let parts = normalized.split('+').collect::<Vec<_>>();
+    (2..=4).contains(&parts.len())
+        && parts.iter().all(|part| {
+            matches!(
+                part.trim(),
+                "ctrl"
+                    | "control"
+                    | "shift"
+                    | "alt"
+                    | "option"
+                    | "cmd"
+                    | "command"
+                    | "meta"
+                    | "win"
+                    | "enter"
+                    | "return"
+                    | "tab"
+                    | "esc"
+                    | "escape"
+            ) || part.trim().len() == 1 && part.trim().bytes().all(|b| b.is_ascii_alphanumeric())
+        })
+}
+
+fn generic_key_value_has_secret_shape(value: &str) -> bool {
+    let value = value.trim();
+    let len = value.chars().count();
+    let has_upper = value.chars().any(|ch| ch.is_ascii_uppercase());
+    let has_lower = value.chars().any(|ch| ch.is_ascii_lowercase());
+    let has_digit = value.chars().any(|ch| ch.is_ascii_digit());
+    let has_symbol = value
+        .chars()
+        .any(|ch| !ch.is_ascii_alphanumeric() && !ch.is_ascii_whitespace());
+    len >= 24 || (len >= 8 && ((has_upper && has_lower && has_digit) || has_symbol))
+}
+
+fn is_schema_type_placeholder(value: &str) -> bool {
+    matches!(
+        normalize_identifier(value).as_str(),
+        "string"
+            | "str"
+            | "number"
+            | "integer"
+            | "int"
+            | "boolean"
+            | "bool"
+            | "object"
+            | "array"
+            | "null"
+    )
+}
+
+fn is_token_key_name(name: &str) -> bool {
+    name == "token"
+        || name.ends_with("_token")
+        || name.contains("_token_")
+        || name == "access_token"
+        || name == "refresh_token"
+        || name == "id_token"
+}
+
+fn token_value_has_secret_shape(value: &str) -> bool {
+    let value = value.trim();
+    let len = value.chars().count();
+    if len >= 24 && !value.chars().any(char::is_whitespace) {
+        return true;
+    }
+    let has_alpha = value.chars().any(|ch| ch.is_ascii_alphabetic());
+    let has_digit = value.chars().any(|ch| ch.is_ascii_digit());
+    let has_symbol = value
+        .chars()
+        .any(|ch| !ch.is_ascii_alphanumeric() && !ch.is_ascii_whitespace());
+    len >= 6 && has_alpha && (has_digit || has_symbol)
 }
 
 fn is_structured_generic_key_name_reference(key: &str, value: &str) -> bool {
@@ -567,6 +787,9 @@ mod tests {
         assert_eq!(sensitive_key_fires(Some("key"), "unknown"), None);
         assert_eq!(sensitive_key_fires(Some("key"), "offset"), None);
         assert_eq!(sensitive_key_fires(Some("key"), "host"), None);
+        assert_eq!(sensitive_key_fires(Some("key"), "path"), None);
+        assert_eq!(sensitive_key_fires(Some("key"), "Team"), None);
+        assert_eq!(sensitive_key_fires(Some("key"), "shift+ctrl+i"), None);
         assert_eq!(sensitive_key_fires(Some("key"), "Vary"), None);
         assert_eq!(sensitive_key_fires(Some("key"), "Dev Gateway Region"), None);
         assert_eq!(sensitive_key_fires(Some("key"), "HappyFace.jpg"), None);
@@ -693,9 +916,52 @@ mod tests {
             sensitive_key_fires(Some("access_token"), "Test Access Token"),
             None
         );
+        assert_eq!(sensitive_key_fires(Some("token"), "string"), None);
+        assert_eq!(sensitive_key_fires(Some("token"), "abcde"), None);
+        assert_eq!(sensitive_key_fires(Some("tokenizer"), "standard"), None);
+        assert_eq!(
+            sensitive_key_fires(Some("learn_about_the_token_sale"), "Learn more"),
+            None
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("AdminResetUserPassword"), "ResetUserPassword"),
+            None
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("GetSecretValue"), "GetSecretValue"),
+            None
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("SecretId"), "MyTestDatabaseSecret"),
+            None
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("SessionLoggerArn"), "arn:aws:logs:region:acct:log/x"),
+            None
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("passwordCannotBeEmpty"), "Password cannot be empty"),
+            None
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("passwordLastUsed"), "2026-01-01T00:00:00Z"),
+            None
+        );
         assert_eq!(
             sensitive_key_fires(Some("access_token"), "abcDEF123456"),
             Some("ACCESS_TOKEN".to_string())
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("refresh_token"), "refresh12345"),
+            Some("REFRESH_TOKEN".to_string())
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("refresh_token"), "refresh-123"),
+            Some("REFRESH_TOKEN".to_string())
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("token"), "hunter2"),
+            Some("TOKEN".to_string())
         );
         assert_eq!(
             sensitive_key_fires(Some("password"), "correct horse battery staple"),

--- a/crates/pentect-core/src/detect/structural.rs
+++ b/crates/pentect-core/src/detect/structural.rs
@@ -108,6 +108,7 @@ impl Detector for SensitiveKeyDetector {
                 || is_structured_secret_identifier_name(key, view.text())
                 || is_structured_generic_key_weak_value(key, view.text())
                 || is_structured_generic_key_name_reference(key, view.text())
+                || is_structured_api_operation_value(key, view.text())
         }) {
             return vec![];
         }
@@ -208,7 +209,7 @@ fn is_non_credential_sensitive_word_name(name: &str) -> bool {
     {
         return true;
     }
-    is_sentence_like_key_name(&parts) || is_api_operation_name(&parts)
+    is_sentence_like_key_name(&parts)
 }
 
 fn is_sentence_like_key_name(parts: &[&str]) -> bool {
@@ -264,6 +265,25 @@ fn is_api_operation_name(parts: &[&str]) -> bool {
     ) && parts
         .iter()
         .any(|part| matches!(*part, "secret" | "secrets" | "password" | "auth" | "token"))
+}
+
+fn is_structured_api_operation_value(key: &str, value: &str) -> bool {
+    // Operation/model names can contain credential words (`GetSecretValue`,
+    // `AdminResetUserPassword`) without carrying the secret itself. This is
+    // value-aware on purpose: a field named `set_auth_token` still masks a
+    // concrete value such as `hunter2`.
+    let key_name = normalize_identifier(key);
+    let key_parts = identifier_parts(&key_name);
+    if !is_api_operation_name(&key_parts) {
+        return false;
+    }
+    let value_name = normalize_identifier(value);
+    let value_parts = identifier_parts(&value_name);
+    !value_parts.is_empty() && is_api_operation_name(&value_parts)
+}
+
+fn identifier_parts(name: &str) -> Vec<&str> {
+    name.split('_').filter(|part| !part.is_empty()).collect()
 }
 
 fn is_last_used_metadata_name(parts: &[&str]) -> bool {
@@ -377,16 +397,12 @@ fn is_structured_token_prose(key: &str, value: &str) -> bool {
     is_token_key && value.chars().any(char::is_whitespace)
 }
 
-fn is_structured_placeholder_value(key: &str, value: &str) -> bool {
-    // JSON/YAML schemas and fixtures commonly put type names or weak examples
-    // under sensitive-looking fields (`token: string`, `token: abcde`). Those
-    // are not usable credentials. Keep this mostly token-scoped; `password:
-    // correct horse battery staple` remains detectable.
-    let name = normalize_identifier(key);
-    if is_schema_type_placeholder(value) {
-        return true;
-    }
-    is_token_key_name(&name) && !token_value_has_secret_shape(value)
+fn is_structured_placeholder_value(_key: &str, value: &str) -> bool {
+    // JSON/YAML schemas commonly put type names under sensitive-looking fields
+    // (`token: string`). Do not apply a general shape gate here: explicit
+    // credential keys can hold weak but usable values (`token: abcdef`,
+    // `refresh_token: refresh`, `user:pass`).
+    is_schema_type_placeholder(value)
 }
 
 fn is_structured_secret_identifier_name(key: &str, value: &str) -> bool {
@@ -450,11 +466,12 @@ fn generic_key_value_has_secret_shape(value: &str) -> bool {
     let len = value.chars().count();
     let has_upper = value.chars().any(|ch| ch.is_ascii_uppercase());
     let has_lower = value.chars().any(|ch| ch.is_ascii_lowercase());
+    let has_alpha = has_upper || has_lower;
     let has_digit = value.chars().any(|ch| ch.is_ascii_digit());
     let has_symbol = value
         .chars()
         .any(|ch| !ch.is_ascii_alphanumeric() && !ch.is_ascii_whitespace());
-    len >= 24 || (len >= 8 && ((has_upper && has_lower && has_digit) || has_symbol))
+    len >= 24 || (len >= 6 && has_alpha && (has_digit || has_symbol))
 }
 
 fn is_schema_type_placeholder(value: &str) -> bool {
@@ -471,29 +488,6 @@ fn is_schema_type_placeholder(value: &str) -> bool {
             | "array"
             | "null"
     )
-}
-
-fn is_token_key_name(name: &str) -> bool {
-    name == "token"
-        || name.ends_with("_token")
-        || name.contains("_token_")
-        || name == "access_token"
-        || name == "refresh_token"
-        || name == "id_token"
-}
-
-fn token_value_has_secret_shape(value: &str) -> bool {
-    let value = value.trim();
-    let len = value.chars().count();
-    if len >= 24 && !value.chars().any(char::is_whitespace) {
-        return true;
-    }
-    let has_alpha = value.chars().any(|ch| ch.is_ascii_alphabetic());
-    let has_digit = value.chars().any(|ch| ch.is_ascii_digit());
-    let has_symbol = value
-        .chars()
-        .any(|ch| !ch.is_ascii_alphanumeric() && !ch.is_ascii_whitespace());
-    len >= 6 && has_alpha && (has_digit || has_symbol)
 }
 
 fn is_structured_generic_key_name_reference(key: &str, value: &str) -> bool {
@@ -790,6 +784,10 @@ mod tests {
         assert_eq!(sensitive_key_fires(Some("key"), "path"), None);
         assert_eq!(sensitive_key_fires(Some("key"), "Team"), None);
         assert_eq!(sensitive_key_fires(Some("key"), "shift+ctrl+i"), None);
+        assert_eq!(
+            sensitive_key_fires(Some("key"), "hunter2"),
+            Some("KEY".to_string())
+        );
         assert_eq!(sensitive_key_fires(Some("key"), "Vary"), None);
         assert_eq!(sensitive_key_fires(Some("key"), "Dev Gateway Region"), None);
         assert_eq!(sensitive_key_fires(Some("key"), "HappyFace.jpg"), None);
@@ -917,7 +915,6 @@ mod tests {
             None
         );
         assert_eq!(sensitive_key_fires(Some("token"), "string"), None);
-        assert_eq!(sensitive_key_fires(Some("token"), "abcde"), None);
         assert_eq!(sensitive_key_fires(Some("tokenizer"), "standard"), None);
         assert_eq!(
             sensitive_key_fires(Some("learn_about_the_token_sale"), "Learn more"),
@@ -930,6 +927,14 @@ mod tests {
         assert_eq!(
             sensitive_key_fires(Some("GetSecretValue"), "GetSecretValue"),
             None
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("set_auth_token"), "hunter2"),
+            Some("SET_AUTH_TOKEN".to_string())
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("rotate_password"), "letmein123"),
+            Some("ROTATE_PASSWORD".to_string())
         );
         assert_eq!(
             sensitive_key_fires(Some("SecretId"), "MyTestDatabaseSecret"),
@@ -950,6 +955,18 @@ mod tests {
         assert_eq!(
             sensitive_key_fires(Some("access_token"), "abcDEF123456"),
             Some("ACCESS_TOKEN".to_string())
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("token"), "abcde"),
+            Some("TOKEN".to_string())
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("access_token"), "abcdefghijk"),
+            Some("ACCESS_TOKEN".to_string())
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("refresh_token"), "refresh"),
+            Some("REFRESH_TOKEN".to_string())
         );
         assert_eq!(
             sensitive_key_fires(Some("refresh_token"), "refresh12345"),

--- a/crates/pentect-core/src/detect/url.rs
+++ b/crates/pentect-core/src/detect/url.rs
@@ -226,6 +226,50 @@ fn userinfo_is_template_or_redaction(userinfo: &str) -> bool {
     userinfo
         .bytes()
         .any(|b| matches!(b, b'[' | b']' | b'{' | b'}' | b'<' | b'>' | b'*'))
+        || userinfo.split(':').all(userinfo_part_is_placeholder)
+}
+
+fn userinfo_part_is_placeholder(part: &str) -> bool {
+    // Placeholder words in URL userinfo are public examples, not credentials.
+    // Keep this to the userinfo grammar: `pass` by itself can be a real weak
+    // password elsewhere, but `https://user:pass@example` is conventional docs.
+    let normalized = part
+        .split('%')
+        .next()
+        .unwrap_or(part)
+        .trim()
+        .trim_matches(|ch: char| matches!(ch, '\'' | '"' | '`'));
+    if normalized.is_empty() {
+        return true;
+    }
+    let folded = normalized
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    matches!(
+        folded.trim_matches('_'),
+        "user"
+            | "username"
+            | "userid"
+            | "my_user"
+            | "my_username"
+            | "password"
+            | "pass"
+            | "my_password"
+            | "apitoken"
+            | "api_token"
+            | "token"
+            | "x_oauth_token"
+            | "secret"
+            | "foo"
+            | "bar"
+    )
 }
 
 fn userinfo_token_like(userinfo: &str) -> bool {
@@ -523,9 +567,9 @@ mod tests {
     #[test]
     fn masks_userinfo_port_query_and_fragment_without_losing_route_shape() {
         assert_eq!(
-            labels("http://user:pass@local.jira.corp:8080/api/issues/ABC-123?token=s3cr3t&project=OPS#comment-456"),
+            labels("http://svc:p4ss@local.jira.corp:8080/api/issues/ABC-123?token=s3cr3t&project=OPS#comment-456"),
             [
-                ("URL_CREDENTIAL".to_string(), "user:pass".to_string()),
+                ("URL_CREDENTIAL".to_string(), "svc:p4ss".to_string()),
                 (
                     "INTERNAL_ENDPOINT".to_string(),
                     "local.jira.corp:8080".to_string()
@@ -585,6 +629,8 @@ mod tests {
             "https://[user[:password]@]service.internal/path",
             "https://***:***@service.internal/path",
             "https://{user}:{password}@service.internal/path",
+            "https://user:pass@service.internal/path",
+            "https://USERID:APITOKEN@service.internal/path",
         ] {
             assert!(
                 labels(raw)

--- a/crates/pentect-core/src/detect/url.rs
+++ b/crates/pentect-core/src/detect/url.rs
@@ -226,50 +226,6 @@ fn userinfo_is_template_or_redaction(userinfo: &str) -> bool {
     userinfo
         .bytes()
         .any(|b| matches!(b, b'[' | b']' | b'{' | b'}' | b'<' | b'>' | b'*'))
-        || userinfo.split(':').all(userinfo_part_is_placeholder)
-}
-
-fn userinfo_part_is_placeholder(part: &str) -> bool {
-    // Placeholder words in URL userinfo are public examples, not credentials.
-    // Keep this to the userinfo grammar: `pass` by itself can be a real weak
-    // password elsewhere, but `https://user:pass@example` is conventional docs.
-    let normalized = part
-        .split('%')
-        .next()
-        .unwrap_or(part)
-        .trim()
-        .trim_matches(|ch: char| matches!(ch, '\'' | '"' | '`'));
-    if normalized.is_empty() {
-        return true;
-    }
-    let folded = normalized
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_lowercase()
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    matches!(
-        folded.trim_matches('_'),
-        "user"
-            | "username"
-            | "userid"
-            | "my_user"
-            | "my_username"
-            | "password"
-            | "pass"
-            | "my_password"
-            | "apitoken"
-            | "api_token"
-            | "token"
-            | "x_oauth_token"
-            | "secret"
-            | "foo"
-            | "bar"
-    )
 }
 
 fn userinfo_token_like(userinfo: &str) -> bool {
@@ -629,8 +585,6 @@ mod tests {
             "https://[user[:password]@]service.internal/path",
             "https://***:***@service.internal/path",
             "https://{user}:{password}@service.internal/path",
-            "https://user:pass@service.internal/path",
-            "https://USERID:APITOKEN@service.internal/path",
         ] {
             assert!(
                 labels(raw)
@@ -640,9 +594,18 @@ mod tests {
                 labels(raw)
             );
         }
+        assert!(labels("https://user:pass@service.internal/path")
+            .iter()
+            .any(|(label, value)| label == "URL_CREDENTIAL" && value == "user:pass"));
+        assert!(labels("https://USERID:APITOKEN@service.internal/path")
+            .iter()
+            .any(|(label, value)| label == "URL_CREDENTIAL" && value == "USERID:APITOKEN"));
         assert!(labels("https://alice:letmein@service.internal/path")
             .iter()
             .any(|(label, value)| label == "URL_CREDENTIAL" && value == "alice:letmein"));
+        assert!(labels("https://user%3Asecret@service.internal/path")
+            .iter()
+            .any(|(label, value)| label == "URL_CREDENTIAL" && value == "user%3Asecret"));
     }
 
     #[test]

--- a/crates/pentect-core/src/detect/validate.rs
+++ b/crates/pentect-core/src/detect/validate.rs
@@ -1137,7 +1137,6 @@ fn userinfo_is_template_or_redaction(userinfo: &str) -> bool {
         || userinfo
             .split(':')
             .any(userinfo_part_is_template_or_redaction)
-        || userinfo.split(':').all(userinfo_part_is_placeholder_name)
 }
 
 fn userinfo_part_is_template_or_redaction(part: &str) -> bool {
@@ -1146,49 +1145,6 @@ fn userinfo_part_is_template_or_redaction(part: &str) -> bool {
         || part
             .bytes()
             .any(|b| matches!(b, b'[' | b']' | b'{' | b'}' | b'<' | b'>' | b'*'))
-}
-
-fn userinfo_part_is_placeholder_name(part: &str) -> bool {
-    // RFC 3986 userinfo examples conventionally use `user:pass`,
-    // `username:password`, or API-token placeholders. In a URI authority that
-    // pair is documentation syntax, while concrete values such as
-    // `admin:s3cr3t` and `svc_42:pAss-rotated` still pass.
-    let part = part
-        .trim()
-        .trim_matches(|ch: char| matches!(ch, '\'' | '"' | '`'));
-    if part.is_empty() {
-        return true;
-    }
-    let normalized = part
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_lowercase()
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    matches!(
-        normalized.trim_matches('_'),
-        "user"
-            | "username"
-            | "userid"
-            | "my_user"
-            | "my_username"
-            | "testuser"
-            | "password"
-            | "pass"
-            | "my_password"
-            | "testpwd"
-            | "apitoken"
-            | "api_token"
-            | "token"
-            | "x_oauth_token"
-            | "secret"
-            | "foo"
-            | "bar"
-    )
 }
 
 #[cfg(test)]
@@ -1276,9 +1232,10 @@ mod tests {
         vectors!(db_connection_string,
             "postgresql://admin:s3cr3t@db.host:5432/sales" => true,
             "mysql://svc:p4ss@localhost" => true,
-            "mysql://user:pass@localhost" => false,
-            "postgresql://username:password@localhost" => false,
-            "postgresql://testuser:testpwd@localhost" => false,
+            "mysql://user:secret@localhost" => true,
+            "mysql://user:pass@localhost" => true,
+            "postgresql://username:password@localhost" => true,
+            "postgresql://testuser:testpwd@localhost" => true,
             "mysql://ofh:ab12c!?@db.example.internal/name" => true,
             "postgresql://[user[:password]@][host][:port][" => false,
             "mongodb://username:<password>@cluster0.example.com:27017" => false,

--- a/crates/pentect-core/src/detect/validate.rs
+++ b/crates/pentect-core/src/detect/validate.rs
@@ -1137,6 +1137,7 @@ fn userinfo_is_template_or_redaction(userinfo: &str) -> bool {
         || userinfo
             .split(':')
             .any(userinfo_part_is_template_or_redaction)
+        || userinfo.split(':').all(userinfo_part_is_placeholder_name)
 }
 
 fn userinfo_part_is_template_or_redaction(part: &str) -> bool {
@@ -1145,6 +1146,49 @@ fn userinfo_part_is_template_or_redaction(part: &str) -> bool {
         || part
             .bytes()
             .any(|b| matches!(b, b'[' | b']' | b'{' | b'}' | b'<' | b'>' | b'*'))
+}
+
+fn userinfo_part_is_placeholder_name(part: &str) -> bool {
+    // RFC 3986 userinfo examples conventionally use `user:pass`,
+    // `username:password`, or API-token placeholders. In a URI authority that
+    // pair is documentation syntax, while concrete values such as
+    // `admin:s3cr3t` and `svc_42:pAss-rotated` still pass.
+    let part = part
+        .trim()
+        .trim_matches(|ch: char| matches!(ch, '\'' | '"' | '`'));
+    if part.is_empty() {
+        return true;
+    }
+    let normalized = part
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    matches!(
+        normalized.trim_matches('_'),
+        "user"
+            | "username"
+            | "userid"
+            | "my_user"
+            | "my_username"
+            | "testuser"
+            | "password"
+            | "pass"
+            | "my_password"
+            | "testpwd"
+            | "apitoken"
+            | "api_token"
+            | "token"
+            | "x_oauth_token"
+            | "secret"
+            | "foo"
+            | "bar"
+    )
 }
 
 #[cfg(test)]
@@ -1231,7 +1275,10 @@ mod tests {
     fn db_connection_strings_reject_uri_templates_only() {
         vectors!(db_connection_string,
             "postgresql://admin:s3cr3t@db.host:5432/sales" => true,
-            "mysql://user:pass@localhost" => true,
+            "mysql://svc:p4ss@localhost" => true,
+            "mysql://user:pass@localhost" => false,
+            "postgresql://username:password@localhost" => false,
+            "postgresql://testuser:testpwd@localhost" => false,
             "mysql://ofh:ab12c!?@db.example.internal/name" => true,
             "postgresql://[user[:password]@][host][:port][" => false,
             "mongodb://username:<password>@cluster0.example.com:27017" => false,

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -821,14 +821,21 @@ mod tests {
 
     #[test]
     fn json_sensitive_key_values_mask_low_entropy_without_masking_public_keys() {
-        let input =
-            r#"{"password":"hunter2","token":"abc12345","public_key":"visible","note":"ok"}"#;
+        let input = r#"{"password":"hunter2","token":"abcdef","access_token":"abcdefghijk","refresh_token":"refresh","public_key":"visible","note":"ok"}"#;
         let r = mj(input);
         let v: serde_json::Value =
             serde_json::from_str(&r.masked).expect("masked output is valid JSON");
         let o = v.as_object().unwrap();
         assert!(o["password"].as_str().unwrap().starts_with("<<PASSWORD_"));
         assert!(o["token"].as_str().unwrap().starts_with("<<TOKEN_"));
+        assert!(o["access_token"]
+            .as_str()
+            .unwrap()
+            .starts_with("<<ACCESS_TOKEN_"));
+        assert!(o["refresh_token"]
+            .as_str()
+            .unwrap()
+            .starts_with("<<REFRESH_TOKEN_"));
         assert_eq!(o["public_key"].as_str().unwrap(), "visible");
         assert_eq!(o["note"].as_str().unwrap(), "ok");
         assert_eq!(restore(&r.masked, &r.recovery).unwrap(), input);
@@ -882,7 +889,7 @@ mod tests {
 
     #[test]
     fn internal_url_does_not_leak_userinfo_query_or_fragment() {
-        let input = "open http://svc:p4ss@local.jira.corp:8080/api/issues/ABC-123?token=s3cr3t&project=OPS#comment-456.";
+        let input = "open http://user:pass@local.jira.corp:8080/api/issues/ABC-123?token=s3cr3t&project=OPS#comment-456.";
         let r = m(input);
         assert!(
             r.masked.starts_with("open http://<<URL_CREDENTIAL_"),
@@ -907,7 +914,7 @@ mod tests {
         );
         assert!(r.masked.contains("#<<RESOURCE_ID_"), "{}", r.masked);
         for leaked in [
-            "svc:p4ss",
+            "user:pass",
             "local.jira.corp",
             "ABC-123",
             "s3cr3t",

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -882,7 +882,7 @@ mod tests {
 
     #[test]
     fn internal_url_does_not_leak_userinfo_query_or_fragment() {
-        let input = "open http://user:pass@local.jira.corp:8080/api/issues/ABC-123?token=s3cr3t&project=OPS#comment-456.";
+        let input = "open http://svc:p4ss@local.jira.corp:8080/api/issues/ABC-123?token=s3cr3t&project=OPS#comment-456.";
         let r = m(input);
         assert!(
             r.masked.starts_with("open http://<<URL_CREDENTIAL_"),
@@ -907,7 +907,7 @@ mod tests {
         );
         assert!(r.masked.contains("#<<RESOURCE_ID_"), "{}", r.masked);
         for leaked in [
-            "user:pass",
+            "svc:p4ss",
             "local.jira.corp",
             "ABC-123",
             "s3cr3t",


### PR DESCRIPTION
## What
- Reduce CredData false positives from structured/key-value source, URL userinfo, DB URI, and JSON numeric OTP contexts.
- Keep MCP/tool-response and structured JSON safety for weak but explicit secrets such as `token: hunter2`, `token: abcdef`, and `user:pass` in URL/DB userinfo.
- Update tests for escaped source payloads, value-aware API operation names, internal URL userinfo, DB URI userinfo, and weak explicit token fields.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `target\release\pentect.exe bench creddata benchmarks\CredData --ignore-x --json --examples 0`

## CredData
- TP 10479 / FP 4999 / FN 4625
- Precision 0.6770 / Recall 0.6938 / F1 0.6853
- Compared with the initial local baseline, this still improves F1 while avoiding the review-identified false-negative regressions.