### PR TITLE
Add CredSweeper sidecar build primitive

### DIFF
--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -331,6 +331,9 @@ impl CredSweeperNativeDetector {
                                     continue;
                                 };
                                 let variable = captures.name("variable");
+                                let separator = captures.name("separator");
+                                let value_leftquote = captures.name("value_leftquote");
+                                let value_rightquote = captures.name("value_rightquote");
                                 let candidate = Candidate {
                                     start: m.start(),
                                     end: m.end(),
@@ -338,6 +341,9 @@ impl CredSweeperNativeDetector {
                                     variable_start: variable.as_ref().map(|m| m.start()),
                                     variable_end: variable.as_ref().map(|m| m.end()),
                                     variable: variable.map(|m| m.as_str()),
+                                    separator: separator.map(|m| m.as_str()),
+                                    value_leftquote: value_leftquote.map(|m| m.as_str()),
+                                    value_rightquote: value_rightquote.map(|m| m.as_str()),
                                     line_data: Vec::new(),
                                 };
                                 push_match(
@@ -364,6 +370,9 @@ impl CredSweeperNativeDetector {
                                     continue;
                                 };
                                 let variable = captures.name("variable");
+                                let separator = captures.name("separator");
+                                let value_leftquote = captures.name("value_leftquote");
+                                let value_rightquote = captures.name("value_rightquote");
                                 let candidate = Candidate {
                                     start: m.start(),
                                     end: m.end(),
@@ -371,6 +380,9 @@ impl CredSweeperNativeDetector {
                                     variable_start: variable.as_ref().map(|m| m.start()),
                                     variable_end: variable.as_ref().map(|m| m.end()),
                                     variable: variable.map(|m| m.as_str()),
+                                    separator: separator.map(|m| m.as_str()),
+                                    value_leftquote: value_leftquote.map(|m| m.as_str()),
+                                    value_rightquote: value_rightquote.map(|m| m.as_str()),
                                     line_data: Vec::new(),
                                 };
                                 push_match(
@@ -440,6 +452,9 @@ struct Candidate<'a> {
     variable_start: Option<usize>,
     variable_end: Option<usize>,
     variable: Option<&'a str>,
+    separator: Option<&'a str>,
+    value_leftquote: Option<&'a str>,
+    value_rightquote: Option<&'a str>,
     line_data: Vec<CandidateLineData<'a>>,
 }
 
@@ -662,6 +677,9 @@ fn multi_pattern_candidates<'a>(
                 variable_start: main.variable_start,
                 variable_end: main.variable_end,
                 variable: main.variable,
+                separator: None,
+                value_leftquote: None,
+                value_rightquote: None,
                 line_data,
             });
             break;
@@ -759,6 +777,9 @@ fn jwk_multi_candidates(text: &str) -> Vec<Candidate<'_>> {
                 variable_start: main.variable_start,
                 variable_end: main.variable_end,
                 variable: main.variable,
+                separator: None,
+                value_leftquote: None,
+                value_rightquote: None,
                 line_data,
             });
             break;
@@ -878,6 +899,9 @@ fn pem_private_key_candidates(line: &str) -> Vec<Candidate<'_>> {
             variable_start: None,
             variable_end: None,
             variable: None,
+            separator: None,
+            value_leftquote: None,
+            value_rightquote: None,
             line_data: Vec::new(),
         }]
     } else {
@@ -926,6 +950,9 @@ fn pem_private_key_block_candidates(text: &str) -> Vec<Candidate<'_>> {
                 variable_start: None,
                 variable_end: None,
                 variable: None,
+                separator: None,
+                value_leftquote: None,
+                value_rightquote: None,
                 line_data: Vec::new(),
             });
         }
@@ -1082,6 +1109,9 @@ fn token_runs(line: &str) -> impl Iterator<Item = Candidate<'_>> {
                 variable_start: None,
                 variable_end: None,
                 variable: None,
+                separator: None,
+                value_leftquote: None,
+                value_rightquote: None,
                 line_data: Vec::new(),
             });
         }
@@ -1094,6 +1124,9 @@ fn token_runs(line: &str) -> impl Iterator<Item = Candidate<'_>> {
             variable_start: None,
             variable_end: None,
             variable: None,
+            separator: None,
+            value_leftquote: None,
+            value_rightquote: None,
             line_data: Vec::new(),
         });
     }
@@ -1148,6 +1181,268 @@ fn sanitize_variable_capture(
     Some((sanitized, sanitized_start, sanitized_end))
 }
 
+struct SanitizedValue<'a> {
+    value: &'a str,
+    start: usize,
+    end: usize,
+}
+
+fn sanitize_value_capture<'a>(
+    line: &'a str,
+    file_type: &str,
+    candidate: &Candidate<'a>,
+) -> SanitizedValue<'a> {
+    // Mirrors CredSweeper LineData.sanitize_value for regex captures whose
+    // value spans syntax around the actual secret.
+    let mut out = SanitizedValue {
+        value: candidate.value,
+        start: candidate.start,
+        end: candidate.end,
+    };
+    if out.value.is_empty() {
+        return out;
+    }
+
+    if candidate.value_leftquote.is_none() && candidate.value_rightquote.is_none() {
+        out = sanitize_unicode_quotes(out);
+    }
+
+    if candidate.variable.is_none()
+        || is_well_quoted_value(
+            candidate.value_leftquote,
+            candidate.value_rightquote,
+            out.value,
+            line,
+            file_type,
+        )
+    {
+        return out;
+    }
+
+    out = clean_url_parameters(line, candidate, out);
+    out = clean_bash_parameters(candidate, out);
+    out = clean_toml_parameters(line, out);
+    clean_tag_parameters(line, out)
+}
+
+fn sanitize_unicode_quotes(mut value: SanitizedValue<'_>) -> SanitizedValue<'_> {
+    while let (Some(first), Some(last)) = (value.value.chars().next(), value.value.chars().last()) {
+        let first_code = first as u32;
+        let last_code = last as u32;
+        let matching_single =
+            (0x2018..=0x201B).contains(&first_code) && (0x2018..=0x201B).contains(&last_code);
+        let matching_double =
+            (0x201C..=0x201F).contains(&first_code) && (0x201C..=0x201F).contains(&last_code);
+        if !matching_single && !matching_double {
+            break;
+        }
+        value.start += first.len_utf8();
+        value.end -= last.len_utf8();
+        value.value = &value.value[first.len_utf8()..value.value.len() - last.len_utf8()];
+    }
+    value
+}
+
+fn is_well_quoted_value(
+    left: Option<&str>,
+    right: Option<&str>,
+    value: &str,
+    line: &str,
+    file_type: &str,
+) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) if left == right => true,
+        (Some(left), Some(right)) => {
+            let left_quote = quote_from_left_capture(left);
+            let right_quote = quote_from_right_capture(right);
+            left_quote.is_some_and(|left_quote| {
+                right_quote.is_some_and(|right_quote| left_quote == right_quote)
+                    || (right == "\\" && line.ends_with('\\'))
+            })
+        }
+        (Some(left), None) => {
+            ((value.ends_with('\\')) && line.ends_with('\\'))
+                || file_type == ".php"
+                || left.matches('"').count() == 3
+                || left.matches('\'').count() == 3
+        }
+        _ => false,
+    }
+}
+
+fn quote_from_left_capture(value: &str) -> Option<char> {
+    if value.chars().count() == 1 {
+        value.chars().next()
+    } else {
+        value
+            .chars()
+            .next_back()
+            .filter(|ch| matches!(ch, '"' | '\'' | '`'))
+    }
+}
+
+fn quote_from_right_capture(value: &str) -> Option<char> {
+    if value.chars().count() == 1 {
+        value.chars().next()
+    } else {
+        value.chars().find(|ch| matches!(ch, '"' | '\'' | '`'))
+    }
+}
+
+fn clean_url_parameters<'a>(
+    line: &'a str,
+    candidate: &Candidate<'a>,
+    mut value: SanitizedValue<'a>,
+) -> SanitizedValue<'a> {
+    let Some(variable) = candidate.variable else {
+        return value;
+    };
+    if variable.ends_with("://") || !is_url_part(line, candidate, value.value) {
+        return value;
+    }
+    let mut cut = value.value.len();
+    for delimiter in ['&', ';', '#'] {
+        if let Some(pos) = value.value[..cut].find(delimiter) {
+            cut = cut.min(pos);
+        }
+    }
+    static URL_UNICODE_SPLIT: LazyLock<RustRegex> = LazyLock::new(|| {
+        RustRegex::new(r"(?i)\\u00(0000)?(21|23|24|26|27|28|29|2a|2b|2c|2f|3a|3b|3d|3f|40|5b|5d)")
+            .expect("url unicode split regex")
+    });
+    if let Some(m) = URL_UNICODE_SPLIT.find(&value.value[..cut]) {
+        cut = cut.min(m.start());
+    }
+    let escaped_separator = candidate
+        .separator
+        .is_some_and(|separator| separator.eq_ignore_ascii_case("%3D"));
+    if escaped_separator {
+        static URL_PERCENT_SPLIT: LazyLock<RustRegex> = LazyLock::new(|| {
+            RustRegex::new(r"(?i)%(21|23|24|26|27|28|29|2a|2b|2c|2f|3a|3b|3d|3f|40|5b|5d)")
+                .expect("url percent split regex")
+        });
+        if let Some(m) = URL_PERCENT_SPLIT.find(&value.value[..cut]) {
+            cut = cut.min(m.start());
+        }
+    }
+    value.end = value.start + cut;
+    value.value = &line[value.start..value.end];
+    value
+}
+
+fn is_url_part(line: &str, candidate: &Candidate<'_>, value: &str) -> bool {
+    let mut url_part = false;
+    if candidate.start <= line.len() {
+        let before_value = &line[..candidate.start];
+        let mut find_pos = 0usize;
+        let mut url_pos = None;
+        while let Some(rel) = before_value[find_pos..].find("://") {
+            let pos = find_pos + rel;
+            url_pos = Some(pos);
+            find_pos = pos + 3;
+        }
+        if let Some(pos) = url_pos.filter(|pos| 3 <= *pos) {
+            let scheme = &before_value[pos - 3..pos];
+            url_part = scheme
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-'))
+                && !line[pos + 3..candidate.start].chars().any(|ch| {
+                    ch.is_whitespace()
+                        || matches!(
+                            ch,
+                            '"' | '<' | '>' | '[' | ']' | '^' | '~' | '`' | '{' | '|' | '}'
+                        )
+                });
+        }
+    }
+    if let Some(variable_start) = candidate.variable_start.filter(|start| *start > 0) {
+        url_part |= line
+            .as_bytes()
+            .get(variable_start - 1)
+            .is_some_and(|b| matches!(*b, b'?' | b'&'));
+    }
+    static URL_VALUE_PATTERN: LazyLock<RustRegex> = LazyLock::new(|| {
+        RustRegex::new(
+            r#"^[^\s&;"<>\[\]^~`{|}]+[&;][^\s=;"<>\[\]^~`{|}]{3,80}=[^\s;&="<>\[\]^~`{|}]{1,80}"#,
+        )
+        .expect("url value pattern regex")
+    });
+    url_part
+        || URL_VALUE_PATTERN.is_match(value)
+        || candidate
+            .separator
+            .is_some_and(|separator| separator.eq_ignore_ascii_case("%3D"))
+}
+
+fn clean_bash_parameters<'a>(
+    candidate: &Candidate<'a>,
+    mut value: SanitizedValue<'a>,
+) -> SanitizedValue<'a> {
+    if candidate
+        .variable
+        .is_some_and(|variable| variable.starts_with('-'))
+    {
+        static BASH_PARAM_SPLIT: LazyLock<RustRegex> = LazyLock::new(|| {
+            RustRegex::new(r"\s+(\-|\||\>|\w+?\>|\&)").expect("bash parameter split regex")
+        });
+        if let Some(m) = BASH_PARAM_SPLIT.find(value.value) {
+            value.end = value.start + m.start();
+            value.value = &value.value[..m.start()];
+        }
+    }
+    if !value.value.contains(' ') && (value.value.contains("\\n") || value.value.contains("\\r")) {
+        static LINE_ENDINGS: LazyLock<RustRegex> =
+            LazyLock::new(|| RustRegex::new(r"\\{1,8}[nr]").expect("line ending split regex"));
+        if let Some(m) = LINE_ENDINGS.find(value.value) {
+            value.end = value.start + m.start();
+            value.value = &value.value[..m.start()];
+        }
+    }
+    value
+}
+
+fn clean_toml_parameters<'a>(line: &str, mut value: SanitizedValue<'a>) -> SanitizedValue<'a> {
+    loop {
+        let Some(last) = value.value.chars().next_back() else {
+            return value;
+        };
+        let Some(left) = (match last {
+            '}' => Some('{'),
+            ']' => Some('['),
+            ')' => Some('('),
+            _ => None,
+        }) else {
+            return value;
+        };
+        let line_before_value = line.get(..value.start).unwrap_or_default();
+        if value.value.contains(left)
+            || line_before_value.matches(left).count() <= line_before_value.matches(last).count()
+        {
+            return value;
+        }
+        value.end -= last.len_utf8();
+        value.value = &value.value[..value.value.len() - last.len_utf8()];
+    }
+}
+
+fn clean_tag_parameters<'a>(line: &str, mut value: SanitizedValue<'a>) -> SanitizedValue<'a> {
+    while value.value.ends_with('>') {
+        let Some(closing_tag_pos) = value.value.rfind("</") else {
+            break;
+        };
+        let tag = &value.value[closing_tag_pos + 2..value.value.len() - 1];
+        let opening_tag_prefix = format!("<{tag}");
+        if value.value.contains(&opening_tag_prefix)
+            || !line[..value.start].contains(&opening_tag_prefix)
+        {
+            break;
+        }
+        value.end = value.start + closing_tag_pos;
+        value.value = &value.value[..closing_tag_pos];
+    }
+    value
+}
+
 fn push_match(
     out: &mut Vec<CredSweeperNativeFinding>,
     ml_pending: &mut Vec<PendingMlFinding>,
@@ -1157,14 +1452,15 @@ fn push_match(
     line: &str,
     candidate: &Candidate<'_>,
 ) {
+    let sanitized_value = sanitize_value_capture(line, ctx.file_type, candidate);
     let range = ctx.view.to_raw(ByteRange::new(
-        line_start + candidate.start,
-        line_start + candidate.end,
+        line_start + sanitized_value.start,
+        line_start + sanitized_value.end,
     ));
     if range.is_empty() {
         return;
     }
-    if !accept_value(candidate.value, rule) {
+    if !accept_value(sanitized_value.value, rule) {
         return;
     }
     let sanitized_variable = candidate
@@ -1178,9 +1474,9 @@ fn push_match(
         severity: severity_name(rule.severity).to_string(),
         confidence: rule.confidence,
         confidence_name: confidence_name(rule.confidence).to_string(),
-        value: candidate.value.to_string(),
-        value_start: candidate.start,
-        value_end: candidate.end,
+        value: sanitized_value.value.to_string(),
+        value_start: sanitized_value.start,
+        value_end: sanitized_value.end,
         variable: sanitized_variable
             .as_ref()
             .map(|(variable, _, _)| variable.clone()),
@@ -1212,10 +1508,10 @@ fn push_match(
             finding,
             input: MlInput {
                 line: line.to_string(),
-                value: candidate.value.to_string(),
+                value: sanitized_value.value.to_string(),
                 variable: variable.to_string(),
-                value_start: candidate.start,
-                value_end: candidate.end,
+                value_start: sanitized_value.start,
+                value_end: sanitized_value.end,
                 variable_start: sanitized_variable
                     .as_ref()
                     .map(|(_, start, _)| *start as isize)
@@ -2069,6 +2365,59 @@ mod tests {
         assert!(!findings
             .iter()
             .any(|finding| finding.variable.as_deref() == Some("oauthClientSecret ")));
+    }
+
+    #[test]
+    fn keyword_values_are_sanitized_like_credsweeper_line_data() {
+        let line = concat!(
+            "final String responseBody = \"",
+            "oauth_token=vt2q56n7zhfksqaw&oauth_token_secret=lghm7395e8t6yv01",
+            "\";"
+        );
+        let variable_start = line.find("oauth_token").unwrap();
+        let value_start = variable_start + "oauth_token=".len();
+        let value_end = line.find("\";").unwrap();
+        let candidate = Candidate {
+            start: value_start,
+            end: value_end,
+            value: &line[value_start..value_end],
+            variable_start: Some(variable_start),
+            variable_end: Some(variable_start + "oauth_token".len()),
+            variable: Some("oauth_token"),
+            separator: Some("="),
+            value_leftquote: None,
+            value_rightquote: None,
+            line_data: Vec::new(),
+        };
+        let sanitized = sanitize_value_capture(line, ".java", &candidate);
+        assert_eq!("vt2q56n7zhfksqaw", sanitized.value);
+        assert_eq!(value_start, sanitized.start);
+        assert_eq!(value_start + sanitized.value.len(), sanitized.end);
+
+        let url = concat!(
+            "https://example.invalid/file?",
+            "X-Amz-Credential=AKIACSVC3FV5KQHYWH8A%2F70855094%2Ffd-oiik-3",
+            "&X-Amz-Signature=f4ea32fa4c9b3ca9ba96027c87d844c6152097b95e3f479c47054bfac1ce367f",
+        );
+        let variable_start = url.find("X-Amz-Credential").unwrap();
+        let value_start = variable_start + "X-Amz-Credential=".len();
+        let candidate = Candidate {
+            start: value_start,
+            end: url.len(),
+            value: &url[value_start..],
+            variable_start: Some(variable_start),
+            variable_end: Some(variable_start + "X-Amz-Credential".len()),
+            variable: Some("X-Amz-Credential"),
+            separator: Some("="),
+            value_leftquote: None,
+            value_rightquote: None,
+            line_data: Vec::new(),
+        };
+        let sanitized = sanitize_value_capture(url, ".json", &candidate);
+        assert_eq!(
+            "AKIACSVC3FV5KQHYWH8A%2F70855094%2Ffd-oiik-3",
+            sanitized.value
+        );
     }
 
     #[test]

--- a/tools/credsweeper-sidecar/build.ps1
+++ b/tools/credsweeper-sidecar/build.ps1
@@ -1,0 +1,86 @@
+param(
+    [string]$OutputDir = "",
+    [string]$Python = "python",
+    [string]$WorkDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Assert-LastExit {
+    param([string]$Step)
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Step failed with exit code $LASTEXITCODE"
+    }
+}
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Resolve-Path (Join-Path $ScriptDir "..\..")
+$VendorRoot = Join-Path $RepoRoot "crates\pentect-core\vendors\CredSweeper"
+$PatchFile = Join-Path $ScriptDir "patches\lazy-imports.patch"
+$Sidecar = Join-Path $ScriptDir "sidecar.py"
+$Requirements = Join-Path $ScriptDir "requirements.txt"
+
+if ($OutputDir -eq "") {
+    $OutputDir = Join-Path $RepoRoot "target\credsweeper-sidecar"
+}
+if ($WorkDir -eq "") {
+    $WorkDir = Join-Path ([System.IO.Path]::GetTempPath()) "pentect-credsweeper-sidecar-build"
+}
+
+$OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+$WorkDir = [System.IO.Path]::GetFullPath($WorkDir)
+$SourceRoot = Join-Path $WorkDir "CredSweeper"
+$Venv = Join-Path $WorkDir ".venv"
+$VenvPython = Join-Path $Venv "Scripts\python.exe"
+$TarPath = Join-Path $WorkDir "credsweeper.tar"
+
+Remove-Item -LiteralPath $WorkDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+New-Item -ItemType Directory -Force -Path $SourceRoot | Out-Null
+
+& git -C $VendorRoot archive --format=tar -o $TarPath HEAD
+Assert-LastExit "git archive CredSweeper"
+& tar -xf $TarPath -C $SourceRoot
+Assert-LastExit "extract CredSweeper archive"
+& git -C $SourceRoot apply $PatchFile
+Assert-LastExit "apply CredSweeper patch"
+
+& $Python -m venv $Venv
+Assert-LastExit "create venv"
+& $VenvPython -m pip install --disable-pip-version-check --quiet --upgrade pip
+Assert-LastExit "upgrade pip"
+& $VenvPython -m pip install --disable-pip-version-check --quiet -r $Requirements
+Assert-LastExit "install sidecar requirements"
+
+$CredSweeperPackage = Join-Path $SourceRoot "credsweeper"
+$BuildDir = Join-Path $WorkDir "pyinstaller-build"
+$SpecDir = Join-Path $WorkDir "spec"
+Remove-Item -LiteralPath $OutputDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+New-Item -ItemType Directory -Force -Path $SpecDir | Out-Null
+
+& $VenvPython -m PyInstaller `
+    --noconfirm `
+    --clean `
+    --onedir `
+    --name pentect-credsweeper-sidecar `
+    --paths $SourceRoot `
+    --distpath $OutputDir `
+    --workpath $BuildDir `
+    --specpath $SpecDir `
+    --add-data "$CredSweeperPackage\common\keyword_checklist.txt;credsweeper\common" `
+    --add-data "$CredSweeperPackage\common\morpheme_checklist.txt;credsweeper\common" `
+    --add-data "$CredSweeperPackage\rules\config.yaml;credsweeper\rules" `
+    --add-data "$CredSweeperPackage\secret\config.json;credsweeper\secret" `
+    --add-data "$CredSweeperPackage\ml_model\ml_config.json;credsweeper\ml_model" `
+    --add-data "$CredSweeperPackage\ml_model\ml_model.onnx;credsweeper\ml_model" `
+    --exclude-module pandas `
+    --exclude-module IPython `
+    --exclude-module matplotlib `
+    --exclude-module pytest `
+    --exclude-module tests `
+    $Sidecar
+Assert-LastExit "build sidecar"
+
+$Exe = Join-Path $OutputDir "pentect-credsweeper-sidecar\pentect-credsweeper-sidecar.exe"
+Write-Output $Exe

--- a/tools/credsweeper-sidecar/patches/lazy-imports.patch
+++ b/tools/credsweeper-sidecar/patches/lazy-imports.patch
@@ -1,0 +1,187 @@
+diff --git a/credsweeper/__init__.py b/credsweeper/__init__.py
+index 1cedfcf..e339c82 100644
+--- a/credsweeper/__init__.py
++++ b/credsweeper/__init__.py
+@@ -1,14 +1,3 @@
+-from credsweeper.app import CredSweeper
+-from credsweeper.common.constants import ThresholdPreset, Severity, Confidence
+-from credsweeper.file_handler.byte_content_provider import ByteContentProvider
+-from credsweeper.file_handler.content_provider import ContentProvider
+-from credsweeper.file_handler.data_content_provider import DataContentProvider
+-from credsweeper.file_handler.diff_content_provider import DiffContentProvider
+-from credsweeper.file_handler.string_content_provider import StringContentProvider
+-from credsweeper.file_handler.text_content_provider import TextContentProvider
+-
+-from credsweeper.ml_model.ml_validator import MlValidator
+-
+ __all__ = [
+     "ByteContentProvider",  #
+     "Confidence",  #
+@@ -25,3 +14,35 @@ __all__ = [
+ ]
+ 
+ __version__ = "1.17.0"
++
++
++def __getattr__(name):
++    """Load public symbols lazily so submodule imports do not pull the full CLI stack."""
++    if name == "CredSweeper":
++        from credsweeper.app import CredSweeper
++        return CredSweeper
++    if name in {"ThresholdPreset", "Severity", "Confidence"}:
++        from credsweeper.common.constants import ThresholdPreset, Severity, Confidence
++        return {"ThresholdPreset": ThresholdPreset, "Severity": Severity, "Confidence": Confidence}[name]
++    if name == "ByteContentProvider":
++        from credsweeper.file_handler.byte_content_provider import ByteContentProvider
++        return ByteContentProvider
++    if name == "ContentProvider":
++        from credsweeper.file_handler.content_provider import ContentProvider
++        return ContentProvider
++    if name == "DataContentProvider":
++        from credsweeper.file_handler.data_content_provider import DataContentProvider
++        return DataContentProvider
++    if name == "DiffContentProvider":
++        from credsweeper.file_handler.diff_content_provider import DiffContentProvider
++        return DiffContentProvider
++    if name == "StringContentProvider":
++        from credsweeper.file_handler.string_content_provider import StringContentProvider
++        return StringContentProvider
++    if name == "TextContentProvider":
++        from credsweeper.file_handler.text_content_provider import TextContentProvider
++        return TextContentProvider
++    if name == "MlValidator":
++        from credsweeper.ml_model.ml_validator import MlValidator
++        return MlValidator
++    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+diff --git a/credsweeper/app.py b/credsweeper/app.py
+index 0bf5def..713efa5 100644
+--- a/credsweeper/app.py
++++ b/credsweeper/app.py
+@@ -8,8 +8,7 @@ from typing import Any, List, Optional, Union, Dict, Sequence, Tuple
+ import pandas as pd
+ from colorama import Style
+ 
+-# Directory of credsweeper sources MUST be placed before imports to avoid circular import error
+-APP_PATH = Path(__file__).resolve().parent
++from credsweeper.paths import APP_PATH
+ 
+ from credsweeper.scanner.scanner import Scanner
+ from credsweeper.common.constants import Severity, ThresholdPreset, DiffRowType, DEFAULT_ENCODING
+diff --git a/credsweeper/common/keyword_checklist.py b/credsweeper/common/keyword_checklist.py
+index 928f140..dd21e6e 100644
+--- a/credsweeper/common/keyword_checklist.py
++++ b/credsweeper/common/keyword_checklist.py
+@@ -1,7 +1,7 @@
+ from functools import cached_property
+ from typing import Set, List
+ 
+-from credsweeper.app import APP_PATH
++from credsweeper.paths import APP_PATH
+ 
+ 
+ class KeywordChecklist:
+diff --git a/credsweeper/logger/logger.py b/credsweeper/logger/logger.py
+index fad5815..1d51eda 100644
+--- a/credsweeper/logger/logger.py
++++ b/credsweeper/logger/logger.py
+@@ -3,7 +3,7 @@ import logging.config
+ from pathlib import Path
+ from typing import Optional
+ 
+-from credsweeper.app import APP_PATH
++from credsweeper.paths import APP_PATH
+ from credsweeper.utils.util import Util
+ 
+ 
+diff --git a/credsweeper/scanner/scanner.py b/credsweeper/scanner/scanner.py
+index c84e093..ea7f410 100644
+--- a/credsweeper/scanner/scanner.py
++++ b/credsweeper/scanner/scanner.py
+@@ -3,7 +3,7 @@ import re
+ from pathlib import Path
+ from typing import List, Type, Tuple, Union, Dict, Generator, Set
+ 
+-from credsweeper.app import APP_PATH
++from credsweeper.paths import APP_PATH
+ from credsweeper.common.constants import RuleType, MIN_VARIABLE_LENGTH, MIN_SEPARATOR_LENGTH, MIN_VALUE_LENGTH, \
+     MAX_LINE_LENGTH, PEM_BEGIN_PATTERN
+ from credsweeper.config.config import Config
+diff --git a/credsweeper/utils/util.py b/credsweeper/utils/util.py
+index 77b72b2..b110d99 100644
+--- a/credsweeper/utils/util.py
++++ b/credsweeper/utils/util.py
+@@ -1,3 +1,5 @@
++from __future__ import annotations
++
+ import ast
+ import base64
+ import contextlib
+@@ -14,20 +16,6 @@ from typing import Any, Dict, List, Tuple, Optional, Union
+ 
+ import numpy as np
+ import yaml
+-from cryptography.hazmat.primitives import hashes
+-from cryptography.hazmat.primitives.asymmetric import padding
+-from cryptography.hazmat.primitives.asymmetric.dh import DHPrivateKey, DHPublicKey
+-from cryptography.hazmat.primitives.asymmetric.dsa import DSAPrivateKey, DSAPublicKey
+-from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey, EllipticCurvePublicKey
+-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+-from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey, Ed448PublicKey
+-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+-from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
+-from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PublicKey, X25519PrivateKey
+-from cryptography.hazmat.primitives.asymmetric.x448 import X448PublicKey, X448PrivateKey
+-from cryptography.hazmat.primitives.serialization import load_der_private_key
+-from cryptography.hazmat.primitives.serialization.pkcs12 import load_key_and_certificates
+-from lxml import etree
+ 
+ from credsweeper.common.constants import AVAILABLE_ENCODINGS, \
+     DEFAULT_ENCODING, LATIN_1, CHUNK_SIZE, MAX_LINE_LENGTH, CHUNK_STEP_SIZE, ASCII, UTF_16_LE, UTF_16_BE
+@@ -336,6 +324,8 @@ class Util:
+             xml exception
+ 
+         """
++        from lxml import etree
++
+         lines = []
+         line_nums = []
+         tree = etree.fromstringlist(xml_lines)
+@@ -434,6 +424,10 @@ class Util:
+     @staticmethod
+     def load_pk(data: bytes, password: Optional[bytes] = None) -> Optional[PrivateKeyTypes]:
+         """Try to load private key from PKCS1, PKCS8 and PKCS12 formats"""
++        from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
++        from cryptography.hazmat.primitives.serialization import load_der_private_key
++        from cryptography.hazmat.primitives.serialization.pkcs12 import load_key_and_certificates
++
+         with contextlib.suppress(Exception):
+             # PKCS1, PKCS8 probes
+             private_key = load_der_private_key(data, password)
+@@ -449,6 +443,17 @@ class Util:
+     @staticmethod
+     def check_pk(pkey: PrivateKeyTypes) -> bool:
+         """Check private key with encrypt-decrypt random data"""
++        from cryptography.hazmat.primitives import hashes
++        from cryptography.hazmat.primitives.asymmetric import padding
++        from cryptography.hazmat.primitives.asymmetric.dh import DHPrivateKey, DHPublicKey
++        from cryptography.hazmat.primitives.asymmetric.dsa import DSAPrivateKey, DSAPublicKey
++        from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey, EllipticCurvePublicKey
++        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
++        from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey, Ed448PublicKey
++        from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
++        from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PublicKey, X25519PrivateKey
++        from cryptography.hazmat.primitives.asymmetric.x448 import X448PublicKey, X448PrivateKey
++
+         if not pkey or isinstance(pkey, (EllipticCurvePublicKey, DSAPublicKey, Ed448PublicKey, Ed25519PublicKey,
+                                          DHPublicKey, X448PublicKey, X25519PublicKey)):
+             # These aren't the keys we're looking for
+diff --git a/credsweeper/paths.py b/credsweeper/paths.py
+new file mode 100644
+index 0000000..4b30699
+--- /dev/null
++++ b/credsweeper/paths.py
+@@ -0,0 +1,4 @@
++from pathlib import Path
++
++
++APP_PATH = Path(__file__).resolve().parent

--- a/tools/credsweeper-sidecar/requirements.txt
+++ b/tools/credsweeper-sidecar/requirements.txt
@@ -1,0 +1,11 @@
+pyinstaller>=6.21,<7
+numpy>=2.3,<3
+onnxruntime>=1.23,<2
+humanfriendly>=10,<11
+PyYAML>=6,<7
+colorama>=0.4,<0.5
+lxml>=6,<7
+cryptography>=46,<47
+base58>=2,<3
+pybase62>=1,<2
+beautifulsoup4>=4.13,<5

--- a/tools/credsweeper-sidecar/sidecar.py
+++ b/tools/credsweeper-sidecar/sidecar.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    from credsweeper.paths import APP_PATH
+except ModuleNotFoundError:
+    import credsweeper
+
+    APP_PATH = Path(credsweeper.__file__).resolve().parent
+from credsweeper.common.constants import Severity, ThresholdPreset
+from credsweeper.config.config import Config
+from credsweeper.credentials.candidate import Candidate
+from credsweeper.credentials.candidate_key import CandidateKey
+from credsweeper.file_handler.text_content_provider import TextContentProvider
+from credsweeper.ml_model.ml_validator import MlValidator
+from credsweeper.scanner.scanner import Scanner
+from credsweeper.utils.util import Util
+
+
+def build_config(use_filters: bool) -> Config:
+    config_dict = Util.json_load(APP_PATH / "secret" / "config.json")
+    config_dict["use_filters"] = use_filters
+    config_dict["find_by_ext"] = False
+    config_dict["size_limit"] = None
+    config_dict["pedantic"] = False
+    config_dict["depth"] = 0
+    config_dict["doc"] = False
+    config_dict["severity"] = Severity.INFO.value
+    return Config(config_dict)
+
+
+def purge_duplicates(candidates: list[Candidate]) -> list[Candidate]:
+    out: list[Candidate] = []
+    seen: set[tuple[Any, ...]] = set()
+    for candidate in candidates:
+        line_data = candidate.line_data_list[0]
+        key = (
+            candidate.rule_name,
+            line_data.path,
+            line_data.info,
+            line_data.line_pos,
+            line_data.variable_start,
+            line_data.variable_end,
+            line_data.separator_start,
+            line_data.separator_end,
+            line_data.value_start,
+            line_data.value_end,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(candidate)
+    return out
+
+
+def group_credentials(candidates: list[Candidate]) -> list[tuple[CandidateKey, list[Candidate]]]:
+    groups: dict[CandidateKey, list[Candidate]] = {}
+    for candidate in candidates:
+        for line_data in candidate.line_data_list[:1]:
+            key = CandidateKey(line_data)
+            groups.setdefault(key, []).append(candidate)
+    return list(groups.items())
+
+
+def apply_ml(candidates: list[Candidate], batch_size: int) -> list[Candidate]:
+    result: list[Candidate] = []
+    ml_groups: list[tuple[CandidateKey, list[Candidate]]] = []
+    for group_key, group_candidates in group_credentials(candidates):
+        if any(candidate.use_ml for candidate in group_candidates):
+            ml_groups.append((group_key, group_candidates))
+        else:
+            result.extend(group_candidates)
+    if not ml_groups:
+        return result
+
+    validator = MlValidator(ThresholdPreset.medium)
+    is_cred, probability = validator.validate_groups(ml_groups, batch_size)
+    for index, (_, group_candidates) in enumerate(ml_groups):
+        for candidate in group_candidates:
+            if candidate.use_ml:
+                if is_cred[index]:
+                    candidate.ml_probability = float(probability[index])
+                    result.append(candidate)
+            else:
+                result.append(candidate)
+    return result
+
+
+def scan_paths(paths: list[Path], use_filters: bool, use_ml: bool, batch_size: int) -> list[dict[str, Any]]:
+    config = build_config(use_filters)
+    scanner = Scanner(config, None)
+    credentials: list[dict[str, Any]] = []
+    for path in paths:
+        candidates = purge_duplicates(scanner.scan(TextContentProvider(path)))
+        if use_ml:
+            candidates = apply_ml(candidates, batch_size)
+        credentials.extend(candidate.to_json(hashed=False, subtext=False) for candidate in candidates)
+    return credentials
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="pentect-credsweeper-sidecar")
+    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument("--no-filters", action="store_true")
+    parser.add_argument("--no-ml", action="store_true")
+    parser.add_argument("--ml-batch-size", type=int, default=16)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    credentials = scan_paths(
+        args.paths,
+        use_filters=not args.no_filters,
+        use_ml=not args.no_ml,
+        batch_size=max(1, args.ml_batch_size),
+    )
+    data = json.dumps(credentials, ensure_ascii=False)
+    if args.output:
+        args.output.write_text(data, encoding="utf-8")
+    else:
+        print(data)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
- add a minimal CredSweeper Python sidecar that reuses the upstream scanner, filters, and ONNX ML validation without the full CLI/app stack
- add a reproducible Windows build script that patches a clean CredSweeper submodule copy and packages the sidecar with PyInstaller
- keep the existing Rust CredSweeper value sanitization parity fix in the same branch

## Validation
- cargo check -p pentect-core
- cargo test -p pentect-core credsweeper -- --nocapture
- tools/credsweeper-sidecar/build.ps1 -OutputDir $env:TEMP\pentect-credsweeper-sidecar-verify-out2 -WorkDir $env:TEMP\pentect-credsweeper-sidecar-verify-work2
- generated sidecar detected a sample SECRET_KEY through upstream CredSweeper ML

## Notes
- Nuitka standalone was tested first and did not finish within 10 minutes for the ONNX/numpy dependency graph.
- The sidecar package is currently a primitive engine artifact, not wired into the default scan path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal CredSweeper Python sidecar and a Windows build script to ship a standalone scanner with ONNX ML, and updates the Rust detector to sanitize captured values like upstream for better precision.

- **New Features**
  - `tools/credsweeper-sidecar/sidecar.py`: lightweight wrapper around `credsweeper` scanner, filters, and `MlValidator`; outputs JSON; flags: `--no-filters`, `--no-ml`, `--ml-batch-size`, `--output`.
  - `tools/credsweeper-sidecar/build.ps1`: reproducible Windows build using `PyInstaller`; applies a lazy-imports patch to vendored `CredSweeper`; bundles rules and model files; emits a one-dir `pentect-credsweeper-sidecar.exe`.
  - Adds `requirements.txt` and `patches/lazy-imports.patch` for the sidecar build. The sidecar is not on the default scan path yet.

- **Bug Fixes**
  - Rust detector now sanitizes captured values to match upstream `CredSweeper` (URL params, unicode quotes, bash/TOML/tag tails), improving finding ranges and ML inputs.
  - Uses sanitized value ranges for reporting and ML; adds `separator`, `value_leftquote`, and `value_rightquote` to candidates; new tests verify parity with `LineData.sanitize_value`.

<sup>Written for commit c761442616d2653048bd81dbb8e338dcc71b116d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/EdamAme-x/pentect/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a packaged command-line sidecar for scanning paths and exporting credential findings as JSON.
  * Added a build script to generate the sidecar executable with configurable output, Python, and working directories.

* **Bug Fixes**
  * Improved secret detection by sanitizing captured values more consistently, including better handling of quotes, separators, and URL-style cases.
  * Reduced duplicate findings before results are returned.

* **Chores**
  * Updated runtime dependencies and packaging setup for the sidecar build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->