### PR TITLE
Keep exec environment pass-through

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -21,7 +21,7 @@ use approve_ui::{ApprovalDecision, ApprovalRequest};
 use config::{approval_bypassed_by_config, approval_config_state};
 use masking::{
     contains_unresolved_masked_handle, env_alias_recovery, is_ascii_word_char, is_env_name_byte,
-    is_sensitive_env_name, live_output_kind, OutputMasker, ToolScalarInput,
+    live_output_kind, OutputMasker, ToolScalarInput,
 };
 #[cfg(test)]
 use masking::{first_reusable_env_name, mask_live_output, mask_tool_output};
@@ -349,7 +349,7 @@ fn cmd_exec(args: &[String]) -> i32 {
         Err(e) => return die(&e),
     };
     if opts.approve {
-        match request_approval(&store, &opts, &approval, false) {
+        match request_approval(&opts, &approval, false) {
             Ok(ApprovalDecision::Once) => {}
             Ok(ApprovalDecision::Always) => {
                 if let Err(e) = ApprovalQueue::open(&opts.session).and_then(|queue| {
@@ -582,7 +582,7 @@ fn cmd_approve(args: &[String]) -> i32 {
         Ok(approval) => approval,
         Err(e) => return die(&e),
     };
-    match request_approval(&store, &opts, &approval, true) {
+    match request_approval(&opts, &approval, true) {
         Ok(ApprovalDecision::Once) => 0,
         Ok(ApprovalDecision::Always) => match ApprovalQueue::open(&opts.session)
             .and_then(|queue| queue.record(&approval.ticket(), ApprovalDecision::Always, "local"))
@@ -622,7 +622,6 @@ fn cmd_vault(args: &[String]) -> i32 {
 }
 
 fn request_approval(
-    store: &RecoveryStore,
     opts: &ExecOpts,
     approval: &ExecApproval,
     preview: bool,
@@ -640,37 +639,13 @@ fn request_approval(
         approve_label: "once".to_string(),
         deny_label: "decline".to_string(),
         allow_always: true,
-        warnings: approval_warnings(store, opts, approval)?,
+        warnings: approval_warnings(opts, approval),
     };
     approve_ui::run(&request).map_err(|e| e.to_string())
 }
 
-fn approval_warnings(
-    store: &RecoveryStore,
-    opts: &ExecOpts,
-    approval: &ExecApproval,
-) -> Result<Vec<String>, String> {
+fn approval_warnings(opts: &ExecOpts, approval: &ExecApproval) -> Vec<String> {
     let mut warnings = Vec::new();
-    let env = requested_env_bindings(store, &opts.mode)?;
-    let policy = exec_env_policy(&env);
-    let guard = match &opts.mode {
-        ExecMode::Program(args) => {
-            let resolved_args = resolve_command_args(store, args)?;
-            let program = resolved_args
-                .first()
-                .map(String::as_str)
-                .unwrap_or_default();
-            guard_program_invocation_with_env(program, &resolved_args[1..], &policy)
-        }
-        ExecMode::Shell(_) => {
-            let command = resolve_command_text(store, &approval.command)?;
-            guard_shell_script_with_env(&command, &policy)
-        }
-        ExecMode::Stdin => Err("internal error: exec stdin was not materialized".to_string()),
-    };
-    if let Err(reason) = guard {
-        warnings.push(reason);
-    }
     if opts.live {
         warnings.push("live output is masked in chunks".to_string());
     }
@@ -683,7 +658,7 @@ fn approval_warnings(
     if approval.materialize_like && approval.requires_approval() {
         warnings.push("this command may write approved capabilities to local files".to_string());
     }
-    Ok(warnings)
+    warnings
 }
 
 fn approval_decision_for_exec(
@@ -1111,14 +1086,12 @@ fn run_resolved_command(
                 return Err("exec requires a program after `--`".to_string());
             }
             let env = requested_env_bindings(store, &opts.mode)?;
-            let env_policy = exec_env_policy(&env);
             let resolved_args = resolve_command_args(store, args)?;
             let program = &resolved_args[0];
             let command_args = &resolved_args[1..];
-            guard_program_invocation_with_env(program, command_args, &env_policy)?;
             let mut command = Command::new(program);
             command.args(command_args);
-            apply_protected_child_env(&mut command, &env, &opts.session);
+            apply_child_env_overlays(&mut command, &env, &opts.session);
             command
                 .output()
                 .map_err(|e| format!("could not execute command: {e}"))
@@ -1127,8 +1100,6 @@ fn run_resolved_command(
             let command = resolve_command_text(store, command)?;
             register_local_file_inputs(store, &command)?;
             let env = requested_env_bindings(store, &opts.mode)?;
-            let env_policy = exec_env_policy(&env);
-            guard_shell_script_with_env(&command, &env_policy)?;
             run_shell_script(&command, &env, &opts.session)
         }
         ExecMode::Stdin => Err("internal error: exec stdin was not materialized".to_string()),
@@ -1142,24 +1113,20 @@ fn run_resolved_command_live(store: &RecoveryStore, opts: &ExecOpts) -> Result<E
                 return Err("exec requires a program after `--`".to_string());
             }
             let env = requested_env_bindings(store, &opts.mode)?;
-            let env_policy = exec_env_policy(&env);
             let resolved_args = resolve_command_args(store, args)?;
             let program = &resolved_args[0];
             let command_args = &resolved_args[1..];
-            guard_program_invocation_with_env(program, command_args, &env_policy)?;
             let mut command = Command::new(program);
             command.args(command_args);
-            apply_protected_child_env(&mut command, &env, &opts.session);
+            apply_child_env_overlays(&mut command, &env, &opts.session);
             run_live_command(command, None, store.clone())
         }
         ExecMode::Shell(command) => {
             let command = resolve_command_text(store, command)?;
             register_local_file_inputs(store, &command)?;
             let env = requested_env_bindings(store, &opts.mode)?;
-            let env_policy = exec_env_policy(&env);
-            guard_shell_script_with_env(&command, &env_policy)?;
             let mut shell = shell_script_command();
-            apply_protected_child_env(&mut shell, &env, &opts.session);
+            apply_child_env_overlays(&mut shell, &env, &opts.session);
             run_live_command(shell, Some(&command), store.clone())
         }
         ExecMode::Stdin => Err("internal error: exec stdin was not materialized".to_string()),
@@ -1201,52 +1168,9 @@ fn resolve_path_in_place(store: &RecoveryStore, path: &Path) -> Result<(), Strin
     Ok(())
 }
 
-fn apply_protected_child_env(command: &mut Command, env: &[(String, String)], session: &str) {
-    command.env_clear();
-    apply_safe_parent_env(command);
+fn apply_child_env_overlays(command: &mut Command, env: &[(String, String)], session: &str) {
     apply_env_bindings(command, env);
     apply_pentect_session(command, session);
-}
-
-fn apply_safe_parent_env(command: &mut Command) {
-    for name in safe_parent_env_names() {
-        if let Some(value) = std::env::var_os(name) {
-            command.env(name, value);
-        }
-    }
-}
-
-fn safe_parent_env_names() -> &'static [&'static str] {
-    if cfg!(windows) {
-        &[
-            "Path",
-            "PATH",
-            "PATHEXT",
-            "SystemRoot",
-            "SYSTEMROOT",
-            "WINDIR",
-            "COMSPEC",
-            "TEMP",
-            "TMP",
-            "USERPROFILE",
-            "PENTECT_BIN",
-            "PENTECT_HOME",
-            "PENTECT_SESSION",
-        ]
-    } else {
-        &[
-            "PATH",
-            "HOME",
-            "SHELL",
-            "TERM",
-            "LANG",
-            "LC_ALL",
-            "TMPDIR",
-            "PENTECT_BIN",
-            "PENTECT_HOME",
-            "PENTECT_SESSION",
-        ]
-    }
 }
 
 fn apply_env_bindings(command: &mut Command, env: &[(String, String)]) {
@@ -1257,34 +1181,6 @@ fn apply_env_bindings(command: &mut Command, env: &[(String, String)]) {
 
 fn apply_pentect_session(command: &mut Command, session: &str) {
     command.env("PENTECT_SESSION", session);
-}
-
-#[derive(Debug, Default)]
-struct EnvPolicy {
-    allowed: Vec<String>,
-}
-
-impl EnvPolicy {
-    fn allows_direct_read(&self, name: &str) -> bool {
-        self.is_allowed(name)
-    }
-
-    fn blocks_shell_var_read(&self, name: &str) -> bool {
-        is_sensitive_env_name(name) && !self.is_allowed(name)
-    }
-
-    fn is_allowed(&self, name: &str) -> bool {
-        let normalized = name.to_ascii_lowercase();
-        self.allowed.iter().any(|allowed| allowed == &normalized)
-    }
-}
-
-fn exec_env_policy(env: &[(String, String)]) -> EnvPolicy {
-    let mut allowed = Vec::new();
-    for (name, _) in env {
-        push_unique_env_name(&mut allowed, name);
-    }
-    EnvPolicy { allowed }
 }
 
 fn requested_env_bindings(
@@ -1414,44 +1310,6 @@ fn collect_printenv_refs(text: &str, out: &mut BTreeSet<String>) {
     }
 }
 
-fn push_unique_env_name(names: &mut Vec<String>, name: &str) {
-    let normalized = name.to_ascii_lowercase();
-    if !names.iter().any(|existing| existing == &normalized) {
-        names.push(normalized);
-    }
-}
-
-fn guard_program_invocation_with_env(
-    program: &str,
-    args: &[String],
-    env_policy: &EnvPolicy,
-) -> Result<(), String> {
-    let mut text = String::from(program);
-    for arg in args {
-        text.push(' ');
-        text.push_str(arg);
-    }
-    guard_sensitive_source_access_with_env(&text, env_policy)
-}
-
-fn guard_shell_script_with_env(script: &str, env_policy: &EnvPolicy) -> Result<(), String> {
-    guard_sensitive_source_access_with_env(script, env_policy)
-}
-
-fn guard_sensitive_source_access_with_env(
-    text: &str,
-    env_policy: &EnvPolicy,
-) -> Result<(), String> {
-    let normalized = normalize_policy_text(text);
-    if contains_env_read_reference(&normalized, env_policy) {
-        return Err(
-            "Pentect only exposes environment variables that came from prior masked output. Run the source command through `pentect exec`; if it prints `KEY=<<...>>`, use `$env:KEY` on PowerShell or `$KEY` on Unix in later `pentect exec` commands."
-                .to_string(),
-        );
-    }
-    Ok(())
-}
-
 fn register_local_file_inputs(store: &RecoveryStore, script: &str) -> Result<(), String> {
     let paths = local_file_input_paths(script);
     if paths.is_empty() {
@@ -1542,7 +1400,7 @@ fn run_shell_script(
     session: &str,
 ) -> Result<std::process::Output, String> {
     let mut command = shell_script_command();
-    apply_protected_child_env(&mut command, env, session);
+    apply_child_env_overlays(&mut command, env, session);
     let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -3164,93 +3022,12 @@ fn normalize_policy_text(text: &str) -> String {
     text.to_ascii_lowercase().replace('\\', "/")
 }
 
-fn contains_env_read_reference(normalized: &str, env_policy: &EnvPolicy) -> bool {
-    has_disallowed_powershell_env_ref(normalized, env_policy)
-        || normalized.contains(" env:")
-        || normalized.starts_with("env:")
-        || normalized.contains("[environment]::getenvironmentvariable")
-        || normalized.contains("[environment]::getenvironmentvariables")
-        || has_disallowed_printenv_reference(normalized, env_policy)
-        || references_sensitive_env_name(normalized, env_policy)
-}
-
-fn has_disallowed_powershell_env_ref(normalized: &str, env_policy: &EnvPolicy) -> bool {
-    let mut offset = 0usize;
-    while let Some(index) = normalized[offset..].find("$env:") {
-        let name_start = offset + index + "$env:".len();
-        let mut name_end = name_start;
-        let bytes = normalized.as_bytes();
-        while name_end < bytes.len() && is_env_name_byte(bytes[name_end]) {
-            name_end += 1;
-        }
-        if name_end == name_start {
-            return true;
-        }
-        if !env_policy.allows_direct_read(&normalized[name_start..name_end]) {
-            return true;
-        }
-        offset = name_end;
-    }
-    false
-}
-
-fn has_disallowed_printenv_reference(normalized: &str, env_policy: &EnvPolicy) -> bool {
-    let mut offset = 0usize;
-    while let Some(index) = normalized[offset..].find("printenv") {
-        let word_start = offset + index;
-        let word_end = word_start + "printenv".len();
-        let before = normalized[..word_start].chars().next_back();
-        let after = normalized[word_end..].chars().next();
-        if !is_ascii_word_char(before) && !is_ascii_word_char(after) {
-            let mut cursor = word_end;
-            let mut saw_name = false;
-            while let Some((word, _, next)) = next_shell_word(normalized, cursor) {
-                if is_shell_separator_word(&word) {
-                    break;
-                }
-                if word.starts_with('-') || !looks_like_env_name(&word) {
-                    return true;
-                }
-                saw_name = true;
-                if !env_policy.allows_direct_read(&word) {
-                    return true;
-                }
-                cursor = next;
-            }
-            if !saw_name {
-                return true;
-            }
-        }
-        offset = word_end;
-    }
-    false
-}
-
 fn is_shell_separator_word(word: &str) -> bool {
     matches!(word, "|" | ";" | "&&" | "||") || word.starts_with('<') || word.starts_with('>')
 }
 
 fn looks_like_env_name(name: &str) -> bool {
     !name.is_empty() && !name.as_bytes()[0].is_ascii_digit() && name.bytes().all(is_env_name_byte)
-}
-
-fn references_sensitive_env_name(normalized: &str, env_policy: &EnvPolicy) -> bool {
-    let bytes = normalized.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        let marker = bytes[i] as char;
-        if marker == '$' || marker == '%' {
-            if let Some((name, next)) = env_name_after_marker(normalized, i + 1, marker) {
-                if env_policy.blocks_shell_var_read(name) {
-                    return true;
-                }
-                i = next;
-                continue;
-            }
-        }
-        i += 1;
-    }
-    false
 }
 
 fn env_name_after_marker(text: &str, start: usize, marker: char) -> Option<(&str, usize)> {

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -25,7 +25,7 @@ use masking::{
 };
 #[cfg(test)]
 use masking::{first_reusable_env_name, mask_live_output, mask_tool_output};
-use memory_vault::MemoryVaultClient;
+use memory_vault::{MemoryVaultClient, ENV_ADDR, ENV_TOKEN};
 use pentect_core::{
     infer_kind, parse_placeholder, Config, Engine, Input, Kind, MaskResult, Pack, Profile,
     RegionKind,
@@ -1169,6 +1169,8 @@ fn resolve_path_in_place(store: &RecoveryStore, path: &Path) -> Result<(), Strin
 }
 
 fn apply_child_env_overlays(command: &mut Command, env: &[(String, String)], session: &str) {
+    command.env_remove(ENV_ADDR);
+    command.env_remove(ENV_TOKEN);
     apply_env_bindings(command, env);
     apply_pentect_session(command, session);
 }

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -82,9 +82,9 @@ fn exec_parse_accepts_live_and_approve_without_env_flags() {
 }
 
 #[test]
-fn protected_child_env_does_not_inherit_memory_vault_credentials() {
+fn child_env_overlays_do_not_add_memory_vault_credentials() {
     let mut cmd = Command::new("echo");
-    apply_protected_child_env(&mut cmd, &[], "demo");
+    apply_child_env_overlays(&mut cmd, &[], "demo");
     let envs: Vec<_> = cmd
         .get_envs()
         .map(|(name, _)| name.to_string_lossy().to_string())
@@ -290,25 +290,43 @@ fn read_dotenv_masks_all_values() {
 
 #[test]
 fn exec_allows_secret_file_reads_because_output_is_remasked() {
-    guard_shell_script_with_env(r"Get-Content .\.env", &EnvPolicy::default()).unwrap();
-    guard_shell_script_with_env("cat .env | Select-String RUNPOD", &EnvPolicy::default()).unwrap();
-    guard_shell_script_with_env(
-        r#"python -c "open('.env').read()" # pentect read"#,
-        &EnvPolicy::default(),
+    let root = temp_root("secret-file-read");
+    let secret = root.join(".env");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(
+        &secret,
+        "RUNPOD_API_KEY=rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\n",
     )
     .unwrap();
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let store = RecoveryStore::load(&session).unwrap();
+    let command = if cfg!(windows) {
+        format!("Get-Content -LiteralPath '{}'", secret.display())
+    } else {
+        format!("cat '{}'", secret.display())
+    };
+    let opts = ExecOpts {
+        session: DEFAULT_SESSION.to_string(),
+        live: false,
+        approve: false,
+        mode: ExecMode::Shell(command),
+    };
+    let output = run_resolved_command(&store, &opts).unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"),
+        "{stdout}"
+    );
+    let masked = mask_tool_output(&session, &stdout).unwrap();
+    assert!(
+        !masked.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"),
+        "{masked}"
+    );
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
 fn exec_registers_referenced_local_files_as_env_capabilities() {
-    guard_shell_script_with_env(
-        "tool --config secrets.json >/dev/null",
-        &EnvPolicy::default(),
-    )
-    .unwrap();
-    guard_shell_script_with_env("curl -H @headers.txt example.test", &EnvPolicy::default())
-        .unwrap();
-
     let root = temp_root("referenced-file-registers");
     let project = root.join("project");
     std::fs::create_dir_all(&project).unwrap();
@@ -536,65 +554,24 @@ fn always_fingerprint_includes_capability_value_identity() {
 }
 
 #[test]
-fn exec_policy_blocks_environment_reads() {
-    let err = guard_shell_script_with_env("Get-ChildItem Env:", &EnvPolicy::default()).unwrap_err();
-    assert!(err.contains("environment variables"), "{err}");
-
-    let err =
-        guard_shell_script_with_env("printenv RUNPOD_API_KEY", &EnvPolicy::default()).unwrap_err();
-    assert!(err.contains("environment variables"), "{err}");
-
-    let err =
-        guard_shell_script_with_env("echo $RUNPOD_API_KEY", &EnvPolicy::default()).unwrap_err();
-    assert!(err.contains("environment variables"), "{err}");
-
-    let err = guard_shell_script_with_env("Write-Output %RUNPOD_API_KEY%", &EnvPolicy::default())
-        .unwrap_err();
-    assert!(err.contains("environment variables"), "{err}");
-}
-
-#[test]
-fn exec_policy_allows_auto_bound_environment_reads_only() {
-    let allowed = env_policy(&["RUNPOD_API_KEY"]);
-    guard_shell_script_with_env("printenv RUNPOD_API_KEY", &allowed).unwrap();
-    guard_shell_script_with_env("echo $RUNPOD_API_KEY", &allowed).unwrap();
-    guard_shell_script_with_env("Write-Output $env:RUNPOD_API_KEY", &allowed).unwrap();
-
-    let err = guard_shell_script_with_env("Write-Output $env:AWS_SECRET_ACCESS_KEY", &allowed)
-        .unwrap_err();
-    assert!(err.contains("environment variables"), "{err}");
-}
-
-#[test]
-fn exec_policy_does_not_block_regular_shell_state_changes() {
-    guard_shell_script_with_env("export PATH=/tmp:$PATH", &EnvPolicy::default()).unwrap();
-    guard_shell_script_with_env("Set-Content note.txt hello", &EnvPolicy::default()).unwrap();
-    guard_shell_script_with_env("echo $AUTHOR", &EnvPolicy::default()).unwrap();
-    guard_shell_script_with_env("Write-Output %USERNAME%", &EnvPolicy::default()).unwrap();
-    guard_shell_script_with_env("$key = 'name'; Write-Output $key", &EnvPolicy::default()).unwrap();
-}
-
-#[test]
-fn exec_does_not_inherit_parent_environment() {
-    let root = temp_root("env-clear");
+fn exec_inherits_parent_environment_and_masks_output() {
+    let root = temp_root("env-pass-through");
     let session = Session::open_capability_at(&root, "t").unwrap();
     let store = RecoveryStore::load(&session).unwrap();
     let var = format!("PENTECT_PARENT_CANARY_{}", unix_millis());
-    let value = "rpa_SHOULD_NOT_LEAK_FROM_PARENT_ENV_1234567890abcdef";
+    let value = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
     std::env::set_var(&var, value);
     let mode = if cfg!(windows) {
         ExecMode::Program(vec![
             "cmd.exe".to_string(),
             "/C".to_string(),
-            format!("if defined {var} (echo %{var}%) else (echo missing)"),
+            format!("echo RUNPOD_API_KEY=%{var}%"),
         ])
     } else {
         ExecMode::Program(vec![
             "sh".to_string(),
             "-c".to_string(),
-            format!(
-                "if [ -z \"${{{var}}}\" ]; then printf missing; else printf '%s' \"${{{var}}}\"; fi"
-            ),
+            format!("printf 'RUNPOD_API_KEY=%s' \"${{{var}}}\""),
         ])
     };
     let opts = ExecOpts {
@@ -607,8 +584,38 @@ fn exec_does_not_inherit_parent_environment() {
     std::env::remove_var(&var);
     let output = output.unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("missing"), "{stdout}");
-    assert!(!stdout.contains(value), "{stdout}");
+    assert!(stdout.contains(value), "{stdout}");
+    let masked = mask_tool_output(&session, &stdout).unwrap();
+    assert!(!masked.contains(value), "{masked}");
+    assert!(masked.contains("RUNPOD_API_KEY=<<"), "{masked}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn exec_capability_env_overlays_parent_environment_when_referenced() {
+    let root = temp_root("env-overlay");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let value = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let _masked = mask_tool_output(&session, &format!("RUNPOD_API_KEY={value}\n")).unwrap();
+    let store = RecoveryStore::load(&session).unwrap();
+    std::env::set_var("RUNPOD_API_KEY", "parent-value");
+    let mode = if cfg!(windows) {
+        ExecMode::Shell("Write-Output $env:RUNPOD_API_KEY".to_string())
+    } else {
+        ExecMode::Shell("printf '%s' \"$RUNPOD_API_KEY\"".to_string())
+    };
+    let opts = ExecOpts {
+        session: DEFAULT_SESSION.to_string(),
+        live: false,
+        approve: false,
+        mode,
+    };
+    let output = run_resolved_command(&store, &opts);
+    std::env::remove_var("RUNPOD_API_KEY");
+    let output = output.unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(value), "{stdout}");
+    assert!(!stdout.contains("parent-value"), "{stdout}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -2333,15 +2340,6 @@ fn temp_root(name: &str) -> PathBuf {
 
 fn strings<const N: usize>(items: [&str; N]) -> Vec<String> {
     items.into_iter().map(str::to_string).collect()
-}
-
-fn env_policy(allowed: &[&str]) -> EnvPolicy {
-    EnvPolicy {
-        allowed: allowed
-            .iter()
-            .map(|name| name.to_ascii_lowercase())
-            .collect(),
-    }
 }
 
 fn masked_handle_from_assignment(masked: &str, key: &str) -> String {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[test]
 fn session_recovery_is_process_local() {
     let root = std::env::temp_dir().join(format!(
@@ -82,15 +84,41 @@ fn exec_parse_accepts_live_and_approve_without_env_flags() {
 }
 
 #[test]
-fn child_env_overlays_do_not_add_memory_vault_credentials() {
+fn child_env_overlays_strip_memory_vault_credentials() {
     let mut cmd = Command::new("echo");
     apply_child_env_overlays(&mut cmd, &[], "demo");
     let envs: Vec<_> = cmd
         .get_envs()
-        .map(|(name, _)| name.to_string_lossy().to_string())
+        .map(|(name, value)| {
+            (
+                name.to_string_lossy().to_string(),
+                value.map(|value| value.to_string_lossy().to_string()),
+            )
+        })
         .collect();
-    assert!(!envs.iter().any(|name| name == "PENTECT_MEMORY_VAULT_ADDR"));
-    assert!(!envs.iter().any(|name| name == "PENTECT_MEMORY_VAULT_TOKEN"));
+    assert!(
+        matches!(
+            envs.iter()
+                .find(|(name, _)| name == "PENTECT_MEMORY_VAULT_ADDR"),
+            Some((_, None))
+        ),
+        "{envs:?}"
+    );
+    assert!(
+        matches!(
+            envs.iter()
+                .find(|(name, _)| name == "PENTECT_MEMORY_VAULT_TOKEN"),
+            Some((_, None))
+        ),
+        "{envs:?}"
+    );
+    assert!(
+        matches!(
+            envs.iter().find(|(name, _)| name == "PENTECT_SESSION"),
+            Some((_, Some(value))) if value == "demo"
+        ),
+        "{envs:?}"
+    );
 }
 
 #[test]
@@ -228,6 +256,7 @@ fn session_does_not_create_key_or_recovery_dir() {
 
 #[test]
 fn default_session_root_lives_under_pentect_dir() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     std::env::remove_var("PENTECT_HOME");
     let root = session_root("demo").unwrap();
     assert_eq!(root, PathBuf::from(".pentect").join("agent").join("demo"));
@@ -555,6 +584,7 @@ fn always_fingerprint_includes_capability_value_identity() {
 
 #[test]
 fn exec_inherits_parent_environment_and_masks_output() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("env-pass-through");
     let session = Session::open_capability_at(&root, "t").unwrap();
     let store = RecoveryStore::load(&session).unwrap();
@@ -593,6 +623,7 @@ fn exec_inherits_parent_environment_and_masks_output() {
 
 #[test]
 fn exec_capability_env_overlays_parent_environment_when_referenced() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("env-overlay");
     let session = Session::open_capability_at(&root, "t").unwrap();
     let value = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";


### PR DESCRIPTION
## Summary
- remove exec-time environment read blocking and parent env clearing
- keep only Pentect session/capability env overlays so masked values stay usable
- update runtime tests around parent env pass-through, output remasking, and capability overrides

## Tests
- cargo test -p pentect-runtime --all-features
- cargo test --workspace --all-features
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution environment handling so inherited environment values are preserved when expected, while requested values still take precedence.
  * Updated approval warnings to focus on visible runtime risks like live output, secret-file access, network use, and local file materialization.
  * Fixed masking behavior so secret values read during execution are hidden in displayed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->