### PR TITLE
Unify tool text output masking

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -36,7 +36,7 @@ const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
     "- Masked handles like `<<NAME_hash>>` work only in this running Pentect-launched session. Use `$env:NAME`/`$env:PENTECT_NAME_hash` on PowerShell or `$NAME`/`$PENTECT_NAME_hash` on Unix.\n",
     "- `pentect view '<handle>'` shows only label, hash, and length. Use handles or generated env vars instead of printing raw values.\n",
     "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:NAME`; on Unix use POSIX commands and `$NAME`.\n",
-    "- Browser/MCP/connector tools may retrieve and use user-authorized secrets. Pentect hooks mask returned tool output when the host supports it; use shell/Pentect for hosts that cannot safely replace tool output.\n",
+    "- MCP, browser, plugin, and connector tools may retrieve and use user-authorized secrets. Pentect masks tool text output when the host supports replacement; otherwise it stops unsafe output.\n",
     "- Image tool output is OCR-inspected when available; detected secrets are blocked.\n",
     "- For user-requested storage, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
     "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
@@ -1906,7 +1906,11 @@ mod tests {
         assert!(rendered.contains("pentect view"), "{rendered}");
         assert!(!rendered.contains("pentect read"), "{rendered}");
         assert!(rendered.contains("PowerShell"), "{rendered}");
-        assert!(rendered.contains("Browser/MCP/connector"), "{rendered}");
+        assert!(
+            rendered.contains("MCP, browser, plugin, and connector"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("tool text output"), "{rendered}");
         assert!(rendered.contains("user-requested storage"), "{rendered}");
         assert!(rendered.contains("exact requested"), "{rendered}");
         assert!(rendered.contains("local file"), "{rendered}");
@@ -1979,7 +1983,11 @@ mod tests {
         assert!(rendered.contains("pentect view"), "{rendered}");
         assert!(!rendered.contains("pentect read"), "{rendered}");
         assert!(rendered.contains("PowerShell"), "{rendered}");
-        assert!(rendered.contains("Browser/MCP/connector"), "{rendered}");
+        assert!(
+            rendered.contains("MCP, browser, plugin, and connector"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("tool text output"), "{rendered}");
         assert!(rendered.contains("user-requested storage"), "{rendered}");
         assert!(rendered.contains("exact requested"), "{rendered}");
         assert!(rendered.contains("local file"), "{rendered}");

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1756,6 +1756,12 @@ enum HookPhase {
     Other,
 }
 
+enum ToolTextOutput {
+    Unchanged,
+    Updated(Value),
+    Block(String),
+}
+
 // Hook hosts disagree on casing and envelope names. Keep that compatibility at
 // the boundary; detection still walks the returned JSON structure generically.
 const HOOK_EVENT_FIELDS: &[&str] = &[
@@ -2238,23 +2244,13 @@ fn handle_hook_with_launch_requirement(
             let Some(tool_response) = hook_tool_result(&input) else {
                 return Ok(json!({}));
             };
-            if let Some(reason) = image_tool_result_block_reason(session, tool_response)? {
-                return Ok(after_tool_block_output(provider, &reason));
-            }
-            if let Some(reason) = unsupported_tool_result_reason(tool_response) {
-                return Ok(after_tool_block_output(provider, &reason));
-            }
             if codex_exec_proxy_owns_shell_output(provider, tool_name) {
                 return Ok(json!({}));
             }
-            let store = RecoveryStore::load(session).map_err(|e| e.to_string())?;
-            let mut masker = OutputMasker::new_deferred(store)?;
-            let (updated, changed) = mask_tool_json(tool_response, &mut masker)?;
-            masker.flush()?;
-            if changed {
-                Ok(after_tool_output(provider, updated))
-            } else {
-                Ok(json!({}))
+            match mask_tool_text_output(session, tool_response)? {
+                ToolTextOutput::Unchanged => Ok(json!({})),
+                ToolTextOutput::Updated(updated) => Ok(after_tool_output(provider, updated)),
+                ToolTextOutput::Block(reason) => Ok(after_tool_block_output(provider, &reason)),
             }
         }
         HookPhase::Other => Ok(json!({})),
@@ -2311,23 +2307,13 @@ fn handle_hook_lazy(
             let Some(tool_response) = hook_tool_result(&input) else {
                 return Ok(json!({}));
             };
-            if let Some(reason) = image_tool_result_block_reason(&session, tool_response)? {
-                return Ok(after_tool_block_output(provider, &reason));
-            }
-            if let Some(reason) = unsupported_tool_result_reason(tool_response) {
-                return Ok(after_tool_block_output(provider, &reason));
-            }
             if codex_exec_proxy_owns_shell_output(provider, tool_name) {
                 return Ok(json!({}));
             }
-            let store = RecoveryStore::load(&session).map_err(|e| e.to_string())?;
-            let mut masker = OutputMasker::new_deferred(store)?;
-            let (updated, changed) = mask_tool_json(tool_response, &mut masker)?;
-            masker.flush()?;
-            if changed {
-                Ok(after_tool_output(provider, updated))
-            } else {
-                Ok(json!({}))
+            match mask_tool_text_output(&session, tool_response)? {
+                ToolTextOutput::Unchanged => Ok(json!({})),
+                ToolTextOutput::Updated(updated) => Ok(after_tool_output(provider, updated)),
+                ToolTextOutput::Block(reason) => Ok(after_tool_block_output(provider, &reason)),
             }
         }
         HookPhase::Other => Ok(json!({})),
@@ -3362,6 +3348,27 @@ fn after_tool_block_output(_provider: HookProvider, reason: &str) -> Value {
         "decision": "block",
         "reason": reason
     })
+}
+
+fn mask_tool_text_output(
+    session: &Session,
+    tool_response: &Value,
+) -> Result<ToolTextOutput, String> {
+    if let Some(reason) = image_tool_result_block_reason(session, tool_response)? {
+        return Ok(ToolTextOutput::Block(reason));
+    }
+    if let Some(reason) = unsupported_tool_result_reason(tool_response) {
+        return Ok(ToolTextOutput::Block(reason));
+    }
+    let store = RecoveryStore::load(session).map_err(|e| e.to_string())?;
+    let mut masker = OutputMasker::new_deferred(store)?;
+    let (updated, changed) = mask_tool_json(tool_response, &mut masker)?;
+    masker.flush()?;
+    if changed {
+        Ok(ToolTextOutput::Updated(updated))
+    } else {
+        Ok(ToolTextOutput::Unchanged)
+    }
 }
 
 fn image_tool_result_block_reason(

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1592,6 +1592,28 @@ fn tool_text_output_masks_mcp_connector_and_plugin_envelopes() {
         assert!(rendered.contains("<<OPENAI_API_KEY_"), "{rendered}");
         assert!(!rendered.contains(raw), "{rendered}");
     }
+
+    let unchanged = json!({
+        "eventName": "PostToolUse",
+        "tool": "plugin__browser_text",
+        "payload": {
+            "text": "visible page title only"
+        }
+    });
+    let output = handle_hook(HookProvider::Generic, "t", &session, unchanged).unwrap();
+    assert_eq!(output, json!({}));
+
+    let blocked = json!({
+        "eventName": "PostToolUse",
+        "tool": "plugin__browser_media",
+        "payload": {
+            "url": "data:video/mp4;base64,AAAA"
+        }
+    });
+    let output = handle_hook(HookProvider::Generic, "t", &session, blocked).unwrap();
+    assert_eq!(output["decision"], "block");
+    let reason = output["reason"].as_str().unwrap();
+    assert!(reason.contains("non-text media"), "{reason}");
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1555,6 +1555,47 @@ fn generic_posttool_masks_payload_alias() {
 }
 
 #[test]
+fn tool_text_output_masks_mcp_connector_and_plugin_envelopes() {
+    let (root, session) = empty_session("hook-post-tool-text-unified");
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let inputs = [
+        json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "mcp__vault__get_key",
+            "tool_response": {
+                "content": [{
+                    "type": "text",
+                    "text": format!("OPENAI_API_KEY={raw}")
+                }]
+            }
+        }),
+        json!({
+            "hookEventName": "PostToolUse",
+            "toolName": "connector__browser__text",
+            "toolResponse": {
+                "visibleText": format!("OPENAI_API_KEY={raw}")
+            }
+        }),
+        json!({
+            "eventName": "PostToolUse",
+            "tool": "plugin__browser_text",
+            "payload": {
+                "text": format!("OPENAI_API_KEY={raw}")
+            }
+        }),
+    ];
+
+    for input in inputs {
+        let output = handle_hook(HookProvider::Generic, "t", &session, input).unwrap();
+        let rendered = serde_json::to_string(&output).unwrap();
+        assert!(rendered.contains("updatedToolOutput"), "{rendered}");
+        assert!(rendered.contains("<<OPENAI_API_KEY_"), "{rendered}");
+        assert!(!rendered.contains(raw), "{rendered}");
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn posttool_allows_unscanned_image_output_by_default() {
     let (root, session) = empty_session("hook-post-image-best-effort");
     write_project_config(


### PR DESCRIPTION
## Summary
- route post-tool text masking through one ToolTextOutput path
- keep MCP/browser/plugin/connector differences at the hook envelope boundary
- add coverage for MCP, connector, and plugin-style tool outputs using the same masker
- update the agent contract wording to say tool text output

## Tests
- cargo test -p pentect-runtime
- cargo test -p pentect-runtime --no-default-features
- cargo test -p pentect-cli
- cargo clippy -p pentect-runtime -p pentect-cli --all-targets --all-features -- -D warnings
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded secret-masking coverage for tool responses, including browser, MCP, plugin, and connector tools.
  * Tool output handling now more consistently updates or blocks content when sensitive data is detected.

* **Bug Fixes**
  * Improved protection against accidental exposure of secrets in tool results.
  * Updated contract text and checks to reflect the latest masking behavior and wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->