### PR TITLE
Add CredSweeper parity CI shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy
@@ -25,3 +28,29 @@ jobs:
         run: cargo test --all-features
       - name: Test (rules-only, no default features)
         run: cargo test -p pentect-core --no-default-features
+      - name: Install CredSweeper oracle dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r tools/credsweeper-sidecar/runtime-requirements.txt
+      - name: CredSweeper parity shard
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/credsweeper-parity"
+          mkdir -p "$out"
+          cargo run --quiet -p pentect-cli -- bench creddata benchmarks/CredData \
+            --repo 02dfa7ec \
+            --limit 100 \
+            --ignore-x \
+            --save-credsweeper-json "$out/rust.json" \
+            --save-credsweeper-paths "$out/paths.txt" \
+            --json
+          mapfile -t paths < "$out/paths.txt"
+          PYTHONPATH="$PWD/crates/pentect-core/vendors/CredSweeper" \
+            python tools/credsweeper-sidecar/sidecar.py "${paths[@]}" --output "$out/oracle.json"
+          cargo run --quiet -p pentect-cli -- bench credsweeper-parity \
+            "$out/rust.json" \
+            "$out/oracle.json" \
+            --min-precision 1 \
+            --min-recall 1 \
+            --json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,31 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tools/credsweeper-sidecar/runtime-requirements.txt
+      - name: Prepare CredData shard
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import binascii
+          import json
+          from pathlib import Path
+
+          root = Path("benchmarks/CredData")
+          snapshot_path = root / "snapshot.json"
+          snapshot = json.loads(snapshot_path.read_text())
+          shard = {
+              repo_id: url
+              for repo_id, url in snapshot.items()
+              if f"{binascii.crc32(bytes.fromhex(repo_id)):08x}" == "02dfa7ec"
+          }
+          if len(shard) != 1:
+              raise SystemExit(f"expected one CredData shard, got {len(shard)}")
+          snapshot_path.write_text(json.dumps(shard, indent=2) + "\n")
+          for meta_path in (root / "meta").glob("*.csv"):
+              if meta_path.name != "02dfa7ec.csv":
+                  meta_path.unlink()
+          PY
+          (cd benchmarks/CredData && python download_data.py --clean_data --jobs 1)
       - name: CredSweeper parity shard
         shell: bash
         run: |

--- a/crates/pentect-cli/src/bench.rs
+++ b/crates/pentect-cli/src/bench.rs
@@ -68,6 +68,11 @@ pub(crate) fn cmd_bench(args: &[String]) {
             die(e);
         }
     }
+    if let Some(path) = &opts.save_credsweeper_paths {
+        if let Err(e) = save_credsweeper_paths(path, &report.credsweeper_paths) {
+            die(e);
+        }
+    }
     if opts.json {
         println!("{}", report.to_json());
     } else {
@@ -143,6 +148,7 @@ struct BenchOpts {
     min_precision: Option<f64>,
     min_recall: Option<f64>,
     save_credsweeper_json: Option<PathBuf>,
+    save_credsweeper_paths: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug)]
@@ -173,6 +179,7 @@ impl BenchOpts {
         let mut min_precision = None;
         let mut min_recall = None;
         let mut save_credsweeper_json = None;
+        let mut save_credsweeper_paths = None;
         let mut i = 4usize;
         while i < args.len() {
             match args[i].as_str() {
@@ -206,6 +213,13 @@ impl BenchOpts {
                         "--save-credsweeper-json",
                     )?));
                 }
+                "--save-credsweeper-paths" => {
+                    save_credsweeper_paths = Some(PathBuf::from(required_value(
+                        args,
+                        &mut i,
+                        "--save-credsweeper-paths",
+                    )?));
+                }
                 flag if flag.starts_with("--") => return Err(format!("unknown option: {flag}")),
                 value => return Err(format!("unexpected argument for bench: {value}")),
             }
@@ -222,6 +236,7 @@ impl BenchOpts {
             min_precision,
             min_recall,
             save_credsweeper_json,
+            save_credsweeper_paths,
         })
     }
 }
@@ -336,6 +351,10 @@ fn run_creddata(root: &Path, opts: &BenchOpts) -> Result<BenchReport, String> {
         ..BenchReport::default()
     };
     let files = by_file.into_iter().collect::<Vec<_>>();
+    report.credsweeper_paths = files
+        .iter()
+        .map(|(path, _)| path.display().to_string())
+        .collect();
 
     for file_report in
         score_creddata_files(files, opts.examples, opts.save_credsweeper_json.is_some())?
@@ -701,6 +720,14 @@ fn save_credsweeper_json(
 ) -> Result<(), String> {
     let data = serde_json::to_vec_pretty(credentials)
         .map_err(|e| format!("could not serialize CredSweeper json: {e}"))?;
+    std::fs::write(path, data).map_err(|e| format!("could not write '{}': {e}", path.display()))
+}
+
+fn save_credsweeper_paths(path: &Path, paths: &[String]) -> Result<(), String> {
+    let mut data = paths.join("\n");
+    if !data.is_empty() {
+        data.push('\n');
+    }
     std::fs::write(path, data).map_err(|e| format!("could not write '{}': {e}", path.display()))
 }
 
@@ -1347,6 +1374,7 @@ struct BenchReport {
     by_detection: BTreeMap<String, DetectionMetric>,
     examples: Vec<BenchExample>,
     credsweeper_json: Vec<CredSweeperJsonCredential>,
+    credsweeper_paths: Vec<String>,
 }
 
 impl BenchReport {
@@ -1559,6 +1587,8 @@ mod tests {
             "0.7".to_string(),
             "--save-credsweeper-json".to_string(),
             "out.json".to_string(),
+            "--save-credsweeper-paths".to_string(),
+            "paths.txt".to_string(),
         ];
         let opts = BenchOpts::parse(&args).unwrap();
         assert!(opts.json);
@@ -1572,6 +1602,42 @@ mod tests {
             opts.save_credsweeper_json.as_deref(),
             Some(Path::new("out.json"))
         );
+        assert_eq!(
+            opts.save_credsweeper_paths.as_deref(),
+            Some(Path::new("paths.txt"))
+        );
+    }
+
+    #[test]
+    fn creddata_runner_records_credsweeper_paths() {
+        let root = temp_root("pentect-creddata-paths");
+        let meta = root.join("meta");
+        let data = root.join("data").join("repo").join("_");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::create_dir_all(&data).unwrap();
+        std::fs::write(data.join("f.env"), "KEY=false-positive\n").unwrap();
+        std::fs::write(
+            meta.join("repo.csv"),
+            "Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,ValueEnd,CryptographyKey,PredefinedPattern,Category\n\
+             1,f,GitHub,repo,data/repo/_/f.env,1,1,F,4,18,,,Key\n",
+        )
+        .unwrap();
+
+        let args = vec![
+            "pentect".to_string(),
+            "bench".to_string(),
+            "creddata".to_string(),
+            root.to_string_lossy().to_string(),
+        ];
+        let opts = BenchOpts::parse(&args).unwrap();
+        let report = run_creddata(&root, &opts).unwrap();
+
+        assert_eq!(report.credsweeper_paths.len(), 1);
+        assert!(
+            report.credsweeper_paths[0].ends_with("data/repo/_/f.env")
+                || report.credsweeper_paths[0].ends_with("data\\repo\\_\\f.env")
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/tools/credsweeper-sidecar/runtime-requirements.txt
+++ b/tools/credsweeper-sidecar/runtime-requirements.txt
@@ -1,0 +1,26 @@
+numpy
+onnxruntime
+humanfriendly
+PyYAML
+colorama
+lxml
+cryptography
+base58
+pybase62
+beautifulsoup4
+GitPython
+odfpy
+openpyxl
+pandas
+pdfminer.six
+pyjks
+python-dateutil
+python-docx
+python-pptx
+PySquashfsImage
+pyxlsb
+rpmfile
+striprtf
+whatthepatch
+xlrd
+zstandard; python_version < "3.14"


### PR DESCRIPTION
## Summary
- adds `--save-credsweeper-paths` to make CredData shards reproducible for oracle runs
- adds CredSweeper sidecar runtime requirements for CI oracle execution
- adds a CI parity shard on CredData repo `02dfa7ec --limit 100` with precision/recall gates set to `1.0`

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --all-features --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings`
- local parity: `rust=17 oracle=17 common=17 f1=1.0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CredSweeper parity shard to CI and a new `--save-credsweeper-paths` flag to make oracle runs reproducible. Enforces 1.0 precision and recall on a small CredData slice.

- **New Features**
  - Added `--save-credsweeper-paths` to `pentect-cli bench creddata` to persist the exact scanned file list.
  - CI prepares and downloads only CredData shard `02dfa7ec`, then runs parity with `--limit 100`, generating Rust JSON and paths, invoking the CredSweeper sidecar, and gating on precision/recall `= 1.0`.

- **Dependencies**
  - Added `tools/credsweeper-sidecar/runtime-requirements.txt` and install step in CI.
  - CI now installs Python `3.12`.
  - CI checks out Git submodules recursively to fetch benchmark/vendor sources.

<sup>Written for commit 4b25f3026a1160156afabbaddeb478e1236ef1b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/EdamAme-x/pentect/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

