### PR TITLE
Improve tool output path UX

### DIFF
--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -128,6 +128,7 @@ impl OutputMasker {
                 recovery.extend_same_key(text_result.recovery);
             }
         }
+        let masked = compact_local_home_paths(&masked);
         recovery.extend_same_key(env_alias_recovery(&masked, &self.store.session.key));
         self.record_recovery(recovery)?;
         Ok(masked)
@@ -240,7 +241,7 @@ impl OutputMasker {
 
     fn record_mask_result(&mut self, result: MaskResult) -> Result<String, String> {
         self.add_masked_count(result.summary.masked_count);
-        let masked = result.masked;
+        let masked = compact_local_home_paths(&result.masked);
         let mut recovery = result.recovery;
         recovery.extend_same_key(env_alias_recovery(&masked, &self.store.session.key));
         self.record_recovery(recovery)?;
@@ -322,6 +323,148 @@ fn masks_only_endpoint_metadata(result: &MaskResult) -> bool {
             .items
             .iter()
             .all(|item| item.category == Category::Endpoint)
+}
+
+// Stack traces and build logs frequently expose the local account segment in a
+// home path. Keep the detector active, but render that path as the familiar
+// shell form (`~\src` / `~/src`) so tool output stays readable without showing
+// the username or a Pentect placeholder.
+fn compact_local_home_paths(masked: &str) -> String {
+    let mut out = String::with_capacity(masked.len());
+    let mut cursor = 0usize;
+    let mut search = 0usize;
+    let mut changed = false;
+    while let Some((placeholder_start, placeholder_end)) =
+        next_local_username_placeholder(masked, search)
+    {
+        search = placeholder_end;
+        if placeholder_start < cursor || !local_home_tail_ok(masked, placeholder_end) {
+            continue;
+        }
+        let Some(root_start) = local_home_root_start(masked, placeholder_start) else {
+            continue;
+        };
+        if root_start < cursor {
+            continue;
+        }
+        out.push_str(&masked[cursor..root_start]);
+        out.push('~');
+        cursor = placeholder_end;
+        changed = true;
+    }
+    if !changed {
+        return masked.to_string();
+    }
+    out.push_str(&masked[cursor..]);
+    out
+}
+
+fn next_local_username_placeholder(text: &str, start: usize) -> Option<(usize, usize)> {
+    let mut search = start.min(text.len());
+    while let Some(offset) = text.get(search..)?.find("<<LOCAL_USERNAME_") {
+        let placeholder_start = search + offset;
+        let close = find_from(text.as_bytes(), placeholder_start + 2, b">>")?;
+        let placeholder_end = close + 2;
+        let placeholder = &text[placeholder_start..placeholder_end];
+        if placeholder_label(placeholder) == Some("LOCAL_USERNAME") {
+            return Some((placeholder_start, placeholder_end));
+        }
+        search = placeholder_start.saturating_add(2);
+    }
+    None
+}
+
+fn local_home_root_start(text: &str, placeholder_start: usize) -> Option<usize> {
+    let before = text.get(..placeholder_start)?;
+    let root_start = windows_home_root_start(before)
+        .or_else(|| unix_home_root_start(before))
+        .or_else(|| tilde_home_root_start(before))?;
+    local_home_root_has_boundary(text, root_start).then_some(root_start)
+}
+
+fn windows_home_root_start(before: &str) -> Option<usize> {
+    let bytes = before.as_bytes();
+    if bytes.is_empty() || !is_path_sep(*bytes.last()?) {
+        return None;
+    }
+    let mut i = bytes.len();
+    while i > 0 && is_path_sep(bytes[i - 1]) {
+        i -= 1;
+    }
+    let users_end = i;
+    while i > 0 && !is_path_sep(bytes[i - 1]) {
+        i -= 1;
+    }
+    if !before.get(i..users_end)?.eq_ignore_ascii_case("Users") {
+        return None;
+    }
+    while i > 0 && is_path_sep(bytes[i - 1]) {
+        i -= 1;
+    }
+    if i >= 2 && bytes[i - 1] == b':' && bytes[i - 2].is_ascii_alphabetic() {
+        Some(i - 2)
+    } else {
+        None
+    }
+}
+
+fn unix_home_root_start(before: &str) -> Option<usize> {
+    [
+        "/export/home/",
+        "/var/home/",
+        "/mnt/c/Users/",
+        "/c/Users/",
+        "/Users/",
+        "/home/",
+    ]
+    .into_iter()
+    .find_map(|root| ascii_suffix_start(before, root))
+}
+
+fn tilde_home_root_start(before: &str) -> Option<usize> {
+    before.strip_suffix('~')?;
+    Some(before.len().saturating_sub(1))
+}
+
+fn ascii_suffix_start(value: &str, suffix: &str) -> Option<usize> {
+    if value.len() < suffix.len() {
+        return None;
+    }
+    let start = value.len() - suffix.len();
+    value
+        .get(start..)
+        .is_some_and(|tail| tail.eq_ignore_ascii_case(suffix))
+        .then_some(start)
+}
+
+fn local_home_root_has_boundary(text: &str, root_start: usize) -> bool {
+    if root_start == 0 {
+        return true;
+    }
+    text.get(..root_start)
+        .and_then(|prefix| prefix.chars().next_back())
+        .is_some_and(|ch| ch.is_whitespace() || matches!(ch, '"' | '\'' | '=' | '(' | '[' | '{'))
+}
+
+fn local_home_tail_ok(text: &str, placeholder_end: usize) -> bool {
+    if placeholder_end >= text.len() {
+        return true;
+    }
+    text.get(placeholder_end..)
+        .and_then(|tail| tail.chars().next())
+        .is_some_and(|ch| {
+            is_path_sep_char(ch)
+                || ch.is_whitespace()
+                || matches!(ch, '"' | '\'' | ',' | ';' | ')' | ']')
+        })
+}
+
+fn is_path_sep(byte: u8) -> bool {
+    matches!(byte, b'/' | b'\\')
+}
+
+fn is_path_sep_char(ch: char) -> bool {
+    matches!(ch, '/' | '\\')
 }
 
 pub(crate) fn mask_read_data(

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2405,6 +2405,82 @@ fn api_reference_text_is_not_redacted_as_env_derivatives() {
 }
 
 #[test]
+fn local_home_paths_render_as_tilde_in_tool_output() {
+    let (root, session) = empty_session("exec-local-home-paths");
+    let output = concat!(
+        r#"at C:\Users\yun40\Desktop\app\src\main.ts:12:34"#,
+        "\n",
+        r#"  File "/home/yun40/demo/app.py", line 8, in main"#,
+        "\n",
+        r#"at /mnt/c/Users/yun40/project/src/main.rs:12:34"#,
+        "\n",
+    );
+    let masked = mask_tool_output(&session, output).unwrap();
+    assert!(!masked.contains("yun40"), "{masked}");
+    assert!(!masked.contains("LOCAL_USERNAME"), "{masked}");
+    assert!(masked.contains(r#"~\Desktop\app\src\main.ts"#), "{masked}");
+    assert!(masked.contains(r#""~/demo/app.py""#), "{masked}");
+    assert!(masked.contains("~/project/src/main.rs"), "{masked}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn common_dev_tool_output_does_not_block_codex_posttool() {
+    let _proxy = ScopedCodexExecProxy::set(false);
+    let cases = [
+        (
+            "next",
+            concat!(
+                "Next.js 15.3.4\n",
+                "- Local:        http://localhost:3000\n",
+                "- Network:      http://192.168.1.42:3000\n",
+                "Ready in 1290ms\n",
+            ),
+        ),
+        (
+            "astro",
+            concat!(
+                "astro 5.9.0 ready in 358 ms\n",
+                "Local    http://localhost:4321/\n",
+                "Network  http://192.168.1.42:4321/\n",
+            ),
+        ),
+        (
+            "webpack",
+            concat!(
+                "Project is running at:\n",
+                "Loopback: http://localhost:8080/\n",
+                "On Your Network (IPv4): http://192.168.1.42:8080/\n",
+                "webpack compiled successfully\n",
+            ),
+        ),
+        (
+            "uvicorn",
+            concat!(
+                "INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)\n",
+                "INFO:     127.0.0.1:53721 - \"GET /docs HTTP/1.1\" 200 OK\n",
+            ),
+        ),
+        (
+            "playwright",
+            "Listening on ws://127.0.0.1:9222/devtools/browser/4f3a2e9e-88a0-4e99-a000-abcdef123456\n",
+        ),
+    ];
+
+    for (name, output) in cases {
+        let (root, session) = empty_session(&format!("hook-post-codex-dev-{name}"));
+        let input = json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_response": output,
+        });
+        let hook_output = handle_hook(HookProvider::Codex, "t", &session, input).unwrap();
+        assert_eq!(hook_output, json!({}), "{name}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+#[test]
 fn codex_posttool_does_not_block_vite_dev_server_banner() {
     let _proxy = ScopedCodexExecProxy::set(false);
     let (root, session) = empty_session("hook-post-codex-vite-banner");


### PR DESCRIPTION
## What
- Render masked local home-directory usernames as `~` in tool output.
- Add regression coverage for common dev-server logs and stack traces.

## Why
Local stack traces often include `C:\Users\name` or `/home/name`. Masking the username as a Pentect placeholder protects it, but makes normal command output look noisy. This keeps the detector active while showing the path in the usual shell form.

## Checks
- cargo test -p pentect-runtime --locked
- cargo clippy -p pentect-runtime --all-targets --all-features --locked -- -D warnings
- cargo test -p pentect-cli --locked
- cargo clippy -p pentect-cli --all-targets --all-features --locked -- -D warnings
- target/debug/pentect.exe exec path-output smoke test
- target/debug/pentect.exe exec fake-key masking smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how file paths are displayed in masked output, replacing local home-directory paths with a shorter `~` form while keeping the rest of the path readable.
  * Reduced cases where common development-server and build-tool banner messages are incorrectly blocked, helping tool output pass through as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->