### PR TITLE
Add configurable binary scan policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,6 +1551,7 @@ dependencies = [
  "crossterm",
  "csv",
  "ignore",
+ "memchr",
  "pdf-extract",
  "pentect-core",
  "pentect-runtime",
@@ -1559,6 +1560,7 @@ dependencies = [
  "sha2",
  "toml",
  "windows-sys 0.61.2",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tract-onnx = "0.23.3"
 simd-json = "0.17"
 regex = "1"
 memchr = "2"
+zerocopy = { version = "0.8.52", features = ["derive"] }
 sha2 = "0.10"
 sha3 = "0.10"
 hmac = "0.12"

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -25,6 +25,8 @@ pdf-extract = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+memchr = { workspace = true }
+zerocopy = { workspace = true }
 crossterm = { workspace = true }
 csv = { workspace = true }
 toml = { workspace = true }

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -80,7 +80,7 @@ fn usage() {
          pentect bench credsweeper-parity RUST_JSON ORACLE_JSON\n\
          pentect extensions list|inspect|test [NAME]\n\
          pentect eval [--json]\n\
-         pentect scan [--exclude PATTERN|~GROUP|!PATTERN] [--gitignore] [PATH...]\n\
+         pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--gitignore] [PATH...]\n\
          pentect view <HANDLE>\n\
          pentect resolve [PATH...]\n\
          pentect help\n\
@@ -113,14 +113,14 @@ fn help_text() -> &'static str {
         "  pentect bench credsweeper-parity RUST_JSON ORACLE_JSON [--json]\n",
         "  pentect extensions list|inspect|test [NAME|PATH] [--json]\n",
         "  pentect eval [--json]\n\n",
-        "  pentect scan [--exclude PATTERN|~GROUP|!PATTERN] [--gitignore] [PATH...]\n\n",
+        "  pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--gitignore] [PATH...]\n\n",
         "  pentect view '<HANDLE>'\n\n",
         "dashboard: approval\n",
         "exec: masked stdout/stderr\n",
         "read: masked file preview\n",
         "view: handle metadata\n",
         "resolve: local materialize\n",
-        "scan: CredSweeper + core; narrow with --exclude, --gitignore, .pentectignore\n",
+        "scan: CredSweeper + core; binary skip|text; narrow with --exclude, --gitignore, .pentectignore\n",
         "groups: ~vcs ~deps ~build ~cache ~pentect ~heavy ~all; ! restores\n",
         "doctor: readiness\n",
         "bench: creddata, parity\n",

--- a/crates/pentect-cli/src/scan.rs
+++ b/crates/pentect-cli/src/scan.rs
@@ -1,4 +1,5 @@
 mod engine;
+mod file_magic;
 mod options;
 mod report;
 mod rules;
@@ -6,7 +7,7 @@ mod walk;
 
 use crate::{die, load_packs};
 use engine::{scan_files, ScanFile};
-use options::ScanOpts;
+use options::{BinaryMode, ScanOpts};
 use report::{print_report, report_json, ScanReport};
 use std::io::Write;
 use walk::collect_scan_roots;
@@ -48,6 +49,7 @@ fn run_scan_with_engine(
     scanner: impl FnOnce(
         Vec<std::path::PathBuf>,
         Vec<pentect_core::Pack>,
+        BinaryMode,
     ) -> Result<(Vec<ScanFile>, String), String>,
 ) -> Result<ScanReport, String> {
     let mut report = ScanReport {
@@ -61,7 +63,7 @@ fn run_scan_with_engine(
         opts.gitignore,
         &mut report.skipped,
     )?;
-    let (results, engine) = scanner(files, packs)?;
+    let (results, engine) = scanner(files, packs, opts.binary)?;
     report.engine = engine;
     for result in results {
         match result {
@@ -97,6 +99,7 @@ mod tests {
         assert!(!opts.json);
         assert!(!opts.no_fail);
         assert!(!opts.gitignore);
+        assert_eq!(opts.binary, BinaryMode::Skip);
     }
 
     #[test]
@@ -107,6 +110,8 @@ mod tests {
             "--json".into(),
             "--no-fail".into(),
             "--gitignore".into(),
+            "--binary".into(),
+            "text".into(),
             "app.env".into(),
         ];
         let opts = ScanOpts::parse(&args).unwrap();
@@ -114,7 +119,20 @@ mod tests {
         assert!(opts.json);
         assert!(opts.no_fail);
         assert!(opts.gitignore);
+        assert_eq!(opts.binary, BinaryMode::Text);
         assert!(opts.excludes.is_empty());
+    }
+
+    #[test]
+    fn scan_parse_rejects_invalid_binary_mode() {
+        let args = vec![
+            "pentect".into(),
+            "scan".into(),
+            "--binary".into(),
+            "raw".into(),
+        ];
+        let err = ScanOpts::parse(&args).unwrap_err();
+        assert!(err.contains("binary must be skip or text"), "{err}");
     }
 
     #[test]
@@ -226,6 +244,41 @@ mod tests {
             "{rendered}"
         );
         assert!(!rendered.contains(&token), "{rendered}");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn binary_text_mode_scans_magic_binary_files() {
+        let root = temp_scan_root("pentect-scan-binary-text");
+        let mut data = b"\x89PNG\r\n\x1A\n\0\0".to_vec();
+        data.extend_from_slice(b"const PASSWORD: string = \"helloworld1234\";\n");
+        std::fs::write(root.join("payload"), data).unwrap();
+
+        let default_args = vec![
+            "pentect".into(),
+            "scan".into(),
+            root.to_string_lossy().to_string(),
+        ];
+        let default_opts = ScanOpts::parse(&default_args).unwrap();
+        let default_report = run_scan_core_for_tests(&default_args, &default_opts).unwrap();
+        assert_eq!(0, default_report.files_scanned);
+        assert_eq!(1, default_report.skipped.len());
+
+        let text_args = vec![
+            "pentect".into(),
+            "scan".into(),
+            "--binary".into(),
+            "text".into(),
+            root.to_string_lossy().to_string(),
+        ];
+        let text_opts = ScanOpts::parse(&text_args).unwrap();
+        let text_report = run_scan_core_for_tests(&text_args, &text_opts).unwrap();
+        let rendered = report_json(&text_report);
+        assert_eq!(1, text_report.files_scanned, "{rendered}");
+        assert_eq!(1, text_report.files.len(), "{rendered}");
+        assert!(text_report.findings >= 1, "{rendered}");
+        assert!(!rendered.contains("helloworld1234"), "{rendered}");
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/pentect-cli/src/scan/engine.rs
+++ b/crates/pentect-cli/src/scan/engine.rs
@@ -1,8 +1,12 @@
+use super::file_magic::{classify, FileMagic};
+use super::options::BinaryMode;
 use super::report::{FileFinding, ScanScope, SkippedFile};
 use super::walk::ignored_file_reason;
 use crate::infer_kind;
+use memchr::memchr;
 use pentect_core::{ByteRange, Category, Engine, Input, Kind, Profile, Span};
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
@@ -13,16 +17,18 @@ const MAX_SCAN_FILE_BYTES: u64 = 1024 * 1024;
 pub(super) fn scan_files(
     files: Vec<PathBuf>,
     packs: Vec<pentect_core::Pack>,
+    binary: BinaryMode,
 ) -> Result<(Vec<ScanFile>, String), String> {
-    ScanPipeline::pentect(packs)?.scan(files)
+    ScanPipeline::pentect(packs, binary)?.scan(files)
 }
 
 #[cfg(test)]
 pub(super) fn scan_files_core_for_tests(
     files: Vec<PathBuf>,
     packs: Vec<pentect_core::Pack>,
+    binary: BinaryMode,
 ) -> Result<(Vec<ScanFile>, String), String> {
-    ScanPipeline::core_for_tests(packs).scan(files)
+    ScanPipeline::core_for_tests(packs, binary).scan(files)
 }
 
 #[derive(Clone, Debug)]
@@ -39,6 +45,9 @@ pub(super) enum ScanFile {
 /// value-free reporting, and final scan counts.
 trait ScanBackend {
     fn name(&self) -> &'static str;
+    fn binary_mode(&self) -> Option<BinaryMode> {
+        None
+    }
     fn scan(&mut self, files: &[PathBuf]) -> Result<Vec<FileFinding>, String>;
 }
 
@@ -48,23 +57,23 @@ struct ScanPipeline {
 }
 
 impl ScanPipeline {
-    fn pentect(packs: Vec<pentect_core::Pack>) -> Result<Self, String> {
+    fn pentect(packs: Vec<pentect_core::Pack>, binary: BinaryMode) -> Result<Self, String> {
         Ok(Self {
             name: ENGINE_NAME,
-            backends: vec![Box::new(CoreBackend::new(packs))],
+            backends: vec![Box::new(CoreBackend::new(packs, binary))],
         })
     }
 
     #[cfg(test)]
-    fn core_for_tests(packs: Vec<pentect_core::Pack>) -> Self {
+    fn core_for_tests(packs: Vec<pentect_core::Pack>, binary: BinaryMode) -> Self {
         Self {
             name: "core",
-            backends: vec![Box::new(CoreBackend::new(packs))],
+            backends: vec![Box::new(CoreBackend::new(packs, binary))],
         }
     }
 
     fn scan(&mut self, files: Vec<PathBuf>) -> Result<(Vec<ScanFile>, String), String> {
-        let (eligible, skipped) = precheck_files(&files)?;
+        let (eligible, skipped) = precheck_files(&files, self.binary_mode())?;
         let mut out = skipped
             .into_iter()
             .map(ScanFile::Skipped)
@@ -98,15 +107,27 @@ impl ScanPipeline {
         }
         Ok((out, self.name.to_string()))
     }
+
+    fn binary_mode(&self) -> BinaryMode {
+        self.backends
+            .iter()
+            .find_map(|backend| backend.binary_mode())
+            .unwrap_or(BinaryMode::Skip)
+    }
 }
 
-fn precheck_files(files: &[PathBuf]) -> Result<(Vec<PathBuf>, Vec<SkippedFile>), String> {
+fn precheck_files(
+    files: &[PathBuf],
+    binary: BinaryMode,
+) -> Result<(Vec<PathBuf>, Vec<SkippedFile>), String> {
     let mut eligible = Vec::new();
     let mut skipped = Vec::new();
     for path in files {
-        if let Some(reason) = ignored_file_reason(path) {
-            skipped.push(SkippedFile::new(path, reason));
-            continue;
+        if binary == BinaryMode::Skip {
+            if let Some(reason) = ignored_file_reason(path) {
+                skipped.push(SkippedFile::new(path, reason));
+                continue;
+            }
         }
         let meta = match std::fs::metadata(path) {
             Ok(meta) => meta,
@@ -120,9 +141,32 @@ fn precheck_files(files: &[PathBuf]) -> Result<(Vec<PathBuf>, Vec<SkippedFile>),
             skipped.push(SkippedFile::new(path, "too large"));
             continue;
         }
+        if binary == BinaryMode::Skip && should_sniff_magic(path) {
+            if let Some(reason) = binary_magic_reason(path)? {
+                skipped.push(SkippedFile::new(path, reason));
+                continue;
+            }
+        }
         eligible.push(path.clone());
     }
     Ok((eligible, skipped))
+}
+
+fn should_sniff_magic(path: &Path) -> bool {
+    path.extension().is_none()
+}
+
+fn binary_magic_reason(path: &Path) -> Result<Option<&'static str>, String> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| format!("could not read '{}': {e}", path.display()))?;
+    let mut buf = [0u8; 16];
+    let len = file
+        .read(&mut buf)
+        .map_err(|e| format!("could not read '{}': {e}", path.display()))?;
+    match classify(&buf[..len]) {
+        FileMagic::TextCandidate => Ok(None),
+        FileMagic::Binary(reason) => Ok(Some(reason)),
+    }
 }
 
 #[derive(Default)]
@@ -243,27 +287,29 @@ impl SourceRange {
 struct CoreBackend {
     packs: Option<Vec<pentect_core::Pack>>,
     engine: Option<Engine>,
+    binary: BinaryMode,
 }
 
 impl CoreBackend {
-    fn new(packs: Vec<pentect_core::Pack>) -> Self {
+    fn new(packs: Vec<pentect_core::Pack>, binary: BinaryMode) -> Self {
         Self {
             packs: Some(packs),
             engine: None,
+            binary,
         }
     }
 
     fn scan_file(&mut self, path: &Path) -> Result<Option<FileFinding>, String> {
-        let Some(data) = read_text_file(path)? else {
+        let Some(data) = read_text_file(path, self.binary)? else {
             return Ok(None);
         };
         let kind = infer_kind(path);
         self.ensure_engine();
+        let line_index = LineIndex::new(&data);
         let result = self.engine.as_ref().unwrap().analyze_spans(Input {
             kind: kind.clone(),
             data: data.clone(),
         });
-        let line_index = LineIndex::new(&data);
         let hits = result
             .spans
             .iter()
@@ -309,6 +355,10 @@ impl ScanBackend for CoreBackend {
         "core"
     }
 
+    fn binary_mode(&self) -> Option<BinaryMode> {
+        Some(self.binary)
+    }
+
     fn scan(&mut self, files: &[PathBuf]) -> Result<Vec<FileFinding>, String> {
         if files.is_empty() {
             return Ok(Vec::new());
@@ -328,8 +378,9 @@ impl ScanBackend for CoreBackend {
                 let next = Arc::clone(&next);
                 let packs = packs.clone();
                 let tx = tx.clone();
+                let binary = self.binary;
                 scope.spawn(move || {
-                    let mut worker = CoreBackend::new(packs);
+                    let mut worker = CoreBackend::new(packs, binary);
                     loop {
                         let index = next.fetch_add(1, Ordering::Relaxed);
                         let Some(path) = files.get(index) else {
@@ -349,14 +400,17 @@ impl ScanBackend for CoreBackend {
     }
 }
 
-fn read_text_file(path: &Path) -> Result<Option<String>, String> {
+fn read_text_file(path: &Path, binary: BinaryMode) -> Result<Option<String>, String> {
     let bytes =
         std::fs::read(path).map_err(|e| format!("could not read '{}': {e}", path.display()))?;
-    if bytes.contains(&0) {
+    if binary == BinaryMode::Skip && memchr(0, &bytes).is_some() {
         return Ok(None);
     }
     match String::from_utf8(bytes) {
         Ok(data) => Ok(Some(data)),
+        Err(e) if binary == BinaryMode::Text => {
+            Ok(Some(String::from_utf8_lossy(e.as_bytes()).into_owned()))
+        }
         Err(_) => Ok(None),
     }
 }

--- a/crates/pentect-cli/src/scan/file_magic.rs
+++ b/crates/pentect-cli/src/scan/file_magic.rs
@@ -1,0 +1,121 @@
+use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
+
+#[derive(FromBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+struct Prefix16 {
+    bytes: [u8; 16],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum FileMagic {
+    TextCandidate,
+    Binary(&'static str),
+}
+
+pub(super) fn classify(bytes: &[u8]) -> FileMagic {
+    if bytes.is_empty() {
+        return FileMagic::TextCandidate;
+    }
+    if bytes.starts_with(b"\xEF\xBB\xBF") {
+        return FileMagic::TextCandidate;
+    }
+    if let Some(reason) = classify_short_magic(bytes) {
+        return FileMagic::Binary(reason);
+    }
+    let Ok((prefix, _)) = Prefix16::ref_from_prefix(bytes) else {
+        return FileMagic::TextCandidate;
+    };
+    classify_prefix(prefix)
+}
+
+fn classify_prefix(prefix: &Prefix16) -> FileMagic {
+    let b = &prefix.bytes;
+    if b.starts_with(b"\x89PNG\r\n\x1A\n") {
+        return FileMagic::Binary("png header");
+    }
+    if b.starts_with(b"\x7FELF") {
+        return FileMagic::Binary("elf header");
+    }
+    if b.starts_with(b"MZ") {
+        return FileMagic::Binary("pe header");
+    }
+    if b.starts_with(b"\xCA\xFE\xBA\xBE") {
+        return FileMagic::Binary("java class header");
+    }
+    if b.starts_with(b"SQLite format 3\0") {
+        return FileMagic::Binary("sqlite header");
+    }
+    if b.starts_with(b"wOFF") || b.starts_with(b"wOF2") {
+        return FileMagic::Binary("font header");
+    }
+    if b.starts_with(b"\0asm") {
+        return FileMagic::Binary("wasm header");
+    }
+    if b.starts_with(b"ONNX") {
+        return FileMagic::Binary("onnx header");
+    }
+    FileMagic::TextCandidate
+}
+
+fn classify_short_magic(bytes: &[u8]) -> Option<&'static str> {
+    [
+        (b"\x89PNG\r\n\x1A\n".as_slice(), "png header"),
+        (b"\x7FELF".as_slice(), "elf header"),
+        (b"MZ".as_slice(), "pe header"),
+        (b"\xFF\xD8\xFF".as_slice(), "jpeg header"),
+        (b"GIF87a".as_slice(), "gif header"),
+        (b"GIF89a".as_slice(), "gif header"),
+        (b"%PDF-".as_slice(), "pdf header"),
+        (b"PK\x03\x04".as_slice(), "zip header"),
+        (b"PK\x05\x06".as_slice(), "zip header"),
+        (b"PK\x07\x08".as_slice(), "zip header"),
+        (b"\x1F\x8B".as_slice(), "gzip header"),
+        (b"BZh".as_slice(), "bzip2 header"),
+        (b"\xFD\x37\x7A\x58\x5A\x00".as_slice(), "xz header"),
+        (b"\x28\xB5\x2F\xFD".as_slice(), "zstd header"),
+        (b"Rar!\x1A\x07\x00".as_slice(), "rar header"),
+        (b"Rar!\x1A\x07\x01\x00".as_slice(), "rar header"),
+        (b"7z\xBC\xAF\x27\x1C".as_slice(), "7z header"),
+        (b"\xFE\xED\xFA\xCE".as_slice(), "mach-o header"),
+        (b"\xFE\xED\xFA\xCF".as_slice(), "mach-o header"),
+        (b"\xCE\xFA\xED\xFE".as_slice(), "mach-o header"),
+        (b"\xCF\xFA\xED\xFE".as_slice(), "mach-o header"),
+        (b"\xCA\xFE\xBA\xBE".as_slice(), "fat mach-o/class header"),
+        (b"\x00\x00\x01\x00".as_slice(), "ico header"),
+        (b"\x00\x00\x02\x00".as_slice(), "cur header"),
+        (b"\x00\x01\x00\x00".as_slice(), "ttf header"),
+        (b"OTTO".as_slice(), "otf header"),
+    ]
+    .into_iter()
+    .find_map(|(magic, reason)| bytes.starts_with(magic).then_some(reason))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_text_as_candidate() {
+        assert_eq!(
+            FileMagic::TextCandidate,
+            classify(b"const PASSWORD = \"helloworld1234\";\n")
+        );
+        assert_eq!(
+            FileMagic::TextCandidate,
+            classify(b"\xEF\xBB\xBFKEY=value\n")
+        );
+    }
+
+    #[test]
+    fn classifies_binary_headers() {
+        assert_eq!(
+            FileMagic::Binary("png header"),
+            classify(b"\x89PNG\r\n\x1A\nxx")
+        );
+        assert_eq!(FileMagic::Binary("zip header"), classify(b"PK\x03\x04xx"));
+        assert_eq!(
+            FileMagic::Binary("sqlite header"),
+            classify(b"SQLite format 3\0more")
+        );
+    }
+}

--- a/crates/pentect-cli/src/scan/options.rs
+++ b/crates/pentect-cli/src/scan/options.rs
@@ -6,7 +6,24 @@ pub(super) struct ScanOpts {
     pub(super) json: bool,
     pub(super) no_fail: bool,
     pub(super) gitignore: bool,
+    pub(super) binary: BinaryMode,
     pub(super) excludes: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum BinaryMode {
+    Skip,
+    Text,
+}
+
+impl BinaryMode {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "skip" => Ok(Self::Skip),
+            "text" => Ok(Self::Text),
+            _ => Err("binary must be skip or text".to_string()),
+        }
+    }
 }
 
 impl ScanOpts {
@@ -15,6 +32,7 @@ impl ScanOpts {
         let mut json = false;
         let mut no_fail = false;
         let mut gitignore = false;
+        let mut binary = BinaryMode::Skip;
         let mut excludes = Vec::new();
         let mut i = 2usize;
         while i < args.len() {
@@ -30,6 +48,11 @@ impl ScanOpts {
                 "--gitignore" => {
                     gitignore = true;
                     i += 1;
+                }
+                "--binary" => {
+                    let flag = args[i].clone();
+                    let value = required_value(args, &mut i, &flag)?;
+                    binary = BinaryMode::parse(&value)?;
                 }
                 "--exclude" => {
                     let flag = args[i].clone();
@@ -57,6 +80,7 @@ impl ScanOpts {
             json,
             no_fail,
             gitignore,
+            binary,
             excludes,
         })
     }


### PR DESCRIPTION
## Summary
- adds `scan --binary skip|text`
- keeps default `skip` fast/safe, while `text` scans binary-looking files through lossy text projection
- uses zerocopy-backed fixed-prefix magic classification for extensionless binary headers
- switches NUL detection to `memchr`

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --all-features --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release -p pentect-cli`
- release `scan . --gitignore --json --no-fail`: 2.975s / 112 files
- release filtered broad scan: 8.679s / 1510 files
- CLI binary mode check: default skipped 1 binary file; `--binary text` scanned it and found 1 secret