### PR TITLE
Support generic external tool hooks

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -33,7 +33,7 @@ const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
     "- Masked handles like `<<NAME_hash>>` are in-memory capabilities for this running Pentect-launched session. Use `$env:NAME`/`$env:PENTECT_NAME_hash` on PowerShell or `$NAME`/`$PENTECT_NAME_hash` on Unix.\n",
     "- `pentect view '<handle>'` shows only label, hash, and length. Use handles/env capabilities instead of re-reading or printing raw values.\n",
     "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:NAME`; on Unix use POSIX commands and `$NAME`.\n",
-    "- Browser/MCP/connector tools are OK for navigation and metadata. If a raw secret must move, route it through shell/Pentect or a local file/service command so output is masked.\n",
+    "- Browser/MCP/connector tools may retrieve and use user-authorized secrets. Pentect hooks mask returned tool output when the host supports it; use shell/Pentect for hosts that cannot safely replace tool output.\n",
     "- For user-requested storage/materialization, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
     "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
 );

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1735,6 +1735,7 @@ fn exit_code(status: ExitStatus) -> i32 {
 enum HookProvider {
     Codex,
     Claude,
+    Generic,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1743,6 +1744,74 @@ enum HookPhase {
     AfterTool,
     Other,
 }
+
+// Hook hosts disagree on casing and envelope names. Keep that compatibility at
+// the boundary; detection still walks the returned JSON structure generically.
+const HOOK_EVENT_FIELDS: &[&str] = &[
+    "hook_event_name",
+    "hookEventName",
+    "event_name",
+    "eventName",
+    "event",
+];
+const HOOK_TOOL_NAME_FIELDS: &[&str] = &["tool_name", "toolName", "name", "tool"];
+const HOOK_TOOL_INPUT_FIELDS: &[&str] = &[
+    "tool_input",
+    "toolInput",
+    "tool_arguments",
+    "toolArguments",
+    "arguments",
+    "args",
+    "input",
+];
+const HOOK_TOOL_RESULT_FIELDS: &[&str] = &[
+    "tool_response",
+    "toolResponse",
+    "tool_output",
+    "toolOutput",
+    "tool_result",
+    "toolResult",
+    "call_tool_result",
+    "callToolResult",
+    "mcp_result",
+    "mcpResult",
+    "mcp_tool_result",
+    "mcpToolResult",
+    "structured_content",
+    "response",
+    "result",
+    "output",
+    "payload",
+    "data",
+    "body",
+    "content",
+    "structuredContent",
+];
+const WRITE_INPUT_FIELDS: &[&str] = &[
+    "arguments",
+    "args",
+    "input",
+    "tool_input",
+    "toolInput",
+    "tool_arguments",
+    "toolArguments",
+];
+const WRITE_PATH_FIELDS: &[&str] = &[
+    "file_path",
+    "filePath",
+    "filepath",
+    "path",
+    "filename",
+    "fileName",
+];
+const WRITE_CONTENT_FIELDS: &[&str] = &[
+    "content",
+    "file_content",
+    "fileContent",
+    "text",
+    "data",
+    "body",
+];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum InputFormat {
@@ -1889,7 +1958,8 @@ impl HookOpts {
             }
         }
         Ok(Self {
-            provider: provider.ok_or_else(|| "hook requires cli: codex or claude".to_string())?,
+            provider: provider
+                .ok_or_else(|| "hook requires cli: codex, claude, or generic".to_string())?,
             session,
             cli,
         })
@@ -2096,10 +2166,10 @@ fn handle_hook(
 ) -> Result<Value, String> {
     match hook_phase(provider, &input) {
         HookPhase::BeforeTool => {
-            let Some(tool_input) = hook_field(&input, &["tool_input"]) else {
+            let Some(tool_input) = hook_tool_input(&input) else {
                 return Ok(json!({}));
             };
-            let tool_name = hook_field(&input, &["tool_name"])
+            let tool_name = hook_tool_name(&input)
                 .and_then(Value::as_str)
                 .unwrap_or_default();
             let (updated, changed) = match before_tool_updated_input(
@@ -2144,10 +2214,10 @@ fn handle_hook_lazy(
 ) -> Result<Value, String> {
     match hook_phase(provider, &input) {
         HookPhase::BeforeTool => {
-            let Some(tool_input) = hook_field(&input, &["tool_input"]) else {
+            let Some(tool_input) = hook_tool_input(&input) else {
                 return Ok(json!({}));
             };
-            let tool_name = hook_field(&input, &["tool_name"])
+            let tool_name = hook_tool_name(&input)
                 .and_then(Value::as_str)
                 .unwrap_or_default();
             let (updated, changed) = match before_tool_updated_input_lazy(
@@ -2376,8 +2446,8 @@ fn is_write_like_tool_name(tool_name: &str) -> bool {
 fn write_path_and_content(value: &Value) -> Option<(&str, &str)> {
     for candidate in write_input_candidates(value) {
         if let (Some(path), Some(content)) = (
-            string_field(candidate, &["file_path", "filepath", "path", "filename"]),
-            string_field(candidate, &["content", "file_content", "text", "data"]),
+            string_field(candidate, WRITE_PATH_FIELDS),
+            string_field(candidate, WRITE_CONTENT_FIELDS),
         ) {
             return Some((path, content));
         }
@@ -2387,7 +2457,7 @@ fn write_path_and_content(value: &Value) -> Option<(&str, &str)> {
 
 fn write_input_candidates(value: &Value) -> Vec<&Value> {
     let mut out = vec![value];
-    for key in ["arguments", "input", "tool_input"] {
+    for key in WRITE_INPUT_FIELDS {
         if let Some(candidate) = value.get(key) {
             out.push(candidate);
         }
@@ -2656,7 +2726,7 @@ fn should_emit_session_arg(session_name: &str) -> bool {
 fn hook_phase(provider: HookProvider, input: &Value) -> HookPhase {
     let event = hook_event_name(input).unwrap_or_default();
     match provider {
-        HookProvider::Codex | HookProvider::Claude => match event {
+        HookProvider::Codex | HookProvider::Claude | HookProvider::Generic => match event {
             "PreToolUse" => HookPhase::BeforeTool,
             "PostToolUse" => HookPhase::AfterTool,
             _ => HookPhase::Other,
@@ -2665,35 +2735,28 @@ fn hook_phase(provider: HookProvider, input: &Value) -> HookPhase {
 }
 
 fn hook_event_name(input: &Value) -> Option<&str> {
-    hook_field(input, &["hook_event_name", "event_name", "event"]).and_then(Value::as_str)
+    hook_field(input, HOOK_EVENT_FIELDS).and_then(Value::as_str)
 }
 
 fn hook_field<'a>(input: &'a Value, names: &[&str]) -> Option<&'a Value> {
     names.iter().find_map(|name| input.get(*name))
 }
 
+fn hook_tool_name(input: &Value) -> Option<&Value> {
+    hook_field(input, HOOK_TOOL_NAME_FIELDS)
+}
+
+fn hook_tool_input(input: &Value) -> Option<&Value> {
+    hook_field(input, HOOK_TOOL_INPUT_FIELDS)
+}
+
 fn hook_tool_result(input: &Value) -> Option<&Value> {
-    hook_field(
-        input,
-        &[
-            "tool_response",
-            "tool_output",
-            "tool_result",
-            "call_tool_result",
-            "mcp_result",
-            "mcp_tool_result",
-            "response",
-            "result",
-            "output",
-            "content",
-            "structuredContent",
-        ],
-    )
+    hook_field(input, HOOK_TOOL_RESULT_FIELDS)
 }
 
 fn before_tool_output(provider: HookProvider, updated_input: Value) -> Value {
     match provider {
-        HookProvider::Codex | HookProvider::Claude => json!({
+        HookProvider::Codex | HookProvider::Claude | HookProvider::Generic => json!({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "permissionDecision": "allow",
@@ -2705,7 +2768,7 @@ fn before_tool_output(provider: HookProvider, updated_input: Value) -> Value {
 
 fn before_tool_block_output(provider: HookProvider, reason: &str) -> Value {
     match provider {
-        HookProvider::Codex | HookProvider::Claude => json!({
+        HookProvider::Codex | HookProvider::Claude | HookProvider::Generic => json!({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "permissionDecision": "deny",
@@ -2717,7 +2780,7 @@ fn before_tool_block_output(provider: HookProvider, reason: &str) -> Value {
 
 fn after_tool_output(provider: HookProvider, updated_output: Value) -> Value {
     match provider {
-        HookProvider::Claude => json!({
+        HookProvider::Claude | HookProvider::Generic => json!({
             "hookSpecificOutput": {
                 "hookEventName": "PostToolUse",
                 "updatedToolOutput": updated_output
@@ -3083,6 +3146,7 @@ fn parse_hook_provider(value: &str) -> Result<HookProvider, String> {
     match value {
         "codex" => Ok(HookProvider::Codex),
         "claude" => Ok(HookProvider::Claude),
+        "generic" | "external" | "update" => Ok(HookProvider::Generic),
         other => Err(format!("unknown hook provider: {other}")),
     }
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1778,6 +1778,7 @@ const HOOK_TOOL_RESULT_FIELDS: &[&str] = &[
     "mcp_tool_result",
     "mcpToolResult",
     "structured_content",
+    "structuredContent",
     "response",
     "result",
     "output",
@@ -1785,7 +1786,6 @@ const HOOK_TOOL_RESULT_FIELDS: &[&str] = &[
     "data",
     "body",
     "content",
-    "structuredContent",
 ];
 const WRITE_INPUT_FIELDS: &[&str] = &[
     "arguments",
@@ -1958,8 +1958,9 @@ impl HookOpts {
             }
         }
         Ok(Self {
-            provider: provider
-                .ok_or_else(|| "hook requires cli: codex, claude, or generic".to_string())?,
+            provider: provider.ok_or_else(|| {
+                "hook requires a provider after --cli: codex, claude, or generic".to_string()
+            })?,
             session,
             cli,
         })

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -933,6 +933,41 @@ fn write_tool_refuses_masked_materialization_outside_current_dir() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+#[test]
+fn write_tool_accepts_camel_case_external_schema() {
+    let root = temp_root("capability-write-camel");
+    let project = PathBuf::from("target").join(format!(
+        "pentect-write-camel-{}-{}",
+        std::process::id(),
+        unix_millis()
+    ));
+    let _ = std::fs::remove_dir_all(&project);
+    std::fs::create_dir_all(&project).unwrap();
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let masked = mask_tool_output(&session, &format!("token={raw}\n")).unwrap();
+
+    let config = project.join("config.txt");
+    let input = json!({
+        "hookEventName": "PreToolUse",
+        "toolName": "external__write_file",
+        "toolInput": {
+            "filePath": config.to_string_lossy(),
+            "fileContent": masked
+        }
+    });
+    let output = handle_hook(HookProvider::Generic, "t", &session, input).unwrap();
+    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
+    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .unwrap();
+    assert!(reason.contains("approval needed"), "{reason}");
+    assert!(!reason.contains(raw), "{reason}");
+    assert!(!config.exists());
+    let _ = std::fs::remove_dir_all(project);
+    let _ = std::fs::remove_dir_all(root);
+}
+
 #[cfg(unix)]
 #[test]
 fn write_tool_refuses_masked_materialization_through_symlink_dir() {
@@ -1026,6 +1061,57 @@ fn mcp_style_tool_result_masks_content_and_structured_content() {
     );
     assert!(updated.is_object(), "{updated}");
     assert!(updated["structuredContent"]["otp"].is_string(), "{updated}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn generic_posttool_masks_external_tool_response_aliases() {
+    let (root, session) = empty_session("hook-post-generic-aliases");
+    let raw_runpod = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let raw_openai = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let input = json!({
+        "hookEventName": "PostToolUse",
+        "toolName": "connector__browser__create_api_key",
+        "toolResponse": {
+            "content": [{
+                "type": "text",
+                "text": format!("RUNPOD_API_KEY={raw_runpod}")
+            }],
+            "structured_content": {
+                "apiKey": raw_openai
+            },
+            "data": {
+                "Authorization": format!("Bearer {raw_openai}")
+            }
+        }
+    });
+    let output = handle_hook(HookProvider::Generic, "t", &session, input).unwrap();
+    let updated = &output["hookSpecificOutput"]["updatedToolOutput"];
+    let rendered = serde_json::to_string(updated).unwrap();
+    assert!(rendered.contains("<<RUNPOD_API_KEY_"), "{rendered}");
+    assert!(rendered.contains("<<OPENAI_API_KEY_"), "{rendered}");
+    assert!(!rendered.contains(raw_runpod), "{rendered}");
+    assert!(!rendered.contains(raw_openai), "{rendered}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn generic_posttool_masks_payload_alias() {
+    let (root, session) = empty_session("hook-post-generic-payload");
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let input = json!({
+        "eventName": "PostToolUse",
+        "tool": "connector",
+        "payload": {
+            "stdout": format!("OPENAI_API_KEY={raw}\n"),
+            "ok": true
+        }
+    });
+    let output = handle_hook(HookProvider::Generic, "t", &session, input).unwrap();
+    let rendered = serde_json::to_string(&output).unwrap();
+    assert!(rendered.contains("updatedToolOutput"), "{rendered}");
+    assert!(rendered.contains("<<OPENAI_API_KEY_"), "{rendered}");
+    assert!(!rendered.contains(raw), "{rendered}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -1972,7 +2058,11 @@ fn pretool_keeps_non_ascii_payloads_readable_in_visible_exec() {
 
 #[test]
 fn pretool_wraps_plain_shell_commands_for_every_provider() {
-    for provider in [HookProvider::Codex, HookProvider::Claude] {
+    for provider in [
+        HookProvider::Codex,
+        HookProvider::Claude,
+        HookProvider::Generic,
+    ] {
         let (root, session) = empty_session("hook-pre-provider");
         let input = json!({
             "hook_event_name": "PreToolUse",
@@ -1990,6 +2080,27 @@ fn pretool_wraps_plain_shell_commands_for_every_provider() {
         assert!(!command.contains("--shell-b64"), "{command}");
         let _ = std::fs::remove_dir_all(root);
     }
+}
+
+#[test]
+fn pretool_wraps_camel_case_external_tool_input() {
+    let (root, session) = empty_session("hook-pre-camel");
+    let input = json!({
+        "hookEventName": "PreToolUse",
+        "toolName": "shell",
+        "toolInput": {
+            "command": r"Get-Content .\.env"
+        }
+    });
+    let output = handle_hook(HookProvider::Generic, DEFAULT_SESSION, &session, input).unwrap();
+    let command = output["hookSpecificOutput"]["updatedInput"]["command"]
+        .as_str()
+        .unwrap();
+    assert!(command.contains("pentect"), "{command}");
+    assert!(command.contains("exec"), "{command}");
+    assert!(command.contains("Get-Content"), "{command}");
+    assert!(!command.contains("--shell-b64"), "{command}");
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a generic hook provider for external hosts that can replace PostToolUse output
- accept common camelCase/snake_case hook envelope aliases for tool input, tool output, and write materialization
- relax the agent contract so Browser/MCP/connector tools may retrieve user-authorized secrets when the host can safely mask returned output

## Validation
- cargo test -p pentect-runtime --all-features
- cargo test -p pentect-cli --all-features contract
- cargo test --workspace --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- manual hook smoke for generic and Claude PostToolUse output replacement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional hook provider mode, expanding compatibility with more tooling setups.
  * Improved handling of hook events so more input formats and field-name variants are recognized.

* **Bug Fixes**
  * Better masking of tool output when sensitive values are returned.
  * Improved approval handling for write actions, including cases using alternate field naming.
  * Extended pre-tool wrapping to work consistently across all supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->