### PR TITLE
Reuse tool output masking state

### DIFF
--- a/crates/pentect-cli/src/exec_proxy.rs
+++ b/crates/pentect-cli/src/exec_proxy.rs
@@ -170,7 +170,9 @@ async fn handle_client(fut: upgrade::UpgradeFut, codex: PathBuf) -> Result<(), S
         });
     }
     let mut backend_lines = BufReader::new(backend_stdout).lines();
-    let mut backend_rewriter = BackendRewriter::new(|text: &str| mask_exec_output_text(text));
+    let mut output_masker = pentect_agent::ActiveToolOutputMasker::new()?;
+    let mut backend_rewriter =
+        BackendRewriter::new(move |text: &str| mask_exec_output_text(&mut output_masker, text));
 
     loop {
         tokio::select! {
@@ -552,8 +554,11 @@ where
     Ok(())
 }
 
-fn mask_exec_output_text(text: &str) -> Result<String, String> {
-    let masked = pentect_agent::mask_tool_output_into_active_in_memory_manager(text)?;
+fn mask_exec_output_text(
+    masker: &mut pentect_agent::ActiveToolOutputMasker,
+    text: &str,
+) -> Result<String, String> {
+    let masked = masker.mask_tool_output(text)?;
     if exec_proxy_debug() {
         eprintln!(
             "[pentect] exec proxy mask memory={} changed={}",

--- a/crates/pentect-cli/src/exec_proxy.rs
+++ b/crates/pentect-cli/src/exec_proxy.rs
@@ -136,6 +136,7 @@ async fn handle_client(fut: upgrade::UpgradeFut, codex: PathBuf) -> Result<(), S
         fut.await
             .map_err(|e| format!("websocket upgrade failed: {e}"))?,
     );
+    let mut output_masker = pentect_agent::ActiveToolOutputMasker::new()?;
     let mut backend = Command::new(codex);
     backend
         .arg("exec-server")
@@ -170,7 +171,6 @@ async fn handle_client(fut: upgrade::UpgradeFut, codex: PathBuf) -> Result<(), S
         });
     }
     let mut backend_lines = BufReader::new(backend_stdout).lines();
-    let mut output_masker = pentect_agent::ActiveToolOutputMasker::new()?;
     let mut backend_rewriter =
         BackendRewriter::new(move |text: &str| mask_exec_output_text(&mut output_masker, text));
 

--- a/crates/pentect-core/src/codec.rs
+++ b/crates/pentect-core/src/codec.rs
@@ -5,7 +5,7 @@ use data_encoding::{
 /// Decodes a contiguous encoded blob to bytes, or None if the run isn't valid in
 /// this encoding. Injected into the decode detector so new encodings are added
 /// without touching the detector.
-pub trait Codec {
+pub trait Codec: Send + Sync {
     fn decode(&self, run: &str) -> Option<Vec<u8>>;
 }
 

--- a/crates/pentect-core/src/detect/mod.rs
+++ b/crates/pentect-core/src/detect/mod.rs
@@ -50,6 +50,6 @@ pub(crate) use util::region;
 
 /// Side-effect-free and deterministic. Runs on a region's normalized view and
 /// returns spans in absolute raw coordinates (each tagged with its `DetectorId`).
-pub trait Detector {
+pub trait Detector: Send + Sync {
     fn detect(&self, view: &NormalizedView) -> Vec<Span>;
 }

--- a/crates/pentect-core/src/parse/mod.rs
+++ b/crates/pentect-core/src/parse/mod.rs
@@ -4,7 +4,7 @@ mod json;
 
 /// Turns raw input into value regions. Injected per `Kind`; the engine falls
 /// back to whole-input plaintext when no parser matches or one returns None.
-pub trait Parser {
+pub trait Parser: Send + Sync {
     fn parse(&self, raw: &str) -> Option<Vec<Region>>;
 }
 

--- a/crates/pentect-core/src/policy/guard.rs
+++ b/crates/pentect-core/src/policy/guard.rs
@@ -2,7 +2,7 @@
 /// context-free over-masking. It only ever retracts a candidate, and the engine
 /// only applies it to context-free spans, so it can never suppress an anchored
 /// secret (a benign-shaped value under a sensitive key is still masked).
-pub trait OverMaskGuard {
+pub trait OverMaskGuard: Send + Sync {
     fn benign(&self, value: &str) -> bool;
 }
 

--- a/crates/pentect-core/src/policy/mod.rs
+++ b/crates/pentect-core/src/policy/mod.rs
@@ -15,7 +15,7 @@ pub enum Action {
 
 /// Decides what to do with each detected span. Injected into the engine.
 /// Per-span and order-independent: it never looks at other spans.
-pub trait Policy {
+pub trait Policy: Send + Sync {
     fn classify(&self, span: &Span) -> Action;
 }
 

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -38,7 +38,7 @@ use sha2::{Digest, Sha256};
 use shell::{next_shell_word, powershell_word, shell_quote_unix};
 #[cfg(test)]
 use std::cell::Cell;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
@@ -52,6 +52,8 @@ const PENTECT_CODEX_EXEC_PROXY_ENV: &str = "PENTECT_CODEX_EXEC_PROXY";
 const LIVE_MASK_CHUNK_BYTES: usize = 64 * 1024;
 const LIVE_MASK_CHUNK_LINES: usize = 2048;
 const DASHBOARD_HEARTBEAT_MAX_AGE: Duration = Duration::from_secs(3);
+const ACTIVE_TOOL_OUTPUT_CACHE_LIMIT: usize = 128;
+const ACTIVE_TOOL_OUTPUT_CACHE_MAX_BYTES: usize = 16 * 1024;
 
 #[cfg(test)]
 thread_local! {
@@ -176,22 +178,109 @@ pub fn preflight_exec_server_process_start_from_active_in_memory_manager(
     requested_env_bindings(&store, &argv_mode).map(Some)
 }
 
+pub struct ActiveToolOutputMasker {
+    client: Option<InMemoryManagerClient>,
+    masker: Option<OutputMasker>,
+    reported_masked_count: u64,
+    cache: HashMap<[u8; 32], CachedToolOutput>,
+    cache_order: VecDeque<[u8; 32]>,
+}
+
+struct CachedToolOutput {
+    masked: String,
+    masked_count: u64,
+}
+
+impl ActiveToolOutputMasker {
+    pub fn new() -> Result<Self, String> {
+        let Some(client) = InMemoryManagerClient::from_env() else {
+            return Ok(Self {
+                client: None,
+                masker: None,
+                reported_masked_count: 0,
+                cache: HashMap::new(),
+                cache_order: VecDeque::new(),
+            });
+        };
+        let session = Session::open_capability("default").map_err(|e| e.to_string())?;
+        let store = RecoveryStore::load(&session).map_err(|e| e.to_string())?;
+        Ok(Self {
+            client: Some(client),
+            masker: Some(OutputMasker::new_shared(store)?),
+            reported_masked_count: 0,
+            cache: HashMap::new(),
+            cache_order: VecDeque::new(),
+        })
+    }
+
+    pub fn mask_tool_output(&mut self, text: &str) -> Result<Option<String>, String> {
+        let Some(masker) = &mut self.masker else {
+            return Ok(None);
+        };
+        let cache_key =
+            (text.len() <= ACTIVE_TOOL_OUTPUT_CACHE_MAX_BYTES).then(|| tool_output_cache_key(text));
+        if let Some(key) = cache_key {
+            if let Some(cached) = self.cache.get(&key) {
+                if cached.masked_count > 0 {
+                    if let Some(client) = &self.client {
+                        client
+                            .add_masked_count(cached.masked_count)
+                            .map_err(|e| e.to_string())?;
+                    }
+                }
+                return Ok(Some(cached.masked.clone()));
+            }
+        }
+        let masked = masker.mask_tool_output(text)?;
+        let total = masker.masked_count();
+        let delta = total.saturating_sub(self.reported_masked_count);
+        self.reported_masked_count = total;
+        if delta > 0 {
+            self.cache.clear();
+            self.cache_order.clear();
+            if let Some(client) = &self.client {
+                client.add_masked_count(delta).map_err(|e| e.to_string())?;
+            }
+        }
+        if let Some(key) = cache_key {
+            self.remember(key, &masked, delta);
+        }
+        Ok(Some(masked))
+    }
+
+    fn remember(&mut self, key: [u8; 32], masked: &str, masked_count: u64) {
+        if self.cache.contains_key(&key) {
+            return;
+        }
+        while self.cache.len() >= ACTIVE_TOOL_OUTPUT_CACHE_LIMIT {
+            let Some(oldest) = self.cache_order.pop_front() else {
+                self.cache.clear();
+                break;
+            };
+            self.cache.remove(&oldest);
+        }
+        self.cache.insert(
+            key,
+            CachedToolOutput {
+                masked: masked.to_string(),
+                masked_count,
+            },
+        );
+        self.cache_order.push_back(key);
+    }
+}
+
+fn tool_output_cache_key(text: &str) -> [u8; 32] {
+    let digest = Sha256::digest(text.as_bytes());
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&digest);
+    key
+}
+
 pub fn mask_tool_output_into_active_in_memory_manager(
     text: &str,
 ) -> Result<Option<String>, String> {
-    let Some(client) = InMemoryManagerClient::from_env() else {
-        return Ok(None);
-    };
-    let session = Session::open_capability("default").map_err(|e| e.to_string())?;
-    let store = RecoveryStore::load(&session).map_err(|e| e.to_string())?;
-    let mut masker = OutputMasker::new_deferred(store)?;
-    let masked = masker.mask_tool_output(text)?;
-    let masked_count = masker.masked_count();
-    masker.flush()?;
-    client
-        .add_masked_count(masked_count)
-        .map_err(|e| e.to_string())?;
-    Ok(Some(masked))
+    ActiveToolOutputMasker::new()?.mask_tool_output(text)
 }
 
 fn exec_server_approval_command(mode: &ExecMode, env: &[(String, String)]) -> String {

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -31,7 +31,7 @@ pub(crate) struct ToolScalarInput {
 
 pub(crate) struct OutputMasker {
     store: RecoveryStore,
-    engine: Engine,
+    engine: &'static Engine,
     model_adapters: ModelAdapters,
     mode: OutputMaskerMode,
     pending: Recovery,
@@ -277,12 +277,10 @@ impl OutputMasker {
             disclose_length: false,
             ..Config::new(self.store.session.key)
         };
-        match self.model_adapters.mask(
-            &self.engine,
-            Input { kind, data },
-            context.as_ref(),
-            &cfg,
-        )? {
+        match self
+            .model_adapters
+            .mask(self.engine, Input { kind, data }, context.as_ref(), &cfg)?
+        {
             Some(result) => self.record_mask_result(result),
             None => Ok(unchanged),
         }
@@ -481,7 +479,7 @@ pub(crate) fn mask_read_data(
     let mut adapter_count = 0usize;
     let mut adapter_recovery = Recovery::empty_for_key(&key);
     let data = match adapters.mask(
-        &engine,
+        engine,
         Input {
             kind: kind.clone(),
             data: data.clone(),
@@ -509,7 +507,15 @@ fn choose_batch_delimiter(values: &[String]) -> Option<&'static str> {
         .find(|delimiter| values.iter().all(|value| !value.contains(delimiter)))
 }
 
-fn tool_boundary_engine() -> Result<Engine, String> {
+fn tool_boundary_engine() -> Result<&'static Engine, String> {
+    static CACHE: OnceLock<Result<Engine, String>> = OnceLock::new();
+    match CACHE.get_or_init(build_tool_boundary_engine) {
+        Ok(engine) => Ok(engine),
+        Err(error) => Err(error.clone()),
+    }
+}
+
+fn build_tool_boundary_engine() -> Result<Engine, String> {
     let mut builder = Engine::builder()
         .standard_stack(Profile::Strict.knobs())
         .parser(Kind::ToolResult, Box::new(ToolResultParser))

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -658,6 +658,42 @@ fn exec_inherits_parent_environment_and_masks_output() {
 }
 
 #[test]
+fn active_tool_output_masker_reuses_in_memory_state() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let token = "active-masker-token".to_string();
+    let addr = in_memory_manager::spawn_test_in_memory_manager(token.clone());
+    std::env::set_var(ENV_ADDR, addr);
+    std::env::set_var(ENV_TOKEN, token);
+
+    let client = InMemoryManagerClient::from_env().unwrap();
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let mut masker = ActiveToolOutputMasker::new().unwrap();
+    let first = masker
+        .mask_tool_output(&format!("OPENAI_API_KEY={raw}\n"))
+        .unwrap()
+        .unwrap();
+    assert!(!first.contains(raw), "{first}");
+    let handle = first.split_once('=').unwrap().1.trim().to_string();
+
+    let repeated = masker
+        .mask_tool_output(&format!("OPENAI_API_KEY={raw}\n"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(repeated, first);
+
+    let second = masker
+        .mask_tool_output(&format!("echoed {raw}\n"))
+        .unwrap()
+        .unwrap();
+    assert!(!second.contains(raw), "{second}");
+    assert!(second.contains(&handle), "{second}");
+    assert_eq!(client.masked_count().unwrap(), 2);
+
+    std::env::remove_var(ENV_ADDR);
+    std::env::remove_var(ENV_TOKEN);
+}
+
+#[test]
 fn exec_capability_env_overlays_parent_environment_when_referenced() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("env-overlay");

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -662,6 +662,14 @@ fn active_tool_output_masker_reuses_in_memory_state() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let token = "active-masker-token".to_string();
     let addr = in_memory_manager::spawn_test_in_memory_manager(token.clone());
+    struct EnvCleanup;
+    impl Drop for EnvCleanup {
+        fn drop(&mut self) {
+            std::env::remove_var(ENV_ADDR);
+            std::env::remove_var(ENV_TOKEN);
+        }
+    }
+    let _cleanup = EnvCleanup;
     std::env::set_var(ENV_ADDR, addr);
     std::env::set_var(ENV_TOKEN, token);
 
@@ -688,9 +696,6 @@ fn active_tool_output_masker_reuses_in_memory_state() {
     assert!(!second.contains(raw), "{second}");
     assert!(second.contains(&handle), "{second}");
     assert_eq!(client.masked_count().unwrap(), 2);
-
-    std::env::remove_var(ENV_ADDR);
-    std::env::remove_var(ENV_TOKEN);
 }
 
 #[test]
@@ -1019,6 +1024,7 @@ fn write_tool_passes_through_non_pentect_templates() {
 
 #[test]
 fn write_tool_blocks_unknown_masked_handles_that_need_resolve() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("write-unknown-handle");
     let project = PathBuf::from("target").join(format!(
         "pentect-write-unknown-{}-{}",
@@ -1051,6 +1057,7 @@ fn write_tool_blocks_unknown_masked_handles_that_need_resolve() {
 
 #[test]
 fn write_tool_allows_resolvable_masked_content_before_tool() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-write-generic");
     let project = PathBuf::from("target").join(format!(
         "pentect-write-{}-{}",
@@ -1081,6 +1088,7 @@ fn write_tool_allows_resolvable_masked_content_before_tool() {
 
 #[test]
 fn write_tool_repairs_masked_file_after_tool() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-write-repair");
     let project = PathBuf::from("target").join(format!(
         "pentect-write-repair-{}-{}",
@@ -1115,6 +1123,7 @@ fn write_tool_repairs_masked_file_after_tool() {
 
 #[test]
 fn write_tool_allows_and_repairs_absolute_file_path() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-write-absolute");
     let project = PathBuf::from("target").join(format!(
         "pentect-write-absolute-{}-{}",
@@ -1187,6 +1196,7 @@ fn write_tool_refuses_masked_repair_outside_current_dir() {
 
 #[test]
 fn write_tool_repairs_camel_case_external_schema_after_tool() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-write-camel");
     let project = PathBuf::from("target").join(format!(
         "pentect-write-camel-{}-{}",
@@ -1227,6 +1237,7 @@ fn write_tool_repairs_camel_case_external_schema_after_tool() {
 
 #[test]
 fn write_tool_repairs_edit_masked_new_string_after_tool() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-edit-repair");
     let project = PathBuf::from("target").join(format!(
         "pentect-edit-repair-{}-{}",
@@ -1275,6 +1286,7 @@ fn write_tool_repairs_edit_masked_new_string_after_tool() {
 
 #[test]
 fn write_tool_repairs_multiedit_masked_new_string_after_tool() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-multiedit-repair");
     let project = PathBuf::from("target").join(format!(
         "pentect-multiedit-repair-{}-{}",
@@ -1326,6 +1338,7 @@ fn write_tool_repairs_multiedit_masked_new_string_after_tool() {
 
 #[test]
 fn write_tool_applies_edit_with_masked_old_string_before_tool() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-edit-old-handle");
     let project = PathBuf::from("target").join(format!(
         "pentect-edit-old-handle-{}-{}",
@@ -1368,6 +1381,7 @@ fn write_tool_applies_edit_with_masked_old_string_before_tool() {
 
 #[test]
 fn write_tool_applies_multiedit_with_masked_old_string_before_tool() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-multiedit-old-handle");
     let project = PathBuf::from("target").join(format!(
         "pentect-multiedit-old-handle-{}-{}",
@@ -1411,6 +1425,7 @@ fn write_tool_applies_multiedit_with_masked_old_string_before_tool() {
 
 #[test]
 fn write_tool_blocks_edit_masked_old_string_on_lazy_hook_path() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let project = PathBuf::from("target").join(format!(
         "pentect-edit-old-handle-lazy-{}-{}",
         std::process::id(),
@@ -1446,6 +1461,7 @@ fn write_tool_blocks_edit_masked_old_string_on_lazy_hook_path() {
 #[cfg(unix)]
 #[test]
 fn write_tool_refuses_masked_repair_through_symlink_dir() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-write-symlink");
     let outside = temp_root("capability-write-symlink-outside");
     std::fs::create_dir_all(&outside).unwrap();

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2678,6 +2678,7 @@ fn pretool_wraps_pentect_resolve_for_approval() {
 
 #[test]
 fn pretool_allows_direct_read_tool_for_clean_file() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (root, session) = empty_session("hook-pre-direct-read-clean");
     let project = PathBuf::from("target").join(format!(
         "pentect-read-clean-{}-{}",
@@ -2703,6 +2704,7 @@ fn pretool_allows_direct_read_tool_for_clean_file() {
 
 #[test]
 fn pretool_rewrites_direct_read_tool_to_masked_copy() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (root, session) = empty_session("hook-pre-direct-read-secret");
     let project = PathBuf::from("target").join(format!(
         "pentect-read-secret-{}-{}",


### PR DESCRIPTION
## Summary
- reuse one active tool-output masker per exec proxy connection
- cache small repeated tool output chunks by SHA-256 key without retaining raw output as the cache key
- share the tool-boundary detection engine through a process-wide OnceLock

## Tests
- cargo test -p pentect-core --locked --quiet
- cargo test -p pentect-runtime --locked --quiet
- cargo test -p pentect-cli --locked --quiet
- cargo clippy -p pentect-core --all-targets --all-features --locked -- -D warnings
- cargo clippy -p pentect-runtime --all-targets --all-features --locked -- -D warnings
- cargo clippy -p pentect-cli --all-targets --all-features --locked -- -D warnings
- cargo build -p pentect-cli --release --locked
- target\\release\\pentect.exe exec smoke with fake key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter caching for masked tool output, helping repeated values reuse prior masked results when possible.
  * Improved backend masking to keep output handling consistent within a session.

* **Bug Fixes**
  * Strengthened thread-safety requirements across core interfaces, improving reliability in concurrent use.
  * Updated masking internals to better preserve previously masked values while avoiding accidental exposure of raw secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->