### PR TITLE
Block direct reads only when masking is needed

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -2240,13 +2240,10 @@ fn validate_read_before_tool(
 
 fn read_tool_has_detected_secret(session: &Session, tool_input: &Value) -> Result<bool, String> {
     for path in read_tool_paths(tool_input) {
-        if path == "-" {
-            continue;
-        }
         let path = Path::new(path);
-        let Ok(data) = read_input(path, InputFormat::Text) else {
-            continue;
-        };
+        let data = read_input(path, InputFormat::Text).map_err(|_| {
+            "read target could not be scanned; use `pentect read PATH`.".to_string()
+        })?;
         let result = Engine::with_profile(Profile::Strict).mask(
             Input {
                 kind: infer_kind(path),

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1664,6 +1664,14 @@ const WRITE_PATH_FIELDS: &[&str] = &[
     "filename",
     "fileName",
 ];
+const READ_PATH_LIST_FIELDS: &[&str] = &[
+    "paths",
+    "file_paths",
+    "filePaths",
+    "filenames",
+    "fileNames",
+    "files",
+];
 const WRITE_CONTENT_FIELDS: &[&str] = &[
     "content",
     "file_content",
@@ -2151,7 +2159,7 @@ fn before_tool_updated_input(
     tool_input: &Value,
 ) -> Result<(Value, bool), String> {
     if is_read_like_tool_name(tool_name) {
-        return Err(read_tool_block_reason(tool_name));
+        validate_read_before_tool(session, tool_name, tool_input)?;
     }
     validate_masked_write_before_tool(session, tool_name, tool_input)?;
     if let Some(command) = tool_input.get("command").and_then(Value::as_str) {
@@ -2179,7 +2187,8 @@ fn before_tool_updated_input_lazy(
     tool_input: &Value,
 ) -> Result<(Value, bool), String> {
     if is_read_like_tool_name(tool_name) {
-        return Err(read_tool_block_reason(tool_name));
+        let session = open_hook_session(cli, session_name)?;
+        validate_read_before_tool(&session, tool_name, tool_input)?;
     }
     if is_write_or_edit_like_tool_name(tool_name) {
         let session = open_hook_session(cli, session_name)?;
@@ -2213,6 +2222,43 @@ fn canonical_hook_shell_command(command: &str) -> Result<String, String> {
         };
         command = payload;
     }
+}
+
+fn validate_read_before_tool(
+    session: &Session,
+    tool_name: &str,
+    tool_input: &Value,
+) -> Result<(), String> {
+    if !is_read_like_tool_name(tool_name) {
+        return Ok(());
+    }
+    if read_tool_has_detected_secret(session, tool_input)? {
+        return Err(read_tool_block_reason(tool_name));
+    }
+    Ok(())
+}
+
+fn read_tool_has_detected_secret(session: &Session, tool_input: &Value) -> Result<bool, String> {
+    for path in read_tool_paths(tool_input) {
+        if path == "-" {
+            continue;
+        }
+        let path = Path::new(path);
+        let Ok(data) = read_input(path, InputFormat::Text) else {
+            continue;
+        };
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: infer_kind(path),
+                data,
+            },
+            &Config::new(session.key),
+        );
+        if result.summary.masked_count > 0 {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn validate_masked_write_before_tool(
@@ -2397,6 +2443,21 @@ fn write_path_and_content(value: &Value) -> Option<(&str, &str)> {
     None
 }
 
+fn read_tool_paths(value: &Value) -> Vec<&str> {
+    let mut paths = Vec::new();
+    for candidate in write_input_candidates(value) {
+        if let Some(path) = string_field(candidate, WRITE_PATH_FIELDS) {
+            paths.push(path);
+        }
+        for field in READ_PATH_LIST_FIELDS {
+            if let Some(items) = candidate.get(*field).and_then(Value::as_array) {
+                paths.extend(items.iter().filter_map(Value::as_str));
+            }
+        }
+    }
+    paths
+}
+
 fn write_input_candidates(value: &Value) -> Vec<&Value> {
     let mut out = vec![value];
     for key in WRITE_INPUT_FIELDS {
@@ -2518,7 +2579,13 @@ fn is_read_like_tool_name(tool_name: &str) -> bool {
     let normalized = tool_name.to_ascii_lowercase().replace('-', "_");
     matches!(
         normalized.as_str(),
-        "read" | "read_file" | "read_many_files" | "multiread" | "notebookread" | "notebook_read"
+        "read"
+            | "read_file"
+            | "readmanyfiles"
+            | "read_many_files"
+            | "multiread"
+            | "notebookread"
+            | "notebook_read"
     ) || normalized.ends_with("__read_file")
         || normalized.ends_with("_read_file")
         || normalized.ends_with("__read_many_files")
@@ -2560,18 +2627,12 @@ fn extract_pentect_exec_shell_payload(command: &str) -> Option<String> {
 fn pentect_human_only_command_reason(command: &str) -> Option<String> {
     let invocation = parse_pentect_subcommand(command)?;
     match invocation.subcommand {
-        PentectSubcommand::Read => Some(
-            "use `pentect exec \"Get-Content ...\"` instead of `pentect read` from AI hooks"
-                .to_string(),
-        ),
-        PentectSubcommand::Exec | PentectSubcommand::Resolve => None,
+        PentectSubcommand::Exec | PentectSubcommand::Read | PentectSubcommand::Resolve => None,
     }
 }
 
 fn read_tool_block_reason(tool_name: &str) -> String {
-    format!(
-        "{tool_name} is human-only; use `pentect exec \"Get-Content ...\"` from AI hooks instead."
-    )
+    format!("{tool_name} found masked content; use `pentect read PATH`.")
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2326,6 +2326,33 @@ fn pretool_blocks_read_many_when_any_file_needs_masking() {
 }
 
 #[test]
+fn pretool_allows_read_many_when_all_files_are_clean() {
+    let (root, session) = empty_session("hook-pre-read-many-clean");
+    let project = PathBuf::from("target").join(format!(
+        "pentect-read-many-clean-{}-{}",
+        std::process::id(),
+        unix_millis()
+    ));
+    let _ = std::fs::remove_dir_all(&project);
+    std::fs::create_dir_all(&project).unwrap();
+    let first = project.join("README.txt");
+    let second = project.join("notes.txt");
+    std::fs::write(&first, "Settings\n").unwrap();
+    std::fs::write(&second, "No credentials here.\n").unwrap();
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "ReadManyFiles",
+        "tool_input": {
+            "paths": [first.to_string_lossy(), second.to_string_lossy()]
+        }
+    });
+    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
+    assert_eq!(output, json!({}));
+    let _ = std::fs::remove_dir_all(project);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn pretool_canonicalizes_quoted_pentect_exec_shell_command() {
     let (root, session) = empty_session("hook-pre-exec");
     let input = json!({

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2190,7 +2190,7 @@ fn claude_pretool_wraps_plain_shell_command() {
 }
 
 #[test]
-fn pretool_blocks_pentect_read_from_ai_hooks() {
+fn pretool_wraps_pentect_read_from_ai_hooks() {
     let (root, session) = empty_session("hook-pre-read");
     let input = json!({
         "hook_event_name": "PreToolUse",
@@ -2200,11 +2200,13 @@ fn pretool_blocks_pentect_read_from_ai_hooks() {
         }
     });
     let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
-    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+    let command = output["hookSpecificOutput"]["updatedInput"]["command"]
         .as_str()
         .unwrap();
-    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
-    assert!(reason.contains("pentect exec"), "{reason}");
+    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
+    assert!(command.contains("pentect"), "{command}");
+    assert!(command.contains("exec"), "{command}");
+    assert!(command.contains("read"), "{command}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -2230,13 +2232,47 @@ fn pretool_wraps_pentect_resolve_for_approval() {
 }
 
 #[test]
-fn pretool_blocks_direct_read_tools() {
-    let (root, session) = empty_session("hook-pre-direct-read");
+fn pretool_allows_direct_read_tool_for_clean_file() {
+    let (root, session) = empty_session("hook-pre-direct-read-clean");
+    let project = PathBuf::from("target").join(format!(
+        "pentect-read-clean-{}-{}",
+        std::process::id(),
+        unix_millis()
+    ));
+    let _ = std::fs::remove_dir_all(&project);
+    std::fs::create_dir_all(&project).unwrap();
+    let readme = project.join("README.txt");
+    std::fs::write(&readme, "Settings\nNo credentials here.\n").unwrap();
     let input = json!({
         "hook_event_name": "PreToolUse",
         "tool_name": "Read",
         "tool_input": {
-            "file_path": r".\.env"
+            "file_path": readme.to_string_lossy()
+        }
+    });
+    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
+    assert_eq!(output, json!({}));
+    let _ = std::fs::remove_dir_all(project);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn pretool_blocks_direct_read_tool_when_file_needs_masking() {
+    let (root, session) = empty_session("hook-pre-direct-read-secret");
+    let project = PathBuf::from("target").join(format!(
+        "pentect-read-secret-{}-{}",
+        std::process::id(),
+        unix_millis()
+    ));
+    let _ = std::fs::remove_dir_all(&project);
+    std::fs::create_dir_all(&project).unwrap();
+    let env = project.join(".env");
+    std::fs::write(&env, "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n").unwrap();
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {
+            "file_path": env.to_string_lossy()
         }
     });
     let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
@@ -2244,8 +2280,48 @@ fn pretool_blocks_direct_read_tools() {
     let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
         .as_str()
         .unwrap();
-    assert!(reason.contains("human-only"), "{reason}");
-    assert!(reason.contains("pentect exec"), "{reason}");
+    assert!(reason.contains("pentect read"), "{reason}");
+    assert!(!reason.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"), "{reason}");
+    let _ = std::fs::remove_dir_all(project);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn pretool_blocks_read_many_when_any_file_needs_masking() {
+    let (root, session) = empty_session("hook-pre-read-many-secret");
+    let project = PathBuf::from("target").join(format!(
+        "pentect-read-many-secret-{}-{}",
+        std::process::id(),
+        unix_millis()
+    ));
+    let _ = std::fs::remove_dir_all(&project);
+    std::fs::create_dir_all(&project).unwrap();
+    let readme = project.join("README.txt");
+    let env = project.join(".env");
+    std::fs::write(&readme, "Settings\n").unwrap();
+    std::fs::write(
+        &env,
+        "RUNPOD_API_KEY=rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\n",
+    )
+    .unwrap();
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "ReadManyFiles",
+        "tool_input": {
+            "paths": [readme.to_string_lossy(), env.to_string_lossy()]
+        }
+    });
+    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
+    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
+    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .unwrap();
+    assert!(reason.contains("pentect read"), "{reason}");
+    assert!(
+        !reason.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"),
+        "{reason}"
+    );
+    let _ = std::fs::remove_dir_all(project);
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -2359,7 +2435,7 @@ fn pretool_collapses_nested_pentect_exec_shell_commands() {
 }
 
 #[test]
-fn pretool_blocks_nested_pentect_read_escape() {
+fn pretool_collapses_nested_pentect_read_command() {
     let (root, session) = empty_session("hook-pre-nested-read");
     let input = json!({
         "hook_event_name": "PreToolUse",
@@ -2369,12 +2445,14 @@ fn pretool_blocks_nested_pentect_read_escape() {
         }
     });
     let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
-    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
-    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
+    let command = output["hookSpecificOutput"]["updatedInput"]["command"]
         .as_str()
         .unwrap();
-    assert!(reason.contains("pentect exec"), "{reason}");
-    assert!(reason.contains("pentect read"), "{reason}");
+    assert!(command.contains("pentect"), "{command}");
+    assert!(command.contains("exec"), "{command}");
+    assert!(command.contains("read"), "{command}");
+    assert_eq!(command.matches(" exec ").count(), 1, "{command}");
     let _ = std::fs::remove_dir_all(root);
 }
 


### PR DESCRIPTION
﻿## Summary
- Let native Read tool calls keep the normal UI when Pentect's preflight scan finds no maskable content.
- Block direct Read/ReadManyFiles only when the target file would need masking, and point the agent to `pentect read PATH`.
- Allow `pentect read` commands inside AI hooks so the blocked ReadTool path has a usable escape hatch.

## Validation
- cargo fmt
- cargo test -p pentect-runtime pretool_ --all-features
- cargo test -p pentect-runtime --all-features
- cargo clippy --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reading files is now allowed when the content is clean, and blocked only when masked secrets are detected.
  * `read` requests now return a clearer denial message when sensitive content is found.
  * Nested `read` commands are handled more consistently, avoiding unnecessary blocking.

* **Tests**
  * Updated coverage for direct and wrapped `read` behavior, including single-file and multi-file cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->