### PR TITLE
Polish agent command wrapping UX

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -27,9 +27,9 @@ pub(crate) type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 const MAX_INPUT_BYTES: usize = 32 * 1024 * 1024;
 const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
     "Pentect agent contract:\n",
-    "- Use normal shell commands. Pentect hooks route stdout/stderr and tool results through masking.\n",
+    "- Use normal shell commands. Pentect hooks implicitly route stdout/stderr through `pentect exec \"<command>\"` and mask tool results.\n",
     "- You may read, fetch, transform, store, sync, and use user-authorized secrets. Pentect is the safety layer; raw secret values must not reach chat.\n",
-    "- Prefer one shell/Pentect command for secret work, e.g. `cat .env`, `pentect read .env`, service CLIs, or a command that reads a source and writes the exact requested destination.\n",
+    "- Prefer one normal shell command for secret work, e.g. `cat .env`, service CLIs, or a command that reads a source and writes the exact requested destination.\n",
     "- Masked handles like `<<NAME_hash>>` are in-memory capabilities for this running Pentect-launched session. Use `$env:NAME`/`$env:PENTECT_NAME_hash` on PowerShell or `$NAME`/`$PENTECT_NAME_hash` on Unix.\n",
     "- `pentect view '<handle>'` shows only label, hash, and length. Use handles/env capabilities instead of re-reading or printing raw values.\n",
     "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:NAME`; on Unix use POSIX commands and `$NAME`.\n",
@@ -98,7 +98,6 @@ fn help_text() -> &'static str {
         "  pentect\n",
         "  pentect --port 7331\n",
         "  pentect codex|claude [--extensions NAME|PATH.toml]\n",
-        "  pentect agent exec \"<command>\"\n",
         "  pentect exec \"<command>\"\n\n",
         "  pentect doctor [--json]\n",
         "  pentect extensions list|inspect|test [NAME|PATH] [--json]\n",
@@ -909,7 +908,6 @@ fn claude_settings_json(agent: &Path, session: Option<&str>) -> String {
 
 fn hook_command_unix(_agent: &Path, provider: &str, session: Option<&str>) -> String {
     let mut words = vec![
-        "agent".to_string(),
         "hook".to_string(),
         "--cli".to_string(),
         provider.to_string(),
@@ -931,7 +929,6 @@ fn hook_command_unix(_agent: &Path, provider: &str, session: Option<&str>) -> St
 
 fn hook_command_windows(_agent: &Path, provider: &str, session: Option<&str>) -> String {
     let mut words = vec![
-        "agent".to_string(),
         "hook".to_string(),
         "--cli".to_string(),
         provider.to_string(),
@@ -955,7 +952,6 @@ fn hook_words(agent: &Path, provider: &str, session: Option<&str>) -> Vec<String
     let agent = agent_command_path(agent);
     let mut words = vec![
         agent.to_string_lossy().into_owned(),
-        "agent".to_string(),
         "hook".to_string(),
         "--cli".to_string(),
         provider.to_string(),
@@ -1432,6 +1428,7 @@ mod tests {
     fn help_text_is_compact() {
         let help = help_text();
         assert!(help.contains("pentect exec"), "{help}");
+        assert!(!help.contains("agent exec"), "{help}");
         assert!(!help.contains("bench"), "{help}");
         assert!(help.contains("doctor: readiness"), "{help}");
         assert!(help.contains("extensions: list, inspect, test"), "{help}");
@@ -1451,14 +1448,13 @@ mod tests {
     }
 
     #[test]
-    fn hook_words_use_pentect_agent_subcommand() {
+    fn hook_words_use_pentect_hook_subcommand() {
         let pentect = absolute_pentect_fixture_path();
         let words = hook_words(&pentect, "codex", Some("demo"));
         assert_eq!(words[0], pentect.to_string_lossy().as_ref());
         assert_eq!(
             words[1..].to_vec(),
             vec![
-                "agent".to_string(),
                 "hook".to_string(),
                 "--cli".to_string(),
                 "codex".to_string(),
@@ -1491,12 +1487,7 @@ mod tests {
         assert_eq!(words[0], pentect.to_string_lossy().as_ref());
         assert_eq!(
             words[1..].to_vec(),
-            vec![
-                "agent".to_string(),
-                "hook".to_string(),
-                "--cli".to_string(),
-                "codex".to_string()
-            ]
+            vec!["hook".to_string(), "--cli".to_string(), "codex".to_string()]
         );
     }
 
@@ -1528,7 +1519,11 @@ mod tests {
         assert!(rendered.contains("developer_instructions="), "{rendered}");
         assert!(rendered.contains("Pentect agent contract"), "{rendered}");
         assert!(rendered.contains("Use normal shell commands"), "{rendered}");
-        assert!(rendered.contains("route stdout/stderr"), "{rendered}");
+        assert!(
+            rendered.contains("implicitly route stdout/stderr"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("pentect exec"), "{rendered}");
         assert!(rendered.contains("tool results"), "{rendered}");
         assert!(rendered.contains("Masked handles"), "{rendered}");
         assert!(rendered.contains("$env:NAME"), "{rendered}");
@@ -1539,7 +1534,7 @@ mod tests {
         );
         assert!(rendered.contains("PENTECT_"), "{rendered}");
         assert!(rendered.contains("pentect view"), "{rendered}");
-        assert!(rendered.contains("pentect read"), "{rendered}");
+        assert!(!rendered.contains("pentect read"), "{rendered}");
         assert!(rendered.contains("PowerShell"), "{rendered}");
         assert!(rendered.contains("Browser/MCP/connector"), "{rendered}");
         assert!(rendered.contains("storage/materialization"), "{rendered}");
@@ -1567,7 +1562,11 @@ mod tests {
         assert!(rendered.contains("--append-system-prompt"), "{rendered}");
         assert!(rendered.contains("Pentect agent contract"), "{rendered}");
         assert!(rendered.contains("Use normal shell commands"), "{rendered}");
-        assert!(rendered.contains("route stdout/stderr"), "{rendered}");
+        assert!(
+            rendered.contains("implicitly route stdout/stderr"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("pentect exec"), "{rendered}");
         assert!(rendered.contains("tool results"), "{rendered}");
         assert!(rendered.contains("$env:NAME"), "{rendered}");
         assert!(rendered.contains("user-authorized secrets"), "{rendered}");
@@ -1577,7 +1576,7 @@ mod tests {
         );
         assert!(rendered.contains("PENTECT_"), "{rendered}");
         assert!(rendered.contains("pentect view"), "{rendered}");
-        assert!(rendered.contains("pentect read"), "{rendered}");
+        assert!(!rendered.contains("pentect read"), "{rendered}");
         assert!(rendered.contains("PowerShell"), "{rendered}");
         assert!(rendered.contains("Browser/MCP/connector"), "{rendered}");
         assert!(rendered.contains("storage/materialization"), "{rendered}");

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -554,15 +554,10 @@ fn exec_help() {
             "pentect exec \"<command>\"\n",
             "pentect exec --stdin\n",
             "pentect exec --live \"<command>\"\n\n",
-            "Runs a command and prints normal stdout/stderr with secrets masked.\n",
-            "`--stdin` reads the shell script from stdin; hooks use it on PowerShell so quotes and pipes survive the outer shell.\n",
-            "Referenced `<<LABEL_hash>>` handles become PENTECT_LABEL_hash env vars in child commands while the same Pentect-launched agent session is running.\n",
-            "If prior output showed `KEY=<<...>>`, commands in that running session can reference KEY as an env var.\n",
-            "Set `no_approve = true` in `.pentect/config.toml` only when this project should bypass approval prompts.\n",
-            "Masked output registers in-memory capabilities; referenced local files are also scanned as hints.\n",
-            "Use normal commands and let Pentect return masked handles; do not hand-roll parsers to avoid output.\n",
-            "Use `$env:KEY` on PowerShell or `$KEY` on Unix; stdout/stderr stays masked.\n",
-            "Masked handles in command text resolve in memory before execution.\n",
+            "stdout/stderr: masked\n",
+            "handles: in memory\n",
+            "env: $env:KEY or $KEY\n",
+            "approve: .pentect/config.toml\n",
         )
     );
 }
@@ -2007,25 +2002,6 @@ impl ExecOpts {
                         mode: ExecMode::Shell(script),
                     });
                 }
-                "--script-handle" => {
-                    if stdin {
-                        return Err(
-                            "exec --stdin does not accept a script handle argument".to_string()
-                        );
-                    }
-                    let script = take_memory_script(&value(args, &mut i, "--script-handle")?)?;
-                    if i < args.len() {
-                        return Err(
-                            "exec --script-handle does not accept trailing arguments".to_string()
-                        );
-                    }
-                    return Ok(Self {
-                        session: checked_session_name(&session).map_err(|e| e.to_string())?,
-                        live,
-                        approve,
-                        mode: ExecMode::Shell(script),
-                    });
-                }
                 "--shell" => {
                     return Err(
                         "`--shell` was removed; use `pentect exec \"<command>\"`".to_string()
@@ -2084,16 +2060,6 @@ fn decode_script_base64(value: &str) -> Result<String, String> {
         .decode(value.as_bytes())
         .map_err(|_| "exec --script-b64 requires valid base64".to_string())?;
     String::from_utf8(bytes).map_err(|_| "exec --script-b64 requires UTF-8 text".to_string())
-}
-
-fn take_memory_script(id: &str) -> Result<String, String> {
-    if id.is_empty() || id.chars().any(|ch| !ch.is_ascii_hexdigit()) {
-        return Err("exec --script-handle requires a hex handle".to_string());
-    }
-    let client = MemoryVaultClient::from_env().ok_or_else(|| {
-        "exec --script-handle requires a running Pentect memory vault".to_string()
-    })?;
-    client.take_script(id).map_err(|e| e.to_string())
 }
 
 fn default_session_name() -> Result<String, String> {
@@ -2641,98 +2607,33 @@ fn wrap_shell_command(
     session_name: &str,
     masked_command: &str,
 ) -> Result<String, String> {
-    if cfg!(windows) {
-        if let Some(command) = powershell_memory_script_exec_command(session_name, masked_command)?
-        {
-            return Ok(command);
-        }
-        let mut args = agent_exec_args(session_name);
-        args.push("--stdin".to_string());
-        Ok(powershell_stdin_exec_command(&args, masked_command))
-    } else {
-        let mut args = agent_exec_args(session_name);
-        args.push(masked_command.to_string());
-        Ok(shell_agent_env_command(&args))
-    }
-}
-
-fn powershell_memory_script_exec_command(
-    session_name: &str,
-    script: &str,
-) -> Result<Option<String>, String> {
-    let Some(client) = MemoryVaultClient::from_env() else {
-        return Ok(None);
-    };
-    let handle = client.put_script(script).map_err(|e| e.to_string())?;
-    let mut args = vec!["agent".to_string(), "exec".to_string()];
+    let mut args = vec!["exec".to_string()];
     add_non_default_session(&mut args, session_name);
-    args.push("--script-handle".to_string());
-    args.push(handle);
-    Ok(Some(powershell_agent_env_command(&args)))
+    args.push(exec_shell_argument(masked_command));
+    Ok(visible_pentect_command(&args))
 }
 
-fn powershell_agent_env_command(args: &[String]) -> String {
-    let mut out = powershell_agent_env_setup();
-    out.push_str("; ");
-    out.push_str(&powershell_agent_env_invocation(args));
-    out
+fn exec_shell_argument(command: &str) -> String {
+    if command.starts_with('-') {
+        format!(" {command}")
+    } else {
+        command.to_string()
+    }
 }
 
-fn powershell_agent_env_setup() -> String {
-    String::from("$p=$env:PENTECT_BIN; if (-not $p) { $p='pentect' }")
-}
-
-fn powershell_agent_env_invocation(args: &[String]) -> String {
-    let mut out = String::from("& $p");
+fn visible_pentect_command(args: &[String]) -> String {
+    let quote = if cfg!(windows) {
+        powershell_word
+    } else {
+        shell_quote_unix
+    };
+    let mut out = String::from("pentect");
     if !args.is_empty() {
         out.push(' ');
         out.push_str(
             &args
                 .iter()
-                .map(|arg| powershell_word(arg))
-                .collect::<Vec<_>>()
-                .join(" "),
-        );
-    }
-    out
-}
-
-fn powershell_stdin_exec_command(args: &[String], script: &str) -> String {
-    if script.is_ascii() && !has_powershell_single_here_string_terminator(script) {
-        let setup = powershell_agent_env_setup();
-        let exec = powershell_agent_env_invocation(args);
-        return format!("{setup}\n@'\n{script}\n'@ | {exec}");
-    }
-    let encoded = data_encoding::BASE64.encode(script.as_bytes());
-    let mut args = args.to_vec();
-    if args.last().is_some_and(|word| word == "--stdin") {
-        args.pop();
-    }
-    args.push("--script-b64".to_string());
-    args.push(encoded);
-    powershell_agent_env_command(&args)
-}
-
-fn has_powershell_single_here_string_terminator(script: &str) -> bool {
-    script
-        .lines()
-        .any(|line| line.trim_end_matches('\r') == "'@")
-}
-
-fn agent_exec_args(session_name: &str) -> Vec<String> {
-    let mut words = vec!["agent".to_string(), "exec".to_string()];
-    add_non_default_session(&mut words, session_name);
-    words
-}
-
-fn shell_agent_env_command(args: &[String]) -> String {
-    let mut out = String::from("${PENTECT_BIN:-pentect}");
-    if !args.is_empty() {
-        out.push(' ');
-        out.push_str(
-            &args
-                .iter()
-                .map(|arg| shell_quote_unix(arg))
+                .map(|arg| quote(arg))
                 .collect::<Vec<_>>()
                 .join(" "),
         );

--- a/crates/pentect-runtime/src/memory_vault.rs
+++ b/crates/pentect-runtime/src/memory_vault.rs
@@ -1,12 +1,11 @@
 use crate::Result;
 use anyhow::{anyhow, bail, Context};
 use pentect_core::{Config, Recovery};
-use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroize;
 
 pub(crate) const ENV_ADDR: &str = "PENTECT_MEMORY_VAULT_ADDR";
 pub(crate) const ENV_TOKEN: &str = "PENTECT_MEMORY_VAULT_TOKEN";
@@ -28,7 +27,6 @@ pub(crate) struct MemoryVaultSnapshot {
 struct MemoryVaultState {
     key: [u8; 32],
     recovery: Recovery,
-    scripts: BTreeMap<String, Zeroizing<String>>,
 }
 
 impl Drop for MemoryVaultState {
@@ -82,29 +80,6 @@ impl MemoryVaultClient {
         }
     }
 
-    pub(crate) fn put_script(&self, script: &str) -> Result<String> {
-        let payload = data_encoding::BASE64.encode(script.as_bytes());
-        let line = self.request("PUT_SCRIPT", &payload)?;
-        let fields = response_fields(&line)?;
-        if fields.len() == 2 && fields[0] == "OK" && !fields[1].is_empty() {
-            Ok(fields[1].to_string())
-        } else {
-            bail!("memory vault put-script response is malformed")
-        }
-    }
-
-    pub(crate) fn take_script(&self, id: &str) -> Result<String> {
-        let line = self.request("TAKE_SCRIPT", id)?;
-        let fields = response_fields(&line)?;
-        if fields.len() != 2 || fields[0] != "OK" {
-            bail!("memory vault take-script response is malformed");
-        }
-        let bytes = data_encoding::BASE64
-            .decode(fields[1].as_bytes())
-            .context("memory vault script response is not valid base64")?;
-        String::from_utf8(bytes).context("memory vault script response is not UTF-8")
-    }
-
     fn request(&self, command: &str, payload: &str) -> Result<String> {
         let mut stream = TcpStream::connect(&self.addr)
             .with_context(|| format!("could not connect to memory vault at {}", self.addr))?;
@@ -148,7 +123,6 @@ fn serve_memory_vault_inner() -> Result<()> {
     let state = Arc::new(Mutex::new(MemoryVaultState {
         key,
         recovery: Recovery::empty_for_key(&key),
-        scripts: BTreeMap::new(),
     }));
     println!(
         "{}",
@@ -189,12 +163,6 @@ fn handle_client(
         [provided_token, "SNAPSHOT", ""] if *provided_token == token => snapshot_response(state),
         [provided_token, "ADD", payload] if *provided_token == token => {
             add_recovery_request(state, payload)
-        }
-        [provided_token, "PUT_SCRIPT", payload] if *provided_token == token => {
-            put_script_request(state, payload)
-        }
-        [provided_token, "TAKE_SCRIPT", payload] if *provided_token == token => {
-            take_script_request(state, payload)
         }
         [provided_token, ..] if *provided_token != token => Err(anyhow!("bad token")),
         _ => Err(anyhow!("malformed request")),
@@ -243,36 +211,6 @@ fn add_recovery_request(state: &Arc<Mutex<MemoryVaultState>>, payload: &str) -> 
     Ok("OK".to_string())
 }
 
-fn put_script_request(state: &Arc<Mutex<MemoryVaultState>>, payload: &str) -> Result<String> {
-    let bytes = data_encoding::BASE64
-        .decode(payload.as_bytes())
-        .context("script payload is not valid base64")?;
-    let script = String::from_utf8(bytes).context("script payload is not UTF-8")?;
-    let id = random_token_hex()?;
-    let mut guard = state
-        .lock()
-        .map_err(|_| anyhow!("memory vault lock poisoned"))?;
-    guard.scripts.insert(id.clone(), Zeroizing::new(script));
-    Ok(format!("OK\t{id}"))
-}
-
-fn take_script_request(state: &Arc<Mutex<MemoryVaultState>>, id: &str) -> Result<String> {
-    if id.is_empty() || id.chars().any(|ch| !ch.is_ascii_hexdigit()) {
-        bail!("script handle is malformed");
-    }
-    let mut guard = state
-        .lock()
-        .map_err(|_| anyhow!("memory vault lock poisoned"))?;
-    let script = guard
-        .scripts
-        .remove(id)
-        .ok_or_else(|| anyhow!("unknown script handle"))?;
-    Ok(format!(
-        "OK\t{}",
-        data_encoding::BASE64.encode(script.as_bytes())
-    ))
-}
-
 fn request_fields(line: &str) -> Vec<&str> {
     line.trim_end_matches(['\r', '\n']).split('\t').collect()
 }
@@ -319,7 +257,6 @@ mod tests {
         let state = Arc::new(Mutex::new(MemoryVaultState {
             key,
             recovery: Recovery::empty_for_key(&key),
-            scripts: BTreeMap::new(),
         }));
         let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let addr = listener.local_addr().unwrap().to_string();
@@ -351,15 +288,6 @@ mod tests {
             snapshot.recovery.resolve(&masked),
             "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n"
         );
-
-        let script_id = client
-            .put_script("Get-Content -LiteralPath $env:USERPROFILE")
-            .unwrap();
-        assert_eq!(
-            client.take_script(&script_id).unwrap(),
-            "Get-Content -LiteralPath $env:USERPROFILE"
-        );
-        assert!(client.take_script(&script_id).is_err());
     }
 
     #[test]
@@ -369,7 +297,6 @@ mod tests {
         let state = Arc::new(Mutex::new(MemoryVaultState {
             key,
             recovery: Recovery::empty_for_key(&key),
-            scripts: BTreeMap::new(),
         }));
         let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let addr = listener.local_addr().unwrap().to_string();

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1923,7 +1923,7 @@ fn pretool_canonicalizes_pentect_exec_shell_commands() {
 }
 
 #[test]
-fn pretool_preserves_powershell_sensitive_regex_pipe_via_stdin_wrapper() {
+fn pretool_preserves_powershell_sensitive_regex_pipe_in_visible_exec() {
     let (root, session) = empty_session("hook-pre-powershell-regex-pipe");
     let input = json!({
         "hook_event_name": "PreToolUse",
@@ -1940,20 +1940,16 @@ fn pretool_preserves_powershell_sensitive_regex_pipe_via_stdin_wrapper() {
         command.contains("TOKEN_ALPHA|TOKEN_BETA|TOKEN_GAMMA"),
         "{command}"
     );
-    if cfg!(windows) {
-        assert!(command.contains("--stdin"), "{command}");
-        assert!(command.starts_with("$p=$env:PENTECT_BIN"), "{command}");
-        assert!(command.contains("\n@'\n"), "{command}");
-        assert!(
-            !command.contains("'rg -n \"TOKEN_ALPHA|TOKEN_BETA|TOKEN_GAMMA\" -S .'"),
-            "{command}"
-        );
-    }
+    assert!(command.starts_with("pentect exec "), "{command}");
+    assert!(!command.contains("agent exec"), "{command}");
+    assert!(!command.contains("--stdin"), "{command}");
+    assert!(!command.contains("$env:PENTECT_BIN"), "{command}");
+    assert!(!command.contains("\n@'\n"), "{command}");
     let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
-fn pretool_uses_base64_script_wrapper_for_non_ascii_powershell_payloads() {
+fn pretool_keeps_non_ascii_payloads_readable_in_visible_exec() {
     let (root, session) = empty_session("hook-pre-powershell-unicode");
     let input = json!({
         "hook_event_name": "PreToolUse",
@@ -1966,12 +1962,11 @@ fn pretool_uses_base64_script_wrapper_for_non_ascii_powershell_payloads() {
     let command = output["hookSpecificOutput"]["updatedInput"]["command"]
         .as_str()
         .unwrap();
-    if cfg!(windows) {
-        assert!(command.contains("--script-b64"), "{command}");
-        assert!(!command.contains("--stdin --script-b64"), "{command}");
-        assert!(!command.contains("日本語"), "{command}");
-        assert!(!command.contains("@'\n"), "{command}");
-    }
+    assert!(command.starts_with("pentect exec "), "{command}");
+    assert!(command.contains("日本語|OK"), "{command}");
+    assert!(!command.contains("--script-b64"), "{command}");
+    assert!(!command.contains("--stdin"), "{command}");
+    assert!(!command.contains("@'\n"), "{command}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -2029,49 +2024,18 @@ fn implicit_directory_session_is_not_rendered_in_wrapped_command() {
 }
 
 #[test]
-fn powershell_memory_script_command_hides_script_body_and_agent_path() {
-    let command = powershell_agent_env_command(&[
-        "agent".to_string(),
-        "exec".to_string(),
-        "--script-handle".to_string(),
-        "abcdef123456".to_string(),
-    ]);
-    assert!(command.contains("$env:PENTECT_BIN"), "{command}");
-    assert!(command.contains("--script-handle"), "{command}");
-    assert!(!command.contains("C:\\Users"), "{command}");
-    assert!(!command.contains("Get-Content"), "{command}");
-}
+fn visible_exec_wrapper_is_short_and_user_facing() {
+    let command = wrap_shell_command(HookProvider::Codex, DEFAULT_SESSION, "cat .env").unwrap();
+    assert_eq!(command, "pentect exec 'cat .env'");
+    assert!(!command.contains("agent exec"), "{command}");
+    assert!(!command.contains("PENTECT_BIN"), "{command}");
+    assert!(!command.contains("--stdin"), "{command}");
 
-#[test]
-fn powershell_stdin_wrapper_uses_env_launcher_not_exe_path() {
-    let command = powershell_stdin_exec_command(
-        &[
-            "agent".to_string(),
-            "exec".to_string(),
-            "--stdin".to_string(),
-        ],
-        "Get-Content -LiteralPath .env",
-    );
-    assert!(command.contains("$env:PENTECT_BIN"), "{command}");
-    assert!(command.contains("}\n@'"), "{command}");
-    assert!(command.contains("agent exec --stdin"), "{command}");
-    assert!(!command.contains("| $p="), "{command}");
-    assert!(!command.contains("C:\\Users"), "{command}");
-}
-
-#[test]
-fn unix_wrapper_uses_env_launcher_not_exe_path() {
-    let command = shell_agent_env_command(&[
-        "agent".to_string(),
-        "exec".to_string(),
-        "cat .env".to_string(),
-    ]);
-    assert!(
-        command.starts_with("${PENTECT_BIN:-pentect} agent exec"),
-        "{command}"
-    );
-    assert!(command.contains("'cat .env'"), "{command}");
-    assert!(!command.contains("/Users/"), "{command}");
+    let command = wrap_shell_command(HookProvider::Codex, DEFAULT_SESSION, "--version").unwrap();
+    assert_eq!(command, "pentect exec ' --version'");
+    let args = strings(["pentect", "exec", " --version"]);
+    let opts = ExecOpts::parse(&args).unwrap();
+    assert!(matches!(opts.mode, ExecMode::Shell(command) if command == " --version"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Wrap shell tools as short `pentect exec '<command>'` commands instead of visible internal `agent exec`/stdin/script wrappers.
- Generate hook configs as `pentect hook --cli ...` and remove `agent exec` from user-facing help.
- Remove the unused in-memory script handle path and update the agent contract to say hooks implicitly use `pentect exec`.

## Verification
- cargo fmt --all --check
- cargo test --workspace --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo install --path crates/pentect-cli --bin pentect --force --locked
- tmux probe: `pentect codex` ran `pentect exec 'Write-Output ...'`, output was masked, no PostToolUse hook failure/block