### PR TITLE
Fix tool image and extension masking gaps

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1008,8 +1008,8 @@ fn codex_hook_config_args(agent: &Path, session: Option<&str>) -> Result<Vec<Str
 fn codex_hooks_inline_table(command: &str, windows: &str) -> Result<String, String> {
     const MATCHER: &str = "*";
     const TIMEOUT: u64 = 30;
-    let pre_hash = codex_command_hook_hash("pre_tool_use", MATCHER, command, TIMEOUT)?;
-    let post_hash = codex_command_hook_hash("post_tool_use", MATCHER, command, TIMEOUT)?;
+    let pre_hash = codex_command_hook_hash("pre_tool_use", MATCHER, command, windows, TIMEOUT)?;
+    let post_hash = codex_command_hook_hash("post_tool_use", MATCHER, command, windows, TIMEOUT)?;
     let pre_key = codex_session_flags_hook_key("pre_tool_use", 0, 0);
     let post_key = codex_session_flags_hook_key("post_tool_use", 0, 0);
     let hook = format!(
@@ -1080,6 +1080,7 @@ fn codex_command_hook_hash(
     event_label: &str,
     matcher: &str,
     command: &str,
+    windows: &str,
     timeout_sec: u64,
 ) -> Result<String, String> {
     let identity = CodexNormalizedHookIdentity {
@@ -1088,7 +1089,7 @@ fn codex_command_hook_hash(
             matcher: Some(matcher),
             hooks: vec![CodexHookHandlerConfig::Command {
                 command,
-                command_windows: None,
+                command_windows: Some(windows),
                 timeout_sec: Some(timeout_sec),
                 r#async: false,
                 status_message: None,

--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -223,7 +223,7 @@ fn filter_git_files(
     git_files: Vec<PathBuf>,
     excludes: &[String],
 ) -> Result<Vec<PathBuf>, String> {
-    if !has_pentectignore(&git_files) {
+    if !has_pentectignore(&base, &git_files) {
         let Some(overrides) = rules::build_overrides(&base, excludes)? else {
             return Ok(git_files);
         };
@@ -247,7 +247,10 @@ fn filter_git_files(
     Ok(filtered)
 }
 
-fn has_pentectignore(paths: &[PathBuf]) -> bool {
+fn has_pentectignore(base: &Path, paths: &[PathBuf]) -> bool {
+    if base.join(".pentectignore").is_file() {
+        return true;
+    }
     paths
         .iter()
         .any(|path| path.file_name().and_then(|name| name.to_str()) == Some(".pentectignore"))
@@ -369,6 +372,14 @@ mod tests {
         push_git_regular_file(&root, "tracked.txt", &mut files);
 
         assert_eq!(vec![root.join("tracked.txt")], files);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn untracked_root_pentectignore_is_detected_for_git_filtering() {
+        let root = temp_root("pentect-untracked-ignore");
+        std::fs::write(root.join(".pentectignore"), "ignored.env\n").unwrap();
+        assert!(has_pentectignore(&root, &[]));
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -2,18 +2,25 @@
 use crate::config::{image_ocr_config, ImageOcrMode};
 use serde_json::Value;
 #[cfg(feature = "ocr")]
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
+const IMAGE_SCAN_MAX_IMAGES_PER_RESULT: usize = 8;
+const IMAGE_SCAN_MAX_TOTAL_BYTES: u64 = 32 * 1024 * 1024;
+const IMAGE_SCAN_MAX_ELAPSED: std::time::Duration = std::time::Duration::from_secs(10);
 #[cfg(feature = "ocr")]
 const IMAGE_URL_MAX_BYTES: u64 = 16 * 1024 * 1024;
 #[cfg(feature = "ocr")]
 const IMAGE_URL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(feature = "ocr")]
+const IMAGE_URL_MAX_REDIRECTS: usize = 5;
 
 pub(crate) struct ImageInspection {
     pub(crate) scanned_images: usize,
     pub(crate) unscanned_images: usize,
     pub(crate) ocr_failures: usize,
     pub(crate) secret_images: usize,
+    total_image_bytes: u64,
+    started_at: std::time::Instant,
 }
 
 pub(crate) fn contains_image_result(value: &Value) -> bool {
@@ -25,29 +32,17 @@ pub(crate) fn contains_image_result(value: &Value) -> bool {
     }
 }
 
-pub(crate) fn is_image_object(value: &Value) -> bool {
-    value.as_object().is_some_and(object_marks_image)
-}
-
 pub(crate) fn skip_text_masking_for_image_payload(text: &str) -> bool {
     text.trim().to_ascii_lowercase().starts_with("data:image/") || looks_like_base64_image(text)
 }
 
-pub(crate) fn image_payload_field_key(key: &str) -> bool {
+pub(crate) fn skip_text_masking_for_image_field(key: &str, text: &str) -> bool {
+    if skip_text_masking_for_image_payload(text) {
+        return true;
+    }
     matches!(
         normalized_json_key(key).as_str(),
-        "data"
-            | "bytes"
-            | "base64"
-            | "content"
-            | "image"
-            | "imagedata"
-            | "imageurl"
-            | "url"
-            | "uri"
-            | "src"
-            | "href"
-            | "dataurl"
+        "data" | "bytes" | "base64" | "content" | "imagedata" | "dataurl"
     )
 }
 
@@ -60,6 +55,8 @@ pub(crate) fn inspect_tool_images_for_secrets(
         unscanned_images: 0,
         ocr_failures: 0,
         secret_images: 0,
+        total_image_bytes: 0,
+        started_at: std::time::Instant::now(),
     };
     collect_image_inspection(value, key, &mut inspection)?;
     Ok(inspection)
@@ -72,7 +69,7 @@ fn collect_image_inspection(
 ) -> Result<(), String> {
     match value {
         Value::String(text) => {
-            if looks_like_image_reference(text) {
+            if looks_like_image_reference(text) || looks_like_base64_image(text) {
                 match image_reference_bytes(text) {
                     Ok(Some(bytes)) => inspect_image_bytes(&bytes, key, inspection),
                     Ok(None) | Err(_) => inspection.unscanned_images += 1,
@@ -88,9 +85,16 @@ fn collect_image_inspection(
         Value::Object(map) => {
             if object_marks_image(map) {
                 match image_object_bytes(map) {
-                    Ok(Some(bytes)) => inspect_image_bytes(&bytes, key, inspection),
+                    Ok(Some(bytes)) => {
+                        inspect_image_bytes(&bytes, key, inspection);
+                        return Ok(());
+                    }
                     Ok(None) | Err(_) => {
-                        if !empty_image_object(map) {
+                        let before = inspection.total_observations();
+                        for item in map.values() {
+                            collect_image_inspection(item, key, inspection)?;
+                        }
+                        if !empty_image_object(map) && inspection.total_observations() == before {
                             inspection.unscanned_images += 1;
                         }
                     }
@@ -106,6 +110,10 @@ fn collect_image_inspection(
 }
 
 fn inspect_image_bytes(bytes: &[u8], key: &[u8; 32], inspection: &mut ImageInspection) {
+    if !inspection.reserve_scan_budget(bytes.len() as u64) {
+        inspection.unscanned_images += 1;
+        return;
+    }
     inspection.scanned_images += 1;
     match ocr_image_bytes(bytes) {
         Ok(text) => {
@@ -116,6 +124,29 @@ fn inspect_image_bytes(bytes: &[u8], key: &[u8; 32], inspection: &mut ImageInspe
         Err(_) => {
             inspection.ocr_failures += 1;
         }
+    }
+}
+
+impl ImageInspection {
+    fn total_observations(&self) -> usize {
+        self.scanned_images + self.unscanned_images + self.ocr_failures + self.secret_images
+    }
+
+    fn reserve_scan_budget(&mut self, bytes: u64) -> bool {
+        if self.scanned_images >= IMAGE_SCAN_MAX_IMAGES_PER_RESULT {
+            return false;
+        }
+        if self.started_at.elapsed() > IMAGE_SCAN_MAX_ELAPSED {
+            return false;
+        }
+        let Some(total) = self.total_image_bytes.checked_add(bytes) else {
+            return false;
+        };
+        if total > IMAGE_SCAN_MAX_TOTAL_BYTES {
+            return false;
+        }
+        self.total_image_bytes = total;
+        true
     }
 }
 
@@ -318,35 +349,60 @@ fn image_signature(bytes: &[u8]) -> Option<&'static str> {
 
 #[cfg(feature = "ocr")]
 fn fetch_image_url_bytes(text: &str) -> Result<Option<Vec<u8>>, String> {
-    use std::io::Read;
-    use std::sync::OnceLock;
-
     let url = text.trim();
     if !(url.starts_with("http://") || url.starts_with("https://")) {
         return Ok(None);
     }
-    let parsed = reqwest::Url::parse(url).map_err(|e| format!("image URL is invalid: {e}"))?;
-    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+    let mut url = reqwest::Url::parse(url).map_err(|e| format!("image URL is invalid: {e}"))?;
+    if url.scheme() != "http" && url.scheme() != "https" {
         return Ok(None);
     }
-    validate_remote_image_url_target(&parsed)?;
 
-    static CLIENT: OnceLock<Result<reqwest::blocking::Client, String>> = OnceLock::new();
-    let client = CLIENT
-        .get_or_init(|| {
-            reqwest::blocking::Client::builder()
-                .timeout(IMAGE_URL_TIMEOUT)
-                .redirect(reqwest::redirect::Policy::limited(5))
-                .build()
-                .map_err(|e| format!("could not initialize image fetcher: {e}"))
-        })
-        .as_ref()
-        .map_err(Clone::clone)?;
+    for _ in 0..=IMAGE_URL_MAX_REDIRECTS {
+        let response = send_image_url_request(&url)?;
+        if response.status().is_redirection() {
+            let location = response
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| "image URL redirect has no location".to_string())?;
+            url = url
+                .join(location)
+                .map_err(|e| format!("image URL redirect is invalid: {e}"))?;
+            if url.scheme() != "http" && url.scheme() != "https" {
+                return Err("image URL redirected to a non-HTTP URL".to_string());
+            }
+            continue;
+        }
+        return read_image_url_response(response).map(Some);
+    }
+    Err(format!(
+        "image URL redirected more than {IMAGE_URL_MAX_REDIRECTS} times"
+    ))
+}
 
-    let response = client
-        .get(parsed)
+#[cfg(feature = "ocr")]
+fn send_image_url_request(url: &reqwest::Url) -> Result<reqwest::blocking::Response, String> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| "image URL has no host".to_string())?;
+    let addrs = resolve_remote_image_url_target(url)?;
+    let client = reqwest::blocking::Client::builder()
+        .timeout(IMAGE_URL_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .resolve_to_addrs(host, &addrs)
+        .build()
+        .map_err(|e| format!("could not initialize image fetcher: {e}"))?;
+    client
+        .get(url.clone())
         .send()
-        .map_err(|e| format!("could not fetch image URL: {e}"))?;
+        .map_err(|e| format!("could not fetch image URL: {e}"))
+}
+
+#[cfg(feature = "ocr")]
+fn read_image_url_response(response: reqwest::blocking::Response) -> Result<Vec<u8>, String> {
+    use std::io::Read;
+
     if !response.status().is_success() {
         return Err(format!("image URL returned {}", response.status()));
     }
@@ -382,11 +438,11 @@ fn fetch_image_url_bytes(text: &str) -> Result<Option<Vec<u8>>, String> {
     if image_signature(&bytes).is_none() {
         return Err("image URL did not return a supported image".to_string());
     }
-    Ok(Some(bytes))
+    Ok(bytes)
 }
 
 #[cfg(feature = "ocr")]
-fn validate_remote_image_url_target(url: &reqwest::Url) -> Result<(), String> {
+fn resolve_remote_image_url_target(url: &reqwest::Url) -> Result<Vec<SocketAddr>, String> {
     use std::net::ToSocketAddrs;
 
     let host = url
@@ -394,27 +450,27 @@ fn validate_remote_image_url_target(url: &reqwest::Url) -> Result<(), String> {
         .ok_or_else(|| "image URL has no host".to_string())?;
     let host_lc = host.to_ascii_lowercase();
     if host_lc == "localhost" || host_lc.ends_with(".localhost") {
-        return local_image_url_result();
+        local_image_url_result()?;
     }
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        return validate_remote_image_ip(ip);
-    }
-
     let port = url
         .port_or_known_default()
         .ok_or_else(|| "image URL has no port".to_string())?;
-    let mut saw_addr = false;
-    for addr in (host, port)
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        validate_remote_image_ip(ip)?;
+        return Ok(vec![SocketAddr::new(ip, port)]);
+    }
+
+    let addrs = (host, port)
         .to_socket_addrs()
         .map_err(|e| format!("could not resolve image URL host: {e}"))?
-    {
-        saw_addr = true;
-        validate_remote_image_ip(addr.ip())?;
-    }
-    if !saw_addr {
+        .collect::<Vec<_>>();
+    if addrs.is_empty() {
         return Err("image URL host did not resolve".to_string());
     }
-    Ok(())
+    for addr in &addrs {
+        validate_remote_image_ip(addr.ip())?;
+    }
+    Ok(addrs)
 }
 
 #[cfg(feature = "ocr")]
@@ -568,6 +624,16 @@ mod tests {
     }
 
     #[test]
+    fn bare_base64_image_is_inspected() {
+        let value = serde_json::json!(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+        );
+        let inspection = inspect_tool_images_for_secrets(&value, &[7; 32]).unwrap();
+        assert_eq!(inspection.scanned_images, 1);
+        assert_eq!(inspection.unscanned_images, 0);
+    }
+
+    #[test]
     fn remote_image_url_with_query_is_reference() {
         assert!(looks_like_image_reference(
             "https://example.test/images/screenshot.png?token=public#main"
@@ -605,6 +671,91 @@ mod tests {
         let bytes = fetch_image_url_bytes(&url).unwrap().unwrap();
         assert_eq!(image_signature(&bytes), Some("png"));
         handle.join().unwrap();
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn nested_remote_image_url_object_is_scanned() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let png = inline_image_bytes(
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        )
+        .unwrap()
+        .unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                png.len()
+            )
+            .unwrap();
+            stream.write_all(&png).unwrap();
+        });
+
+        let value = serde_json::json!({
+            "type": "image_url",
+            "image_url": {
+                "url": format!("http://{addr}/nested.png")
+            }
+        });
+        let inspection = inspect_tool_images_for_secrets(&value, &[7; 32]).unwrap();
+        assert_eq!(inspection.scanned_images, 1);
+        assert_eq!(inspection.unscanned_images, 0);
+        handle.join().unwrap();
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn remote_image_redirect_is_validated_and_followed() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let image_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let image_addr = image_listener.local_addr().unwrap();
+        let redirect_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let redirect_addr = redirect_listener.local_addr().unwrap();
+        let png = inline_image_bytes(
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        )
+        .unwrap()
+        .unwrap();
+
+        let image_handle = std::thread::spawn(move || {
+            let (mut stream, _) = image_listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                png.len()
+            )
+            .unwrap();
+            stream.write_all(&png).unwrap();
+        });
+        let redirect_handle = std::thread::spawn(move || {
+            let (mut stream, _) = redirect_listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            write!(
+                stream,
+                "HTTP/1.1 302 Found\r\nLocation: http://{image_addr}/final.png\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            .unwrap();
+        });
+
+        let url = format!("http://{redirect_addr}/start.png");
+        let bytes = fetch_image_url_bytes(&url).unwrap().unwrap();
+        assert_eq!(image_signature(&bytes), Some("png"));
+        redirect_handle.join().unwrap();
+        image_handle.join().unwrap();
     }
 
     #[cfg(feature = "ocr")]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -24,7 +24,7 @@ use config::{approval_bypassed_by_config, approval_config_state};
 use in_memory_manager::{InMemoryManagerClient, ENV_ADDR, ENV_TOKEN};
 use masking::{
     contains_unresolved_masked_handle, env_alias_recovery, is_ascii_word_char, is_env_name_byte,
-    live_output_kind, OutputMasker, ToolScalarInput,
+    live_output_kind, mask_read_data, OutputMasker, ToolScalarInput,
 };
 #[cfg(test)]
 use masking::{first_reusable_env_name, mask_live_output, mask_tool_output};
@@ -2518,13 +2518,7 @@ fn masked_read_copy(session: &Session, path_text: &str) -> Result<Option<PathBuf
     let path = Path::new(path_text);
     let data = read_input(path, InputFormat::Text)
         .map_err(|_| "read target could not be scanned.".to_string())?;
-    let result = Engine::with_profile(Profile::Strict).mask(
-        Input {
-            kind: infer_kind(path),
-            data: data.clone(),
-        },
-        &Config::new(session.key),
-    );
+    let result = mask_read_data(session.key, data.clone(), infer_kind(path))?;
     if result.summary.masked_count == 0 {
         return Ok(None);
     }
@@ -3568,7 +3562,7 @@ fn collect_tool_json_scalars(
             }
         }
         Value::Object(map) => {
-            let image_object = image_ocr::is_image_object(value);
+            let image_object = image_ocr::contains_image_result(value);
             for (object_key, item) in map {
                 let child_path = path_with_segment(path, object_key);
                 out.push(ToolScalarInput {
@@ -3580,8 +3574,9 @@ fn collect_tool_json_scalars(
                 });
                 let child_hints = sibling_context_hints(map, object_key);
                 if !(image_object
-                    && item.is_string()
-                    && image_ocr::image_payload_field_key(object_key))
+                    && item.as_str().is_some_and(|text| {
+                        image_ocr::skip_text_masking_for_image_field(object_key, text)
+                    }))
                 {
                     collect_tool_json_scalars(
                         item,
@@ -3627,13 +3622,14 @@ fn rebuild_masked_tool_json(
             Ok(Value::Array(out))
         }
         Value::Object(map) => {
-            let image_object = image_ocr::is_image_object(value);
+            let image_object = image_ocr::contains_image_result(value);
             let mut out = serde_json::Map::with_capacity(map.len());
             for (key, item) in map {
                 let masked_key = take_masked(masked, cursor)?;
                 let item = if image_object
-                    && item.is_string()
-                    && image_ocr::image_payload_field_key(key)
+                    && item
+                        .as_str()
+                        .is_some_and(|text| image_ocr::skip_text_masking_for_image_field(key, text))
                 {
                     item.clone()
                 } else {

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -160,6 +160,19 @@ impl OutputMasker {
         if scalars.is_empty() {
             return Ok(Vec::new());
         }
+        if !self.model_adapters.is_empty() {
+            let mut out = Vec::with_capacity(scalars.len());
+            for scalar in scalars {
+                out.push(self.mask_tool_result_scalar(
+                    &scalar.text,
+                    scalar.region_kind,
+                    scalar.key.as_deref(),
+                    scalar.path.as_deref(),
+                    &scalar.hints,
+                )?);
+            }
+            return Ok(out);
+        }
         let mut prepared = Vec::with_capacity(scalars.len());
         for scalar in scalars {
             let redacted = redact_env_derivative_lines(&scalar.text);
@@ -278,6 +291,41 @@ impl OutputMasker {
             }
         }
     }
+}
+
+pub(crate) fn mask_read_data(
+    key: [u8; 32],
+    data: String,
+    kind: Kind,
+) -> Result<MaskResult, String> {
+    let engine = tool_boundary_engine()?;
+    let adapters = ModelAdapters::from_env()?;
+    let cfg = Config {
+        disclose_length: false,
+        ..Config::new(key)
+    };
+    let mut adapter_count = 0usize;
+    let mut adapter_recovery = Recovery::empty_for_key(&key);
+    let data = match adapters.mask(
+        &engine,
+        Input {
+            kind: kind.clone(),
+            data: data.clone(),
+        },
+        None,
+        &cfg,
+    )? {
+        Some(result) => {
+            adapter_count = result.summary.masked_count;
+            adapter_recovery = result.recovery;
+            result.masked
+        }
+        None => data,
+    };
+    let mut result = engine.mask(Input { kind, data }, &cfg);
+    result.summary.masked_count = result.summary.masked_count.saturating_add(adapter_count);
+    result.recovery.extend_same_key(adapter_recovery);
+    Ok(result)
 }
 
 fn choose_batch_delimiter(values: &[String]) -> Option<&'static str> {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1555,6 +1555,39 @@ fn generic_posttool_masks_payload_alias() {
 }
 
 #[test]
+fn posttool_masks_secret_query_inside_image_url() {
+    let (root, session) = empty_session("hook-post-image-url-query");
+    write_project_config(
+        &root,
+        "[image]\nocr = \"off\"\nunscanned_images = \"allow\"\n",
+    );
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let input = json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "mcp__browser__screenshot",
+        "tool_response": {
+            "content": [{
+                "type": "image_url",
+                "image_url": {
+                    "url": format!("https://cdn.example.com/screenshot.png?api_key={raw}")
+                }
+            }]
+        }
+    });
+    let output = {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _cwd = enter_temp_cwd(&root);
+        handle_hook(HookProvider::Claude, "t", &session, input).unwrap()
+    };
+    let updated = &output["hookSpecificOutput"]["updatedToolOutput"];
+    let rendered = serde_json::to_string(updated).unwrap();
+    assert!(rendered.contains("<<URL_CREDENTIAL_"), "{rendered}");
+    assert!(!rendered.contains(raw), "{rendered}");
+    assert!(rendered.contains("screenshot.png?api_key="), "{rendered}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn tool_text_output_masks_mcp_connector_and_plugin_envelopes() {
     let (root, session) = empty_session("hook-post-tool-text-unified");
     let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
@@ -2566,49 +2599,46 @@ fn pretool_rewrites_direct_read_tool_to_masked_copy() {
 #[test]
 fn pretool_rewrites_secret_read_many_paths_to_masked_copies() {
     let (root, session) = empty_session("hook-pre-read-many-secret");
-    let project = PathBuf::from("target").join(format!(
-        "pentect-read-many-secret-{}-{}",
-        std::process::id(),
-        unix_millis()
-    ));
-    let _ = std::fs::remove_dir_all(&project);
-    std::fs::create_dir_all(&project).unwrap();
-    let readme = project.join("README.txt");
-    let env = project.join(".env");
-    std::fs::write(&readme, "Settings\n").unwrap();
-    std::fs::write(
-        &env,
-        "RUNPOD_API_KEY=rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\n",
-    )
-    .unwrap();
-    let input = json!({
-        "hook_event_name": "PreToolUse",
-        "tool_name": "ReadManyFiles",
-        "tool_input": {
-            "paths": [readme.to_string_lossy(), env.to_string_lossy()]
-        }
-    });
-    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
-    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
-    let paths = output["hookSpecificOutput"]["updatedInput"]["paths"]
-        .as_array()
+    let project = temp_root("pentect-read-many-secret");
+    let result = {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _cwd = enter_temp_cwd(&project);
+        let readme = PathBuf::from("README.txt");
+        let env = PathBuf::from(".env");
+        std::fs::write(&readme, "Settings\n").unwrap();
+        std::fs::write(
+            &env,
+            "RUNPOD_API_KEY=rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\n",
+        )
         .unwrap();
-    assert_eq!(paths.len(), 2);
-    assert_eq!(paths[0].as_str().unwrap(), readme.to_string_lossy());
-    let masked_path = paths[1].as_str().unwrap();
-    let masked_path_buf = PathBuf::from(masked_path);
-    assert!(
-        masked_path_buf.starts_with(Path::new(".pentect").join("read")),
-        "{masked_path}"
-    );
-    assert!(masked_path_buf.ends_with(env), "{masked_path}");
-    assert!(!masked_path.contains("masked-read"), "{masked_path}");
-    let masked = std::fs::read_to_string(masked_path).unwrap();
-    assert!(masked.contains("<<RUNPOD_API_KEY_"), "{masked}");
-    assert!(!masked.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"));
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "ReadManyFiles",
+            "tool_input": {
+                "paths": [readme.to_string_lossy(), env.to_string_lossy()]
+            }
+        });
+        let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
+        assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
+        let paths = output["hookSpecificOutput"]["updatedInput"]["paths"]
+            .as_array()
+            .unwrap();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0].as_str().unwrap(), readme.to_string_lossy());
+        let masked_path = paths[1].as_str().unwrap();
+        let masked_path_buf = PathBuf::from(masked_path);
+        assert!(
+            masked_path_buf.starts_with(Path::new(".pentect").join("read")),
+            "{masked_path}"
+        );
+        assert!(masked_path_buf.ends_with(&env), "{masked_path}");
+        assert!(!masked_path.contains("masked-read"), "{masked_path}");
+        std::fs::read_to_string(masked_path).unwrap()
+    };
+    assert!(result.contains("<<RUNPOD_API_KEY_"), "{result}");
+    assert!(!result.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"));
     let _ = std::fs::remove_dir_all(project);
     let _ = std::fs::remove_dir_all(root);
-    let _ = std::fs::remove_dir_all(".pentect/read");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- fix image OCR inspection for nested `image_url.url` payloads and bare base64 images
- keep signed image URL query values in normal text masking while skipping only image bytes/data payload fields
- validate every image URL redirect and pin requests to validated resolved addresses
- add per-tool-result image scan budgets for count, total bytes, and elapsed time
- make structured tool-output masking fall back to per-scalar masking when model adapters are active
- make Read-tool masked copies use the tool-boundary engine so extension packs/adapters are applied
- include `commandWindows` in Codex hook trust hash identity
- detect root `.pentectignore` from the filesystem in gitignore scan mode

## Review
- Subagent review covered runtime image/OCR/tool-output masking paths.
- Subagent review covered config/CLI/scan/runtime integration paths.

## Verification
- cargo test -p pentect-runtime
- cargo test -p pentect-runtime --no-default-features
- cargo test -p pentect-cli
- cargo clippy -p pentect-runtime --all-targets --all-features -- -D warnings
- cargo clippy -p pentect-cli --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret masking in tool results, including secrets embedded in image URLs and nested image-related content.
  * Read-file masking now uses a shared path, keeping masked copies consistent across platforms.
  * Root-level `.pentectignore` files are now detected more reliably during scans, even when not listed by git.

* **New Features**
  * Image inspection now respects scan limits and better handles base64 and nested image data.
  * Windows-specific command handling is now included in trusted hook identity generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->