### PR TITLE
Reduce detector false positives without recall loss

### DIFF
--- a/crates/pentect-core/src/detect/key_value.rs
+++ b/crates/pentect-core/src/detect/key_value.rs
@@ -220,6 +220,9 @@ fn try_push(ctx: &mut ScanCtx<'_, '_, '_>, separator: SeparatorCandidate) -> boo
     if !value.quoted && is_code_type_or_expression(raw_value, &key_name, kind) {
         return false;
     }
+    if is_analysis_token_result_literal(ctx.text, ctx.line_end, &key_name, raw_value) {
+        return false;
+    }
     if !looks_like_secret_value(
         raw_value,
         kind,
@@ -634,6 +637,7 @@ fn looks_like_secret_value(
         || is_source_prefix_constant_literal(value, key_name)
         || is_source_variable_reference_literal(value, source_key)
         || is_source_string_fragment_literal(value, source_key)
+        || is_source_concatenation_template_literal(value)
         || is_shell_command_substitution_literal(value, source_key)
         || is_inline_code_key_value_tail_literal(value, key_name, source_key)
         || is_source_code_fragment_literal(value)
@@ -649,6 +653,7 @@ fn looks_like_secret_value(
         || is_plain_prose_literal_for_generic_key(value, key_name)
         || is_locator_literal_for_key(value, key_name)
         || is_secret_resource_metadata_literal(value, key_name)
+        || is_package_dependency_coordinate_literal(value, source_key)
     {
         return false;
     }
@@ -2643,6 +2648,131 @@ fn is_resource_name_literal(value: &str) -> bool {
     has_name_char && (has_separator || value.contains('/') || value.contains('.'))
 }
 
+fn is_package_dependency_coordinate_literal(value: &str, source_key: &str) -> bool {
+    // Maven/Gradle coordinates are `group:artifact:version`. The key/value
+    // scanner sees the first colon and may treat `com.google.auth` as an auth
+    // key. Suppress only when the left side is a dotted package group and the
+    // right side is an artifact plus a version range.
+    let value = value
+        .trim()
+        .trim_matches(|ch| matches!(ch, '"' | '\'' | '`'));
+    let Some((artifact, version)) = value.rsplit_once(':') else {
+        return false;
+    };
+    is_package_group_prefix(source_key)
+        && is_package_artifact_name(artifact)
+        && is_semverish_version_literal(version)
+}
+
+fn is_package_group_prefix(source_key: &str) -> bool {
+    let Some(candidate) = source_key
+        .split_whitespace()
+        .next_back()
+        .map(|part| part.trim_matches(|ch| matches!(ch, '"' | '\'' | '`')))
+    else {
+        return false;
+    };
+    let parts = candidate.split('.').collect::<Vec<_>>();
+    parts.len() >= 2
+        && parts.iter().all(|part| {
+            (1..=64).contains(&part.len())
+                && part
+                    .bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+                && part.bytes().any(|b| b.is_ascii_lowercase())
+        })
+}
+
+fn is_package_artifact_name(value: &str) -> bool {
+    (1..=128).contains(&value.len())
+        && value.bytes().any(|b| b.is_ascii_alphabetic())
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+}
+
+fn is_semverish_version_literal(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 96 {
+        return false;
+    }
+    let mut saw_digit = false;
+    let mut saw_dot = false;
+    for token in value.split_whitespace() {
+        if matches!(token, "||" | "|" | "&&") {
+            continue;
+        }
+        let token = token.trim_start_matches(['^', '~', '=', '<', '>']);
+        if token.is_empty() || token == "*" || token.eq_ignore_ascii_case("latest") {
+            continue;
+        }
+        if !token.bytes().next().is_some_and(|b| b.is_ascii_digit()) {
+            return false;
+        }
+        saw_digit = true;
+        saw_dot |= token.contains('.');
+        if !token.bytes().all(|b| {
+            b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'+' | b'*' | b'x' | b'X')
+        }) {
+            return false;
+        }
+    }
+    saw_digit && saw_dot
+}
+
+fn is_source_concatenation_template_literal(value: &str) -> bool {
+    // Source snippets can build JSON credential fixtures with runtime
+    // expressions: `"private_key_id": "` + UUID.randomUUID() or a PEM wrapper
+    // around `encodedKey`. Those fragments are templates; the runtime value is
+    // not present in the file. Require explicit concatenation syntax so base64
+    // values containing `+` are unaffected.
+    let value = value.trim();
+    if !value.contains('+') || value.matches('+').count() < 2 {
+        return false;
+    }
+    let lower = value.to_ascii_lowercase();
+    contains_any(&lower, &["uuid.", "randomuuid", ".tostring()"])
+        || (value.contains("-----BEGIN ")
+            && value.contains("-----END ")
+            && value
+                .split('+')
+                .any(|part| is_code_reference_segment(part.trim())))
+}
+
+fn is_analysis_token_result_literal(
+    text: &str,
+    line_end: usize,
+    key_name: &str,
+    value: &str,
+) -> bool {
+    // Search/analyzer docs emit objects like
+    // `{ "token": "quick", "start_offset": 0, ... }`. Here `token` means a
+    // parsed word, not an auth token. Require the neighboring analyzer metadata
+    // fields in the same small window so ordinary `token: abcde` still masks.
+    if key_name != "token" || !is_plain_analyzer_token_text(value) {
+        return false;
+    }
+    let after = &text[line_end..];
+    let mut window_end = after.len().min(512);
+    while !after.is_char_boundary(window_end) {
+        window_end -= 1;
+    }
+    let window = &after[..window_end];
+    contains_any(window, &["\"start_offset\"", "\"end_offset\""])
+        && contains_any(window, &["\"position\"", "\"type\""])
+}
+
+fn is_plain_analyzer_token_text(value: &str) -> bool {
+    let value = value
+        .trim()
+        .trim_matches(|ch| matches!(ch, '"' | '\'' | '`' | ','));
+    (1..=64).contains(&value.len())
+        && !value.chars().any(|ch| ch.is_ascii_digit())
+        && value
+            .chars()
+            .all(|ch| ch.is_alphabetic() || matches!(ch, '_' | '-'))
+}
+
 fn key_name_indicates_locator(key_name: &str) -> bool {
     has_identifier_component(key_name, "endpoint")
         || has_identifier_component(key_name, "url")
@@ -3029,6 +3159,8 @@ mod tests {
             "OAuth app client_secret 'tenant-7-trial'",
             "tenant-7-trial"
         ));
+        assert!(has(r#"credential: "hunter2""#, "hunter2"));
+        assert!(has(r#"token: "quick-token-123""#, "quick-token-123"));
     }
 
     #[test]
@@ -3297,6 +3429,22 @@ mod tests {
             r#"{"body":"\u003cpre\u003e\u003ccode\u003ecredentials: @\"apiURL\\n];\u003c/code\u003e\u003c/pre\u003e"}"#,
             "/// Bitcoin address: base58check, P2PKH (0x00, '1') or P2SH (0x05, '3').",
             "/// Bitcoin WIF private key: base58check, version 0x80.",
+            r#"api 'com.google.auth:google-auth-library-credentials:0.20.0'"#,
+            r#"'  "private_key_id": "' + UUID.randomUUID().toString() + '","\n' +"#,
+            r#"'  "private_key": "-----BEGIN PRIVATE KEY-----\n' + encodedKey + '\n-----END PRIVATE KEY-----\n","\n' +"#,
+            r#"
+{
+  "tokens": [
+    {
+      "token": "quick",
+      "start_offset": 0,
+      "end_offset": 5,
+      "type": "<ALPHANUM>",
+      "position": 0
+    }
+  ]
+}
+"#,
         ] {
             assert!(hits(raw).is_empty(), "{raw}: {:?}", hits(raw));
         }

--- a/crates/pentect-core/src/detect/structural.rs
+++ b/crates/pentect-core/src/detect/structural.rs
@@ -103,6 +103,7 @@ impl Detector for SensitiveKeyDetector {
         }
         if region.ctx.key.as_deref().is_some_and(|key| {
             is_ui_copy_sensitive_key(key, view.text())
+                || is_structured_localization_label_value(key, view.text())
                 || is_structured_token_prose(key, view.text())
                 || is_structured_placeholder_value(key, view.text())
                 || is_structured_secret_identifier_name(key, view.text())
@@ -384,6 +385,75 @@ fn is_short_ui_label_value(value: &str) -> bool {
         })
 }
 
+fn is_structured_localization_label_value(key: &str, value: &str) -> bool {
+    // Translation JSON often has bare label keys such as `token`,
+    // `userPassword`, and `sessionToken`. Their values are displayed labels in
+    // many languages, not credentials. This is deliberately narrower than
+    // `is_ui_copy_sensitive_key`: require a label-shaped key and either a value
+    // that normalizes back to the key words or a short non-ASCII display label.
+    let name = normalize_identifier(key);
+    if !is_localization_label_key(&name) {
+        return false;
+    }
+    let value = value.trim();
+    is_key_equivalent_display_label(&name, value) || is_short_non_ascii_display_label(value)
+}
+
+fn is_localization_label_key(name: &str) -> bool {
+    let parts = identifier_parts(name);
+    if parts.is_empty() {
+        return false;
+    }
+    let has_sensitive = parts.iter().any(|part| {
+        matches!(
+            *part,
+            "password"
+                | "passwords"
+                | "token"
+                | "tokens"
+                | "credential"
+                | "credentials"
+                | "auth"
+                | "authentication"
+        )
+    });
+    has_sensitive
+        && (matches!(
+            name,
+            "password" | "token" | "user_password" | "session_token" | "lock_room_password"
+        ) || parts.iter().any(|part| {
+            matches!(
+                *part,
+                "user" | "session" | "room" | "meeting" | "lock" | "label" | "title"
+            )
+        }))
+}
+
+fn is_key_equivalent_display_label(key_name: &str, value: &str) -> bool {
+    let value_name = normalize_identifier(value);
+    if value_name.is_empty() {
+        return false;
+    }
+    let key_parts = identifier_parts(key_name);
+    let value_parts = identifier_parts(&value_name);
+    !value_parts.is_empty()
+        && value_parts
+            .iter()
+            .all(|part| key_parts.iter().any(|key_part| key_part == part))
+}
+
+fn is_short_non_ascii_display_label(value: &str) -> bool {
+    let value = value.trim().trim_end_matches(':');
+    (1..=72).contains(&value.chars().count())
+        && !value.is_ascii()
+        && !value.chars().any(|ch| ch.is_ascii_digit())
+        && value.chars().all(|ch| {
+            ch.is_alphabetic()
+                || ch.is_whitespace()
+                || matches!(ch, '-' | '\'' | ':' | '\u{200f}' | '\u{200e}')
+        })
+}
+
 fn is_structured_token_prose(key: &str, value: &str) -> bool {
     // Structured token fields must contain compact token material. Fixture/UI
     // prose such as "Test Access Token" is not a usable bearer/session token.
@@ -586,12 +656,31 @@ fn is_version_literal(value: &str) -> bool {
     if matches!(t, "*" | "latest") {
         return true;
     }
-    if !(3..=64).contains(&t.len()) || !t.as_bytes()[0].is_ascii_digit() {
+    if !(3..=96).contains(&t.len()) {
         return false;
     }
-    t.bytes()
-        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'+' | b'*' | b'x' | b'X'))
-        && t.bytes().filter(|b| *b == b'.').count() >= 1
+    let mut saw_digit = false;
+    let mut saw_dot = false;
+    for token in t.split_whitespace() {
+        if matches!(token, "||" | "|" | "&&") {
+            continue;
+        }
+        let token = token.trim_start_matches(['^', '~', '=', '<', '>']);
+        if token.is_empty() || token == "*" || token.eq_ignore_ascii_case("latest") {
+            continue;
+        }
+        if !token.bytes().next().is_some_and(|b| b.is_ascii_digit()) {
+            return false;
+        }
+        saw_digit = true;
+        saw_dot |= token.contains('.');
+        if !token.bytes().all(|b| {
+            b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'+' | b'*' | b'x' | b'X')
+        }) {
+            return false;
+        }
+    }
+    saw_digit && saw_dot
 }
 
 fn is_rendered_placeholder(v: &str) -> bool {
@@ -914,7 +1003,28 @@ mod tests {
             sensitive_key_fires(Some("access_token"), "Test Access Token"),
             None
         );
+        assert_eq!(sensitive_key_fires(Some("token"), "Token"), None);
+        assert_eq!(
+            sensitive_key_fires(Some("userPassword"), "user password"),
+            None
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("sessionToken"), "Token de la session"),
+            None
+        );
+        assert_eq!(
+            sensitive_key_fires(
+                Some("userPassword"),
+                "\u{30e6}\u{30fc}\u{30b6}\u{30fc}\u{30d1}\u{30b9}\u{30ef}\u{30fc}\u{30c9}"
+            ),
+            None
+        );
         assert_eq!(sensitive_key_fires(Some("token"), "string"), None);
+        assert_eq!(
+            sensitive_key_fires(Some("js-tokens"), "^3.0.0 || ^4.0.0"),
+            None
+        );
+        assert_eq!(sensitive_key_fires(Some("parse-passwd"), "~1.0.0"), None);
         assert_eq!(sensitive_key_fires(Some("tokenizer"), "standard"), None);
         assert_eq!(
             sensitive_key_fires(Some("learn_about_the_token_sale"), "Learn more"),
@@ -955,6 +1065,10 @@ mod tests {
         assert_eq!(
             sensitive_key_fires(Some("access_token"), "abcDEF123456"),
             Some("ACCESS_TOKEN".to_string())
+        );
+        assert_eq!(
+            sensitive_key_fires(Some("userPassword"), "hunter2"),
+            Some("USERPASSWORD".to_string())
         );
         assert_eq!(
             sensitive_key_fires(Some("token"), "abcde"),


### PR DESCRIPTION
## Summary
- suppress analyzer-token result snippets that look like search/tokenizer output, not auth tokens
- suppress Maven/Gradle dependency coordinates and source concatenation templates in `KEYED_SECRET`
- treat semver ranges and short localization labels as structured metadata, while preserving weak real token/password values

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `target\release\pentect.exe bench creddata benchmarks\CredData --ignore-x --json --examples 120`

## CredData
- TP: 10479 -> 10479
- FP: 4999 -> 4756
- FN: 4625 -> 4625
- precision: 0.6770 -> 0.6878
- recall: 0.6938 -> 0.6938
- F1: 0.6853 -> 0.6908

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces detector false positives by ignoring analyzer output, package coordinates, and templated source fragments while keeping recall unchanged. CredData: precision 0.6770 → 0.6878 (FP -243), TP/FN unchanged, F1 0.6853 → 0.6908.

- **Bug Fixes**
  - Ignore analyzer/token result snippets (e.g., { "token": "quick", "start_offset": ... }).
  - Suppress Maven/Gradle dependency coordinates like com.foo:bar:1.2.3.
  - Suppress source concatenation templates that build credentials at runtime (e.g., PEM wrapped via string + encodedKey).
  - Treat semver ranges and version constraints as version metadata.
  - Treat short localization labels for sensitive keys (e.g., token, userPassword, sessionToken) as display text, not secrets.
  - Preserve detection of real token/password values when present.

<sup>Written for commit 8e289d19949ebb48b70547aab2e2ab7e0c795a60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/EdamAme-x/pentect/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

