### PR TITLE
Agent approval env and Codex hook trust UX

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -27,23 +27,18 @@ pub(crate) type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 const MAX_INPUT_BYTES: usize = 32 * 1024 * 1024;
 const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
     "Pentect agent contract:\n",
-    "- Treat every command/tool stdout, stderr, and result as potentially sensitive. Run normal shell commands; the hook layer automatically routes shell stdout/stderr through Pentect and unwraps nested Pentect calls.\n",
-    "- On Codex, current PostToolUse hooks cannot non-block replace non-shell tool output. Use browser/MCP/connector tools for navigation, clicks, and non-secret metadata; do not extract raw secret values through those tool results. Move secret bytes through local files, service CLIs, or shell commands so Pentect can route stdout/stderr before it reaches the model.\n",
-    "- On providers that support PostToolUse result replacement, browser/MCP/connector and other non-shell tool results are masked before they reach the model.\n",
-    "- Masked handles like `<<NAME_hash>>` are in-memory capabilities for this running Pentect-launched session. Later commands in this session get them as `$env:PENTECT_NAME_hash` on PowerShell or `$PENTECT_NAME_hash` on Unix; `KEY=<<...>>` also exposes `$env:KEY` / `$KEY`.\n",
-    "- To inspect a handle's public metadata only, run `pentect view '<handle>'`; it prints label, hash, and length without resolving, verifying, or revealing the secret.\n",
-    "- You may read, fetch, receive, transform, and use secrets or credentials from local files, credential stores, command output, authenticated browser/API/MCP/tool/connector responses, and other user-authorized sources. Pentect is the safety layer: returned secret values are masked before they reach the model.\n",
-    "- To register a secret from any local or authenticated source, run the normal read/fetch command through shell/Pentect exec and let masked output appear, for example `cat .env`, `pentect read .env`, or service CLIs. `pentect read` registers masked handles in the running in-memory vault when launched under Pentect; outside a Pentect session it is preview-only.\n",
-    "- If a secret must be copied from one local source to an approved local destination, prefer one `pentect exec` shell command that reads the source and writes the target without printing the raw value; print only a non-secret verification.\n",
-    "- Use the syntax of the current shell tool. In PowerShell, use PowerShell-native commands and `$env:NAME`; in Unix shells, use POSIX commands and `$NAME`.\n",
-    "- Do not switch to Node/Python/browser/MCP only to bypass a shell/Pentect wrapper problem. Fix the shell syntax or use one Pentect exec command unless the user explicitly requested that tool.\n",
-    "- Avoid exposing user-profile absolute paths in visible commands or logs; prefer relative paths, `$env:USERPROFILE`, `$HOME`, or app/service commands. Pentect keeps hook shell scripts in the running in-memory vault when available.\n",
-    "- If `.pentect/config.toml` sets `no_approve = true`, approval/materialization is non-interactive in this project; proceed with the user's requested operation using masked handles/env capabilities.\n",
-    "- If the user asks to store, sync, configure, or materialize a secret, it is OK to write it to the user-requested destination: local files, project configuration, credential stores, service CLIs, authenticated accounts, or another exact target named by the task. Use the handle/env capability in the write/update command; do not print the raw value.\n",
-    "- When using a registered secret, prefer its env var capability instead of re-reading or echoing it only to inspect/copy it. Do not run help just to discover extra flags.\n",
-    "- Do not disclose raw secrets in chat, logs, screenshots, derived previews, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or persistent external services that are not the exact target of the user's requested operation. Report only non-secret outcomes.\n",
+    "- Use normal shell commands. Pentect hooks route stdout/stderr and tool results through masking.\n",
+    "- You may read, fetch, transform, store, sync, and use user-authorized secrets. Pentect is the safety layer; raw secret values must not reach chat.\n",
+    "- Prefer one shell/Pentect command for secret work, e.g. `cat .env`, `pentect read .env`, service CLIs, or a command that reads a source and writes the exact requested destination.\n",
+    "- Masked handles like `<<NAME_hash>>` are in-memory capabilities for this running Pentect-launched session. Use `$env:NAME`/`$env:PENTECT_NAME_hash` on PowerShell or `$NAME`/`$PENTECT_NAME_hash` on Unix.\n",
+    "- `pentect view '<handle>'` shows only label, hash, and length. Use handles/env capabilities instead of re-reading or printing raw values.\n",
+    "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:NAME`; on Unix use POSIX commands and `$NAME`.\n",
+    "- Browser/MCP/connector tools are OK for navigation and metadata. If a raw secret must move, route it through shell/Pentect or a local file/service command so output is masked.\n",
+    "- For user-requested storage/materialization, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
+    "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
 );
 const PENTECT_BIN_ENV: &str = "PENTECT_BIN";
+const PENTECT_AGENT_AUTO_APPROVE_ENV: &str = "PENTECT_AGENT_AUTO_APPROVE";
 const PENTECT_MEMORY_VAULT_ADDR_ENV: &str = "PENTECT_MEMORY_VAULT_ADDR";
 const PENTECT_MEMORY_VAULT_TOKEN_ENV: &str = "PENTECT_MEMORY_VAULT_TOKEN";
 const MEMORY_VAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -110,7 +105,7 @@ fn help_text() -> &'static str {
         "  pentect eval [--json]\n\n",
         "  pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--gitignore] [PATH...]\n\n",
         "  pentect view '<HANDLE>'\n\n",
-        "dashboard: approval\n",
+        "dashboard: vault\n",
         "exec: masked stdout/stderr\n",
         "read: masked file preview\n",
         "view: handle metadata\n",
@@ -576,14 +571,14 @@ fn run_codex(
     if opts.dry_run {
         if codex_uses_unverified_headless_hook_path(&opts.tool_args) {
             eprintln!(
-                "[pentect] note: Codex headless hook execution was not verified for this invocation; non-dry runs fail closed for this subcommand."
+                "[pentect] note: headless Codex may skip hooks; use interactive `pentect codex` for protected tool use."
             );
         }
         print_dry_run(&opts.command, &codex_args(&configs, &opts.tool_args));
         return success_status();
     }
     if codex_uses_unverified_headless_hook_path(&opts.tool_args) && !opts.allow_unverified_hooks {
-        die("refusing to start Codex headless subcommand with Pentect hooks: local probes showed `codex exec` runs shell commands without dispatching PreToolUse/PostToolUse hooks, even under a TTY. Use interactive `pentect codex`, `pentect claude`, `pentect exec`, or pass --allow-unverified-hooks only for debugging.");
+        die("headless Codex may skip hooks. Use interactive `pentect codex` for protected tool use.");
     }
     let active_extensions = match extensions::active_from_specs(opts.extensions.clone(), true) {
         Ok(active) => active,
@@ -591,12 +586,10 @@ fn run_codex(
     };
     let mut cmd = Command::new(&opts.command);
     apply_pentect_env(&mut cmd, pentect);
+    apply_agent_auto_approve_env(&mut cmd);
     apply_memory_vault_env(&mut cmd, memory_vault);
     apply_extension_env(&mut cmd, &active_extensions);
-    for config in configs {
-        cmd.arg("--config").arg(config);
-    }
-    cmd.args(&opts.tool_args);
+    cmd.args(codex_args(&configs, &opts.tool_args));
     run_interactive_command(cmd, &opts.command)
 }
 
@@ -617,6 +610,7 @@ fn run_claude(
     };
     let mut cmd = Command::new(&opts.command);
     apply_pentect_env(&mut cmd, pentect);
+    apply_agent_auto_approve_env(&mut cmd);
     apply_memory_vault_env(&mut cmd, memory_vault);
     apply_extension_env(&mut cmd, &active_extensions);
     cmd.args(&args);
@@ -720,6 +714,10 @@ fn apply_pentect_env(cmd: &mut Command, pentect: &Path) {
     cmd.env(PENTECT_BIN_ENV, pentect);
 }
 
+fn apply_agent_auto_approve_env(cmd: &mut Command) {
+    cmd.env(PENTECT_AGENT_AUTO_APPROVE_ENV, "1");
+}
+
 fn apply_memory_vault_env(cmd: &mut Command, memory_vault: Option<&MemoryVaultGuard>) {
     let Some(memory_vault) = memory_vault else {
         return;
@@ -762,7 +760,13 @@ fn apply_extension_env(cmd: &mut Command, active: &extensions::ActiveExtensions)
 }
 
 fn codex_args(configs: &[String], tool_args: &[String]) -> Vec<String> {
-    let mut args = Vec::with_capacity(configs.len() * 2 + 2 + tool_args.len());
+    let mut args = Vec::with_capacity(configs.len() * 2 + 3 + tool_args.len());
+    if !tool_args
+        .iter()
+        .any(|arg| arg == "--dangerously-bypass-hook-trust")
+    {
+        args.push("--dangerously-bypass-hook-trust".to_string());
+    }
     for config in configs {
         args.push("--config".to_string());
         args.push(config.clone());
@@ -793,12 +797,12 @@ fn codex_hook_config_args(agent: &Path, session: Option<&str>) -> Vec<String> {
     vec![
         "features.hooks=true".to_string(),
         format!(
-            "hooks.PreToolUse=[{{matcher=\"*\",hooks=[{{type=\"command\",command={},commandWindows={},timeout=30}}]}}]",
+            "hooks.PreToolUse=[{{matcher=\"*\",hooks=[{{type=\"command\",command={},commandWindows={},timeout=30,statusMessage=\"Pentect\"}}]}}]",
             toml_string(&unix),
             toml_string(&windows)
         ),
         format!(
-            "hooks.PostToolUse=[{{matcher=\"*\",hooks=[{{type=\"command\",command={},commandWindows={},timeout=30}}]}}]",
+            "hooks.PostToolUse=[{{matcher=\"*\",hooks=[{{type=\"command\",command={},commandWindows={},timeout=30,statusMessage=\"Pentect\"}}]}}]",
             toml_string(&unix),
             toml_string(&windows)
         ),
@@ -1501,105 +1505,47 @@ mod tests {
         let pentect = Path::new(r"C:\repo\target\debug\pentect.exe");
         let mut cmd = Command::new("codex");
         apply_pentect_env(&mut cmd, pentect);
+        apply_agent_auto_approve_env(&mut cmd);
         let actual = cmd
             .get_envs()
             .find(|(key, _)| *key == std::ffi::OsStr::new(PENTECT_BIN_ENV))
             .and_then(|(_, value)| value)
             .unwrap();
         assert_eq!(actual, pentect.as_os_str());
+        let auto_approve = cmd
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new(PENTECT_AGENT_AUTO_APPROVE_ENV))
+            .and_then(|(_, value)| value)
+            .unwrap();
+        assert_eq!(auto_approve, std::ffi::OsStr::new("1"));
     }
 
     #[test]
     fn codex_args_inject_model_visible_pentect_contract() {
         let args = codex_args(&["features.hooks=true".to_string()], &["hello".to_string()]);
         let rendered = args.join("\n");
+        assert!(args.contains(&"--dangerously-bypass-hook-trust".to_string()));
         assert!(rendered.contains("developer_instructions="), "{rendered}");
         assert!(rendered.contains("Pentect agent contract"), "{rendered}");
+        assert!(rendered.contains("Use normal shell commands"), "{rendered}");
+        assert!(rendered.contains("route stdout/stderr"), "{rendered}");
+        assert!(rendered.contains("tool results"), "{rendered}");
         assert!(rendered.contains("Masked handles"), "{rendered}");
-        assert!(
-            rendered.contains("Treat every command/tool stdout, stderr, and result"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("Run normal shell commands"), "{rendered}");
-        assert!(
-            rendered.contains("automatically routes shell stdout/stderr through Pentect"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("PostToolUse hook"), "{rendered}");
-        assert!(rendered.contains("$env:KEY"), "{rendered}");
-        assert!(rendered.contains("secrets or credentials"), "{rendered}");
-        assert!(rendered.contains("credential stores"), "{rendered}");
-        assert!(
-            rendered.contains("authenticated browser/API/MCP/tool/connector responses"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("user-authorized sources"), "{rendered}");
-        assert!(
-            rendered.contains("You may read, fetch, receive, transform, and use"),
-            "{rendered}"
-        );
+        assert!(rendered.contains("$env:NAME"), "{rendered}");
+        assert!(rendered.contains("user-authorized secrets"), "{rendered}");
         assert!(
             rendered.contains("Pentect is the safety layer"),
             "{rendered}"
         );
-        assert!(
-            rendered.contains("any local or authenticated source"),
-            "{rendered}"
-        );
         assert!(rendered.contains("PENTECT_"), "{rendered}");
-        assert!(rendered.contains("env var capability"), "{rendered}");
         assert!(rendered.contains("pentect view"), "{rendered}");
-        assert!(rendered.contains("public metadata only"), "{rendered}");
-        assert!(
-            rendered.contains("without resolving, verifying, or revealing"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("normal read/fetch command"), "{rendered}");
         assert!(rendered.contains("pentect read"), "{rendered}");
-        assert!(
-            rendered.contains("registers masked handles in the running in-memory vault"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("preview-only"), "{rendered}");
-        assert!(
-            rendered.contains("one `pentect exec` shell command"),
-            "{rendered}"
-        );
-        assert!(
-            rendered.contains("PowerShell-native commands"),
-            "{rendered}"
-        );
-        assert!(
-            rendered.contains("Do not switch to Node/Python/browser/MCP"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("masked output"), "{rendered}");
-        assert!(
-            rendered.contains("store, sync, configure, or materialize"),
-            "{rendered}"
-        );
-        assert!(
-            rendered.contains("user-requested destination"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("local files"), "{rendered}");
-        assert!(rendered.contains("project configuration"), "{rendered}");
+        assert!(rendered.contains("PowerShell"), "{rendered}");
+        assert!(rendered.contains("Browser/MCP/connector"), "{rendered}");
+        assert!(rendered.contains("storage/materialization"), "{rendered}");
+        assert!(rendered.contains("exact requested"), "{rendered}");
+        assert!(rendered.contains("local file"), "{rendered}");
         assert!(rendered.contains("service CLIs"), "{rendered}");
-        assert!(rendered.contains("authenticated accounts"), "{rendered}");
-        assert!(
-            rendered.contains("another exact target named by the task"),
-            "{rendered}"
-        );
-        assert!(
-            rendered.contains("do not print the raw value"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("write/update command"), "{rendered}");
-        assert!(
-            rendered.contains("instead of re-reading or echoing it only to inspect/copy it"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("run help"), "{rendered}");
         assert!(!rendered.contains("pentect resolve"), "{rendered}");
         assert!(!rendered.contains("pentect materialize"), "{rendered}");
         assert!(
@@ -1608,11 +1554,6 @@ mod tests {
         );
         assert!(rendered.contains("encodings"), "{rendered}");
         assert!(rendered.contains("third-party destinations"), "{rendered}");
-        assert!(rendered.contains("public locations"), "{rendered}");
-        assert!(
-            rendered.contains("persistent external services that are not the exact target"),
-            "{rendered}"
-        );
         assert!(
             !rendered.contains("pentect exec \\\"pentect exec"),
             "{rendered}"
@@ -1625,79 +1566,24 @@ mod tests {
         let rendered = args.join("\n");
         assert!(rendered.contains("--append-system-prompt"), "{rendered}");
         assert!(rendered.contains("Pentect agent contract"), "{rendered}");
-        assert!(rendered.contains("$env:KEY"), "{rendered}");
-        assert!(rendered.contains("secrets or credentials"), "{rendered}");
-        assert!(rendered.contains("credential stores"), "{rendered}");
-        assert!(
-            rendered.contains("authenticated browser/API/MCP/tool/connector responses"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("user-authorized sources"), "{rendered}");
-        assert!(
-            rendered.contains("You may read, fetch, receive, transform, and use"),
-            "{rendered}"
-        );
+        assert!(rendered.contains("Use normal shell commands"), "{rendered}");
+        assert!(rendered.contains("route stdout/stderr"), "{rendered}");
+        assert!(rendered.contains("tool results"), "{rendered}");
+        assert!(rendered.contains("$env:NAME"), "{rendered}");
+        assert!(rendered.contains("user-authorized secrets"), "{rendered}");
         assert!(
             rendered.contains("Pentect is the safety layer"),
             "{rendered}"
         );
-        assert!(
-            rendered.contains("any local or authenticated source"),
-            "{rendered}"
-        );
         assert!(rendered.contains("PENTECT_"), "{rendered}");
-        assert!(rendered.contains("env var capability"), "{rendered}");
         assert!(rendered.contains("pentect view"), "{rendered}");
-        assert!(rendered.contains("public metadata only"), "{rendered}");
-        assert!(
-            rendered.contains("without resolving, verifying, or revealing"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("normal read/fetch command"), "{rendered}");
         assert!(rendered.contains("pentect read"), "{rendered}");
-        assert!(
-            rendered.contains("registers masked handles in the running in-memory vault"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("preview-only"), "{rendered}");
-        assert!(
-            rendered.contains("one `pentect exec` shell command"),
-            "{rendered}"
-        );
-        assert!(
-            rendered.contains("PowerShell-native commands"),
-            "{rendered}"
-        );
-        assert!(
-            rendered.contains("Do not switch to Node/Python/browser/MCP"),
-            "{rendered}"
-        );
-        assert!(
-            rendered.contains("store, sync, configure, or materialize"),
-            "{rendered}"
-        );
-        assert!(
-            rendered.contains("user-requested destination"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("local files"), "{rendered}");
-        assert!(rendered.contains("project configuration"), "{rendered}");
+        assert!(rendered.contains("PowerShell"), "{rendered}");
+        assert!(rendered.contains("Browser/MCP/connector"), "{rendered}");
+        assert!(rendered.contains("storage/materialization"), "{rendered}");
+        assert!(rendered.contains("exact requested"), "{rendered}");
+        assert!(rendered.contains("local file"), "{rendered}");
         assert!(rendered.contains("service CLIs"), "{rendered}");
-        assert!(rendered.contains("authenticated accounts"), "{rendered}");
-        assert!(
-            rendered.contains("another exact target named by the task"),
-            "{rendered}"
-        );
-        assert!(
-            rendered.contains("do not print the raw value"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("write/update command"), "{rendered}");
-        assert!(
-            rendered.contains("instead of re-reading or echoing it only to inspect/copy it"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("run help"), "{rendered}");
         assert!(!rendered.contains("pentect resolve"), "{rendered}");
         assert!(!rendered.contains("pentect materialize"), "{rendered}");
         assert!(
@@ -1706,11 +1592,6 @@ mod tests {
         );
         assert!(rendered.contains("encodings"), "{rendered}");
         assert!(rendered.contains("third-party destinations"), "{rendered}");
-        assert!(rendered.contains("public locations"), "{rendered}");
-        assert!(
-            rendered.contains("persistent external services that are not the exact target"),
-            "{rendered}"
-        );
         assert!(
             !rendered.contains("pentect exec \"pentect exec"),
             "{rendered}"

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 const PENTECT_DIR: &str = ".pentect";
 const CONFIG_FILE: &str = "config.toml";
+const AUTO_APPROVE_ENV: &str = "PENTECT_AGENT_AUTO_APPROVE";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ApprovalConfigState {
@@ -49,12 +50,26 @@ pub(crate) fn approval_config_state() -> Result<ApprovalConfigState, String> {
 
 #[cfg(not(test))]
 pub(crate) fn approval_bypassed_by_config() -> Result<bool, String> {
-    Ok(approval_config_state()?.effective_no_approve)
+    let state = approval_config_state()?;
+    Ok(approval_bypassed_with_state(
+        &state,
+        env_bool(AUTO_APPROVE_ENV),
+    ))
 }
 
 #[cfg(test)]
 pub(crate) fn approval_bypassed_by_config() -> Result<bool, String> {
-    Ok(false)
+    Ok(env_bool(AUTO_APPROVE_ENV))
+}
+
+fn approval_bypassed_with_state(state: &ApprovalConfigState, agent_auto_approve: bool) -> bool {
+    if state.effective_no_approve {
+        return true;
+    }
+    if state.effective_source != ApprovalConfigSource::Default {
+        return false;
+    }
+    agent_auto_approve
 }
 
 pub(crate) fn set_approval_config(
@@ -189,6 +204,15 @@ fn approval_mode_bypasses(value: &str) -> bool {
     )
 }
 
+fn env_bool(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on" | "no_approve" | "no-approve"
+        )
+    })
+}
+
 fn project_config_path() -> PathBuf {
     PathBuf::from(PENTECT_DIR).join(CONFIG_FILE)
 }
@@ -244,5 +268,36 @@ mod tests {
     fn approval_config_detects_explicit_required() {
         let value = "no_approve = false".parse::<toml::Value>().unwrap();
         assert_eq!(approval_config_override_value(&value).unwrap(), Some(false));
+    }
+
+    #[test]
+    fn agent_auto_approve_respects_explicit_required_config() {
+        let explicit_required = ApprovalConfigState {
+            project: ApprovalConfigScope {
+                display_path: ".pentect/config.toml".to_string(),
+                no_approve: Some(false),
+            },
+            global: ApprovalConfigScope {
+                display_path: "$HOME/.pentect/config.toml".to_string(),
+                no_approve: None,
+            },
+            effective_no_approve: false,
+            effective_source: ApprovalConfigSource::Project,
+        };
+        assert!(!approval_bypassed_with_state(&explicit_required, true));
+
+        let default_required = ApprovalConfigState {
+            project: ApprovalConfigScope {
+                display_path: ".pentect/config.toml".to_string(),
+                no_approve: None,
+            },
+            global: ApprovalConfigScope {
+                display_path: "$HOME/.pentect/config.toml".to_string(),
+                no_approve: None,
+            },
+            effective_no_approve: false,
+            effective_source: ApprovalConfigSource::Default,
+        };
+        assert!(approval_bypassed_with_state(&default_required, true));
     }
 }

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 const PENTECT_DIR: &str = ".pentect";
 const CONFIG_FILE: &str = "config.toml";
+#[cfg(not(test))]
 const AUTO_APPROVE_ENV: &str = "PENTECT_AGENT_AUTO_APPROVE";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -59,7 +60,7 @@ pub(crate) fn approval_bypassed_by_config() -> Result<bool, String> {
 
 #[cfg(test)]
 pub(crate) fn approval_bypassed_by_config() -> Result<bool, String> {
-    Ok(env_bool(AUTO_APPROVE_ENV))
+    Ok(false)
 }
 
 fn approval_bypassed_with_state(state: &ApprovalConfigState, agent_auto_approve: bool) -> bool {
@@ -204,6 +205,7 @@ fn approval_mode_bypasses(value: &str) -> bool {
     )
 }
 
+#[cfg(not(test))]
 fn env_bool(name: &str) -> bool {
     std::env::var(name).is_ok_and(|value| {
         matches!(

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -27,7 +27,8 @@ use masking::{
 use masking::{first_reusable_env_name, mask_live_output, mask_tool_output};
 use memory_vault::MemoryVaultClient;
 use pentect_core::{
-    parse_placeholder, Config, Engine, Input, Kind, MaskResult, Pack, Profile, RegionKind,
+    infer_kind, parse_placeholder, Config, Engine, Input, Kind, MaskResult, Pack, Profile,
+    RegionKind,
 };
 use serde_json::{json, Value};
 use session::{checked_session_name, session_root, RecoveryStore, Session};
@@ -709,7 +710,7 @@ fn approval_decision_for_ticket(
     if !queue.dashboard_alive(DASHBOARD_HEARTBEAT_MAX_AGE) {
         queue.record(ticket, ApprovalDecision::Decline, "auto")?;
         return Err(
-            "Pentect blocked this command because the approval UI is not running. Ask the user to run `pentect` in this project, then retry the command."
+            "approval needed; run `pentect` or set `.pentect/config.toml` no_approve = true."
                 .to_string(),
         );
     }
@@ -3164,30 +3165,6 @@ fn env_name_after_marker(text: &str, start: usize, marker: char) -> Option<(&str
     }
     let next = if marker == '%' { end + 1 } else { end };
     Some((&text[start..end], next))
-}
-
-fn infer_kind(path: &Path) -> Kind {
-    if path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| {
-            let lower = name.to_ascii_lowercase();
-            lower == ".env" || lower.starts_with(".env.")
-        })
-    {
-        return Kind::Env;
-    }
-    match path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| ext.to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("json") => Kind::Json,
-        Some("env") => Kind::Env,
-        Some("har") => Kind::Har,
-        _ => Kind::Text,
-    }
 }
 
 fn parse_kind(value: &str) -> Result<Kind, String> {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -405,7 +405,7 @@ fn network_like_exec_requires_approval_without_dashboard() {
     assert!(approval.requires_approval(), "{approval:?}");
     assert!(approval.network_like, "{approval:?}");
     let err = approval_decision_for_exec(&opts.session, &approval).unwrap_err();
-    assert!(err.contains("approval UI is not running"), "{err}");
+    assert!(err.contains("approval needed"), "{err}");
     let _ = std::fs::remove_dir_all(session_root(&approval_session).unwrap());
     let _ = std::fs::remove_dir_all(root);
 }
@@ -463,7 +463,7 @@ fn resolve_file_materialization_requires_approval_without_dashboard() {
 
     let err = approval_decision_for_resolve(&approval_session, &[PathBuf::from(".env.prod")])
         .unwrap_err();
-    assert!(err.contains("approval UI is not running"), "{err}");
+    assert!(err.contains("approval needed"), "{err}");
     let _ = std::fs::remove_dir_all(session_root(&approval_session).unwrap());
     let _ = std::fs::remove_dir_all(root);
 }
@@ -499,7 +499,7 @@ fn resolve_stdin_materialization_requires_approval_without_dashboard() {
     let input = "OPENAI_API_KEY=<<OPENAI_API_KEY_abcdef0123456789>>\n";
 
     let err = approval_decision_for_resolve_stdin(&approval_session, input).unwrap_err();
-    assert!(err.contains("approval UI is not running"), "{err}");
+    assert!(err.contains("approval needed"), "{err}");
     let _ = std::fs::remove_dir_all(session_root(&approval_session).unwrap());
     let _ = std::fs::remove_dir_all(root);
 }
@@ -901,7 +901,7 @@ fn write_tool_materialization_requires_approval_without_dashboard() {
     let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
         .as_str()
         .unwrap();
-    assert!(reason.contains("approval UI is not running"), "{reason}");
+    assert!(reason.contains("approval needed"), "{reason}");
     assert!(!reason.contains(raw), "{reason}");
     assert!(!config.exists());
     let _ = std::fs::remove_dir_all(project);


### PR DESCRIPTION
## Summary
- tighten the Pentect agent contract injected into Codex/Claude
- launch agents with the in-memory vault and default non-interactive approval for agent sessions
- keep explicit `no_approve = false` config authoritative
- pass Codex hook trust bypass in the real launch path, not only dry-run
- keep Codex PostToolUse on the known safe `decision/reason` path when tool output contains raw secrets

## Validation
- cargo fmt --all --check
- cargo test --workspace --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --release -p pentect-cli --bin pentect
- hook smoke tests for Codex PreToolUse/PostToolUse
- release help/string checks for no production bench command exposure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for automatically approving agent actions in supported CLI flows.
  - Updated CLI help text and contract messaging to reflect the latest agent/tool behavior.

- **Bug Fixes**
  - Improved approval handling when the dashboard isn’t running by showing clearer guidance.
  - Refined approval-bypass behavior to respect both config settings and environment-based overrides.
  - Standardized approval-related error messages to be more consistent across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->