### PR TITLE
Block writes only when resolve is needed

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -2246,6 +2246,12 @@ fn materialize_masked_write_content(
 ) -> Result<Option<String>, String> {
     let store = RecoveryStore::load(session).map_err(|e| e.to_string())?;
     let resolved = store.resolve_all(content).map_err(|e| e.to_string())?;
+    if contains_pentect_masked_handle(&resolved) {
+        return Err(
+            "Pentect blocked Write because masked content needs resolve, but this session cannot resolve every handle. Re-read the source in this Pentect session, then retry."
+                .to_string(),
+        );
+    }
     if resolved == content {
         return Ok(None);
     }
@@ -2259,9 +2265,25 @@ fn materialize_masked_write_content(
     }
     materialize_file(&path, &resolved)?;
     Ok(Some(format!(
-        "Pentect wrote resolved masked content to '{}' locally. The original Write tool was blocked so plaintext never returns to the AI; treat this as success and do not retry.",
+        "Pentect resolved masked content and wrote '{}'. Original Write stopped to avoid writing masked handles.",
         path.display()
     )))
+}
+
+fn contains_pentect_masked_handle(text: &str) -> bool {
+    let mut offset = 0usize;
+    while let Some(start_rel) = text[offset..].find("<<") {
+        let start = offset + start_rel;
+        let Some(end_rel) = text[start + 2..].find(">>") else {
+            return false;
+        };
+        let end = start + 2 + end_rel + 2;
+        if parse_placeholder(&text[start..end]).is_ok() {
+            return true;
+        }
+        offset = end;
+    }
+    false
 }
 
 fn approval_decision_for_materialized_write(

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -929,6 +929,55 @@ fn write_tool_passes_through_regular_ui_content() {
 }
 
 #[test]
+fn write_tool_passes_through_non_pentect_templates() {
+    let (root, session) = empty_session("write-template-ui");
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": "templates/email.txt",
+            "content": "Hello <<customer_name>>, your order is ready.\n"
+        }
+    });
+
+    let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
+    assert_eq!(output, json!({}));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn write_tool_blocks_unknown_masked_handles_that_need_resolve() {
+    let root = temp_root("write-unknown-handle");
+    let project = PathBuf::from("target").join(format!(
+        "pentect-write-unknown-{}-{}",
+        std::process::id(),
+        unix_millis()
+    ));
+    let _ = std::fs::remove_dir_all(&project);
+    std::fs::create_dir_all(&project).unwrap();
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let config = project.join("config.env");
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": config.to_string_lossy(),
+            "content": "RUNPOD_API_KEY=<<RUNPOD_API_KEY_0123456789abcdef>>\n"
+        }
+    });
+
+    let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
+    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
+    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .unwrap();
+    assert!(reason.contains("needs resolve"), "{reason}");
+    assert!(!config.exists());
+    let _ = std::fs::remove_dir_all(project);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn write_tool_materialization_requires_approval_without_dashboard() {
     let root = temp_root("capability-write-generic");
     let project = PathBuf::from("target").join(format!(


### PR DESCRIPTION
## Summary
- keep regular Write tool content pass-through, including non-Pentect templates like <<customer_name>>
- block only real Pentect masked handles that still need resolve in the current session
- shorten the successful materialized-write warning

## Tests
- cargo test -p pentect-runtime write_tool_ --all-features
- cargo test -p pentect-runtime --all-features
- cargo clippy --all-targets --all-features -- -D warnings