### PR TITLE
Fix scan stability edge cases

### DIFF
--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -303,9 +303,16 @@ fn git_files_for_root(root: &Path) -> Option<(PathBuf, Vec<PathBuf>)> {
             continue;
         }
         let rel = String::from_utf8_lossy(raw);
-        files.push(top.join(rel.as_ref()));
+        push_git_regular_file(&top, rel.as_ref(), &mut files);
     }
     Some((top, files))
+}
+
+fn push_git_regular_file(top: &Path, rel: &str, files: &mut Vec<PathBuf>) {
+    let path = top.join(rel);
+    if path.is_file() {
+        files.push(path);
+    }
 }
 
 fn git_pathspec(path: &Path) -> String {
@@ -331,4 +338,37 @@ fn walk_threads() -> usize {
         .map(|n| n.get())
         .unwrap_or(1)
         .min(8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root(name: &str) -> PathBuf {
+        let mut root = std::env::temp_dir();
+        root.push(format!(
+            "{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn git_listed_directories_are_not_scanned_as_files() {
+        let root = temp_root("pentect-git-listed-dir");
+        std::fs::create_dir_all(root.join("vendor-submodule")).unwrap();
+        std::fs::write(root.join("tracked.txt"), "ok").unwrap();
+
+        let mut files = Vec::new();
+        push_git_regular_file(&root, "vendor-submodule", &mut files);
+        push_git_regular_file(&root, "tracked.txt", &mut files);
+
+        assert_eq!(vec![root.join("tracked.txt")], files);
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -1244,9 +1244,14 @@ fn sanitize_unicode_quotes(mut value: SanitizedValue<'_>) -> SanitizedValue<'_> 
         if !matching_single && !matching_double {
             break;
         }
-        value.start += first.len_utf8();
-        value.end -= last.len_utf8();
-        value.value = &value.value[first.len_utf8()..value.value.len() - last.len_utf8()];
+        let first_len = first.len_utf8();
+        let last_len = last.len_utf8();
+        if value.value.len() < first_len + last_len {
+            break;
+        }
+        value.start += first_len;
+        value.end -= last_len;
+        value.value = &value.value[first_len..value.value.len() - last_len];
     }
     value
 }
@@ -2563,6 +2568,29 @@ mod tests {
         let view = NormalizedView::build(&region, raw);
         let spans = CredSweeperNativeDetector::builtin().detect(&view);
         assert!(spans.is_empty(), "{spans:?}");
+    }
+
+    #[test]
+    fn unicode_quote_sanitizer_handles_single_quote_value() {
+        let single = "‘";
+        let sanitized = sanitize_unicode_quotes(SanitizedValue {
+            value: single,
+            start: 0,
+            end: single.len(),
+        });
+        assert_eq!("‘", sanitized.value);
+        assert_eq!(0, sanitized.start);
+        assert_eq!(single.len(), sanitized.end);
+
+        let quoted = "‘secret’";
+        let sanitized = sanitize_unicode_quotes(SanitizedValue {
+            value: quoted,
+            start: 0,
+            end: quoted.len(),
+        });
+        assert_eq!("secret", sanitized.value);
+        assert_eq!("‘".len(), sanitized.start);
+        assert_eq!("‘secret".len(), sanitized.end);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- prevent CredSweeper unicode quote sanitization from panicking on single smart-quote values
- skip git-listed directories, such as submodule entries, when `scan --gitignore` builds its file list
- add regression tests for both edge cases

## Speed notes
- release `bench creddata benchmarks/CredData --repo 02dfa7ec --limit 100 --ignore-x`: 0.655s
- release `scan crates/pentect-core/src crates/pentect-cli/src --json --no-fail`: 2.662s for 64 files
- release `scan . --gitignore --json --no-fail`: 2.649s for 111 files
- release filtered broad repo scan: 8.829s for 1543 files

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --all-features --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release -p pentect-cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directory entries from tracked file lists are no longer treated as scan targets, preventing non-file paths from being included in results.
  * Improved handling of quoted text during credential detection so single-quote cases are processed more accurately, including correct position tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->