### PR TITLE
Fix binary scan reporting

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -120,7 +120,7 @@ fn help_text() -> &'static str {
         "read: masked file preview\n",
         "view: handle metadata\n",
         "resolve: local materialize\n",
-        "scan: CredSweeper + core; binary skip|text; narrow with --exclude, --gitignore, .pentectignore\n",
+        "scan: CredSweeper + core; binary skip(default)|text(lossy); narrow with --exclude, --gitignore, .pentectignore\n",
         "groups: ~vcs ~deps ~build ~cache ~pentect ~heavy ~all; ! restores\n",
         "doctor: readiness\n",
         "bench: creddata, parity\n",

--- a/crates/pentect-cli/src/scan.rs
+++ b/crates/pentect-cli/src/scan.rs
@@ -284,6 +284,79 @@ mod tests {
     }
 
     #[test]
+    fn binary_skip_reports_nul_files_as_skipped_not_clean() {
+        let root = temp_scan_root("pentect-scan-nul-skip");
+        std::fs::write(
+            root.join("payload.txt"),
+            b"const PASSWORD: string = \"helloworld1234\";\0\n",
+        )
+        .unwrap();
+
+        let args = vec![
+            "pentect".into(),
+            "scan".into(),
+            root.to_string_lossy().to_string(),
+        ];
+        let opts = ScanOpts::parse(&args).unwrap();
+        let report = run_scan_core_for_tests(&args, &opts).unwrap();
+
+        assert_eq!(0, report.files_scanned, "{}", report_json(&report));
+        assert_eq!(1, report.skipped.len(), "{}", report_json(&report));
+        assert_eq!("binary content", report.skipped[0].reason);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn binary_skip_reports_invalid_utf8_files_as_skipped_not_clean() {
+        let root = temp_scan_root("pentect-scan-invalid-utf8-skip");
+        let mut data = vec![0xFF, 0xFE];
+        data.extend_from_slice(b"const PASSWORD: string = \"helloworld1234\";\n");
+        std::fs::write(root.join("payload.txt"), data).unwrap();
+
+        let args = vec![
+            "pentect".into(),
+            "scan".into(),
+            root.to_string_lossy().to_string(),
+        ];
+        let opts = ScanOpts::parse(&args).unwrap();
+        let report = run_scan_core_for_tests(&args, &opts).unwrap();
+
+        assert_eq!(0, report.files_scanned, "{}", report_json(&report));
+        assert_eq!(1, report.skipped.len(), "{}", report_json(&report));
+        assert_eq!("invalid utf-8", report.skipped[0].reason);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn extensionless_text_starting_with_mz_is_scanned() {
+        let root = temp_scan_root("pentect-scan-extensionless-mz");
+        std::fs::write(
+            root.join("payload"),
+            "MZ\nconst PASSWORD: string = \"helloworld1234\";\n",
+        )
+        .unwrap();
+
+        let args = vec![
+            "pentect".into(),
+            "scan".into(),
+            root.to_string_lossy().to_string(),
+        ];
+        let opts = ScanOpts::parse(&args).unwrap();
+        let report = run_scan_core_for_tests(&args, &opts).unwrap();
+        let rendered = report_json(&report);
+
+        assert_eq!(1, report.files_scanned, "{rendered}");
+        assert!(report.skipped.is_empty(), "{rendered}");
+        assert_eq!(1, report.files.len(), "{rendered}");
+        assert!(report.findings >= 1, "{rendered}");
+        assert!(!rendered.contains("helloworld1234"), "{rendered}");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn scan_exclude_removes_files_from_scan_set() {
         let root = temp_scan_root("pentect-scan-exclude");
         std::fs::write(

--- a/crates/pentect-cli/src/scan/engine.rs
+++ b/crates/pentect-cli/src/scan/engine.rs
@@ -48,7 +48,7 @@ trait ScanBackend {
     fn binary_mode(&self) -> Option<BinaryMode> {
         None
     }
-    fn scan(&mut self, files: &[PathBuf]) -> Result<Vec<FileFinding>, String>;
+    fn scan(&mut self, files: &[PathBuf]) -> Result<Vec<ScanFile>, String>;
 }
 
 struct ScanPipeline {
@@ -78,17 +78,32 @@ impl ScanPipeline {
             .into_iter()
             .map(ScanFile::Skipped)
             .collect::<Vec<_>>();
-        let mut scanned_paths = eligible.iter().cloned().collect::<BTreeSet<_>>();
+        let mut scanned_paths = BTreeSet::new();
+        let mut skipped_paths = BTreeMap::new();
         let mut findings = FindingSet::default();
 
         for backend in &mut self.backends {
             let backend_name = backend.name();
-            for file in backend
+            for result in backend
                 .scan(&eligible)
                 .map_err(|e| format!("{backend_name}: {e}"))?
             {
-                scanned_paths.insert(file.path.clone());
-                findings.merge_file(file);
+                match result {
+                    ScanFile::Clean(path) => {
+                        skipped_paths.remove(&path);
+                        scanned_paths.insert(path);
+                    }
+                    ScanFile::Finding(file) => {
+                        skipped_paths.remove(&file.path);
+                        scanned_paths.insert(file.path.clone());
+                        findings.merge_file(file);
+                    }
+                    ScanFile::Skipped(skipped) => {
+                        if !scanned_paths.contains(&skipped.path) {
+                            skipped_paths.entry(skipped.path.clone()).or_insert(skipped);
+                        }
+                    }
+                }
             }
         }
 
@@ -105,6 +120,7 @@ impl ScanPipeline {
         for file in finding_files {
             out.push(ScanFile::Finding(file));
         }
+        out.extend(skipped_paths.into_values().map(ScanFile::Skipped));
         Ok((out, self.name.to_string()))
     }
 
@@ -299,9 +315,12 @@ impl CoreBackend {
         }
     }
 
-    fn scan_file(&mut self, path: &Path) -> Result<Option<FileFinding>, String> {
-        let Some(data) = read_text_file(path, self.binary)? else {
-            return Ok(None);
+    fn scan_file(&mut self, path: &Path) -> Result<ScanFile, String> {
+        let data = match read_text_file(path, self.binary)? {
+            ReadTextFile::Text(data) => data,
+            ReadTextFile::Skipped(reason) => {
+                return Ok(ScanFile::Skipped(SkippedFile::new(path, reason)));
+            }
         };
         let kind = infer_kind(path);
         self.ensure_engine();
@@ -322,9 +341,9 @@ impl CoreBackend {
             .filter(|note| note.category == Category::Secret)
             .count();
         if hits.is_empty() && warnings == 0 {
-            return Ok(None);
+            return Ok(ScanFile::Clean(path.to_path_buf()));
         }
-        Ok(Some(FileFinding {
+        Ok(ScanFile::Finding(FileFinding {
             path: path.to_path_buf(),
             scope: ScanScope::classify(path),
             kind,
@@ -359,7 +378,7 @@ impl ScanBackend for CoreBackend {
         Some(self.binary)
     }
 
-    fn scan(&mut self, files: &[PathBuf]) -> Result<Vec<FileFinding>, String> {
+    fn scan(&mut self, files: &[PathBuf]) -> Result<Vec<ScanFile>, String> {
         if files.is_empty() {
             return Ok(Vec::new());
         }
@@ -393,25 +412,28 @@ impl ScanBackend for CoreBackend {
                 });
             }
             drop(tx);
-            rx.into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .map(|items| items.into_iter().flatten().collect())
+            rx.into_iter().collect::<Result<Vec<_>, _>>()
         })
     }
 }
 
-fn read_text_file(path: &Path, binary: BinaryMode) -> Result<Option<String>, String> {
+enum ReadTextFile {
+    Text(String),
+    Skipped(&'static str),
+}
+
+fn read_text_file(path: &Path, binary: BinaryMode) -> Result<ReadTextFile, String> {
     let bytes =
         std::fs::read(path).map_err(|e| format!("could not read '{}': {e}", path.display()))?;
     if binary == BinaryMode::Skip && memchr(0, &bytes).is_some() {
-        return Ok(None);
+        return Ok(ReadTextFile::Skipped("binary content"));
     }
     match String::from_utf8(bytes) {
-        Ok(data) => Ok(Some(data)),
-        Err(e) if binary == BinaryMode::Text => {
-            Ok(Some(String::from_utf8_lossy(e.as_bytes()).into_owned()))
-        }
-        Err(_) => Ok(None),
+        Ok(data) => Ok(ReadTextFile::Text(data)),
+        Err(e) if binary == BinaryMode::Text => Ok(ReadTextFile::Text(
+            String::from_utf8_lossy(e.as_bytes()).into_owned(),
+        )),
+        Err(_) => Ok(ReadTextFile::Skipped("invalid utf-8")),
     }
 }
 

--- a/crates/pentect-cli/src/scan/file_magic.rs
+++ b/crates/pentect-cli/src/scan/file_magic.rs
@@ -36,9 +36,6 @@ fn classify_prefix(prefix: &Prefix16) -> FileMagic {
     if b.starts_with(b"\x7FELF") {
         return FileMagic::Binary("elf header");
     }
-    if b.starts_with(b"MZ") {
-        return FileMagic::Binary("pe header");
-    }
     if b.starts_with(b"\xCA\xFE\xBA\xBE") {
         return FileMagic::Binary("java class header");
     }
@@ -61,7 +58,6 @@ fn classify_short_magic(bytes: &[u8]) -> Option<&'static str> {
     [
         (b"\x89PNG\r\n\x1A\n".as_slice(), "png header"),
         (b"\x7FELF".as_slice(), "elf header"),
-        (b"MZ".as_slice(), "pe header"),
         (b"\xFF\xD8\xFF".as_slice(), "jpeg header"),
         (b"GIF87a".as_slice(), "gif header"),
         (b"GIF89a".as_slice(), "gif header"),
@@ -99,6 +95,10 @@ mod tests {
         assert_eq!(
             FileMagic::TextCandidate,
             classify(b"const PASSWORD = \"helloworld1234\";\n")
+        );
+        assert_eq!(
+            FileMagic::TextCandidate,
+            classify(b"MZ\nconst PASSWORD = \"helloworld1234\";\n")
         );
         assert_eq!(
             FileMagic::TextCandidate,


### PR DESCRIPTION
## Summary
- Report backend binary/UTF-8 skips as skipped instead of clean files
- Stop treating extensionless text beginning with `MZ` as PE based only on a 2-byte prefix
- Add regression tests for NUL, invalid UTF-8, and extensionless `MZ` text cases

## Root Cause
Eligible paths were counted as scanned before the core backend read them, so `read_text_file` returning `None` for NUL or invalid UTF-8 turned an unscanned file into a clean file. The magic sniffer also used the short ASCII `MZ` prefix as enough proof of a PE binary.

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release -p pentect-cli`
- release binary smoke test for default skip and `--binary text`