### PR TITLE
Scan remote image URLs with OCR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +379,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -640,6 +652,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,7 +805,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "305d3ba574508e27190906d11707dad683e0494e6b85eae9b044cb2734a5e422"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "http-body-util",
  "hyper",
@@ -896,6 +919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -903,6 +927,18 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -917,7 +953,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -939,8 +978,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -962,11 +1003,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1171,18 +1214,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -1190,6 +1339,27 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -1276,6 +1446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1575,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1440,6 +1633,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maplit"
@@ -1790,6 +1989,7 @@ dependencies = [
  "ocrs",
  "pdf-extract",
  "pentect-core",
+ "reqwest",
  "rten",
  "serde",
  "serde_json",
@@ -1914,6 +2114,15 @@ name = "postscript"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2044,6 +2253,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2413,15 @@ checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
  "rand 0.10.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2266,6 +2540,60 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rten"
@@ -2420,6 +2748,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2796,6 +3159,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tar"
@@ -2862,6 +3239,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,6 +3288,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2958,6 +3355,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3281,10 +3696,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3376,6 +3815,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,6 +3891,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3483,6 +3961,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3670,6 +4157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3677,6 +4170,29 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -3700,10 +4216,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ pdf-extract = "0.10.0"
 image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "webp", "bmp", "gif"] }
 ocrs = "0.12.2"
 rten = { version = "0.24.0", default-features = false, features = ["rten_format"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 anstream = "0.6"
 crossterm = "0.28"
 ed25519-dalek = "2"

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [features]
 default = ["pdf", "ocr"]
 pdf = ["dep:pdf-extract"]
-ocr = ["dep:image", "dep:ocrs", "dep:rten"]
+ocr = ["dep:image", "dep:ocrs", "dep:reqwest", "dep:rten"]
 
 [dependencies]
 pentect-core = { path = "../pentect-core" }
@@ -24,6 +24,7 @@ data-encoding = { workspace = true }
 pdf-extract = { workspace = true, optional = true }
 image = { workspace = true, optional = true }
 ocrs = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
 rten = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -1,9 +1,16 @@
 #[cfg(feature = "ocr")]
 use crate::config::{image_ocr_config, ImageOcrMode};
 use serde_json::Value;
+#[cfg(feature = "ocr")]
+use std::net::IpAddr;
+
+#[cfg(feature = "ocr")]
+const IMAGE_URL_MAX_BYTES: u64 = 16 * 1024 * 1024;
+#[cfg(feature = "ocr")]
+const IMAGE_URL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub(crate) struct ImageInspection {
-    pub(crate) inline_images: usize,
+    pub(crate) scanned_images: usize,
     pub(crate) unscanned_images: usize,
     pub(crate) ocr_failures: usize,
     pub(crate) secret_images: usize,
@@ -49,7 +56,7 @@ pub(crate) fn inspect_tool_images_for_secrets(
     key: &[u8; 32],
 ) -> Result<ImageInspection, String> {
     let mut inspection = ImageInspection {
-        inline_images: 0,
+        scanned_images: 0,
         unscanned_images: 0,
         ocr_failures: 0,
         secret_images: 0,
@@ -65,10 +72,11 @@ fn collect_image_inspection(
 ) -> Result<(), String> {
     match value {
         Value::String(text) => {
-            if let Some(bytes) = inline_image_bytes(text)? {
-                inspect_image_bytes(&bytes, key, inspection);
-            } else if looks_like_image_reference(text) {
-                inspection.unscanned_images += 1;
+            if looks_like_image_reference(text) {
+                match image_reference_bytes(text) {
+                    Ok(Some(bytes)) => inspect_image_bytes(&bytes, key, inspection),
+                    Ok(None) | Err(_) => inspection.unscanned_images += 1,
+                }
             }
         }
         Value::Number(_) | Value::Bool(_) | Value::Null => {}
@@ -79,10 +87,13 @@ fn collect_image_inspection(
         }
         Value::Object(map) => {
             if object_marks_image(map) {
-                if let Some(bytes) = inline_image_object_bytes(map)? {
-                    inspect_image_bytes(&bytes, key, inspection);
-                } else if !empty_image_object(map) {
-                    inspection.unscanned_images += 1;
+                match image_object_bytes(map) {
+                    Ok(Some(bytes)) => inspect_image_bytes(&bytes, key, inspection),
+                    Ok(None) | Err(_) => {
+                        if !empty_image_object(map) {
+                            inspection.unscanned_images += 1;
+                        }
+                    }
                 }
                 return Ok(());
             }
@@ -95,7 +106,7 @@ fn collect_image_inspection(
 }
 
 fn inspect_image_bytes(bytes: &[u8], key: &[u8; 32], inspection: &mut ImageInspection) {
-    inspection.inline_images += 1;
+    inspection.scanned_images += 1;
     match ocr_image_bytes(bytes) {
         Ok(text) => {
             if ocr_text_has_secret(&text, key) {
@@ -130,9 +141,7 @@ fn object_marks_image(map: &serde_json::Map<String, Value>) -> bool {
     })
 }
 
-fn inline_image_object_bytes(
-    map: &serde_json::Map<String, Value>,
-) -> Result<Option<Vec<u8>>, String> {
+fn image_object_bytes(map: &serde_json::Map<String, Value>) -> Result<Option<Vec<u8>>, String> {
     for key in [
         "data",
         "bytes",
@@ -153,11 +162,18 @@ fn inline_image_object_bytes(
         let Some(text) = map.get(key).and_then(Value::as_str) else {
             continue;
         };
-        if let Some(bytes) = inline_image_bytes(text)? {
+        if let Some(bytes) = image_reference_bytes(text)? {
             return Ok(Some(bytes));
         }
     }
     Ok(None)
+}
+
+fn image_reference_bytes(text: &str) -> Result<Option<Vec<u8>>, String> {
+    if let Some(bytes) = inline_image_bytes(text)? {
+        return Ok(Some(bytes));
+    }
+    fetch_image_url_bytes(text)
 }
 
 fn inline_image_bytes(text: &str) -> Result<Option<Vec<u8>>, String> {
@@ -209,12 +225,25 @@ fn compact_base64(text: &str) -> String {
 fn looks_like_image_reference(text: &str) -> bool {
     let value = text.trim().to_ascii_lowercase();
     value.starts_with("data:image/")
-        || value.ends_with(".png")
-        || value.ends_with(".jpg")
-        || value.ends_with(".jpeg")
-        || value.ends_with(".webp")
-        || value.ends_with(".gif")
-        || value.ends_with(".bmp")
+        || image_extension_path(&value)
+        || looks_like_remote_image_url(&value)
+}
+
+fn looks_like_remote_image_url(value: &str) -> bool {
+    if !(value.starts_with("http://") || value.starts_with("https://")) {
+        return false;
+    }
+    let path = value.split(['?', '#']).next().unwrap_or(value);
+    image_extension_path(path)
+}
+
+fn image_extension_path(path: &str) -> bool {
+    path.ends_with(".png")
+        || path.ends_with(".jpg")
+        || path.ends_with(".jpeg")
+        || path.ends_with(".webp")
+        || path.ends_with(".gif")
+        || path.ends_with(".bmp")
 }
 
 fn key_marks_image_value(key: &str, value: &Value) -> bool {
@@ -285,6 +314,151 @@ fn image_signature(bytes: &[u8]) -> Option<&'static str> {
     } else {
         None
     }
+}
+
+#[cfg(feature = "ocr")]
+fn fetch_image_url_bytes(text: &str) -> Result<Option<Vec<u8>>, String> {
+    use std::io::Read;
+    use std::sync::OnceLock;
+
+    let url = text.trim();
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return Ok(None);
+    }
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("image URL is invalid: {e}"))?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Ok(None);
+    }
+    validate_remote_image_url_target(&parsed)?;
+
+    static CLIENT: OnceLock<Result<reqwest::blocking::Client, String>> = OnceLock::new();
+    let client = CLIENT
+        .get_or_init(|| {
+            reqwest::blocking::Client::builder()
+                .timeout(IMAGE_URL_TIMEOUT)
+                .redirect(reqwest::redirect::Policy::limited(5))
+                .build()
+                .map_err(|e| format!("could not initialize image fetcher: {e}"))
+        })
+        .as_ref()
+        .map_err(Clone::clone)?;
+
+    let response = client
+        .get(parsed)
+        .send()
+        .map_err(|e| format!("could not fetch image URL: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("image URL returned {}", response.status()));
+    }
+    if let Some(content_type) = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+    {
+        let content_type = content_type.to_ascii_lowercase();
+        if !content_type.starts_with("image/") {
+            return Err(format!("image URL content type is {content_type}"));
+        }
+    }
+    if response
+        .content_length()
+        .is_some_and(|len| len > IMAGE_URL_MAX_BYTES)
+    {
+        return Err(format!(
+            "image URL is larger than {IMAGE_URL_MAX_BYTES} bytes"
+        ));
+    }
+
+    let mut bytes = Vec::new();
+    let mut limited = response.take(IMAGE_URL_MAX_BYTES + 1);
+    limited
+        .read_to_end(&mut bytes)
+        .map_err(|e| format!("could not read image URL: {e}"))?;
+    if bytes.len() as u64 > IMAGE_URL_MAX_BYTES {
+        return Err(format!(
+            "image URL is larger than {IMAGE_URL_MAX_BYTES} bytes"
+        ));
+    }
+    if image_signature(&bytes).is_none() {
+        return Err("image URL did not return a supported image".to_string());
+    }
+    Ok(Some(bytes))
+}
+
+#[cfg(feature = "ocr")]
+fn validate_remote_image_url_target(url: &reqwest::Url) -> Result<(), String> {
+    use std::net::ToSocketAddrs;
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| "image URL has no host".to_string())?;
+    let host_lc = host.to_ascii_lowercase();
+    if host_lc == "localhost" || host_lc.ends_with(".localhost") {
+        return local_image_url_result();
+    }
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return validate_remote_image_ip(ip);
+    }
+
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| "image URL has no port".to_string())?;
+    let mut saw_addr = false;
+    for addr in (host, port)
+        .to_socket_addrs()
+        .map_err(|e| format!("could not resolve image URL host: {e}"))?
+    {
+        saw_addr = true;
+        validate_remote_image_ip(addr.ip())?;
+    }
+    if !saw_addr {
+        return Err("image URL host did not resolve".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(feature = "ocr")]
+fn validate_remote_image_ip(ip: IpAddr) -> Result<(), String> {
+    if remote_image_ip_is_private(ip) {
+        return local_image_url_result();
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "ocr", test))]
+fn local_image_url_result() -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(all(feature = "ocr", not(test)))]
+fn local_image_url_result() -> Result<(), String> {
+    Err("image URL points to a local or private network address".to_string())
+}
+
+#[cfg(feature = "ocr")]
+fn remote_image_ip_is_private(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+                || ip.is_broadcast()
+                || ip.is_multicast()
+        }
+        IpAddr::V6(ip) => {
+            ip.is_loopback()
+                || ip.is_unspecified()
+                || ip.is_unique_local()
+                || ip.is_unicast_link_local()
+                || ip.is_multicast()
+        }
+    }
+}
+
+#[cfg(not(feature = "ocr"))]
+fn fetch_image_url_bytes(_text: &str) -> Result<Option<Vec<u8>>, String> {
+    Ok(None)
 }
 
 #[cfg(feature = "ocr")]
@@ -375,7 +549,7 @@ mod tests {
         });
         let map = value.as_object().unwrap();
         assert!(object_marks_image(map));
-        assert!(inline_image_object_bytes(map).unwrap().is_some());
+        assert!(image_object_bytes(map).unwrap().is_some());
     }
 
     #[test]
@@ -390,7 +564,84 @@ mod tests {
         assert!(!object_marks_image(outer));
         let inner = value["image_url"].as_object().unwrap();
         assert!(object_marks_image(inner));
-        assert!(inline_image_object_bytes(inner).unwrap().is_some());
+        assert!(image_object_bytes(inner).unwrap().is_some());
+    }
+
+    #[test]
+    fn remote_image_url_with_query_is_reference() {
+        assert!(looks_like_image_reference(
+            "https://example.test/images/screenshot.png?token=public#main"
+        ));
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn remote_image_url_bytes_are_downloaded() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let png = inline_image_bytes(
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        )
+        .unwrap()
+        .unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                png.len()
+            )
+            .unwrap();
+            stream.write_all(&png).unwrap();
+        });
+
+        let url = format!("http://{addr}/scan.png?cache=1");
+        let bytes = fetch_image_url_bytes(&url).unwrap().unwrap();
+        assert_eq!(image_signature(&bytes), Some("png"));
+        handle.join().unwrap();
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn failed_remote_image_url_is_unscanned() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            write!(
+                stream,
+                "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            .unwrap();
+        });
+
+        let value = serde_json::json!(format!("http://{addr}/missing.png"));
+        let inspection = inspect_tool_images_for_secrets(&value, &[7; 32]).unwrap();
+        assert_eq!(inspection.unscanned_images, 1);
+        assert_eq!(inspection.scanned_images, 0);
+        handle.join().unwrap();
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn private_image_url_targets_are_recognized() {
+        assert!(remote_image_ip_is_private("127.0.0.1".parse().unwrap()));
+        assert!(remote_image_ip_is_private(
+            "169.254.169.254".parse().unwrap()
+        ));
+        assert!(remote_image_ip_is_private("10.0.0.1".parse().unwrap()));
+        assert!(!remote_image_ip_is_private("8.8.8.8".parse().unwrap()));
     }
 
     #[test]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -3394,7 +3394,7 @@ fn image_tool_result_block_reason(
     }
     if inspection.unscanned_images > 0 {
         return Ok(Some(
-            "image blocked: image bytes were not available to scan.".to_string(),
+            "image blocked: image could not be fetched or scanned.".to_string(),
         ));
     }
     if inspection.ocr_failures > 0 {


### PR DESCRIPTION
## Summary
- fetch HTTP(S) image URLs and scan them through the existing OCR path
- keep data URLs/base64 image payloads on the same path
- treat failed fetches, non-image responses, oversize images, and unsupported bytes as unscanned images
- block local/private image URL targets before fetching in release builds

## Verification
- cargo test -p pentect-runtime
- cargo test -p pentect-runtime --no-default-features
- cargo clippy -p pentect-runtime --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings