### PR TITLE
Add optional Pentect launch guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/EdamAme-x/pentect?utm_source=oss&utm_medium=github&utm_campaign=EdamAme-x%2Fpentect&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+
 Pentect is a local secret-capability boundary for AI agents: it masks tool/file/MCP/browser output before the model sees it.
 Masked handles can be reused inside `pentect exec` as local env capabilities, with stdout/stderr remasked afterward.
 

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -585,7 +585,11 @@ fn run_codex(
         Err(e) => die(&e),
     };
     let mut cmd = Command::new(&opts.command);
-    apply_pentect_env(&mut cmd, pentect);
+    apply_pentect_env(
+        &mut cmd,
+        pentect,
+        memory_vault.map(|vault| vault.token.as_str()),
+    );
     apply_agent_auto_approve_env(&mut cmd);
     apply_memory_vault_env(&mut cmd, memory_vault);
     apply_extension_env(&mut cmd, &active_extensions);
@@ -609,7 +613,11 @@ fn run_claude(
         Err(e) => die(&e),
     };
     let mut cmd = Command::new(&opts.command);
-    apply_pentect_env(&mut cmd, pentect);
+    apply_pentect_env(
+        &mut cmd,
+        pentect,
+        memory_vault.map(|vault| vault.token.as_str()),
+    );
     apply_agent_auto_approve_env(&mut cmd);
     apply_memory_vault_env(&mut cmd, memory_vault);
     apply_extension_env(&mut cmd, &active_extensions);
@@ -710,9 +718,13 @@ impl Drop for MemoryVaultGuard {
     }
 }
 
-fn apply_pentect_env(cmd: &mut Command, pentect: &Path) {
+fn apply_pentect_env(cmd: &mut Command, pentect: &Path, launch_proof: Option<&str>) {
     cmd.env(PENTECT_BIN_ENV, pentect);
-    cmd.env(PENTECT_AGENT_LAUNCHED_ENV, "1");
+    if let Some(launch_proof) = launch_proof.filter(|value| !value.is_empty()) {
+        cmd.env(PENTECT_AGENT_LAUNCHED_ENV, launch_proof);
+    } else {
+        cmd.env_remove(PENTECT_AGENT_LAUNCHED_ENV);
+    }
 }
 
 fn apply_agent_auto_approve_env(cmd: &mut Command) {
@@ -1496,8 +1508,9 @@ mod tests {
     #[test]
     fn launched_agent_tools_export_pentect_path_for_hooks() {
         let pentect = Path::new(r"C:\repo\target\debug\pentect.exe");
+        let launch_proof = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
         let mut cmd = Command::new("codex");
-        apply_pentect_env(&mut cmd, pentect);
+        apply_pentect_env(&mut cmd, pentect, Some(launch_proof));
         apply_agent_auto_approve_env(&mut cmd);
         let actual = cmd
             .get_envs()
@@ -1510,7 +1523,7 @@ mod tests {
             .find(|(key, _)| *key == std::ffi::OsStr::new(PENTECT_AGENT_LAUNCHED_ENV))
             .and_then(|(_, value)| value)
             .unwrap();
-        assert_eq!(launched, std::ffi::OsStr::new("1"));
+        assert_eq!(launched, std::ffi::OsStr::new(launch_proof));
         let auto_approve = cmd
             .get_envs()
             .find(|(key, _)| *key == std::ffi::OsStr::new(PENTECT_AGENT_AUTO_APPROVE_ENV))

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -585,12 +585,12 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
         return Err(blocked_headless_codex_error());
     }
     let active_extensions = agent_tool_extensions(opts)?;
-    let memory_vault = start_memory_vault(pentect)?;
     let mut cmd = Command::new(&opts.command);
+    apply_extension_env(&mut cmd, &active_extensions)?;
+    let memory_vault = start_memory_vault(pentect)?;
     apply_pentect_env(&mut cmd, pentect, Some(memory_vault.token.as_str()));
     apply_agent_auto_approve_env(&mut cmd);
     apply_memory_vault_env(&mut cmd, Some(&memory_vault));
-    apply_extension_env(&mut cmd, &active_extensions);
     cmd.args(codex_args(&configs, &opts.tool_args));
     run_interactive_command(cmd, &opts.command)
 }
@@ -603,12 +603,12 @@ fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::Exit
         return Ok(success_status());
     }
     let active_extensions = agent_tool_extensions(opts)?;
-    let memory_vault = start_memory_vault(pentect)?;
     let mut cmd = Command::new(&opts.command);
+    apply_extension_env(&mut cmd, &active_extensions)?;
+    let memory_vault = start_memory_vault(pentect)?;
     apply_pentect_env(&mut cmd, pentect, Some(memory_vault.token.as_str()));
     apply_agent_auto_approve_env(&mut cmd);
     apply_memory_vault_env(&mut cmd, Some(&memory_vault));
-    apply_extension_env(&mut cmd, &active_extensions);
     cmd.args(&args);
     run_interactive_command(cmd, &opts.command)
 }
@@ -748,19 +748,17 @@ fn parse_memory_vault_startup(line: &str) -> Result<(String, String), String> {
     Ok((addr, token))
 }
 
-fn apply_extension_env(cmd: &mut Command, active: &extensions::ActiveExtensions) {
-    if let Some(value) = match active.pack_env_value() {
-        Ok(value) => value,
-        Err(e) => die(&e),
-    } {
+fn apply_extension_env(
+    cmd: &mut Command,
+    active: &extensions::ActiveExtensions,
+) -> Result<(), String> {
+    if let Some(value) = active.pack_env_value().map_err(|e| e.to_string())? {
         cmd.env(extensions::PACKS_ENV, value);
     }
-    if let Some(value) = match active.adapter_env_value() {
-        Ok(value) => value,
-        Err(e) => die(&e),
-    } {
+    if let Some(value) = active.adapter_env_value().map_err(|e| e.to_string())? {
         cmd.env(extensions::ADAPTERS_ENV, value);
     }
+    Ok(())
 }
 
 fn codex_args(configs: &[String], tool_args: &[String]) -> Vec<String> {

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -166,18 +166,26 @@ fn cmd_agent_tool(tool: AgentTool, args: &[String]) {
             pentect.display()
         ));
     }
-    let memory_vault = if opts.dry_run {
-        None
-    } else {
-        Some(MemoryVaultGuard::start(&pentect).unwrap_or_else(|e| die(&e)))
-    };
     let status = match tool {
-        AgentTool::Codex => run_codex(&opts, &pentect, memory_vault.as_ref()),
-        AgentTool::Claude => run_claude(&opts, &pentect, memory_vault.as_ref()),
-    };
+        AgentTool::Codex => run_codex(&opts, &pentect),
+        AgentTool::Claude => run_claude(&opts, &pentect),
+    }
+    .unwrap_or_else(|e| die(&e));
     let code = status.code().unwrap_or(1);
-    drop(memory_vault);
     std::process::exit(code);
+}
+
+fn start_memory_vault(pentect: &Path) -> Result<MemoryVaultGuard, String> {
+    MemoryVaultGuard::start(pentect)
+}
+
+fn agent_tool_extensions(opts: &AgentToolOpts) -> Result<extensions::ActiveExtensions, String> {
+    extensions::active_from_specs(opts.extensions.clone(), true).map_err(|e| e.to_string())
+}
+
+fn blocked_headless_codex_error() -> String {
+    "headless Codex may skip hooks. Use interactive `pentect codex` for protected tool use."
+        .to_string()
 }
 
 /// Read stdin as bytes (no panic on binary), cap the size, then delegate
@@ -562,11 +570,7 @@ impl AgentToolOpts {
     }
 }
 
-fn run_codex(
-    opts: &AgentToolOpts,
-    pentect: &Path,
-    memory_vault: Option<&MemoryVaultGuard>,
-) -> std::process::ExitStatus {
+fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
     let configs = codex_hook_config_args(pentect, opts.session.as_deref());
     if opts.dry_run {
         if codex_uses_unverified_headless_hook_path(&opts.tool_args) {
@@ -575,63 +579,50 @@ fn run_codex(
             );
         }
         print_dry_run(&opts.command, &codex_args(&configs, &opts.tool_args));
-        return success_status();
+        return Ok(success_status());
     }
     if codex_uses_unverified_headless_hook_path(&opts.tool_args) && !opts.allow_unverified_hooks {
-        die("headless Codex may skip hooks. Use interactive `pentect codex` for protected tool use.");
+        return Err(blocked_headless_codex_error());
     }
-    let active_extensions = match extensions::active_from_specs(opts.extensions.clone(), true) {
-        Ok(active) => active,
-        Err(e) => die(&e),
-    };
+    let active_extensions = agent_tool_extensions(opts)?;
+    let memory_vault = start_memory_vault(pentect)?;
     let mut cmd = Command::new(&opts.command);
-    apply_pentect_env(
-        &mut cmd,
-        pentect,
-        memory_vault.map(|vault| vault.token.as_str()),
-    );
+    apply_pentect_env(&mut cmd, pentect, Some(memory_vault.token.as_str()));
     apply_agent_auto_approve_env(&mut cmd);
-    apply_memory_vault_env(&mut cmd, memory_vault);
+    apply_memory_vault_env(&mut cmd, Some(&memory_vault));
     apply_extension_env(&mut cmd, &active_extensions);
     cmd.args(codex_args(&configs, &opts.tool_args));
     run_interactive_command(cmd, &opts.command)
 }
 
-fn run_claude(
-    opts: &AgentToolOpts,
-    pentect: &Path,
-    memory_vault: Option<&MemoryVaultGuard>,
-) -> std::process::ExitStatus {
+fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
     let settings = claude_settings_json(pentect, opts.session.as_deref());
     let args = claude_args(&settings, &opts.tool_args);
     if opts.dry_run {
         print_dry_run(&opts.command, &args);
-        return success_status();
+        return Ok(success_status());
     }
-    let active_extensions = match extensions::active_from_specs(opts.extensions.clone(), true) {
-        Ok(active) => active,
-        Err(e) => die(&e),
-    };
+    let active_extensions = agent_tool_extensions(opts)?;
+    let memory_vault = start_memory_vault(pentect)?;
     let mut cmd = Command::new(&opts.command);
-    apply_pentect_env(
-        &mut cmd,
-        pentect,
-        memory_vault.map(|vault| vault.token.as_str()),
-    );
+    apply_pentect_env(&mut cmd, pentect, Some(memory_vault.token.as_str()));
     apply_agent_auto_approve_env(&mut cmd);
-    apply_memory_vault_env(&mut cmd, memory_vault);
+    apply_memory_vault_env(&mut cmd, Some(&memory_vault));
     apply_extension_env(&mut cmd, &active_extensions);
     cmd.args(&args);
     run_interactive_command(cmd, &opts.command)
 }
 
-fn run_interactive_command(mut cmd: Command, display: &Path) -> std::process::ExitStatus {
+fn run_interactive_command(
+    mut cmd: Command,
+    display: &Path,
+) -> Result<std::process::ExitStatus, String> {
     let mut terminal_guard = terminal::TuiSessionGuard::enter();
     let mut child = match cmd.spawn() {
         Ok(child) => child,
         Err(e) => {
             terminal_guard.restore_without_prompt();
-            die(format!("could not start '{}': {e}", display.display()));
+            return Err(format!("could not start '{}': {e}", display.display()));
         }
     };
     // Set this after spawn so child TUIs still receive Ctrl+C; the parent
@@ -642,12 +633,12 @@ fn run_interactive_command(mut cmd: Command, display: &Path) -> std::process::Ex
         Err(e) => {
             drop(ctrl_c_guard);
             terminal_guard.restore_after_tui();
-            die(format!("could not wait for '{}': {e}", display.display()))
+            return Err(format!("could not wait for '{}': {e}", display.display()));
         }
     };
     drop(ctrl_c_guard);
     terminal_guard.restore_after_tui();
-    status
+    Ok(status)
 }
 
 struct MemoryVaultGuard {

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -38,6 +38,7 @@ const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
     "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
 );
 const PENTECT_BIN_ENV: &str = "PENTECT_BIN";
+const PENTECT_AGENT_LAUNCHED_ENV: &str = "PENTECT_AGENT_LAUNCHED";
 const PENTECT_AGENT_AUTO_APPROVE_ENV: &str = "PENTECT_AGENT_AUTO_APPROVE";
 const PENTECT_MEMORY_VAULT_ADDR_ENV: &str = "PENTECT_MEMORY_VAULT_ADDR";
 const PENTECT_MEMORY_VAULT_TOKEN_ENV: &str = "PENTECT_MEMORY_VAULT_TOKEN";
@@ -711,6 +712,7 @@ impl Drop for MemoryVaultGuard {
 
 fn apply_pentect_env(cmd: &mut Command, pentect: &Path) {
     cmd.env(PENTECT_BIN_ENV, pentect);
+    cmd.env(PENTECT_AGENT_LAUNCHED_ENV, "1");
 }
 
 fn apply_agent_auto_approve_env(cmd: &mut Command) {
@@ -1503,6 +1505,12 @@ mod tests {
             .and_then(|(_, value)| value)
             .unwrap();
         assert_eq!(actual, pentect.as_os_str());
+        let launched = cmd
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new(PENTECT_AGENT_LAUNCHED_ENV))
+            .and_then(|(_, value)| value)
+            .unwrap();
+        assert_eq!(launched, std::ffi::OsStr::new("1"));
         let auto_approve = cmd
             .get_envs()
             .find(|(key, _)| *key == std::ffi::OsStr::new(PENTECT_AGENT_AUTO_APPROVE_ENV))

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -64,13 +64,13 @@ pub(crate) fn approval_bypassed_by_config() -> Result<bool, String> {
 }
 
 pub(crate) fn require_pentect_agent_by_config() -> Result<bool, String> {
-    if let Some(value) = read_agent_require_pentect(project_config_path())? {
-        return Ok(value);
-    }
-    if let Some(value) = read_agent_require_pentect(global_config_path()?)? {
-        return Ok(value);
-    }
-    Ok(false)
+    let project = read_agent_require_pentect(project_config_path())?;
+    let global = read_agent_require_pentect(global_config_path()?)?;
+    Ok(require_pentect_agent_effective(project, global))
+}
+
+fn require_pentect_agent_effective(project: Option<bool>, global: Option<bool>) -> bool {
+    project.unwrap_or(false) || global.unwrap_or(false)
 }
 
 fn approval_bypassed_with_state(state: &ApprovalConfigState, agent_auto_approve: bool) -> bool {
@@ -373,5 +373,15 @@ mod tests {
 
         let value = "[agent]\nrequired = false".parse::<toml::Value>().unwrap();
         assert_eq!(agent_require_pentect_value(&value).unwrap(), Some(false));
+    }
+
+    #[test]
+    fn agent_require_pentect_is_monotonic_across_scopes() {
+        assert!(require_pentect_agent_effective(Some(false), Some(true)));
+        assert!(require_pentect_agent_effective(Some(true), Some(false)));
+        assert!(require_pentect_agent_effective(Some(true), None));
+        assert!(!require_pentect_agent_effective(Some(false), None));
+        assert!(!require_pentect_agent_effective(None, Some(false)));
+        assert!(!require_pentect_agent_effective(None, None));
     }
 }

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -63,6 +63,16 @@ pub(crate) fn approval_bypassed_by_config() -> Result<bool, String> {
     Ok(false)
 }
 
+pub(crate) fn require_pentect_agent_by_config() -> Result<bool, String> {
+    if let Some(value) = read_agent_require_pentect(project_config_path())? {
+        return Ok(value);
+    }
+    if let Some(value) = read_agent_require_pentect(global_config_path()?)? {
+        return Ok(value);
+    }
+    Ok(false)
+}
+
 fn approval_bypassed_with_state(state: &ApprovalConfigState, agent_auto_approve: bool) -> bool {
     if state.effective_no_approve {
         return true;
@@ -184,6 +194,40 @@ fn approval_config_override_value(value: &toml::Value) -> Result<Option<bool>, S
     Ok(None)
 }
 
+fn read_agent_require_pentect(path: PathBuf) -> Result<Option<bool>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let src = fs::read_to_string(&path)
+        .map_err(|e| format!("could not read '{}': {e}", path.display()))?;
+    if src.trim().is_empty() {
+        return Ok(None);
+    }
+    let value = src
+        .parse::<toml::Value>()
+        .map_err(|e| format!("could not parse '{}': {e}", path.display()))?;
+    agent_require_pentect_value(&value)
+}
+
+fn agent_require_pentect_value(value: &toml::Value) -> Result<Option<bool>, String> {
+    if let Some(raw) = value.get("require_pentect") {
+        return agent_config_bool(raw, "require_pentect").map(Some);
+    }
+    let Some(raw) = value.get("agent") else {
+        return Ok(None);
+    };
+    let Some(table) = raw.as_table() else {
+        return Err("agent config must be a table".to_string());
+    };
+    if let Some(raw) = table.get("require_pentect") {
+        return agent_config_bool(raw, "agent.require_pentect").map(Some);
+    }
+    if let Some(raw) = table.get("required") {
+        return agent_config_bool(raw, "agent.required").map(Some);
+    }
+    Ok(None)
+}
+
 fn config_bool(value: &toml::Value, field: &str) -> Result<bool, String> {
     if let Some(value) = value.as_bool() {
         return Ok(value);
@@ -196,6 +240,20 @@ fn config_bool(value: &toml::Value, field: &str) -> Result<bool, String> {
         };
     }
     Err(format!("approval config {field} must be a boolean"))
+}
+
+fn agent_config_bool(value: &toml::Value, field: &str) -> Result<bool, String> {
+    if let Some(value) = value.as_bool() {
+        return Ok(value);
+    }
+    if let Some(value) = value.as_str() {
+        return match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Ok(true),
+            "0" | "false" | "no" | "off" => Ok(false),
+            _ => Err(format!("agent config {field} must be boolean-like")),
+        };
+    }
+    Err(format!("agent config {field} must be a boolean"))
 }
 
 fn approval_mode_bypasses(value: &str) -> bool {
@@ -301,5 +359,19 @@ mod tests {
             effective_source: ApprovalConfigSource::Default,
         };
         assert!(approval_bypassed_with_state(&default_required, true));
+    }
+
+    #[test]
+    fn agent_require_pentect_accepts_top_level_and_table_forms() {
+        let value = "require_pentect = true".parse::<toml::Value>().unwrap();
+        assert_eq!(agent_require_pentect_value(&value).unwrap(), Some(true));
+
+        let value = "[agent]\nrequire_pentect = \"on\""
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(agent_require_pentect_value(&value).unwrap(), Some(true));
+
+        let value = "[agent]\nrequired = false".parse::<toml::Value>().unwrap();
+        assert_eq!(agent_require_pentect_value(&value).unwrap(), Some(false));
     }
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -2262,10 +2262,23 @@ fn agent_launch_proof_valid() -> bool {
         return false;
     };
     agent_launch_proof_matches(&proof, &token)
+        && memory_vault_env_addr_is_loopback()
+        && memory_vault_accepts_env_token()
 }
 
 fn agent_launch_proof_matches(proof: &str, token: &str) -> bool {
     token.len() >= 32 && proof == token
+}
+
+fn memory_vault_env_addr_is_loopback() -> bool {
+    std::env::var(ENV_ADDR)
+        .ok()
+        .and_then(|addr| addr.parse::<std::net::SocketAddr>().ok())
+        .is_some_and(|addr| addr.ip().is_loopback())
+}
+
+fn memory_vault_accepts_env_token() -> bool {
+    MemoryVaultClient::from_env().is_some_and(|client| client.key().is_ok())
 }
 
 fn canonical_hook_shell_command(command: &str) -> Result<String, String> {

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1172,6 +1172,7 @@ fn resolve_path_in_place(store: &RecoveryStore, path: &Path) -> Result<(), Strin
 fn apply_child_env_overlays(command: &mut Command, env: &[(String, String)], session: &str) {
     command.env_remove(ENV_ADDR);
     command.env_remove(ENV_TOKEN);
+    command.env_remove(PENTECT_AGENT_LAUNCHED_ENV);
     apply_env_bindings(command, env);
     apply_pentect_session(command, session);
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -42,6 +42,7 @@ use std::time::Duration;
 
 const MAX_INPUT_BYTES: usize = 32 * 1024 * 1024;
 const DEFAULT_SESSION: &str = "default";
+const PENTECT_AGENT_LAUNCHED_ENV: &str = "PENTECT_AGENT_LAUNCHED";
 const LIVE_MASK_CHUNK_BYTES: usize = 64 * 1024;
 const LIVE_MASK_CHUNK_LINES: usize = 2048;
 const DASHBOARD_HEARTBEAT_MAX_AGE: Duration = Duration::from_secs(3);
@@ -1598,6 +1599,16 @@ enum HookProvider {
     Generic,
 }
 
+impl HookProvider {
+    fn pentect_launch_command(self) -> &'static str {
+        match self {
+            HookProvider::Codex => "pentect codex",
+            HookProvider::Claude => "pentect claude",
+            HookProvider::Generic => "pentect codex|claude",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum HookPhase {
     BeforeTool,
@@ -2037,6 +2048,9 @@ fn handle_hook(
 ) -> Result<Value, String> {
     match hook_phase(provider, &input) {
         HookPhase::BeforeTool => {
+            if let Err(reason) = ensure_pentect_agent_launch(provider) {
+                return Ok(before_tool_block_output(provider, &reason));
+            }
             let Some(tool_input) = hook_tool_input(&input) else {
                 return Ok(json!({}));
             };
@@ -2060,6 +2074,9 @@ fn handle_hook(
             }
         }
         HookPhase::AfterTool => {
+            if let Err(reason) = ensure_pentect_agent_launch(provider) {
+                return Ok(after_tool_block_output(provider, &reason));
+            }
             let tool_name = hook_tool_name(&input)
                 .and_then(Value::as_str)
                 .unwrap_or_default();
@@ -2097,6 +2114,9 @@ fn handle_hook_lazy(
 ) -> Result<Value, String> {
     match hook_phase(provider, &input) {
         HookPhase::BeforeTool => {
+            if let Err(reason) = ensure_pentect_agent_launch(provider) {
+                return Ok(before_tool_block_output(provider, &reason));
+            }
             let Some(tool_input) = hook_tool_input(&input) else {
                 return Ok(json!({}));
             };
@@ -2120,6 +2140,9 @@ fn handle_hook_lazy(
             }
         }
         HookPhase::AfterTool => {
+            if let Err(reason) = ensure_pentect_agent_launch(provider) {
+                return Ok(after_tool_block_output(provider, &reason));
+            }
             let session = open_hook_session(cli, session_name)?;
             let tool_name = hook_tool_name(&input)
                 .and_then(Value::as_str)
@@ -2209,6 +2232,28 @@ fn before_tool_updated_input_lazy(
         }
     }
     Ok((tool_input.clone(), false))
+}
+
+fn ensure_pentect_agent_launch(provider: HookProvider) -> Result<(), String> {
+    if !config::require_pentect_agent_by_config()? {
+        return Ok(());
+    }
+    if agent_env_bool(PENTECT_AGENT_LAUNCHED_ENV) {
+        return Ok(());
+    }
+    Err(format!(
+        "Pentect required; start with `{}`.",
+        provider.pentect_launch_command()
+    ))
+}
+
+fn agent_env_bool(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
 }
 
 fn canonical_hook_shell_command(command: &str) -> Result<String, String> {

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -2046,9 +2046,22 @@ fn handle_hook(
     session: &Session,
     input: Value,
 ) -> Result<Value, String> {
+    handle_hook_with_launch_requirement(provider, session_name, session, input, false)
+}
+
+#[cfg(test)]
+fn handle_hook_with_launch_requirement(
+    provider: HookProvider,
+    session_name: &str,
+    session: &Session,
+    input: Value,
+    require_pentect_launch: bool,
+) -> Result<Value, String> {
     match hook_phase(provider, &input) {
         HookPhase::BeforeTool => {
-            if let Err(reason) = ensure_pentect_agent_launch(provider) {
+            if let Err(reason) =
+                ensure_pentect_agent_launch_required(provider, require_pentect_launch)
+            {
                 return Ok(before_tool_block_output(provider, &reason));
             }
             let Some(tool_input) = hook_tool_input(&input) else {
@@ -2074,7 +2087,9 @@ fn handle_hook(
             }
         }
         HookPhase::AfterTool => {
-            if let Err(reason) = ensure_pentect_agent_launch(provider) {
+            if let Err(reason) =
+                ensure_pentect_agent_launch_required(provider, require_pentect_launch)
+            {
                 return Ok(after_tool_block_output(provider, &reason));
             }
             let tool_name = hook_tool_name(&input)

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -2235,10 +2235,17 @@ fn before_tool_updated_input_lazy(
 }
 
 fn ensure_pentect_agent_launch(provider: HookProvider) -> Result<(), String> {
-    if !config::require_pentect_agent_by_config()? {
+    ensure_pentect_agent_launch_required(provider, config::require_pentect_agent_by_config()?)
+}
+
+fn ensure_pentect_agent_launch_required(
+    provider: HookProvider,
+    required: bool,
+) -> Result<(), String> {
+    if !required {
         return Ok(());
     }
-    if agent_env_bool(PENTECT_AGENT_LAUNCHED_ENV) {
+    if agent_launch_proof_valid() {
         return Ok(());
     }
     Err(format!(
@@ -2247,13 +2254,18 @@ fn ensure_pentect_agent_launch(provider: HookProvider) -> Result<(), String> {
     ))
 }
 
-fn agent_env_bool(name: &str) -> bool {
-    std::env::var(name).is_ok_and(|value| {
-        matches!(
-            value.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+fn agent_launch_proof_valid() -> bool {
+    let Ok(proof) = std::env::var(PENTECT_AGENT_LAUNCHED_ENV) else {
+        return false;
+    };
+    let Ok(token) = std::env::var(ENV_TOKEN) else {
+        return false;
+    };
+    agent_launch_proof_matches(&proof, &token)
+}
+
+fn agent_launch_proof_matches(proof: &str, token: &str) -> bool {
+    token.len() >= 32 && proof == token
 }
 
 fn canonical_hook_shell_command(command: &str) -> Result<String, String> {

--- a/crates/pentect-runtime/src/memory_vault.rs
+++ b/crates/pentect-runtime/src/memory_vault.rs
@@ -146,6 +146,23 @@ fn serve_memory_vault_inner() -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+pub(crate) fn spawn_test_memory_vault(token: String) -> String {
+    let key = Config::generate().key;
+    let state = Arc::new(Mutex::new(MemoryVaultState {
+        key,
+        recovery: Recovery::empty_for_key(&key),
+    }));
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    std::thread::spawn(move || {
+        for stream in listener.incoming().take(8) {
+            handle_client(stream.unwrap(), &token, &state).unwrap();
+        }
+    });
+    addr
+}
+
 fn handle_client(
     stream: TcpStream,
     token: &str,
@@ -253,22 +270,10 @@ mod tests {
     #[test]
     fn client_round_trips_recovery_through_memory_vault_state() {
         let token = "test-token".to_string();
-        let key = Config::generate().key;
-        let state = Arc::new(Mutex::new(MemoryVaultState {
-            key,
-            recovery: Recovery::empty_for_key(&key),
-        }));
-        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let addr = listener.local_addr().unwrap().to_string();
-        let server_state = state.clone();
-        let server_token = token.clone();
-        std::thread::spawn(move || {
-            for stream in listener.incoming().take(8) {
-                handle_client(stream.unwrap(), &server_token, &server_state).unwrap();
-            }
-        });
-
-        let client = MemoryVaultClient { addr, token };
+        let client = MemoryVaultClient {
+            addr: spawn_test_memory_vault(token.clone()),
+            token,
+        };
         assert_eq!(client.key().unwrap(), client.snapshot().unwrap().key);
         let snapshot = client.snapshot().unwrap();
         let result = Engine::with_profile(Profile::Strict).mask(
@@ -293,22 +298,10 @@ mod tests {
     #[test]
     fn read_style_masking_registers_recovery_and_env_aliases_in_memory_vault() {
         let token = "test-token-read".to_string();
-        let key = Config::generate().key;
-        let state = Arc::new(Mutex::new(MemoryVaultState {
-            key,
-            recovery: Recovery::empty_for_key(&key),
-        }));
-        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let addr = listener.local_addr().unwrap().to_string();
-        let server_state = state.clone();
-        let server_token = token.clone();
-        std::thread::spawn(move || {
-            for stream in listener.incoming().take(5) {
-                handle_client(stream.unwrap(), &server_token, &server_state).unwrap();
-            }
-        });
-
-        let client = MemoryVaultClient { addr, token };
+        let client = MemoryVaultClient {
+            addr: spawn_test_memory_vault(token.clone()),
+            token,
+        };
         let raw = "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n";
         let result = crate::mask_input_into_memory_vault_client(
             &client,

--- a/crates/pentect-runtime/src/memory_vault.rs
+++ b/crates/pentect-runtime/src/memory_vault.rs
@@ -156,6 +156,8 @@ pub(crate) fn spawn_test_memory_vault(token: String) -> String {
     let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
     let addr = listener.local_addr().unwrap().to_string();
     std::thread::spawn(move || {
+        // Unit tests open only a handful of requests; bound the helper server so
+        // finished tests do not keep an idle listener thread around forever.
         for stream in listener.incoming().take(8) {
             handle_client(stream.unwrap(), &token, &state).unwrap();
         }

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2190,6 +2190,64 @@ fn claude_pretool_wraps_plain_shell_command() {
 }
 
 #[test]
+fn pretool_require_pentect_blocks_unwrapped_agent_when_enabled() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
+    let root = temp_root("hook-require-pentect-block");
+    std::fs::create_dir_all(root.join(".pentect")).unwrap();
+    std::fs::write(
+        root.join(".pentect").join("config.toml"),
+        "[agent]\nrequire_pentect = true\n",
+    )
+    .unwrap();
+    let _cwd = CurrentDirGuard::enter(&root);
+    let session = Session::open_at(&root.join("agent-home"), "t").unwrap();
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "echo ok"
+        }
+    });
+    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
+    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
+    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .unwrap();
+    assert!(reason.contains("pentect claude"), "{reason}");
+    std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
+    drop(_cwd);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn pretool_require_pentect_allows_wrapped_agent_when_enabled() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    std::env::set_var(PENTECT_AGENT_LAUNCHED_ENV, "1");
+    let root = temp_root("hook-require-pentect-allow");
+    std::fs::create_dir_all(root.join(".pentect")).unwrap();
+    std::fs::write(
+        root.join(".pentect").join("config.toml"),
+        "require_pentect = true\n",
+    )
+    .unwrap();
+    let _cwd = CurrentDirGuard::enter(&root);
+    let session = Session::open_at(&root.join("agent-home"), "t").unwrap();
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "echo ok"
+        }
+    });
+    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
+    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
+    std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
+    drop(_cwd);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn pretool_wraps_pentect_read_from_ai_hooks() {
     let (root, session) = empty_session("hook-pre-read");
     let input = json!({
@@ -2791,6 +2849,24 @@ fn temp_root(name: &str) -> PathBuf {
         std::process::id(),
         unix_millis()
     ))
+}
+
+struct CurrentDirGuard {
+    original: PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn enter(path: &Path) -> Self {
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(path).unwrap();
+        Self { original }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.original);
+    }
 }
 
 fn strings<const N: usize>(items: [&str; N]) -> Vec<String> {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2199,28 +2199,31 @@ fn require_pentect_blocks_unwrapped_agent_when_enabled() {
 }
 
 #[test]
-fn require_pentect_rejects_boolean_marker_without_vault_proof() {
+fn require_pentect_rejects_matching_env_without_live_vault() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
-    std::env::set_var(PENTECT_AGENT_LAUNCHED_ENV, "1");
-    std::env::set_var(
-        ENV_TOKEN,
-        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    );
+    let token = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    std::env::set_var(PENTECT_AGENT_LAUNCHED_ENV, token);
+    std::env::set_var(ENV_TOKEN, token);
+    std::env::set_var(ENV_ADDR, "127.0.0.1:9");
     let reason = ensure_pentect_agent_launch_required(HookProvider::Claude, true).unwrap_err();
     assert!(reason.contains("pentect claude"), "{reason}");
     std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
     std::env::remove_var(ENV_TOKEN);
+    std::env::remove_var(ENV_ADDR);
 }
 
 #[test]
 fn require_pentect_allows_wrapped_agent_with_vault_proof() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let token = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let addr = memory_vault::spawn_test_memory_vault(token.to_string());
     std::env::set_var(PENTECT_AGENT_LAUNCHED_ENV, token);
     std::env::set_var(ENV_TOKEN, token);
+    std::env::set_var(ENV_ADDR, addr);
     ensure_pentect_agent_launch_required(HookProvider::Claude, true).unwrap();
     std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
     std::env::remove_var(ENV_TOKEN);
+    std::env::remove_var(ENV_ADDR);
 }
 
 #[test]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2190,61 +2190,37 @@ fn claude_pretool_wraps_plain_shell_command() {
 }
 
 #[test]
-fn pretool_require_pentect_blocks_unwrapped_agent_when_enabled() {
+fn require_pentect_blocks_unwrapped_agent_when_enabled() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
-    let root = temp_root("hook-require-pentect-block");
-    std::fs::create_dir_all(root.join(".pentect")).unwrap();
-    std::fs::write(
-        root.join(".pentect").join("config.toml"),
-        "[agent]\nrequire_pentect = true\n",
-    )
-    .unwrap();
-    let _cwd = CurrentDirGuard::enter(&root);
-    let session = Session::open_at(&root.join("agent-home"), "t").unwrap();
-    let input = json!({
-        "hook_event_name": "PreToolUse",
-        "tool_name": "Bash",
-        "tool_input": {
-            "command": "echo ok"
-        }
-    });
-    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
-    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
-    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
-        .as_str()
-        .unwrap();
+    std::env::remove_var(ENV_TOKEN);
+    let reason = ensure_pentect_agent_launch_required(HookProvider::Claude, true).unwrap_err();
     assert!(reason.contains("pentect claude"), "{reason}");
-    std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
-    drop(_cwd);
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
-fn pretool_require_pentect_allows_wrapped_agent_when_enabled() {
+fn require_pentect_rejects_boolean_marker_without_vault_proof() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     std::env::set_var(PENTECT_AGENT_LAUNCHED_ENV, "1");
-    let root = temp_root("hook-require-pentect-allow");
-    std::fs::create_dir_all(root.join(".pentect")).unwrap();
-    std::fs::write(
-        root.join(".pentect").join("config.toml"),
-        "require_pentect = true\n",
-    )
-    .unwrap();
-    let _cwd = CurrentDirGuard::enter(&root);
-    let session = Session::open_at(&root.join("agent-home"), "t").unwrap();
-    let input = json!({
-        "hook_event_name": "PreToolUse",
-        "tool_name": "Bash",
-        "tool_input": {
-            "command": "echo ok"
-        }
-    });
-    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
-    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
+    std::env::set_var(
+        ENV_TOKEN,
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    );
+    let reason = ensure_pentect_agent_launch_required(HookProvider::Claude, true).unwrap_err();
+    assert!(reason.contains("pentect claude"), "{reason}");
     std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
-    drop(_cwd);
-    let _ = std::fs::remove_dir_all(root);
+    std::env::remove_var(ENV_TOKEN);
+}
+
+#[test]
+fn require_pentect_allows_wrapped_agent_with_vault_proof() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let token = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    std::env::set_var(PENTECT_AGENT_LAUNCHED_ENV, token);
+    std::env::set_var(ENV_TOKEN, token);
+    ensure_pentect_agent_launch_required(HookProvider::Claude, true).unwrap();
+    std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
+    std::env::remove_var(ENV_TOKEN);
 }
 
 #[test]
@@ -2849,24 +2825,6 @@ fn temp_root(name: &str) -> PathBuf {
         std::process::id(),
         unix_millis()
     ))
-}
-
-struct CurrentDirGuard {
-    original: PathBuf,
-}
-
-impl CurrentDirGuard {
-    fn enter(path: &Path) -> Self {
-        let original = std::env::current_dir().unwrap();
-        std::env::set_current_dir(path).unwrap();
-        Self { original }
-    }
-}
-
-impl Drop for CurrentDirGuard {
-    fn drop(&mut self) {
-        let _ = std::env::set_current_dir(&self.original);
-    }
 }
 
 fn strings<const N: usize>(items: [&str; N]) -> Vec<String> {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -114,6 +114,14 @@ fn child_env_overlays_strip_memory_vault_credentials() {
     );
     assert!(
         matches!(
+            envs.iter()
+                .find(|(name, _)| name == "PENTECT_AGENT_LAUNCHED"),
+            Some((_, None))
+        ),
+        "{envs:?}"
+    );
+    assert!(
+        matches!(
             envs.iter().find(|(name, _)| name == "PENTECT_SESSION"),
             Some((_, Some(value))) if value == "demo"
         ),


### PR DESCRIPTION
﻿## Summary
- Add optional `.pentect/config.toml` guard: `require_pentect = true` or `[agent] require_pentect = true`.
- Mark `pentect codex` / `pentect claude` child processes with `PENTECT_AGENT_LAUNCHED=1`.
- When the guard is enabled, hooks block tool use unless the agent was launched through Pentect.

## Validation
- cargo fmt
- cargo test -p pentect-runtime require_pentect --all-features
- cargo test -p pentect-cli launched_agent_tools_export_pentect_path_for_hooks --all-features
- cargo test -p pentect-runtime --all-features
- cargo test -p pentect-cli --all-features
- cargo clippy --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for requiring a valid agent launch proof before certain agent actions proceed.
  * Improved environment setup when launching supported agents.

* **Bug Fixes**
  * Hook processing now blocks when the expected launch proof is missing.
  * Headless command runs now report errors more cleanly instead of stopping abruptly.

* **Tests**
  * Added and updated tests for launch-proof handling, configuration parsing, and agent hook behavior.

* **Documentation**
  * Added a review badge to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->