### PR TITLE
Cover regular Write pass-through

### DIFF
--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -912,6 +912,23 @@ fn unresolved_masked_command_handle_is_rejected() {
 }
 
 #[test]
+fn write_tool_passes_through_regular_ui_content() {
+    let (root, session) = empty_session("write-regular-ui");
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": "src/App.tsx",
+            "content": "export function App() { return <main>Settings</main>; }\n"
+        }
+    });
+
+    let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
+    assert_eq!(output, json!({}));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn write_tool_materialization_requires_approval_without_dashboard() {
     let root = temp_root("capability-write-generic");
     let project = PathBuf::from("target").join(format!(


### PR DESCRIPTION
## Summary
- add a regression test that normal UI/code Write tool content is not blocked by Pentect hooks
- keeps blocking limited to detected masked-handle materialization and unsafe destinations

## Tests
- cargo test -p pentect-runtime write_tool_passes_through_regular_ui_content --all-features
- cargo test -p pentect-runtime --all-features