### PR TITLE
Clarify image scan policy

### DIFF
--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -29,7 +29,7 @@ pub(crate) enum ImageOcrMode {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum UnreadableImagePolicy {
+pub(crate) enum UnscannedImagePolicy {
     Allow,
     Block,
 }
@@ -39,7 +39,7 @@ pub(crate) struct ImageOcrConfig {
     pub(crate) mode: ImageOcrMode,
     pub(crate) max_pixels: u64,
     pub(crate) max_edge: u32,
-    pub(crate) unreadable_images: UnreadableImagePolicy,
+    pub(crate) unscanned_images: UnscannedImagePolicy,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -47,7 +47,7 @@ struct ImageOcrConfigPartial {
     mode: Option<ImageOcrMode>,
     max_pixels: Option<u64>,
     max_edge: Option<u32>,
-    unreadable_images: Option<UnreadableImagePolicy>,
+    unscanned_images: Option<UnscannedImagePolicy>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -287,9 +287,6 @@ fn read_image_ocr_config(path: PathBuf) -> Result<ImageOcrConfigPartial, String>
 
 fn image_ocr_config_value(value: &toml::Value) -> Result<ImageOcrConfigPartial, String> {
     let mut out = ImageOcrConfigPartial::default();
-    if let Some(raw) = value.get("image_ocr") {
-        out.mode = Some(image_ocr_mode(raw, "image_ocr")?);
-    }
     let Some(raw) = value.get("image") else {
         return Ok(out);
     };
@@ -305,8 +302,8 @@ fn image_ocr_config_value(value: &toml::Value) -> Result<ImageOcrConfigPartial, 
     if let Some(raw) = table.get("max_edge") {
         out.max_edge = Some(config_u32(raw, "image.max_edge")?);
     }
-    if let Some(raw) = table.get("unreadable_images") {
-        out.unreadable_images = Some(unreadable_image_policy(raw, "image.unreadable_images")?);
+    if let Some(raw) = table.get("unscanned_images") {
+        out.unscanned_images = Some(unscanned_image_policy(raw, "image.unscanned_images")?);
     }
     Ok(out)
 }
@@ -374,16 +371,16 @@ fn image_ocr_mode(value: &toml::Value, field: &str) -> Result<ImageOcrMode, Stri
     }
 }
 
-fn unreadable_image_policy(
+fn unscanned_image_policy(
     value: &toml::Value,
     field: &str,
-) -> Result<UnreadableImagePolicy, String> {
+) -> Result<UnscannedImagePolicy, String> {
     let Some(value) = value.as_str() else {
         return Err(format!("{field} must be allow or block"));
     };
     match value.trim().to_ascii_lowercase().as_str() {
-        "allow" => Ok(UnreadableImagePolicy::Allow),
-        "block" => Ok(UnreadableImagePolicy::Block),
+        "allow" => Ok(UnscannedImagePolicy::Allow),
+        "block" => Ok(UnscannedImagePolicy::Block),
         _ => Err(format!("{field} must be allow or block")),
     }
 }
@@ -422,10 +419,10 @@ fn merge_image_ocr_config(
             .max_edge
             .or(global.max_edge)
             .unwrap_or(DEFAULT_IMAGE_OCR_MAX_EDGE),
-        unreadable_images: project
-            .unreadable_images
-            .or(global.unreadable_images)
-            .unwrap_or(UnreadableImagePolicy::Allow),
+        unscanned_images: project
+            .unscanned_images
+            .or(global.unscanned_images)
+            .unwrap_or(UnscannedImagePolicy::Allow),
     }
 }
 
@@ -575,16 +572,16 @@ mod tests {
     #[test]
     fn image_ocr_config_accepts_mode_and_limit() {
         let value =
-            "[image]\nocr = \"on\"\nmax_pixels = 1234\nmax_edge = 2048\nunreadable_images = \"block\""
+            "[image]\nocr = \"on\"\nmax_pixels = 1234\nmax_edge = 2048\nunscanned_images = \"block\""
                 .parse::<toml::Value>()
             .unwrap();
         let cfg = image_ocr_config_value(&value).unwrap();
         assert_eq!(cfg.mode, Some(ImageOcrMode::On));
         assert_eq!(cfg.max_pixels, Some(1234));
         assert_eq!(cfg.max_edge, Some(2048));
-        assert_eq!(cfg.unreadable_images, Some(UnreadableImagePolicy::Block));
+        assert_eq!(cfg.unscanned_images, Some(UnscannedImagePolicy::Block));
 
-        let value = "image_ocr = false".parse::<toml::Value>().unwrap();
+        let value = "[image]\nocr = false".parse::<toml::Value>().unwrap();
         let cfg = image_ocr_config_value(&value).unwrap();
         assert_eq!(cfg.mode, Some(ImageOcrMode::Off));
     }

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 pub(crate) struct ImageInspection {
     pub(crate) inline_images: usize,
-    pub(crate) unreadable_images: usize,
+    pub(crate) unscanned_images: usize,
     pub(crate) ocr_failures: usize,
     pub(crate) secret_images: usize,
 }
@@ -50,7 +50,7 @@ pub(crate) fn inspect_tool_images_for_secrets(
 ) -> Result<ImageInspection, String> {
     let mut inspection = ImageInspection {
         inline_images: 0,
-        unreadable_images: 0,
+        unscanned_images: 0,
         ocr_failures: 0,
         secret_images: 0,
     };
@@ -68,7 +68,7 @@ fn collect_image_inspection(
             if let Some(bytes) = inline_image_bytes(text)? {
                 inspect_image_bytes(&bytes, key, inspection);
             } else if looks_like_image_reference(text) {
-                inspection.unreadable_images += 1;
+                inspection.unscanned_images += 1;
             }
         }
         Value::Number(_) | Value::Bool(_) | Value::Null => {}
@@ -82,7 +82,7 @@ fn collect_image_inspection(
                 if let Some(bytes) = inline_image_object_bytes(map)? {
                     inspect_image_bytes(&bytes, key, inspection);
                 } else if !empty_image_object(map) {
-                    inspection.unreadable_images += 1;
+                    inspection.unscanned_images += 1;
                 }
                 return Ok(());
             }
@@ -391,6 +391,12 @@ mod tests {
         let inner = value["image_url"].as_object().unwrap();
         assert!(object_marks_image(inner));
         assert!(inline_image_object_bytes(inner).unwrap().is_some());
+    }
+
+    #[test]
+    fn empty_ocr_text_is_not_secret() {
+        assert!(!ocr_text_has_secret("", &[7; 32]));
+        assert!(!ocr_text_has_secret("   \n\t", &[7; 32]));
     }
 
     #[cfg(feature = "ocr")]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -3374,7 +3374,7 @@ fn image_tool_result_block_reason(
     let cfg = config::image_ocr_config()?;
     if matches!(cfg.mode, config::ImageOcrMode::Off) {
         return Ok(
-            matches!(cfg.unreadable_images, config::UnreadableImagePolicy::Block)
+            matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Block)
                 .then_some("image blocked: OCR is off.".to_string()),
         );
     }
@@ -3382,16 +3382,16 @@ fn image_tool_result_block_reason(
     if inspection.secret_images > 0 {
         return Ok(Some("image blocked: secret text detected.".to_string()));
     }
-    if matches!(cfg.unreadable_images, config::UnreadableImagePolicy::Allow) {
+    if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Allow) {
         return Ok(None);
     }
-    if inspection.unreadable_images > 0 {
+    if inspection.unscanned_images > 0 {
         return Ok(Some(
-            "image blocked: OCR needs inline image bytes.".to_string(),
+            "image blocked: image bytes were not available to scan.".to_string(),
         ));
     }
     if inspection.ocr_failures > 0 {
-        return Ok(Some("image blocked: OCR failed.".to_string()));
+        return Ok(Some("image blocked: image scan failed.".to_string()));
     }
     Ok(None)
 }

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1555,11 +1555,11 @@ fn generic_posttool_masks_payload_alias() {
 }
 
 #[test]
-fn posttool_allows_unreadable_image_output_by_default() {
+fn posttool_allows_unscanned_image_output_by_default() {
     let (root, session) = empty_session("hook-post-image-best-effort");
     write_project_config(
         &root,
-        "[image]\nocr = \"on\"\nunreadable_images = \"allow\"\n",
+        "[image]\nocr = \"on\"\nunscanned_images = \"allow\"\n",
     );
     let input = json!({
         "hook_event_name": "PostToolUse",
@@ -1583,11 +1583,11 @@ fn posttool_allows_unreadable_image_output_by_default() {
 }
 
 #[test]
-fn posttool_blocks_unreadable_image_output_when_configured() {
+fn posttool_blocks_unscanned_image_output_when_configured() {
     let (root, session) = empty_session("hook-post-image-strict");
     write_project_config(
         &root,
-        "[image]\nocr = \"on\"\nunreadable_images = \"block\"\n",
+        "[image]\nocr = \"on\"\nunscanned_images = \"block\"\n",
     );
     let input = json!({
         "hookEventName": "PostToolUse",
@@ -1604,7 +1604,7 @@ fn posttool_blocks_unreadable_image_output_when_configured() {
     assert_eq!(output["decision"], "block");
     let reason = output["reason"].as_str().unwrap();
     assert!(reason.contains("image blocked"), "{reason}");
-    assert!(reason.contains("OCR failed"), "{reason}");
+    assert!(reason.contains("image scan failed"), "{reason}");
     let _ = std::fs::remove_dir_all(root);
 }
 


### PR DESCRIPTION
## Summary
- rename unreadable image policy to unscanned_images
- remove the old top-level image_ocr alias
- keep scenery/empty OCR text as non-secret
- update block reasons to describe scan failures instead of unreadable images

## Tests
- cargo test -p pentect-runtime
- cargo test -p pentect-runtime --no-default-features
- cargo clippy -p pentect-runtime --all-targets --all-features -- -D warnings
- git diff --check