### PR TITLE
Shorten Write resolve feedback

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -2248,7 +2248,7 @@ fn materialize_masked_write_content(
     let resolved = store.resolve_all(content).map_err(|e| e.to_string())?;
     if contains_pentect_masked_handle(&resolved) {
         return Err(
-            "Pentect blocked Write because masked content needs resolve, but this session cannot resolve every handle. Re-read the source in this Pentect session, then retry."
+            "resolve needed: re-read the source in this Pentect session, then retry Write."
                 .to_string(),
         );
     }
@@ -2264,10 +2264,7 @@ fn materialize_masked_write_content(
         }
     }
     materialize_file(&path, &resolved)?;
-    Ok(Some(format!(
-        "Pentect resolved masked content and wrote '{}'. Original Write stopped to avoid writing masked handles.",
-        path.display()
-    )))
+    Ok(Some(format!("resolved write: {}", path.display())))
 }
 
 fn contains_pentect_masked_handle(text: &str) -> bool {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -971,7 +971,7 @@ fn write_tool_blocks_unknown_masked_handles_that_need_resolve() {
     let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
         .as_str()
         .unwrap();
-    assert!(reason.contains("needs resolve"), "{reason}");
+    assert!(reason.contains("resolve needed"), "{reason}");
     assert!(!config.exists());
     let _ = std::fs::remove_dir_all(project);
     let _ = std::fs::remove_dir_all(root);


### PR DESCRIPTION
## Summary
- shorten successful masked Write materialization feedback to esolved write: <path>
- shorten unresolved masked-handle Write warning to esolve needed

## Tests
- cargo test -p pentect-runtime --all-features
- cargo clippy --all-targets --all-features -- -D warnings