### PR TITLE
Make Codex tool output masking less visible

### DIFF
--- a/crates/pentect-core/src/detect/rule.rs
+++ b/crates/pentect-core/src/detect/rule.rs
@@ -179,12 +179,6 @@ impl RuleDetector {
                 "MAC_ADDRESS",
                 Medium,
             ),
-            (
-                r"\b(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}(?:/(?:3[0-2]|[12][0-9]|[0-9]))?\b",
-                Endpoint,
-                "IP_ADDRESS_V4",
-                High,
-            ),
             // Structural national IDs (no public checksum) — the regex encodes the
             // grammar; confidence reflects how distinctive it is. Higher false-
             // positive risk than the checksummed ones, kept lower-confidence.
@@ -391,6 +385,7 @@ impl RuleDetector {
             (r"\b[0-8][0-9]{2}[- ][0-9]{2}[- ][0-9]{4}\b", Pii, "US_SSN", Medium, V::UsSsn),
             (r"\bbc1[02-9ac-hj-np-z]{6,87}\b", Identifier, "BTC_ADDRESS_BECH32", High, V::BtcBech32),
             (r"\b0x[0-9a-fA-F]{40}\b", Identifier, "ETH_ADDRESS", High, V::EthAddress),
+            (r"\b(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}(?:/(?:3[0-2]|[12][0-9]|[0-9]))?\b", Endpoint, "IP_ADDRESS_V4", High, V::Ipv4NonLoopback),
             (r"\b[0-9]{6}[-+A-Y][0-9]{3}[0-9A-Y]\b", Identifier, "FI_HETU", High, V::FiHetu),
             (r"(?i)\b[A-Z]{6}[0-9A-Z]{2}[A-Z][0-9A-Z]{2}[A-Z][0-9A-Z]{3}[A-Z]\b", Identifier, "IT_FISCAL_CODE", High, V::ItFiscalCode),
             (r"\b[12][0-9]{4}(?:[0-9]{2}|2[AB])[0-9]{8}\b", Identifier, "FR_NIR_INSEE", High, V::FrNir),
@@ -430,7 +425,7 @@ impl RuleDetector {
             // segment that frequently leaks in stack traces and tool output.
             (r#"(?i)\bAccountKey\b[ \t]*=[ \t]*([A-Za-z0-9+/=]{40,})(?:;|$|[\s"',)])"#, Secret, "AZURE_STORAGE_ACCOUNT_KEY", High, 1, V::None),
             (r#"(?i)\bclient[-_]?key[-_]?data\b[ \t]*:[ \t]*['"]?([A-Za-z0-9+/=]{40,})['"]?(?:$|[\s"',;)])"#, Secret, "KUBE_CLIENT_KEY_DATA", High, 1, V::None),
-            (r#"(?i)(?:^|[^A-Za-z0-9_:.])((?:[0-9A-F]{0,4}:){2,}[0-9A-F]{0,4}(?:%[0-9A-Za-z]+)?(?:/(?:12[0-8]|1[01][0-9]|[1-9]?[0-9]))?)(?:$|[^A-Za-z0-9_:.])"#, Endpoint, "IP_ADDRESS_V6", High, 1, V::Ipv6),
+            (r#"(?i)(?:^|[^A-Za-z0-9_:.])((?:[0-9A-F]{0,4}:){2,}[0-9A-F]{0,4}(?:%[0-9A-Za-z]+)?(?:/(?:12[0-8]|1[01][0-9]|[1-9]?[0-9]))?)(?:$|[^A-Za-z0-9_:.])"#, Endpoint, "IP_ADDRESS_V6", High, 1, V::Ipv6NonLoopback),
             (r#"(?i)\b[A-Z]:[\\/]+Users[\\/]+([^\\/\s:\r\n"<>|?*]{1,64})(?:[\\/]|$|[\s"',;)])"#, Pii, "LOCAL_USERNAME", Medium, 1, V::LocalUsername),
             (r#"(?i)(?:^|[\s"'=(:])/(?:home|Users|var/home|export/home)/([^/\s\r\n"']{1,64})(?:/|$|[\s"',;)])"#, Pii, "LOCAL_USERNAME", Medium, 1, V::LocalUsername),
             (r#"(?i)(?:^|[\s"'=(:])~([^/\s\r\n"']{1,64})(?:/|$|[\s"',;)])"#, Pii, "LOCAL_USERNAME", Medium, 1, V::LocalUsername),
@@ -705,6 +700,23 @@ mod tests {
                 spans.iter().map(|s| &s.label).collect::<Vec<_>>()
             );
         }
+    }
+
+    #[test]
+    fn loopback_ips_are_not_reported_as_endpoint_secrets() {
+        let det = RuleDetector::builtin();
+        let labels = |s: &str| {
+            let reg = region(s);
+            let v = NormalizedView::build(&reg, s);
+            det.detect(&v)
+                .into_iter()
+                .map(|sp| sp.label)
+                .collect::<Vec<_>>()
+        };
+        assert!(!labels("localhost, 127.0.0.1, or ::1").contains(&"IP_ADDRESS_V4".to_string()));
+        assert!(!labels("localhost, 127.0.0.1, or ::1").contains(&"IP_ADDRESS_V6".to_string()));
+        assert!(labels("service at 192.168.1.1").contains(&"IP_ADDRESS_V4".to_string()));
+        assert!(labels("service at fe80::1%eth0").contains(&"IP_ADDRESS_V6".to_string()));
     }
 
     // Every label must be UPPER_SNAKE so it renders into a well-formed

--- a/crates/pentect-core/src/detect/validate.rs
+++ b/crates/pentect-core/src/detect/validate.rs
@@ -7,6 +7,7 @@ use bip39::{Language, Mnemonic};
 use data_encoding::BASE64;
 use std::borrow::Cow;
 use std::collections::HashSet;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::LazyLock;
 
 static BIP39_WORDSETS: LazyLock<Vec<(Language, HashSet<&'static str>)>> = LazyLock::new(|| {
@@ -900,7 +901,9 @@ pub enum Validator {
     BtcBech32,
     EthAddress,
     Bip39,
+    Ipv4NonLoopback,
     Ipv6,
+    Ipv6NonLoopback,
     FiHetu,
     ItFiscalCode,
     FrNir,
@@ -950,7 +953,9 @@ impl Validator {
             "btc_bech32" => Validator::BtcBech32,
             "eth_address" => Validator::EthAddress,
             "bip39" => Validator::Bip39,
+            "ipv4_non_loopback" => Validator::Ipv4NonLoopback,
             "ipv6" => Validator::Ipv6,
+            "ipv6_non_loopback" => Validator::Ipv6NonLoopback,
             "fi_hetu" => Validator::FiHetu,
             "it_codice_fiscale" => Validator::ItFiscalCode,
             "fr_nir" => Validator::FrNir,
@@ -998,7 +1003,9 @@ impl Validator {
             Validator::BtcBech32 => btc_bech32(s),
             Validator::EthAddress => eth_address(s),
             Validator::Bip39 => bip39_mnemonic(s),
+            Validator::Ipv4NonLoopback => ipv4_non_loopback(s),
             Validator::Ipv6 => ipv6(s),
+            Validator::Ipv6NonLoopback => ipv6_non_loopback(s),
             Validator::FiHetu => fi_hetu(s),
             Validator::ItFiscalCode => it_codice_fiscale(s),
             Validator::FrNir => fr_nir(s),
@@ -1012,6 +1019,25 @@ impl Validator {
             Validator::TwilioApiKey => twilio_api_key(s),
         }
     }
+}
+
+pub fn ipv4_non_loopback(s: &str) -> bool {
+    let host = s.split_once('/').map_or(s, |(host, _)| host);
+    host.parse::<Ipv4Addr>()
+        .is_ok_and(|addr| !addr.is_loopback())
+}
+
+pub fn ipv6_non_loopback(s: &str) -> bool {
+    if !ipv6(s) {
+        return false;
+    }
+    let without_prefix = s.split_once('/').map_or(s, |(host, _)| host);
+    let without_zone = without_prefix
+        .split_once('%')
+        .map_or(without_prefix, |(host, _)| host);
+    without_zone
+        .parse::<Ipv6Addr>()
+        .is_ok_and(|addr| !addr.is_loopback())
 }
 
 pub fn twilio_api_key(s: &str) -> bool {

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -721,15 +721,27 @@ fn is_env_summary_key_char(ch: char) -> bool {
 }
 
 fn looks_like_env_summary_key(key: &str) -> bool {
-    if key.is_empty() || key.as_bytes()[0].is_ascii_digit() {
+    if key.is_empty()
+        || key.as_bytes()[0].is_ascii_digit()
+        || !key.chars().any(|ch| ch.is_ascii_alphanumeric())
+    {
         return false;
     }
     let lower = key.to_ascii_lowercase();
     is_sensitive_env_output_name(&lower)
+        || is_derived_output_key(key)
         || key.contains('_')
         || key.contains('.')
         || key.contains('-')
-        || key.chars().any(|ch| ch.is_ascii_uppercase())
+        || is_all_caps_summary_key(key)
+}
+
+fn is_all_caps_summary_key(key: &str) -> bool {
+    key.len() >= 2
+        && key.chars().any(|ch| ch.is_ascii_uppercase())
+        && key
+            .chars()
+            .all(|ch| !ch.is_ascii_lowercase() && is_env_summary_key_char(ch))
 }
 
 fn is_sensitive_env_output_name(name: &str) -> bool {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2387,6 +2387,24 @@ fn derived_env_summary_output_does_not_leak_prefix_suffix_or_length() {
 }
 
 #[test]
+fn api_reference_text_is_not_redacted_as_env_derivatives() {
+    let (root, session) = empty_session("exec-api-reference-text");
+    let output = concat!(
+        "- Do not pass a regex as `name` to `getByRole(...)` in this environment.\n",
+        "openTabs(): Promise<Array<BrowserUserTabInfo>>; // List currently open tabs.\n",
+        "downloadMedia(options: LocatorDownloadMediaOptions): Promise<void>;\n",
+        "getAttribute(name: string): Promise<string | null>;\n",
+        "innerText(): Promise<string>;\n",
+        "isEnabled(): Promise<boolean>;\n",
+        "lastOpened?: string; // User-visible timestamp.\n",
+        "On `getByRole(..., { name })`, prefer plain strings.\n",
+    );
+    let masked = mask_tool_output(&session, output).unwrap();
+    assert_eq!(masked, output);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn encoded_env_derivatives_do_not_leak() {
     let (root, session) = empty_session("exec-encoded-env-derivatives");
     let dotenv = "RUNPOD_API_KEY=rpa_FAKEPENTECTJAILBREAK1234567890abcdef\nTEST_SECRET=114514810\nNOTE=hello world\n";


### PR DESCRIPTION
## Summary
- Stop treating API/reference text like `openTabs(): Promise<...>` as secret-derived env summaries.
- Keep derived secret summaries masked for real prefix/suffix/length/hash output.
- Stop masking loopback IPs (`127.0.0.1`, `::1`) as endpoint findings while keeping normal IP endpoint detection.

## UX comparison
- vanilla Codex Chrome tab-count run: 3.6KB, no PostToolUse block, `tabs=28`
- Pentect fixed Chrome tab-count run: 3.2KB, no PostToolUse block, no hook output temp-file handoff, `tabs=28`

## Verification
- `cargo test -p pentect-core --locked`
- `cargo test -p pentect-runtime --locked`
- `cargo test -p pentect-cli --locked`
- `cargo clippy -p pentect-core --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p pentect-runtime --all-targets --all-features --locked -- -D warnings`
- tmux comparison: vanilla Codex vs `pentect codex` Chrome Connector tab count