### PR TITLE
Split entropy route paths conservatively

### DIFF
--- a/crates/pentect-core/src/detect/entropy.rs
+++ b/crates/pentect-core/src/detect/entropy.rs
@@ -65,6 +65,10 @@ impl EntropyDetector {
     ) {
         let run = &text[start..end];
         if is_slash_delimited_path_like(run) {
+            if path_contains_uuid_segment(run) {
+                self.push_single_entropy_span(text, start, end, view, out);
+                return;
+            }
             for (seg_start, seg_end) in slash_segments(run, start) {
                 self.push_single_entropy_span(text, seg_start, seg_end, view, out);
             }
@@ -516,11 +520,47 @@ fn slash_segments(run: &str, base: usize) -> impl Iterator<Item = (usize, usize)
 
 fn is_word_path_segment(segment: &str) -> bool {
     let bytes = segment.as_bytes();
+    if !(2..=48).contains(&bytes.len())
+        || !bytes
+            .iter()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-'))
+        || !bytes.iter().any(u8::is_ascii_alphabetic)
+    {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|b| b.is_ascii_lowercase() || matches!(b, b'_' | b'-'))
+        || is_short_uppercase_route_segment(bytes)
+        || is_title_case_route_segment(bytes)
+        || wordlike_mixed_case_identifier(bytes)
+}
+
+fn is_short_uppercase_route_segment(bytes: &[u8]) -> bool {
+    (2..=8).contains(&bytes.len()) && bytes.iter().all(u8::is_ascii_uppercase)
+}
+
+fn is_title_case_route_segment(bytes: &[u8]) -> bool {
     (3..=32).contains(&bytes.len())
+        && bytes[0].is_ascii_uppercase()
+        && bytes[1..].iter().all(u8::is_ascii_lowercase)
+}
+
+fn path_contains_uuid_segment(run: &str) -> bool {
+    // A bare UUID is normally spared by policy, but a UUID embedded as a path
+    // segment is part of a concrete local/resource locator. Keep that local
+    // context intact instead of splitting it into a guard-suppressed UUID.
+    run.split('/').any(is_uuid_segment)
+}
+
+fn is_uuid_segment(segment: &str) -> bool {
+    let bytes = segment.as_bytes();
+    bytes.len() == 36
+        && [8, 13, 18, 23].iter().all(|&i| bytes[i] == b'-')
         && bytes
             .iter()
-            .all(|b| b.is_ascii_lowercase() || matches!(b, b'_' | b'-'))
-        && bytes.iter().any(u8::is_ascii_lowercase)
+            .enumerate()
+            .all(|(i, b)| [8, 13, 18, 23].contains(&i) || b.is_ascii_hexdigit())
 }
 
 fn is_source_identifier_like(run: &str, text: &str, start: usize, end: usize) -> bool {
@@ -933,6 +973,33 @@ mod tests {
             let v = NormalizedView::build(&reg, raw);
             assert!(EntropyDetector::default().detect(&v).is_empty(), "{raw}");
         }
+    }
+
+    #[test]
+    fn api_route_paths_are_not_entropy_candidates() {
+        for raw in [
+            "\"authorized_connect_apps\": \"/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AuthorizedConnectApps.json\"",
+            "\"uri\": \"/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP/Domains/SDaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Auth/Calls/CredentialListMappings.json?PageSize=50\"",
+        ] {
+            let reg = region(raw);
+            let v = NormalizedView::build(&reg, raw);
+            assert!(EntropyDetector::default().detect(&v).is_empty(), "{raw}");
+        }
+    }
+
+    #[test]
+    fn uuid_path_segments_keep_path_context() {
+        let raw = "/Users/eln/Library/Application/Simulator/5/Applications/5172D1BB-AAB2-1124-C5AD-061D1DD22290/Documents/weatherForecast";
+        let reg = region(raw);
+        let v = NormalizedView::build(&reg, raw);
+        let spans = EntropyDetector::default().detect(&v);
+        assert!(
+            spans
+                .iter()
+                .any(|span| raw[span.range.start..span.range.end]
+                    .contains("5172D1BB-AAB2-1124-C5AD-061D1DD22290")),
+            "{spans:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- split TitleCase/acronym API route paths before entropy scoring so public route fragments do not become `LIKELY_SECRET`
- keep UUID-bearing path context intact so local/resource locator UUIDs are not lost to the bare-UUID guard
- add regression coverage for Twilio-style API routes, UUID path segments, and existing webhook entropy recall

## CredData
Compared with `ee2ae21` baseline:
- TP: 10649 -> 10660 (+11)
- FP: 4575 -> 4523 (-52)
- FN: 4455 -> 4444 (-11)
- precision: 0.6994876511 -> 0.7021010341
- recall: 0.7050450212 -> 0.7057733051
- F1: 0.7022553416 -> 0.7039323802 (+0.0016770386)

The removed FP cluster is entropy on API route path fragments such as `/2010-04-01/Accounts/`, `/AuthorizedConnectApps`, and Twilio SIP route paths.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p pentect-core`
- `cargo test --workspace --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `target\\release\\pentect.exe bench creddata benchmarks\\CredData --ignore-x --json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split API route path segments before entropy scoring while keeping UUID-bearing paths intact. This reduces false positives on public routes (e.g., Twilio) and preserves local resource UUID context.

- **Bug Fixes**
  - Split TitleCase, uppercase acronym, and mixed-case segments in slash-delimited paths before scoring.
  - Keep paths with a UUID segment unsplit to avoid losing local locator context.
  - Added regression tests for Twilio-style routes, UUID path segments, and webhook entropy recall.
  - CredData: FP −52, TP +11, FN −11; precision 0.7021, recall 0.7058, F1 +0.00168.

<sup>Written for commit a19b4cf10be00c238d0c0e0a5527b172421b92e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/EdamAme-x/pentect/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

