### PR TITLE
Improve safe scan hot paths

### DIFF
--- a/crates/pentect-cli/src/bench.rs
+++ b/crates/pentect-cli/src/bench.rs
@@ -565,18 +565,16 @@ fn score_file(
     report: &mut BenchReport,
     example_limit: usize,
 ) {
+    let index = ScoreIndex::new(cases, spans);
     let mut true_hits = BTreeMap::new();
     let mut line_only_hits = BTreeSet::new();
     for (i, case) in cases.iter().enumerate() {
         if case.truth != Truth::True {
             continue;
         }
-        if let Some(span) = strongest_overlap(spans, case.strict_range) {
+        if let Some(span) = index.strongest_overlap(case.strict_range) {
             true_hits.insert(i, detection_key(span));
-        } else if spans
-            .iter()
-            .any(|span| span.range.overlaps(&case.line_range))
-        {
+        } else if index.any_span_overlap(case.line_range) {
             line_only_hits.insert(i);
         }
     }
@@ -625,16 +623,10 @@ fn score_file(
     }
 
     for span in spans {
-        if cases
-            .iter()
-            .any(|case| case.truth == Truth::True && span.range.overlaps(&case.strict_range))
-        {
+        if index.any_true_case_overlap(span.range) {
             continue;
         }
-        if let Some(case) = cases
-            .iter()
-            .find(|case| case.truth == Truth::False && span.range.overlaps(&case.line_range))
-        {
+        if let Some(case) = index.first_false_case_overlap(span.range) {
             report.fp += 1;
             let key = detection_key(span);
             report.by_detection.entry(key.clone()).or_default().fp += 1;
@@ -676,6 +668,98 @@ fn score_file(
                 span.range,
             );
         }
+    }
+}
+
+struct ScoreIndex<'a> {
+    cases: &'a [BenchCase],
+    spans: &'a [Span],
+    spans_by_start: Vec<usize>,
+    true_cases_by_start: Vec<usize>,
+    false_cases_by_start: Vec<usize>,
+}
+
+impl<'a> ScoreIndex<'a> {
+    fn new(cases: &'a [BenchCase], spans: &'a [Span]) -> Self {
+        let mut spans_by_start = (0..spans.len()).collect::<Vec<_>>();
+        spans_by_start.sort_by_key(|&i| (spans[i].range.start, i));
+
+        let mut true_cases_by_start = cases
+            .iter()
+            .enumerate()
+            .filter_map(|(i, case)| (case.truth == Truth::True).then_some(i))
+            .collect::<Vec<_>>();
+        true_cases_by_start.sort_by_key(|&i| (cases[i].strict_range.start, i));
+
+        let mut false_cases_by_start = cases
+            .iter()
+            .enumerate()
+            .filter_map(|(i, case)| (case.truth == Truth::False).then_some(i))
+            .collect::<Vec<_>>();
+        false_cases_by_start.sort_by_key(|&i| (cases[i].line_range.start, i));
+
+        Self {
+            cases,
+            spans,
+            spans_by_start,
+            true_cases_by_start,
+            false_cases_by_start,
+        }
+    }
+
+    fn strongest_overlap(&self, range: ByteRange) -> Option<&'a Span> {
+        let mut best = None;
+        for span_index in self.span_candidates(range) {
+            let span = &self.spans[span_index];
+            if !span.range.overlaps(&range) {
+                continue;
+            }
+            let replace = match best {
+                None => true,
+                Some(best_index) => match span.cmp_strength(&self.spans[best_index]) {
+                    std::cmp::Ordering::Greater => true,
+                    std::cmp::Ordering::Equal => span_index > best_index,
+                    std::cmp::Ordering::Less => false,
+                },
+            };
+            if replace {
+                best = Some(span_index);
+            }
+        }
+        best.map(|i| &self.spans[i])
+    }
+
+    fn any_span_overlap(&self, range: ByteRange) -> bool {
+        self.span_candidates(range)
+            .any(|i| self.spans[i].range.overlaps(&range))
+    }
+
+    fn any_true_case_overlap(&self, range: ByteRange) -> bool {
+        let end = self
+            .true_cases_by_start
+            .partition_point(|&i| self.cases[i].strict_range.start < range.end);
+        self.true_cases_by_start[..end]
+            .iter()
+            .any(|&i| self.cases[i].strict_range.overlaps(&range))
+    }
+
+    fn first_false_case_overlap(&self, range: ByteRange) -> Option<&'a BenchCase> {
+        let end = self
+            .false_cases_by_start
+            .partition_point(|&i| self.cases[i].line_range.start < range.end);
+        self.false_cases_by_start[..end]
+            .iter()
+            .copied()
+            .filter(|&i| self.cases[i].line_range.overlaps(&range))
+            .min()
+            .map(|i| &self.cases[i])
+    }
+
+    fn span_candidates(&self, range: ByteRange) -> impl Iterator<Item = usize> + '_ {
+        let end = self
+            .spans_by_start
+            .partition_point(|&i| self.spans[i].range.start < range.end);
+        self.spans_by_start[..end].iter().copied()
     }
 }
 
@@ -817,13 +901,6 @@ fn clipped(value: &str, max_chars: usize) -> String {
     }
 }
 
-fn strongest_overlap(spans: &[Span], range: ByteRange) -> Option<&Span> {
-    spans
-        .iter()
-        .filter(|span| span.range.overlaps(&range))
-        .max_by(|a, b| a.cmp_strength(b))
-}
-
 fn detection_key(span: &Span) -> String {
     format!("{}:{}", span.source.as_str(), span.label)
 }
@@ -925,23 +1002,20 @@ enum Truth {
 }
 
 #[derive(Clone, Debug)]
-struct LineIndex {
-    text: String,
+struct LineIndex<'a> {
+    text: &'a str,
     starts: Vec<usize>,
 }
 
-impl LineIndex {
-    fn new(text: &str) -> Self {
+impl<'a> LineIndex<'a> {
+    fn new(text: &'a str) -> Self {
         let mut starts = vec![0];
         for (i, byte) in text.bytes().enumerate() {
             if byte == b'\n' {
                 starts.push(i + 1);
             }
         }
-        Self {
-            text: text.to_string(),
-            starts,
-        }
+        Self { text, starts }
     }
 
     fn line_range(&self, line_start: usize, line_end: usize) -> Option<ByteRange> {

--- a/crates/pentect-cli/src/scan/engine.rs
+++ b/crates/pentect-cli/src/scan/engine.rs
@@ -6,7 +6,6 @@ use crate::infer_kind;
 use memchr::memchr;
 use pentect_core::{ByteRange, Category, Engine, Input, Kind, Profile, Span};
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
@@ -157,12 +156,6 @@ fn precheck_files(
             skipped.push(SkippedFile::new(path, "too large"));
             continue;
         }
-        if binary == BinaryMode::Skip && should_sniff_magic(path) {
-            if let Some(reason) = binary_magic_reason(path)? {
-                skipped.push(SkippedFile::new(path, reason));
-                continue;
-            }
-        }
         eligible.push(path.clone());
     }
     Ok((eligible, skipped))
@@ -170,19 +163,6 @@ fn precheck_files(
 
 fn should_sniff_magic(path: &Path) -> bool {
     path.extension().is_none()
-}
-
-fn binary_magic_reason(path: &Path) -> Result<Option<&'static str>, String> {
-    let mut file = std::fs::File::open(path)
-        .map_err(|e| format!("could not read '{}': {e}", path.display()))?;
-    let mut buf = [0u8; 16];
-    let len = file
-        .read(&mut buf)
-        .map_err(|e| format!("could not read '{}': {e}", path.display()))?;
-    match classify(&buf[..len]) {
-        FileMagic::TextCandidate => Ok(None),
-        FileMagic::Binary(reason) => Ok(Some(reason)),
-    }
 }
 
 #[derive(Default)]
@@ -425,6 +405,11 @@ enum ReadTextFile {
 fn read_text_file(path: &Path, binary: BinaryMode) -> Result<ReadTextFile, String> {
     let bytes =
         std::fs::read(path).map_err(|e| format!("could not read '{}': {e}", path.display()))?;
+    if binary == BinaryMode::Skip && should_sniff_magic(path) {
+        if let FileMagic::Binary(reason) = classify(&bytes) {
+            return Ok(ReadTextFile::Skipped(reason));
+        }
+    }
     if binary == BinaryMode::Skip && memchr(0, &bytes).is_some() {
         return Ok(ReadTextFile::Skipped("binary content"));
     }

--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -2,12 +2,14 @@ use super::credsweeper_ml::{self, MlInput, RuleSeverity};
 use super::Detector;
 use crate::model::{ByteRange, Category, Confidence, DetectorId, Span};
 use crate::normalize::NormalizedView;
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 use data_encoding::{BASE64, BASE64URL, BASE64URL_NOPAD, BASE64_NOPAD};
 use fancy_regex::Regex as FancyRegex;
 use regex::Regex as RustRegex;
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
 const RULES_YAML: &str = include_str!("../../vendors/credsweeper-assets/rules/config.yaml");
@@ -29,6 +31,7 @@ static BUILTIN: LazyLock<CredSweeperNativeDetector> = LazyLock::new(|| {
 #[derive(Clone)]
 pub struct CredSweeperNativeDetector {
     rules: Vec<NativeRule>,
+    line_prefilter: LineRulePrefilter,
     stats: CredSweeperNativeStats,
 }
 
@@ -246,7 +249,9 @@ impl CredSweeperNativeDetector {
                 patterns,
             });
         }
+        let line_prefilter = LineRulePrefilter::build(&rules)?;
         Ok(Self {
+            line_prefilter,
             rules,
             stats: CredSweeperNativeStats {
                 total_rules: raw_rules.len(),
@@ -276,6 +281,8 @@ impl CredSweeperNativeDetector {
         let text = view.text();
         let mut out = Vec::new();
         let mut ml_pending = Vec::new();
+        let mut seen_rules = vec![false; self.rules.len()];
+        let mut rule_candidates = Vec::new();
         let ml_path = credsweeper_ml::ml_path(view.region.ctx.path.as_deref());
         let ml_file_type = credsweeper_ml::ml_file_type(view.region.ctx.path.as_deref());
         let push_ctx = PushMatchCtx {
@@ -312,13 +319,11 @@ impl CredSweeperNativeDetector {
         for (line_start, line) in LineRanges::new(text) {
             let line_body = line.trim_end_matches(['\r', '\n']);
             let line_lower = LazyLower::new(line_body);
-            for rule in &self.rules {
-                if !rule_available_for_code_scan(rule) {
-                    continue;
-                }
-                if line_body.len() < rule.min_line_len
-                    || !required_substring_present(&rule.required_substrings, &line_lower)
-                {
+            self.line_prefilter
+                .collect(&line_lower, &mut seen_rules, &mut rule_candidates);
+            for &rule_index in &rule_candidates {
+                let rule = &self.rules[rule_index];
+                if line_body.len() < rule.min_line_len {
                     continue;
                 }
                 for pattern in &rule.patterns {
@@ -420,6 +425,7 @@ impl CredSweeperNativeDetector {
                     }
                 }
             }
+            clear_seen_rules(&rule_candidates, &mut seen_rules);
         }
         push_ml_accepted(&mut out, &ml_pending);
         dedupe_findings(out)
@@ -466,6 +472,128 @@ struct Candidate<'a> {
     line_data: Vec<CandidateLineData<'a>>,
 }
 
+#[derive(Clone)]
+struct LineRulePrefilter {
+    always_rules: Vec<usize>,
+    ascii_ac: Option<AhoCorasick>,
+    ascii_rules_by_pattern: Vec<Vec<usize>>,
+    unicode_ac: Option<AhoCorasick>,
+    unicode_rules_by_pattern: Vec<Vec<usize>>,
+}
+
+impl LineRulePrefilter {
+    fn build(rules: &[NativeRule]) -> Result<Self, String> {
+        let mut always_rules = Vec::new();
+        let mut ascii_by_literal: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+        let mut unicode_by_literal: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+        for (rule_index, rule) in rules.iter().enumerate() {
+            if !rule_available_for_code_scan(rule) || !has_line_matcher(rule) {
+                continue;
+            }
+            if rule.required_substrings.is_empty()
+                || rule.required_substrings.iter().any(String::is_empty)
+            {
+                always_rules.push(rule_index);
+                continue;
+            }
+            for literal in &rule.required_substrings {
+                let by_literal = if literal.is_ascii() {
+                    &mut ascii_by_literal
+                } else {
+                    &mut unicode_by_literal
+                };
+                by_literal
+                    .entry(literal.clone())
+                    .or_default()
+                    .push(rule_index);
+            }
+        }
+        let (ascii_ac, ascii_rules_by_pattern) = build_line_prefilter_ac(ascii_by_literal, true)?;
+        let (unicode_ac, unicode_rules_by_pattern) =
+            build_line_prefilter_ac(unicode_by_literal, false)?;
+        Ok(Self {
+            always_rules,
+            ascii_ac,
+            ascii_rules_by_pattern,
+            unicode_ac,
+            unicode_rules_by_pattern,
+        })
+    }
+
+    fn collect(&self, line_lower: &LazyLower<'_>, seen_rules: &mut [bool], out: &mut Vec<usize>) {
+        out.clear();
+        for &rule_index in &self.always_rules {
+            seen_rules[rule_index] = true;
+            out.push(rule_index);
+        }
+        if let Some(ac) = &self.ascii_ac {
+            collect_prefilter_matches(
+                ac,
+                &self.ascii_rules_by_pattern,
+                line_lower.original,
+                seen_rules,
+                out,
+            );
+        }
+        if !line_lower.original.is_ascii() {
+            if let Some(ac) = &self.unicode_ac {
+                collect_prefilter_matches(
+                    ac,
+                    &self.unicode_rules_by_pattern,
+                    line_lower.as_lower(),
+                    seen_rules,
+                    out,
+                );
+            }
+        }
+        out.sort_unstable();
+    }
+}
+
+fn build_line_prefilter_ac(
+    by_literal: BTreeMap<String, Vec<usize>>,
+    ascii_case_insensitive: bool,
+) -> Result<(Option<AhoCorasick>, Vec<Vec<usize>>), String> {
+    let mut patterns = Vec::new();
+    let mut rules_by_pattern = Vec::new();
+    for (literal, rules) in by_literal {
+        patterns.push(literal);
+        rules_by_pattern.push(rules);
+    }
+    if patterns.is_empty() {
+        return Ok((None, rules_by_pattern));
+    }
+    let ac = AhoCorasickBuilder::new()
+        .match_kind(MatchKind::Standard)
+        .ascii_case_insensitive(ascii_case_insensitive)
+        .build(&patterns)
+        .map_err(|e| format!("credsweeper line prefilter: {e}"))?;
+    Ok((Some(ac), rules_by_pattern))
+}
+
+fn collect_prefilter_matches(
+    ac: &AhoCorasick,
+    rules_by_pattern: &[Vec<usize>],
+    haystack: &str,
+    seen_rules: &mut [bool],
+    out: &mut Vec<usize>,
+) {
+    for m in ac.find_overlapping_iter(haystack) {
+        for &rule_index in &rules_by_pattern[m.pattern().as_usize()] {
+            if !seen_rules[rule_index] {
+                seen_rules[rule_index] = true;
+                out.push(rule_index);
+            }
+        }
+    }
+}
+
+fn clear_seen_rules(rule_indices: &[usize], seen_rules: &mut [bool]) {
+    for &rule_index in rule_indices {
+        seen_rules[rule_index] = false;
+    }
+}
+
 #[derive(Clone, Copy)]
 struct CandidateLineData<'a> {
     start: usize,
@@ -506,6 +634,15 @@ impl SpecialMatcher {
 fn has_whole_text_matcher(rule: &NativeRule) -> bool {
     rule.patterns.iter().any(|pattern| {
         matches!(
+            &pattern.matcher,
+            PatternMatcher::Special(matcher) if matcher.is_whole_text()
+        )
+    })
+}
+
+fn has_line_matcher(rule: &NativeRule) -> bool {
+    rule.patterns.iter().any(|pattern| {
+        !matches!(
             &pattern.matcher,
             PatternMatcher::Special(matcher) if matcher.is_whole_text()
         )
@@ -1656,14 +1793,6 @@ impl<'a> LazyLower<'a> {
     }
 }
 
-fn required_substring_present(required: &[String], line_lower: &LazyLower<'_>) -> bool {
-    if required.is_empty() {
-        return true;
-    }
-    let lower = line_lower.as_lower();
-    required.iter().any(|needle| lower.contains(needle))
-}
-
 fn rule_available_for_code_scan(rule: &NativeRule) -> bool {
     rule.targets.iter().any(|target| target == "code")
 }
@@ -2488,6 +2617,41 @@ mod tests {
         assert!(findings.iter().any(|finding| {
             finding.rule_name == "Key" && finding.variable.as_deref() == Some("DJANGO_SECRET_KEY")
         }));
+    }
+
+    #[test]
+    fn line_prefilter_preserves_rule_order() {
+        let rules = vec![
+            test_native_rule("late", &["late"]),
+            test_native_rule("always", &[]),
+            test_native_rule("early", &["early"]),
+        ];
+        let prefilter = LineRulePrefilter::build(&rules).unwrap();
+        let line_lower = LazyLower::new("early late");
+        let mut seen_rules = vec![false; rules.len()];
+        let mut candidates = Vec::new();
+
+        prefilter.collect(&line_lower, &mut seen_rules, &mut candidates);
+
+        assert_eq!(candidates, vec![0, 1, 2]);
+    }
+
+    fn test_native_rule(name: &str, required_substrings: &[&str]) -> NativeRule {
+        NativeRule {
+            rule_name: name.to_string(),
+            label: normalize_label(name),
+            severity: RuleSeverity::Medium,
+            confidence: Confidence::Medium,
+            min_line_len: 0,
+            required_substrings: required_substrings.iter().map(|s| s.to_string()).collect(),
+            filter_types: Vec::new(),
+            targets: vec!["code".to_string()],
+            ml_validated: false,
+            patterns: vec![NativePattern {
+                matcher: PatternMatcher::Rust(RustRegex::new("value").unwrap()),
+                value_capture: true,
+            }],
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- avoid the serial extensionless binary-magic read and classify after the worker has read the file once
- index CredData benchmark spans/cases to avoid repeated naive overlap scans
- add an Aho-Corasick line prefilter for CredSweeper required substrings while preserving original rule order

## Validation
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- .\target\release\pentect.exe bench creddata benchmarks\CredData --limit 5000
- .\target\release\pentect.exe bench creddata benchmarks\CredData

CredData full stayed at tp=14741 fp=3924 fn=363, with elapsed_ms=141194 in this run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved credential detection accuracy and speed by narrowing the rules checked for each line.
  * Enhanced file scanning to better handle binary files during read time.

* **Bug Fixes**
  * Reduced false positives and unnecessary checks during benchmark scoring.
  * Improved handling of extension-less files when binary skipping is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->