### PR TITLE
Repair masked writes after tool use

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -2050,6 +2050,15 @@ fn handle_hook(
             }
         }
         HookPhase::AfterTool => {
+            let tool_name = hook_tool_name(&input)
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if let Some(tool_input) = hook_tool_input(&input) {
+                if let Err(reason) = repair_masked_write_after_tool(session, tool_name, tool_input)
+                {
+                    return Ok(after_tool_block_output(provider, &reason));
+                }
+            }
             let Some(tool_response) = hook_tool_result(&input) else {
                 return Ok(json!({}));
             };
@@ -2102,6 +2111,15 @@ fn handle_hook_lazy(
         }
         HookPhase::AfterTool => {
             let session = open_hook_session(cli, session_name)?;
+            let tool_name = hook_tool_name(&input)
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if let Some(tool_input) = hook_tool_input(&input) {
+                if let Err(reason) = repair_masked_write_after_tool(&session, tool_name, tool_input)
+                {
+                    return Ok(after_tool_block_output(provider, &reason));
+                }
+            }
             let Some(tool_response) = hook_tool_result(&input) else {
                 return Ok(json!({}));
             };
@@ -2133,11 +2151,7 @@ fn before_tool_updated_input(
     if is_read_like_tool_name(tool_name) {
         return Err(read_tool_block_reason(tool_name));
     }
-    if let Some(reason) =
-        maybe_materialize_masked_write(session_name, session, tool_name, tool_input)?
-    {
-        return Err(reason);
-    }
+    validate_masked_write_before_tool(session, tool_name, tool_input)?;
     if let Some(command) = tool_input.get("command").and_then(Value::as_str) {
         if let Some(reason) = pentect_human_only_command_reason(command) {
             return Err(reason);
@@ -2165,10 +2179,9 @@ fn before_tool_updated_input_lazy(
     if is_read_like_tool_name(tool_name) {
         return Err(read_tool_block_reason(tool_name));
     }
-    if let Some(reason) =
-        maybe_materialize_masked_write_lazy(session_name, cli, tool_name, tool_input)?
-    {
-        return Err(reason);
+    if is_write_like_tool_name(tool_name) {
+        let session = open_hook_session(cli, session_name)?;
+        validate_masked_write_before_tool(&session, tool_name, tool_input)?;
     }
     if let Some(command) = tool_input.get("command").and_then(Value::as_str) {
         if let Some(reason) = pentect_human_only_command_reason(command) {
@@ -2200,50 +2213,54 @@ fn canonical_hook_shell_command(command: &str) -> Result<String, String> {
     }
 }
 
-#[cfg(test)]
-fn maybe_materialize_masked_write(
-    session_name: &str,
+fn validate_masked_write_before_tool(
     session: &Session,
     tool_name: &str,
     tool_input: &Value,
-) -> Result<Option<String>, String> {
+) -> Result<(), String> {
     if !is_write_like_tool_name(tool_name) {
-        return Ok(None);
+        return Ok(());
     }
     let Some((path, content)) = write_path_and_content(tool_input) else {
-        return Ok(None);
+        return Ok(());
     };
-    if !content.contains("<<") {
-        return Ok(None);
+    if !contains_pentect_masked_handle(content) {
+        return Ok(());
     }
-    materialize_masked_write_content(session_name, session, path, content)
+    let (path, _) = resolved_write_parts(session, path, content)?;
+    ensure_materialize_path_within_cwd(&path)?;
+    Ok(())
 }
 
-fn maybe_materialize_masked_write_lazy(
-    session_name: &str,
-    cli: bool,
+fn repair_masked_write_after_tool(
+    session: &Session,
     tool_name: &str,
     tool_input: &Value,
-) -> Result<Option<String>, String> {
+) -> Result<bool, String> {
     if !is_write_like_tool_name(tool_name) {
-        return Ok(None);
+        return Ok(false);
     }
     let Some((path, content)) = write_path_and_content(tool_input) else {
-        return Ok(None);
+        return Ok(false);
     };
-    if !content.contains("<<") {
-        return Ok(None);
+    if !contains_pentect_masked_handle(content) {
+        return Ok(false);
     }
-    let session = open_hook_session(cli, session_name)?;
-    materialize_masked_write_content(session_name, &session, path, content)
+    let (path, resolved) = resolved_write_parts(session, path, content)?;
+    ensure_materialize_path_within_cwd(&path)?;
+    if !path.is_file() {
+        return Ok(false);
+    }
+    std::fs::write(&path, resolved)
+        .map_err(|e| format!("could not repair '{}': {e}", path.display()))?;
+    Ok(true)
 }
 
-fn materialize_masked_write_content(
-    session_name: &str,
+fn resolved_write_parts(
     session: &Session,
     path: &str,
     content: &str,
-) -> Result<Option<String>, String> {
+) -> Result<(PathBuf, String), String> {
     let store = RecoveryStore::load(session).map_err(|e| e.to_string())?;
     let resolved = store.resolve_all(content).map_err(|e| e.to_string())?;
     if contains_pentect_masked_handle(&resolved) {
@@ -2253,18 +2270,10 @@ fn materialize_masked_write_content(
         );
     }
     if resolved == content {
-        return Ok(None);
+        return Err("resolve needed: no matching handle in this Pentect session.".to_string());
     }
     let path = checked_materialize_path(path)?;
-    ensure_materialize_path_within_cwd(&path)?;
-    match approval_decision_for_materialized_write(session_name, &path, content, &resolved)? {
-        ApprovalDecision::Once | ApprovalDecision::Always => {}
-        ApprovalDecision::Decline => {
-            return Err("Pentect declined masked file materialization".into())
-        }
-    }
-    materialize_file(&path, &resolved)?;
-    Ok(Some(format!("resolved write: {}", path.display())))
+    Ok((path, resolved))
 }
 
 fn contains_pentect_masked_handle(text: &str) -> bool {
@@ -2281,43 +2290,6 @@ fn contains_pentect_masked_handle(text: &str) -> bool {
         offset = end;
     }
     false
-}
-
-fn approval_decision_for_materialized_write(
-    session: &str,
-    path: &Path,
-    masked_content: &str,
-    resolved_content: &str,
-) -> Result<ApprovalDecision, String> {
-    let ticket = materialized_write_approval_ticket(path, masked_content, resolved_content);
-    if ApprovalQueue::open(session)?.always_granted(&ticket.fingerprint) {
-        return Ok(ApprovalDecision::Always);
-    }
-    approval_decision_for_ticket(session, &ticket)
-}
-
-fn materialized_write_approval_ticket(
-    path: &Path,
-    masked_content: &str,
-    resolved_content: &str,
-) -> ApprovalTicket {
-    let command = format!("write {}", shell_quote_path(path));
-    let mut material = String::from("write-materialize-v1\0");
-    material.push_str(&path.to_string_lossy());
-    material.push('\0');
-    material.push_str(&secret_value_hash(resolved_content));
-    material.push('\0');
-    let digest = Sha256::digest(material.as_bytes());
-    ApprovalTicket::new(ApprovalTicketDraft {
-        fingerprint: data_encoding::HEXLOWER.encode(&digest[..16]),
-        command,
-        env_names: Vec::new(),
-        secret_files: vec![path.to_string_lossy().to_string()],
-        direct_handles: masked_handles_in_text(masked_content).len(),
-        destinations: Vec::new(),
-        network_like: false,
-        materialize_like: true,
-    })
 }
 
 fn is_write_like_tool_name(tool_name: &str) -> bool {
@@ -2382,17 +2354,6 @@ fn checked_materialize_path(path: &str) -> Result<PathBuf, String> {
         return Err("Pentect refused to materialize masked content to an empty path".to_string());
     }
     Ok(clean)
-}
-
-fn materialize_file(path: &Path, content: &str) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("could not create '{}': {e}", parent.display()))?;
-        }
-    }
-    ensure_materialize_path_within_cwd(path)?;
-    std::fs::write(path, content).map_err(|e| format!("could not write '{}': {e}", path.display()))
 }
 
 fn ensure_materialize_path_within_cwd(path: &Path) -> Result<(), String> {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -978,7 +978,7 @@ fn write_tool_blocks_unknown_masked_handles_that_need_resolve() {
 }
 
 #[test]
-fn write_tool_materialization_requires_approval_without_dashboard() {
+fn write_tool_allows_resolvable_masked_content_before_tool() {
     let root = temp_root("capability-write-generic");
     let project = PathBuf::from("target").join(format!(
         "pentect-write-{}-{}",
@@ -1001,19 +1001,48 @@ fn write_tool_materialization_requires_approval_without_dashboard() {
         }
     });
     let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
-    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
-    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
-        .as_str()
-        .unwrap();
-    assert!(reason.contains("approval needed"), "{reason}");
-    assert!(!reason.contains(raw), "{reason}");
+    assert_eq!(output, json!({}));
     assert!(!config.exists());
     let _ = std::fs::remove_dir_all(project);
     let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
-fn write_tool_refuses_masked_materialization_outside_current_dir() {
+fn write_tool_repairs_masked_file_after_tool() {
+    let root = temp_root("capability-write-repair");
+    let project = PathBuf::from("target").join(format!(
+        "pentect-write-repair-{}-{}",
+        std::process::id(),
+        unix_millis()
+    ));
+    let _ = std::fs::remove_dir_all(&project);
+    std::fs::create_dir_all(&project).unwrap();
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let masked = mask_tool_output(&session, &format!("token={raw}\n")).unwrap();
+    let config = project.join("config.txt");
+
+    std::fs::write(&config, &masked).unwrap();
+    let input = json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": config.to_string_lossy(),
+            "content": masked
+        },
+        "tool_response": "Edited config.txt"
+    });
+    let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
+    assert_eq!(output, json!({}));
+    let written = std::fs::read_to_string(&config).unwrap();
+    assert!(written.contains(raw), "{written}");
+    assert!(!written.contains("<<"), "{written}");
+    let _ = std::fs::remove_dir_all(project);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn write_tool_refuses_masked_repair_outside_current_dir() {
     let root = temp_root("capability-write-outside");
     let session = Session::open_capability_at(&root, "t").unwrap();
     let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
@@ -1038,7 +1067,7 @@ fn write_tool_refuses_masked_materialization_outside_current_dir() {
 }
 
 #[test]
-fn write_tool_accepts_camel_case_external_schema() {
+fn write_tool_repairs_camel_case_external_schema_after_tool() {
     let root = temp_root("capability-write-camel");
     let project = PathBuf::from("target").join(format!(
         "pentect-write-camel-{}-{}",
@@ -1060,21 +1089,26 @@ fn write_tool_accepts_camel_case_external_schema() {
             "fileContent": masked
         }
     });
-    let output = handle_hook(HookProvider::Generic, "t", &session, input).unwrap();
-    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
-    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
-        .as_str()
-        .unwrap();
-    assert!(reason.contains("approval needed"), "{reason}");
-    assert!(!reason.contains(raw), "{reason}");
-    assert!(!config.exists());
+    let output = handle_hook(HookProvider::Generic, "t", &session, input.clone()).unwrap();
+    assert_eq!(output, json!({}));
+
+    std::fs::write(&config, &masked).unwrap();
+    let mut post = input;
+    let object = post.as_object_mut().unwrap();
+    object.insert("hookEventName".to_string(), json!("PostToolUse"));
+    object.insert("toolResponse".to_string(), json!("Edited config.txt"));
+    let output = handle_hook(HookProvider::Generic, "t", &session, post).unwrap();
+    assert_eq!(output, json!({}));
+    let written = std::fs::read_to_string(&config).unwrap();
+    assert!(written.contains(raw), "{written}");
+    assert!(!written.contains("<<"), "{written}");
     let _ = std::fs::remove_dir_all(project);
     let _ = std::fs::remove_dir_all(root);
 }
 
 #[cfg(unix)]
 #[test]
-fn write_tool_refuses_masked_materialization_through_symlink_dir() {
+fn write_tool_refuses_masked_repair_through_symlink_dir() {
     let root = temp_root("capability-write-symlink");
     let outside = temp_root("capability-write-symlink-outside");
     std::fs::create_dir_all(&outside).unwrap();


### PR DESCRIPTION
﻿## Summary
- Let resolvable masked-handle writes pass through PreToolUse so the normal Write/Edit UI remains visible.
- Repair the written file in PostToolUse by resolving Pentect handles locally without returning raw secrets to the agent.
- Keep unresolved handles and unsafe paths blocked before the host Write runs.

## Validation
- cargo fmt
- cargo test -p pentect-runtime write_tool_ --all-features
- cargo test -p pentect-runtime --all-features
- cargo clippy --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Write actions now support masked content that can be safely validated before execution and repaired after completion.
  * Successful write operations can now restore the original secret values in the target file.

* **Bug Fixes**
  * Improved handling of masked write content so invalid or unsafe paths are denied earlier.
  * Strengthened protections against writes outside the current directory, including via symlinks.
  * Added coverage for alternate input formats and post-action repair behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->