### PR TITLE
Reduce dev-server tool output false positives

### DIFF
--- a/crates/pentect-core/src/detect/url.rs
+++ b/crates/pentect-core/src/detect/url.rs
@@ -445,6 +445,17 @@ fn inspect_url(view: &NormalizedView, base: usize, url: &str, out: &mut Vec<Span
         return;
     }
 
+    if endpoint_is_display_only(host, view.text(), base) {
+        if let Some(q) = query_at {
+            let query_end = fragment_at.unwrap_or(url.len());
+            inspect_query_values(view, base, url, q + 1, query_end, false, out);
+        }
+        if let Some(f) = fragment_at {
+            inspect_external_fragment_query(view, base, url, f + 1, url.len(), out);
+        }
+        return;
+    }
+
     push_span(
         view,
         out,
@@ -685,6 +696,28 @@ fn is_internal_host(host: &str) -> bool {
     ]
     .iter()
     .any(|suffix| host.ends_with(suffix))
+}
+
+fn endpoint_is_display_only(host: &str, text: &str, url_start: usize) -> bool {
+    is_loopback_or_localhost_host(host) || is_dev_server_status_url_context(text, url_start)
+}
+
+fn is_loopback_or_localhost_host(host: &str) -> bool {
+    let host = host
+        .trim()
+        .trim_end_matches('.')
+        .trim_matches(|ch| matches!(ch, '[' | ']'))
+        .to_ascii_lowercase();
+    if matches!(host.as_str(), "localhost" | "::1") {
+        return true;
+    }
+    parse_ipv4(&host).is_some_and(|(a, _, _, _)| a == 127)
+}
+
+fn is_dev_server_status_url_context(text: &str, url_start: usize) -> bool {
+    let line_start = text[..url_start].rfind('\n').map_or(0, |pos| pos + 1);
+    let line_prefix = text[line_start..url_start].trim();
+    line_prefix.ends_with("Local:") || line_prefix.ends_with("Network:")
 }
 
 fn parse_ipv4(host: &str) -> Option<(u8, u8, u8, u8)> {
@@ -1398,6 +1431,53 @@ mod tests {
         assert!(labels("http://jira/api/users/abc12345")
             .iter()
             .any(|(_, value)| value == "jira"));
+    }
+
+    #[test]
+    fn localhost_and_loopback_urls_are_status_not_internal_endpoints() {
+        for raw in [
+            "http://localhost:5173/",
+            "http://127.0.0.1:5173/",
+            "http://[::1]:5173/",
+        ] {
+            assert!(
+                labels(raw)
+                    .iter()
+                    .all(|(label, _)| label != "INTERNAL_ENDPOINT"),
+                "{raw}: {:?}",
+                labels(raw)
+            );
+        }
+    }
+
+    #[test]
+    fn dev_server_status_urls_are_not_internal_endpoint_findings() {
+        let raw = concat!(
+            "  VITE v6.3.5  ready in 281 ms\n\n",
+            "  Local:   http://localhost:5173/\n",
+            "  Local:   http://127.0.0.1:5173/\n",
+            "  Local:   http://[::1]:5173/\n",
+            "  Network: http://192.168.1.42:5173/\n",
+            "  press h + enter to show help\n",
+        );
+        let got = labels(raw);
+        assert!(
+            got.iter()
+                .all(|(label, _)| label != "INTERNAL_ENDPOINT" && label != "RESOURCE_ID"),
+            "{got:?}"
+        );
+    }
+
+    #[test]
+    fn display_only_local_urls_still_scan_credentials() {
+        let got = labels("Local: http://alice:letmein@localhost:5173/?access_token=abc12345abcdef");
+        assert!(got
+            .iter()
+            .any(|(label, value)| label == "URL_CREDENTIAL" && value == "alice:letmein"));
+        assert!(got
+            .iter()
+            .any(|(label, value)| label == "URL_CREDENTIAL" && value == "abc12345abcdef"));
+        assert!(got.iter().all(|(label, _)| label != "INTERNAL_ENDPOINT"));
     }
 
     #[test]

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -4,8 +4,9 @@ use crate::session::RecoveryStore;
 use crate::session::Session;
 use pentect_core::placeholder::{identity_hash, render_placeholder};
 use pentect_core::{
-    load_pack, ByteRange, Config, Context, Engine, Input, Kind, MaskResult, Profile, ProfilePolicy,
-    Recovery, Region, RegionKind, SensitiveKeyDetector, ShapeGuard, ToolResultParser,
+    load_pack, ByteRange, Category, Config, Context, Engine, Input, Kind, MaskResult, Profile,
+    ProfilePolicy, Recovery, Region, RegionKind, SensitiveKeyDetector, ShapeGuard,
+    ToolResultParser,
 };
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -99,6 +100,7 @@ impl OutputMasker {
             disclose_length: false,
             ..Config::new(self.store.session.key)
         };
+        let endpoint_unchanged = remasked.clone();
         let result = self.engine.mask(
             Input {
                 kind,
@@ -106,6 +108,9 @@ impl OutputMasker {
             },
             &cfg,
         );
+        if !needs_text_pass && masks_only_endpoint_metadata(&result) {
+            return Ok(endpoint_unchanged);
+        }
         self.add_masked_count(result.summary.masked_count);
         let mut masked = result.masked;
         let mut recovery = result.recovery;
@@ -113,13 +118,15 @@ impl OutputMasker {
             let text_result = self.engine.mask(
                 Input {
                     kind: Kind::Text,
-                    data: masked,
+                    data: masked.clone(),
                 },
                 &cfg,
             );
-            self.add_masked_count(text_result.summary.masked_count);
-            masked = text_result.masked;
-            recovery.extend_same_key(text_result.recovery);
+            if !masks_only_endpoint_metadata(&text_result) {
+                self.add_masked_count(text_result.summary.masked_count);
+                masked = text_result.masked;
+                recovery.extend_same_key(text_result.recovery);
+            }
         }
         recovery.extend_same_key(env_alias_recovery(&masked, &self.store.session.key));
         self.record_recovery(recovery)?;
@@ -149,8 +156,9 @@ impl OutputMasker {
             disclose_length: false,
             ..Config::new(self.store.session.key)
         };
+        let endpoint_unchanged = remasked.clone();
         let result = self.engine.mask_context(remasked, context, &cfg);
-        self.record_mask_result(result)
+        self.record_tool_result_mask_result(result, endpoint_unchanged)
     }
 
     pub(crate) fn mask_tool_result_scalars(
@@ -219,6 +227,9 @@ impl OutputMasker {
             ..Config::new(self.store.session.key)
         };
         let result = self.engine.mask_regions(raw, regions, &cfg);
+        if masks_only_endpoint_metadata(&result) {
+            return Ok(prepared);
+        }
         let masked = self.record_mask_result(result)?;
         let parts: Vec<String> = masked.split(delimiter).map(str::to_string).collect();
         if parts.len() != scalars.len() {
@@ -234,6 +245,17 @@ impl OutputMasker {
         recovery.extend_same_key(env_alias_recovery(&masked, &self.store.session.key));
         self.record_recovery(recovery)?;
         Ok(masked)
+    }
+
+    fn record_tool_result_mask_result(
+        &mut self,
+        result: MaskResult,
+        endpoint_unchanged: String,
+    ) -> Result<String, String> {
+        if masks_only_endpoint_metadata(&result) {
+            return Ok(endpoint_unchanged);
+        }
+        self.record_mask_result(result)
     }
 
     fn add_masked_count(&mut self, count: usize) {
@@ -291,6 +313,15 @@ impl OutputMasker {
             }
         }
     }
+}
+
+fn masks_only_endpoint_metadata(result: &MaskResult) -> bool {
+    result.summary.masked_count > 0
+        && !result.items.is_empty()
+        && result
+            .items
+            .iter()
+            .all(|item| item.category == Category::Endpoint)
 }
 
 pub(crate) fn mask_read_data(

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2405,6 +2405,27 @@ fn api_reference_text_is_not_redacted_as_env_derivatives() {
 }
 
 #[test]
+fn codex_posttool_does_not_block_vite_dev_server_banner() {
+    let _proxy = ScopedCodexExecProxy::set(false);
+    let (root, session) = empty_session("hook-post-codex-vite-banner");
+    let input = json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_response": concat!(
+            "  VITE v6.3.5  ready in 281 ms\n\n",
+            "  Local:   http://localhost:5173/\n",
+            "  Local:   http://127.0.0.1:5173/\n",
+            "  Local:   http://[::1]:5173/\n",
+            "  Network: http://192.168.1.42:5173/\n",
+            "  press h + enter to show help\n",
+        )
+    });
+    let output = handle_hook(HookProvider::Codex, "t", &session, input).unwrap();
+    assert_eq!(output, json!({}));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn encoded_env_derivatives_do_not_leak() {
     let (root, session) = empty_session("exec-encoded-env-derivatives");
     let dotenv = "RUNPOD_API_KEY=rpa_FAKEPENTECTJAILBREAK1234567890abcdef\nTEST_SECRET=114514810\nNOTE=hello world\n";


### PR DESCRIPTION
## Summary
- Classify Vite/dev-server `Local:` and `Network:` display URLs as status output, not internal endpoint findings.
- Keep credential scanning on those URLs: userinfo and query secrets still mask/block.
- In runtime tool-output masking, preserve endpoint-only changes so Codex PostToolUse does not block on URL/IP-only display noise.

## FP cause
- Chrome docs/Vite logs were not raw secrets.
- They were changed by endpoint detectors (`URL`, `IP_ADDRESS_V4`, `INTERNAL_ENDPOINT`).
- Because Codex PostToolUse cannot cleanly replace tool output, any endpoint-only change turned into visible `blocked` UX.

## Verification
- `cargo test -p pentect-core --locked`
- `cargo test -p pentect-runtime --locked`
- `cargo test -p pentect-cli --locked`
- `cargo clippy -p pentect-core --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p pentect-runtime --all-targets --all-features --locked -- -D warnings`
- `target/debug/pentect.exe hook --cli codex` on a Vite banner returns `{}`
- Same hook with an API key still returns masked `decision=block`