### PR TITLE
Expose bundled OCR status

### DIFF
--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -11,14 +11,15 @@ name = "pentect"
 path = "src/main.rs"
 
 [features]
-default = ["pdf"]
+default = ["pdf", "ocr"]
 # PDF input is an adapter concern: extract text locally, then feed the normal
 # masking kernel. Disable default features for a slimmer text-only CLI.
-pdf = ["dep:pdf-extract"]
+pdf = ["dep:pdf-extract", "pentect-runtime/pdf"]
+ocr = ["pentect-runtime/ocr"]
 
 [dependencies]
 pentect-core = { path = "../pentect-core" }
-pentect-runtime = { path = "../pentect-runtime" }
+pentect-runtime = { path = "../pentect-runtime", default-features = false }
 anyhow = { workspace = true }
 ignore = { workspace = true }
 pdf-extract = { workspace = true, optional = true }

--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -16,7 +16,7 @@ pub(crate) fn cmd_doctor(args: &[String]) {
         println!("{}", checks_json(&checks));
     } else {
         for check in &checks {
-            println!("{}: {}", check.name, check.status.as_str());
+            println!("{}: {} {}", check.name, check.status.as_str(), check.detail);
         }
     }
     if checks.iter().any(|check| check.status == Status::Fail) {
@@ -65,6 +65,7 @@ fn run_checks() -> Vec<Check> {
         check_pentect_binary(),
         check_in_memory_manager(),
         check_config_extensions(),
+        check_ocr(),
         check_command("codex"),
         check_command("claude"),
     ]
@@ -132,6 +133,14 @@ fn check_config_extensions() -> Check {
     match extensions::active_from_specs(Vec::new(), true) {
         Ok(_) => Check::ok("extensions", "ready"),
         Err(e) => Check::fail("extensions", e.to_string()),
+    }
+}
+
+fn check_ocr() -> Check {
+    match pentect_agent::ocr_status() {
+        "bundled" => Check::ok("ocr", "bundled"),
+        "disabled" => Check::warn("ocr", "disabled"),
+        status => Check::warn("ocr", status),
     }
 }
 
@@ -237,5 +246,13 @@ mod tests {
     fn doctor_accepts_json() {
         let args = vec!["pentect".into(), "doctor".into(), "--json".into()];
         assert!(parse_args(&args).unwrap());
+    }
+
+    #[test]
+    fn doctor_reports_ocr_status() {
+        let check = check_ocr();
+        assert_eq!(check.name, "ocr");
+        assert!(matches!(check.status, Status::Ok | Status::Warn));
+        assert!(matches!(check.detail.as_str(), "bundled" | "disabled"));
     }
 }

--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -252,7 +252,10 @@ mod tests {
     fn doctor_reports_ocr_status() {
         let check = check_ocr();
         assert_eq!(check.name, "ocr");
-        assert!(matches!(check.status, Status::Ok | Status::Warn));
-        assert!(matches!(check.detail.as_str(), "bundled" | "disabled"));
+        match check.detail.as_str() {
+            "bundled" => assert_eq!(check.status, Status::Ok),
+            "disabled" => assert_eq!(check.status, Status::Warn),
+            other => panic!("unexpected ocr detail: {other}"),
+        }
     }
 }

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -37,7 +37,7 @@ const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
     "- `pentect view '<handle>'` shows only label, hash, and length. Use handles or generated env vars instead of printing raw values.\n",
     "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:NAME`; on Unix use POSIX commands and `$NAME`.\n",
     "- MCP, browser, plugin, and connector tools may retrieve and use user-authorized secrets. Pentect masks tool text output when the host supports replacement; otherwise it stops unsafe output.\n",
-    "- Image tool output is checked by bundled OCR; detected secrets are blocked.\n",
+    "- Default builds check image tool output with bundled OCR; detected secrets are blocked.\n",
     "- For user-requested storage, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
     "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
 );

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -37,7 +37,7 @@ const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
     "- `pentect view '<handle>'` shows only label, hash, and length. Use handles or generated env vars instead of printing raw values.\n",
     "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:NAME`; on Unix use POSIX commands and `$NAME`.\n",
     "- MCP, browser, plugin, and connector tools may retrieve and use user-authorized secrets. Pentect masks tool text output when the host supports replacement; otherwise it stops unsafe output.\n",
-    "- Image tool output is OCR-inspected when available; detected secrets are blocked.\n",
+    "- Image tool output is checked by bundled OCR; detected secrets are blocked.\n",
     "- For user-requested storage, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
     "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
 );

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -611,6 +611,16 @@ fn fetch_image_url_bytes(
 }
 
 #[cfg(feature = "ocr")]
+pub fn ocr_status() -> &'static str {
+    "bundled"
+}
+
+#[cfg(not(feature = "ocr"))]
+pub fn ocr_status() -> &'static str {
+    "disabled"
+}
+
+#[cfg(feature = "ocr")]
 pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
     use image::GenericImageView;
     use ocrs::{ImageSource, OcrEngine, OcrEngineParams};

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -136,6 +136,10 @@ pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
     image_ocr::ocr_image_bytes(bytes)
 }
 
+pub fn ocr_status() -> &'static str {
+    image_ocr::ocr_status()
+}
+
 pub fn resolve_text_from_active_in_memory_manager(text: &str) -> Result<Option<String>, String> {
     if InMemoryManagerClient::from_env().is_none() {
         return Ok(None);


### PR DESCRIPTION
## Summary
- Add OCR status to doctor output.
- Expose whether OCR is bundled or disabled from the runtime.
- Clarify the agent contract uses bundled OCR, not an external Tesseract install.

## Validation
- cargo fmt --all --check
- cargo test -p pentect-cli doctor --locked --quiet
- cargo test -p pentect-runtime image_ocr --locked --quiet
- cargo check -p pentect-runtime --no-default-features --locked --quiet
- cargo test -p pentect-cli --locked --quiet
- cargo run -p pentect-cli --quiet -- doctor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `doctor` command now shows each check’s detail alongside its status in standard output.
  * Added a new OCR status check so users can see whether OCR support is bundled or disabled.

* **Bug Fixes**
  * Updated tool-boundary guidance to reflect that image output is handled with bundled OCR when available, improving consistency in reported behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->