### PR TITLE
Extract option-wrapped keyed literals

### DIFF
--- a/crates/pentect-core/src/detect/key_value.rs
+++ b/crates/pentect-core/src/detect/key_value.rs
@@ -550,6 +550,10 @@ fn parse_value_item(
         });
     }
 
+    if let Some(item) = parse_option_wrapper_value(text, pos, line_end) {
+        return Some(item);
+    }
+
     if matches!(kind, KeyKind::Token | KeyKind::Strong) {
         let first_end = scan_unquoted_token_end(text, pos, line_end);
         let first = &text[pos..first_end];
@@ -571,6 +575,64 @@ fn parse_value_item(
         },
         next: end,
     })
+}
+
+fn parse_option_wrapper_value(
+    text: &str,
+    start: usize,
+    line_end: usize,
+) -> Option<ParsedValueItem> {
+    // Scala/Rust Option wrappers such as `Some("secret")` are transparent
+    // containers: the string literal is the credential value, while `Some` is
+    // just source syntax. Only unwrap a single quoted argument followed by the
+    // closing parenthesis so calls and expressions stay with the normal parser.
+    let name_end = scan_ascii_identifier_end(text, start, line_end);
+    if &text[start..name_end] != "Some" {
+        return None;
+    }
+    let mut pos = trim_ascii_ws_start(text, name_end, line_end);
+    if text.as_bytes().get(pos) != Some(&b'(') {
+        return None;
+    }
+    pos += 1;
+    pos = trim_ascii_ws_start(text, pos, line_end);
+    let quote = text
+        .as_bytes()
+        .get(pos)
+        .copied()
+        .filter(|b| matches!(b, b'"' | b'\'' | b'`'))?;
+    pos += 1;
+    let end = find_quote_or_line_end(text, pos, line_end, quote);
+    let value_start = trim_ascii_ws_start(text, pos, end);
+    let value_end = trim_ascii_ws_end(text, value_start, end);
+    if value_start >= value_end {
+        return None;
+    }
+    let next = (end + 1).min(line_end);
+    let after_quote = trim_ascii_ws_start(text, next, line_end);
+    if text.as_bytes().get(after_quote) != Some(&b')') {
+        return None;
+    }
+    Some(ParsedValueItem {
+        value: ValueCandidate {
+            start: value_start,
+            end: value_end,
+            quoted: true,
+        },
+        next: (after_quote + 1).min(line_end),
+    })
+}
+
+fn scan_ascii_identifier_end(text: &str, start: usize, line_end: usize) -> usize {
+    let mut end = start;
+    while end < line_end {
+        let b = text.as_bytes()[end];
+        if !(b.is_ascii_alphanumeric() || b == b'_') {
+            break;
+        }
+        end += 1;
+    }
+    end
 }
 
 fn parse_tuple_assignment_value(
@@ -740,6 +802,7 @@ fn looks_like_secret_value(
         || is_plain_prose_literal_for_generic_key(value, key_name)
         || is_locator_literal_for_key(value, key_name)
         || is_secret_resource_metadata_literal(value, key_name)
+        || is_web_credentials_mode_literal(value, key_name)
         || is_package_dependency_coordinate_literal(value, source_key)
         || is_package_dependency_version_literal(value, source_key)
         || is_password_reset_duration_literal(value, key_name)
@@ -2917,6 +2980,20 @@ fn is_resource_name_literal(value: &str) -> bool {
     has_name_char && (has_separator || value.contains('/') || value.contains('.'))
 }
 
+fn is_web_credentials_mode_literal(value: &str, key_name: &str) -> bool {
+    // The Fetch API `credentials` field is an enum controlling cookie/auth
+    // inclusion behavior, not credential material. Keep this to the exact
+    // plural field name and standard enum values so singular `credential`
+    // assignments and arbitrary secrets still flow through.
+    if key_name != "credentials" {
+        return false;
+    }
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "same-origin" | "include" | "omit"
+    )
+}
+
 fn is_package_dependency_coordinate_literal(value: &str, source_key: &str) -> bool {
     // Maven/Gradle coordinates are `group:artifact:version`. The key/value
     // scanner sees the first colon and may treat `com.google.auth` as an auth
@@ -3483,6 +3560,8 @@ mod tests {
             r#"refresh_token="6nA7WEJ/bBBCY06IrWwAlks7""#,
             "6nA7WEJ/bBBCY06IrWwAlks7"
         ));
+        assert!(has(r#"password = Some("owlknh")"#, "owlknh"));
+        assert!(has(r#"api_token = Some("tok-12345")"#, "tok-12345"));
         assert!(has(
             r#"authorization: 'Basic Wv0dTjLryp=='"#,
             "Wv0dTjLryp=="
@@ -3583,6 +3662,9 @@ mod tests {
             r#"var response = "id_token=my_id_token&state=protected_state&code=my_code";"#,
             r#"access_token = "Test Access Token","#,
             r#"refresh_token = "Test Refresh Token""#,
+            r#"credentials: "same-origin""#,
+            r#"credentials: "include""#,
+            r#"credentials: "omit""#,
             r#"const string expectedTokenValue = "GITHUB_TOKEN_VALUE";"#,
             r#"public const string OAuthClientSecret = "GCM_BITBUCKET_CLOUD_CLIENTSECRET";"#,
             r#""privateKey": "LINE_1\nLINE_2\nLINE_2","#,
@@ -3775,6 +3857,7 @@ mod tests {
             r#"$token = Get-NtToken -Primary -Duplicate"#,
             r#"$token = $this->createMock(TokenInterface::class);"#,
             r#"*token = yaml_token_t{}"#,
+            r#"password = Some(password_value)"#,
             r#"key: Some("password".to_string()),"#,
             r#"path: Some("structured.password".to_string()),"#,
             r#"prompt: "Use secret?","#,


### PR DESCRIPTION
## Summary
- unwrap single-literal `Some(...)` option values in KeyValueDetector so the literal, not the wrapper syntax, is scored
- suppress Fetch API `credentials` enum values (`same-origin`, `include`, `omit`) as non-secret control modes
- adds regression coverage for both behaviors

## Verification
- cargo test -p pentect-core key_value -- --nocapture
- cargo test --workspace --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- target\release\pentect.exe bench creddata benchmarks\CredData --ignore-x --json --examples 120 > target\creddata-pass7-option-web-full.json

## CredData
Compared against `target\creddata-pass6-tuple-full.json`:
- TP: 10483 -> 10513 (+30)
- FP: 4648 -> 4645 (-3)
- FN: 4621 -> 4591 (-30)
- precision: 0.6928160729627916 -> 0.6935611558253068
- recall: 0.6940545550847458 -> 0.696040783898305
- F1: 0.6934347610385315 -> 0.6947987575176789

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unwraps single-literal `Some("...")` values in keyed assignments and ignores Fetch API `credentials` enum values to reduce noise. Improves CredData F1 to 0.6948 (+30 TP, -3 FP, -30 FN).

- **Bug Fixes**
  - Unwrap `Some(...)` so the inner string is scored, not the wrapper.
  - Treat `credentials` values `same-origin`, `include`, and `omit` as non-secrets.

<sup>Written for commit 032b3b3f6e5370c596ebf2d4e0ae286fbcac8f8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/EdamAme-x/pentect/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

