### PR TITLE
Add file pointer manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -271,6 +271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,7 +349,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -372,6 +381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -382,8 +392,19 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -513,6 +534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,8 +634,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -639,7 +669,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1111,6 +1141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1255,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1732,9 +1780,11 @@ dependencies = [
  "anstream",
  "anyhow",
  "axum",
+ "chacha20",
  "data-encoding",
  "ed25519-dalek",
  "getrandom 0.2.17",
+ "hmac",
  "image",
  "jiff",
  "ocrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ hmac = "0.12"
 zeroize = "1"
 unicode-normalization = "0.1"
 data-encoding = "2"
+chacha20 = "0.10.1"
 bs58 = "0.5"
 bip39 = { version = "2.2.2", features = ["all-languages"] }
 flate2 = "1"

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -29,6 +29,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }
 sha2 = { workspace = true }
+hmac = { workspace = true }
+chacha20 = { workspace = true }
 toml = { workspace = true }
 anstream = { workspace = true }
 zeroize = { workspace = true }

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -112,6 +112,12 @@ pub(crate) fn image_ocr_config() -> Result<ImageOcrConfig, String> {
     })
 }
 
+pub(crate) fn file_pointer_manager_save_enabled() -> Result<bool, String> {
+    let project = read_file_pointer_manager_save(project_config_path())?;
+    let global = read_file_pointer_manager_save(global_config_path()?)?;
+    Ok(project.or(global).unwrap_or(true))
+}
+
 fn require_pentect_agent_effective(project: Option<bool>, global: Option<bool>) -> bool {
     project.unwrap_or(false) || global.unwrap_or(false)
 }
@@ -307,6 +313,37 @@ fn image_ocr_config_value(value: &toml::Value) -> Result<ImageOcrConfigPartial, 
         out.unreadable_images = Some(unreadable_image_policy(raw, "image.unreadable_images")?);
     }
     Ok(out)
+}
+
+fn read_file_pointer_manager_save(path: PathBuf) -> Result<Option<bool>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let src = fs::read_to_string(&path)
+        .map_err(|e| format!("could not read '{}': {e}", path.display()))?;
+    if src.trim().is_empty() {
+        return Ok(None);
+    }
+    let value = src
+        .parse::<toml::Value>()
+        .map_err(|e| format!("could not parse '{}': {e}", path.display()))?;
+    file_pointer_manager_save_value(&value)
+}
+
+fn file_pointer_manager_save_value(value: &toml::Value) -> Result<Option<bool>, String> {
+    let Some(raw) = value.get("file_pointer_manager") else {
+        return Ok(None);
+    };
+    if raw.is_bool() || raw.is_str() {
+        return config_bool(raw, "file_pointer_manager").map(Some);
+    }
+    let Some(table) = raw.as_table() else {
+        return Err("file_pointer_manager config must be a boolean or table".to_string());
+    };
+    let Some(raw) = table.get("save") else {
+        return Ok(None);
+    };
+    config_bool(raw, "file_pointer_manager.save").map(Some)
 }
 
 fn config_bool(value: &toml::Value, field: &str) -> Result<bool, String> {
@@ -519,5 +556,21 @@ mod tests {
         let value = "image_ocr = false".parse::<toml::Value>().unwrap();
         let cfg = image_ocr_config_value(&value).unwrap();
         assert_eq!(cfg.mode, Some(ImageOcrMode::Off));
+    }
+
+    #[test]
+    fn file_pointer_manager_save_config_accepts_table_and_bool() {
+        let value = "[file_pointer_manager]\nsave = false"
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(
+            file_pointer_manager_save_value(&value).unwrap(),
+            Some(false)
+        );
+
+        let value = "file_pointer_manager = \"on\""
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(file_pointer_manager_save_value(&value).unwrap(), Some(true));
     }
 }

--- a/crates/pentect-runtime/src/file_pointer_manager.rs
+++ b/crates/pentect-runtime/src/file_pointer_manager.rs
@@ -1,0 +1,546 @@
+//! Persistent recovery hints for file-backed masked handles.
+//!
+//! This deliberately stores file pointers, not secret values. A pointer is only
+//! usable while the original file still has the exact same size and SHA-256, so
+//! stale handles fail closed instead of expanding to the wrong bytes.
+
+use chacha20::cipher::StreamCipher;
+use chacha20::{ChaCha20, Key, KeyIvInit, Nonce};
+use hmac::{Hmac, Mac};
+use pentect_core::{parse_placeholder, MaskResult, Recovery, RenderSegment};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashMap};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+#[cfg(not(test))]
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+use zeroize::Zeroize;
+
+const MANAGER_DIR: &str = "file-pointer-manager";
+const INDEX_FILE: &str = "index.bin";
+const KEY_FILE: &str = "key.bin";
+const ENVELOPE_MAGIC: &[u8] = b"PNFPM1";
+const NONCE_BYTES: usize = 12;
+const TAG_BYTES: usize = 32;
+const INDEX_VERSION: u32 = 1;
+const MAX_RECORDS: usize = 4096;
+const MAX_INDEX_BYTES: u64 = 4 * 1024 * 1024;
+const ENV_MANAGER_DIR: &str = "PENTECT_FILE_POINTER_MANAGER_DIR";
+const ENV_ALIAS_LABEL: &str = "PENTECT_ENV_ALIAS";
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct FilePointerIndex {
+    version: u32,
+    records: Vec<FilePointerRecord>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct FilePointerRecord {
+    handle: String,
+    path: String,
+    file_size: u64,
+    file_hash: String,
+    offset: u64,
+    length: u64,
+    label: String,
+    created_at: u64,
+}
+
+/// Register only file-backed handles. Shell/MCP/browser handles do not have a
+/// stable local source file, so they remain in-memory-only.
+pub(crate) fn register_file_pointers(path: &Path, source: &str, result: &MaskResult) {
+    if !save_enabled() {
+        return;
+    }
+    if result.summary.masked_count == 0 {
+        return;
+    }
+    let records = records_for_result(path, source, result);
+    if records.is_empty() {
+        return;
+    }
+    let mut index = load_index();
+    let mut changed = false;
+    for record in records {
+        changed |= upsert_record(&mut index.records, record);
+    }
+    if changed {
+        trim_index(&mut index.records);
+        let _ = save_index(&index);
+    }
+}
+
+/// Rebuild a temporary recovery map from unchanged files. No value is recovered
+/// from the index itself; the index only tells us where to read after verifying
+/// the full file hash.
+pub(crate) fn recover_text(text: &str, key: &[u8; 32]) -> Option<Recovery> {
+    if !save_enabled() {
+        return None;
+    }
+    let handles = handles_in_text(text);
+    if handles.is_empty() {
+        return None;
+    }
+    let index = load_index();
+    if index.records.is_empty() {
+        return None;
+    }
+    let by_handle: HashMap<&str, &FilePointerRecord> = index
+        .records
+        .iter()
+        .map(|record| (record.handle.as_str(), record))
+        .collect();
+    let mut by_path: BTreeMap<&str, Vec<&FilePointerRecord>> = BTreeMap::new();
+    for handle in handles {
+        let Some(record) = by_handle.get(handle.as_str()).copied() else {
+            continue;
+        };
+        by_path
+            .entry(record.path.as_str())
+            .or_default()
+            .push(record);
+    }
+    let mut recovered = HashMap::new();
+    for (path, records) in by_path {
+        recover_from_file(path, &records, &mut recovered);
+    }
+    if recovered.is_empty() {
+        None
+    } else {
+        Some(Recovery::seal(recovered, key))
+    }
+}
+
+/// `pentect view` can show length for a persisted file-backed handle without
+/// exposing the value. It reads the original file only after the hash matches.
+pub(crate) fn handle_length(handle: &str) -> Option<usize> {
+    if !save_enabled() {
+        return None;
+    }
+    let index = load_index();
+    let record = index
+        .records
+        .iter()
+        .find(|record| record.handle == handle)?;
+    let bytes = read_verified_file(record)?;
+    let value = slice_record_value(&bytes, record)?;
+    Some(value.chars().count())
+}
+
+fn records_for_result(path: &Path, source: &str, result: &MaskResult) -> Vec<FilePointerRecord> {
+    let file_size = source.len() as u64;
+    let file_hash = sha256_hex(source.as_bytes());
+    let path = stored_path(path);
+    let created_at = unix_seconds();
+    let mut records = Vec::new();
+    let mut offset = 0usize;
+    for segment in &result.segments {
+        match segment {
+            RenderSegment::Literal { text } => {
+                offset = offset.saturating_add(text.len());
+            }
+            RenderSegment::Masked { text, label, .. } => {
+                let mut value = result.recovery.resolve(text);
+                if value == *text
+                    || value.is_empty()
+                    || label == ENV_ALIAS_LABEL
+                    || result
+                        .summary
+                        .collisions
+                        .iter()
+                        .any(|handle| handle == text)
+                {
+                    offset = offset.saturating_add(value.len());
+                    value.zeroize();
+                    continue;
+                }
+                records.push(FilePointerRecord {
+                    handle: text.clone(),
+                    path: path.clone(),
+                    file_size,
+                    file_hash: file_hash.clone(),
+                    offset: offset as u64,
+                    length: value.len() as u64,
+                    label: label.clone(),
+                    created_at,
+                });
+                offset = offset.saturating_add(value.len());
+                value.zeroize();
+            }
+        }
+    }
+    records
+}
+
+fn recover_from_file(
+    path: &str,
+    records: &[&FilePointerRecord],
+    recovered: &mut HashMap<String, String>,
+) {
+    let Some(first) = records.first() else {
+        return;
+    };
+    let Some(bytes) = read_verified_file(first) else {
+        return;
+    };
+    if records.iter().any(|record| {
+        record.file_size != first.file_size
+            || record.file_hash != first.file_hash
+            || record.path != path
+    }) {
+        return;
+    }
+    for record in records {
+        let Some(value) = slice_record_value(&bytes, record) else {
+            continue;
+        };
+        recovered.insert(record.handle.clone(), value);
+    }
+}
+
+fn read_verified_file(record: &FilePointerRecord) -> Option<Vec<u8>> {
+    let path = Path::new(&record.path);
+    let meta = std::fs::metadata(path).ok()?;
+    if meta.len() != record.file_size {
+        return None;
+    }
+    let bytes = std::fs::read(path).ok()?;
+    if bytes.len() as u64 != record.file_size {
+        return None;
+    }
+    if sha256_hex(&bytes) != record.file_hash {
+        return None;
+    }
+    Some(bytes)
+}
+
+fn slice_record_value(bytes: &[u8], record: &FilePointerRecord) -> Option<String> {
+    let start = usize::try_from(record.offset).ok()?;
+    let len = usize::try_from(record.length).ok()?;
+    let end = start.checked_add(len)?;
+    let slice = bytes.get(start..end)?;
+    std::str::from_utf8(slice).ok().map(str::to_string)
+}
+
+fn handles_in_text(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0usize;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'<' && bytes[i + 1] == b'<' {
+            if let Some(close) = find_from(bytes, i + 2, b">>") {
+                let handle = &text[i..close + 2];
+                if parse_placeholder(handle).is_ok() && !out.iter().any(|v| v == handle) {
+                    out.push(handle.to_string());
+                }
+                i = close + 2;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+fn find_from(hay: &[u8], start: usize, needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || start >= hay.len() {
+        return None;
+    }
+    let mut i = start;
+    while i + needle.len() <= hay.len() {
+        if &hay[i..i + needle.len()] == needle {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn upsert_record(records: &mut Vec<FilePointerRecord>, record: FilePointerRecord) -> bool {
+    if records.iter().any(|existing| existing == &record) {
+        return false;
+    }
+    records.retain(|existing| existing.handle != record.handle);
+    records.push(record);
+    true
+}
+
+fn trim_index(records: &mut Vec<FilePointerRecord>) {
+    records.sort_by_key(|record| record.created_at);
+    if records.len() > MAX_RECORDS {
+        let drop_count = records.len() - MAX_RECORDS;
+        records.drain(0..drop_count);
+    }
+}
+
+fn load_index() -> FilePointerIndex {
+    let path = index_path();
+    let Ok(meta) = std::fs::metadata(&path) else {
+        return empty_index();
+    };
+    if meta.len() > MAX_INDEX_BYTES {
+        return empty_index();
+    }
+    let Ok(bytes) = std::fs::read(&path) else {
+        return empty_index();
+    };
+    let Some(key) = manager_key(false).ok().flatten() else {
+        return empty_index();
+    };
+    let Some(plaintext) = decrypt_payload(&bytes, &key) else {
+        return empty_index();
+    };
+    let Ok(index) = serde_json::from_slice::<FilePointerIndex>(&plaintext) else {
+        return empty_index();
+    };
+    if index.version == INDEX_VERSION {
+        index
+    } else {
+        empty_index()
+    }
+}
+
+fn save_index(index: &FilePointerIndex) -> Result<(), String> {
+    let path = index_path();
+    let parent = path
+        .parent()
+        .ok_or_else(|| "file pointer manager path has no parent".to_string())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("could not create '{}': {e}", parent.display()))?;
+    let mut index = index.clone();
+    trim_index(&mut index.records);
+    let mut bytes = serde_json::to_vec(&index).map_err(|e| e.to_string())?;
+    let max_plaintext = MAX_INDEX_BYTES.saturating_sub(envelope_overhead() as u64);
+    while bytes.len() as u64 > max_plaintext && !index.records.is_empty() {
+        index.records.remove(0);
+        bytes = serde_json::to_vec(&index).map_err(|e| e.to_string())?;
+    }
+    let key =
+        manager_key(true)?.ok_or_else(|| "file pointer manager key unavailable".to_string())?;
+    let encrypted = encrypt_payload(&bytes, &key)?;
+    let tmp = temp_index_path(&path);
+    std::fs::write(&tmp, encrypted)
+        .map_err(|e| format!("could not write '{}': {e}", tmp.display()))?;
+    replace_file(&tmp, &path)
+}
+
+fn index_path() -> PathBuf {
+    manager_dir().join(INDEX_FILE)
+}
+
+fn key_path() -> PathBuf {
+    manager_dir().join(KEY_FILE)
+}
+
+fn temp_index_path(path: &Path) -> PathBuf {
+    let nonce = random_hex_8();
+    path.with_extension(format!("bin.{nonce}.tmp"))
+}
+
+fn replace_file(tmp: &Path, path: &Path) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        std::fs::copy(tmp, path).map_err(|e| {
+            let _ = std::fs::remove_file(tmp);
+            format!("could not replace '{}': {e}", path.display())
+        })?;
+        std::fs::remove_file(tmp)
+            .map_err(|e| format!("could not remove '{}': {e}", tmp.display()))?;
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        std::fs::rename(tmp, path).map_err(|e| {
+            let _ = std::fs::remove_file(tmp);
+            format!("could not replace '{}': {e}", path.display())
+        })
+    }
+}
+
+fn manager_dir() -> PathBuf {
+    std::env::var_os(ENV_MANAGER_DIR)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(".pentect").join(MANAGER_DIR))
+}
+
+fn empty_index() -> FilePointerIndex {
+    FilePointerIndex {
+        version: INDEX_VERSION,
+        records: Vec::new(),
+    }
+}
+
+fn envelope_overhead() -> usize {
+    ENVELOPE_MAGIC.len() + NONCE_BYTES + TAG_BYTES
+}
+
+fn stored_path(path: &Path) -> String {
+    if path.is_absolute() {
+        if let Ok(cwd) = std::env::current_dir() {
+            if let Ok(relative) = path.strip_prefix(cwd) {
+                return relative.to_string_lossy().into_owned();
+            }
+        }
+    }
+    path.to_string_lossy().into_owned()
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    data_encoding::HEXLOWER.encode(&digest)
+}
+
+fn save_enabled() -> bool {
+    #[cfg(not(test))]
+    {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| crate::config::file_pointer_manager_save_enabled().unwrap_or(false))
+    }
+    #[cfg(test)]
+    {
+        crate::config::file_pointer_manager_save_enabled().unwrap_or(false)
+    }
+}
+
+fn manager_key(create: bool) -> Result<Option<[u8; 32]>, String> {
+    let path = key_path();
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            let key: [u8; 32] = bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| "file pointer manager key has wrong length".to_string())?;
+            Ok(Some(key))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && !create => Ok(None),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let mut key = [0u8; 32];
+            getrandom::getrandom(&mut key)
+                .map_err(|e| format!("could not create file pointer manager key: {e}"))?;
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| format!("could not create '{}': {e}", parent.display()))?;
+            }
+            std::fs::write(&path, key)
+                .map_err(|e| format!("could not write '{}': {e}", path.display()))?;
+            harden_key_permissions(&path);
+            Ok(Some(key))
+        }
+        Err(e) => Err(format!("could not read '{}': {e}", path.display())),
+    }
+}
+
+fn random_hex_8() -> String {
+    let mut bytes = [0u8; 8];
+    if getrandom::getrandom(&mut bytes).is_ok() {
+        return data_encoding::HEXLOWER.encode(&bytes);
+    }
+    let fallback = format!(
+        "{}-{:?}",
+        std::process::id(),
+        SystemTime::now().duration_since(UNIX_EPOCH).ok()
+    );
+    let digest = Sha256::digest(fallback.as_bytes());
+    data_encoding::HEXLOWER.encode(&digest[..8])
+}
+
+fn harden_key_permissions(path: &Path) {
+    #[cfg(unix)]
+    {
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+fn encrypt_payload(plaintext: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, String> {
+    let mut nonce = [0u8; NONCE_BYTES];
+    getrandom::getrandom(&mut nonce)
+        .map_err(|e| format!("could not create file pointer manager nonce: {e}"))?;
+    let mut ciphertext = plaintext.to_vec();
+    apply_keystream(&mut ciphertext, key, &nonce);
+    let tag = auth_tag(key, &nonce, &ciphertext)?;
+    let mut out =
+        Vec::with_capacity(ENVELOPE_MAGIC.len() + NONCE_BYTES + TAG_BYTES + ciphertext.len());
+    out.extend_from_slice(ENVELOPE_MAGIC);
+    out.extend_from_slice(&nonce);
+    out.extend_from_slice(&tag);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+fn decrypt_payload(bytes: &[u8], key: &[u8; 32]) -> Option<Vec<u8>> {
+    let header_len = ENVELOPE_MAGIC.len() + NONCE_BYTES + TAG_BYTES;
+    if bytes.len() < header_len || !bytes.starts_with(ENVELOPE_MAGIC) {
+        return None;
+    }
+    let nonce_start = ENVELOPE_MAGIC.len();
+    let tag_start = nonce_start + NONCE_BYTES;
+    let ciphertext_start = tag_start + TAG_BYTES;
+    let nonce: [u8; NONCE_BYTES] = bytes.get(nonce_start..tag_start)?.try_into().ok()?;
+    let tag = bytes.get(tag_start..ciphertext_start)?;
+    let ciphertext = bytes.get(ciphertext_start..)?;
+    let expected = auth_tag(key, &nonce, ciphertext).ok()?;
+    if !constant_time_eq(tag, &expected) {
+        return None;
+    }
+    let mut plaintext = ciphertext.to_vec();
+    apply_keystream(&mut plaintext, key, &nonce);
+    Some(plaintext)
+}
+
+fn apply_keystream(buf: &mut [u8], key: &[u8; 32], nonce: &[u8; NONCE_BYTES]) {
+    let stream_key = derived_key(key, b"pentect-file-pointer-manager-stream-v1");
+    let key = Key::from(stream_key);
+    let nonce = Nonce::from(*nonce);
+    let mut cipher = ChaCha20::new(&key, &nonce);
+    cipher.apply_keystream(buf);
+}
+
+fn auth_tag(
+    key: &[u8; 32],
+    nonce: &[u8; NONCE_BYTES],
+    ciphertext: &[u8],
+) -> Result<[u8; TAG_BYTES], String> {
+    let mac_key = derived_key(key, b"pentect-file-pointer-manager-mac-v1");
+    let mut mac = HmacSha256::new_from_slice(&mac_key).map_err(|e| e.to_string())?;
+    mac.update(ENVELOPE_MAGIC);
+    mac.update(nonce);
+    mac.update(ciphertext);
+    let bytes = mac.finalize().into_bytes();
+    let mut tag = [0u8; TAG_BYTES];
+    tag.copy_from_slice(&bytes);
+    Ok(tag)
+}
+
+fn derived_key(key: &[u8; 32], domain: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update(key);
+    hasher.finalize().into()
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (a, b) in a.iter().zip(b) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -11,6 +11,7 @@ mod approval;
 mod approve_ui;
 mod config;
 mod extension_adapter;
+mod file_pointer_manager;
 mod image_ocr;
 mod in_memory_manager;
 mod masking;
@@ -367,9 +368,11 @@ fn cmd_read(args: &[String]) -> i32 {
         Err(e) => return die(&e),
     };
     let kind = opts.kind.unwrap_or_else(|| infer_kind(&opts.path));
+    let source = data.clone();
     let input = Input { kind, data };
     match mask_input_into_active_in_memory_manager(input.clone(), Profile::Strict, Vec::new()) {
         Ok(Some(result)) => {
+            register_read_file_pointers(&opts.path, &input.data, &result, opts.input_format);
             print_read_result(result, opts.emit_meta);
             return 0;
         }
@@ -379,8 +382,22 @@ fn cmd_read(args: &[String]) -> i32 {
     let engine = Engine::with_profile(Profile::Strict);
     let cfg = Config::generate();
     let result = engine.mask(input, &cfg);
+    register_read_file_pointers(&opts.path, &source, &result, opts.input_format);
     print_read_result(result, opts.emit_meta);
     0
+}
+
+fn register_read_file_pointers(
+    path: &Path,
+    source: &str,
+    result: &MaskResult,
+    input_format: InputFormat,
+) -> bool {
+    if input_format != InputFormat::Text {
+        return false;
+    }
+    file_pointer_manager::register_file_pointers(path, source, result);
+    true
 }
 
 fn print_read_result(result: MaskResult, emit_meta: bool) {
@@ -419,10 +436,11 @@ fn cmd_view(args: &[String]) -> i32 {
 
 pub fn active_handle_length(handle: &str) -> Result<Option<usize>, String> {
     let Some(client) = InMemoryManagerClient::from_env() else {
-        return Ok(None);
+        return Ok(file_pointer_manager::handle_length(handle));
     };
     let snapshot = client.snapshot().map_err(|e| e.to_string())?;
-    Ok(handle_length_from_recovery(&snapshot.recovery, handle))
+    Ok(handle_length_from_recovery(&snapshot.recovery, handle)
+        .or_else(|| file_pointer_manager::handle_length(handle)))
 }
 
 fn handle_length_from_recovery(recovery: &pentect_core::Recovery, handle: &str) -> Option<usize> {
@@ -2517,7 +2535,7 @@ fn masked_read_copy(session: &Session, path_text: &str) -> Result<Option<PathBuf
     let result = Engine::with_profile(Profile::Strict).mask(
         Input {
             kind: infer_kind(path),
-            data,
+            data: data.clone(),
         },
         &Config::new(session.key),
     );
@@ -2530,6 +2548,7 @@ fn masked_read_copy(session: &Session, path_text: &str) -> Result<Option<PathBuf
         .map_err(|e| e.to_string())?
         .add_recovery(recovery)
         .map_err(|e| e.to_string())?;
+    file_pointer_manager::register_file_pointers(path, &data, &result);
 
     let masked_path = masked_read_copy_path(path);
     if let Some(parent) = masked_path.parent() {

--- a/crates/pentect-runtime/src/session.rs
+++ b/crates/pentect-runtime/src/session.rs
@@ -156,6 +156,11 @@ impl RecoveryStore {
         for rec in recoveries.iter() {
             out = rec.resolve(&out);
         }
+        drop(recoveries);
+        if let Some(recovery) = crate::file_pointer_manager::recover_text(&out, &self.session.key) {
+            self.add_recovery(recovery.clone())?;
+            out = recovery.resolve(&out);
+        }
         Ok(out)
     }
 

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2561,6 +2561,157 @@ fn masked_read_copy_path_mirrors_relative_paths() {
 }
 
 #[test]
+fn file_pointer_manager_recovers_read_handle_after_restart() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("file-pointer-recover");
+    let _cwd = enter_temp_cwd(&root);
+    write_project_config(&root, "[file_pointer_manager]\nsave = true\n");
+    let project = PathBuf::from("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let env = project.join(".env");
+    std::fs::write(&env, "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n").unwrap();
+
+    let session = Session::open_at(&root, "t").unwrap();
+    let masked_path = masked_read_copy(&session, env.to_str().unwrap())
+        .unwrap()
+        .unwrap();
+    let masked = std::fs::read_to_string(masked_path).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+
+    let restarted = Session::open_at(&root.join("restart"), "t").unwrap();
+    let store = RecoveryStore::load(&restarted).unwrap();
+    assert_eq!(
+        store.resolve_all(&handle).unwrap(),
+        "sk-ABCDEFGHIJKLMNOPQRSTUVWX"
+    );
+
+    let index = std::fs::read(
+        Path::new(".pentect")
+            .join("file-pointer-manager")
+            .join("index.bin"),
+    )
+    .unwrap();
+    assert!(
+        !String::from_utf8_lossy(&index).contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"),
+        "{}",
+        String::from_utf8_lossy(&index)
+    );
+    drop(_cwd);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn file_pointer_manager_refuses_changed_source_file() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("file-pointer-changed");
+    let _cwd = enter_temp_cwd(&root);
+    write_project_config(&root, "[file_pointer_manager]\nsave = true\n");
+    let project = PathBuf::from("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let env = project.join(".env");
+    std::fs::write(&env, "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n").unwrap();
+
+    let session = Session::open_at(&root, "t").unwrap();
+    let masked_path = masked_read_copy(&session, env.to_str().unwrap())
+        .unwrap()
+        .unwrap();
+    let masked = std::fs::read_to_string(masked_path).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+
+    std::fs::write(&env, "OPENAI_API_KEY=sk-CHANGEDABCDEFGHIJKLMNOP\n").unwrap();
+    let restarted = Session::open_at(&root.join("restart"), "t").unwrap();
+    let store = RecoveryStore::load(&restarted).unwrap();
+    assert_eq!(store.resolve_all(&handle).unwrap(), handle);
+    drop(_cwd);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn file_pointer_manager_refuses_grown_source_before_reading_value() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("file-pointer-grown");
+    let _cwd = enter_temp_cwd(&root);
+    write_project_config(&root, "[file_pointer_manager]\nsave = true\n");
+    let env = PathBuf::from(".env");
+    std::fs::write(&env, "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n").unwrap();
+
+    let session = Session::open_at(&root, "t").unwrap();
+    let masked_path = masked_read_copy(&session, env.to_str().unwrap())
+        .unwrap()
+        .unwrap();
+    let masked = std::fs::read_to_string(masked_path).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+
+    std::fs::write(&env, format!("{}\n{}", "x".repeat(128 * 1024), handle)).unwrap();
+    let restarted = Session::open_at(&root.join("restart"), "t").unwrap();
+    let store = RecoveryStore::load(&restarted).unwrap();
+    assert_eq!(store.resolve_all(&handle).unwrap(), handle);
+    drop(_cwd);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn file_pointer_manager_save_can_be_disabled() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("file-pointer-disabled");
+    let _cwd = enter_temp_cwd(&root);
+    write_project_config(&root, "[file_pointer_manager]\nsave = false\n");
+    let env = PathBuf::from(".env");
+    std::fs::write(&env, "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n").unwrap();
+
+    let session = Session::open_at(&root, "t").unwrap();
+    let masked_path = masked_read_copy(&session, env.to_str().unwrap())
+        .unwrap()
+        .unwrap();
+    let masked = std::fs::read_to_string(masked_path).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+
+    let restarted = Session::open_at(&root.join("restart"), "t").unwrap();
+    let store = RecoveryStore::load(&restarted).unwrap();
+    assert_eq!(store.resolve_all(&handle).unwrap(), handle);
+    assert!(!Path::new(".pentect")
+        .join("file-pointer-manager")
+        .join("index.bin")
+        .exists());
+    assert!(!Path::new(".pentect")
+        .join("file-pointer-manager")
+        .join("key.bin")
+        .exists());
+    drop(_cwd);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn file_pointer_manager_skips_non_text_read_inputs() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("file-pointer-non-text");
+    let _cwd = enter_temp_cwd(&root);
+    write_project_config(&root, "[file_pointer_manager]\nsave = true\n");
+    let path = PathBuf::from("image.txt");
+    std::fs::write(&path, "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n").unwrap();
+    let result = Engine::with_profile(Profile::Strict).mask(
+        Input {
+            kind: Kind::Env,
+            data: std::fs::read_to_string(&path).unwrap(),
+        },
+        &Config::generate(),
+    );
+    assert!(result.summary.masked_count > 0);
+    assert!(!register_read_file_pointers(
+        &path,
+        &result.masked,
+        &result,
+        InputFormat::Pdf
+    ));
+    assert!(!Path::new(".pentect")
+        .join("file-pointer-manager")
+        .join("index.bin")
+        .exists());
+    drop(_cwd);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn pretool_allows_read_many_when_all_files_are_clean() {
     let (root, session) = empty_session("hook-pre-read-many-clean");
     let project = PathBuf::from("target").join(format!(


### PR DESCRIPTION
## Summary
- adds file pointer manager for file-backed masked handles
- persists only encrypted pointer metadata, never secret values
- restores old Read-derived handles only when the source file size/hash still match
- adds `[file_pointer_manager] save = false` to disable persistent pointers

## Validation
- `cargo test -p pentect-runtime`
- `cargo test -p pentect-cli`
- `cargo clippy -p pentect-cli -p pentect-runtime --all-targets -- -D warnings`
- `git diff --check`
- `cargo run -q -p pentect-cli -- doctor --json`