### PR TITLE
Use native OCR on desktop platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  native-ocr:
+    name: Native OCR (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check native OCR build
+        run: cargo check -p pentect-cli --features ocr --locked
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-vision"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc194758a2d5d7540b1ad283bfb9ca318ec608991892326e95b428230b2689b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "ocrs"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2021,9 @@ dependencies = [
  "hmac",
  "image",
  "jiff",
+ "objc2",
+ "objc2-foundation",
+ "objc2-vision",
  "ocrs",
  "pdf-extract",
  "pentect-core",
@@ -1997,6 +2035,7 @@ dependencies = [
  "simd-json",
  "tokio",
  "toml",
+ "windows",
  "zeroize",
 ]
 
@@ -3957,10 +3996,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -4003,6 +4137,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,7 @@ anstream = "0.6"
 crossterm = "0.28"
 ed25519-dalek = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }
+windows = "0.62.2"
+objc2 = { version = "0.6.3", default-features = false }
+objc2-foundation = { version = "0.3.2", default-features = false }
+objc2-vision = { version = "0.3.2", default-features = false }

--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -137,9 +137,11 @@ fn check_config_extensions() -> Check {
 }
 
 fn check_ocr() -> Check {
-    match pentect_agent::ocr_status() {
-        "bundled" => Check::ok("ocr", "bundled"),
+    let status = pentect_agent::ocr_status();
+    match status {
+        "bundled" | "windows" | "macos" => Check::ok("ocr", status),
         "disabled" => Check::warn("ocr", "disabled"),
+        "unsupported" => Check::warn("ocr", "unsupported"),
         status => Check::warn("ocr", status),
     }
 }
@@ -253,8 +255,8 @@ mod tests {
         let check = check_ocr();
         assert_eq!(check.name, "ocr");
         match check.detail.as_str() {
-            "bundled" => assert_eq!(check.status, Status::Ok),
-            "disabled" => assert_eq!(check.status, Status::Warn),
+            "bundled" | "windows" | "macos" => assert_eq!(check.status, Status::Ok),
+            "disabled" | "unsupported" => assert_eq!(check.status, Status::Warn),
             other => panic!("unexpected ocr detail: {other}"),
         }
     }

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -37,7 +37,7 @@ const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
     "- `pentect view '<handle>'` shows only label, hash, and length. Use handles or generated env vars instead of printing raw values.\n",
     "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:NAME`; on Unix use POSIX commands and `$NAME`.\n",
     "- MCP, browser, plugin, and connector tools may retrieve and use user-authorized secrets. Pentect masks tool text output when the host supports replacement; otherwise it stops unsafe output.\n",
-    "- Default builds check image tool output with bundled OCR; detected secrets are blocked.\n",
+    "- Default builds check image output with OS OCR on Windows/macOS and bundled OCR on Linux.\n",
     "- For user-requested storage, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
     "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
 );

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -14,7 +14,14 @@ path = "src/main.rs"
 [features]
 default = ["pdf", "ocr"]
 pdf = ["dep:pdf-extract"]
-ocr = ["dep:image", "dep:ocrs", "dep:reqwest", "dep:rten"]
+ocr = ["dep:reqwest", "native-ocr", "bundled-ocr"]
+native-ocr = [
+    "dep:windows",
+    "dep:objc2",
+    "dep:objc2-foundation",
+    "dep:objc2-vision",
+]
+bundled-ocr = ["dep:image", "dep:ocrs", "dep:rten"]
 
 [dependencies]
 pentect-core = { path = "../pentect-core" }
@@ -22,10 +29,7 @@ anyhow = { workspace = true }
 axum = { workspace = true }
 data-encoding = { workspace = true }
 pdf-extract = { workspace = true, optional = true }
-image = { workspace = true, optional = true }
-ocrs = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
-rten = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }
@@ -39,3 +43,36 @@ ed25519-dalek = { workspace = true }
 getrandom = { workspace = true }
 jiff = { workspace = true }
 tokio = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { workspace = true, optional = true, features = [
+    "Foundation",
+    "Graphics_Imaging",
+    "Media_Ocr",
+    "Storage_Streams",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = { workspace = true, optional = true }
+objc2-foundation = { workspace = true, optional = true, default-features = false, features = [
+    "std",
+    "NSArray",
+    "NSData",
+    "NSDictionary",
+    "NSError",
+    "NSObject",
+    "NSString",
+] }
+objc2-vision = { workspace = true, optional = true, default-features = false, features = [
+    "std",
+    "VNObservation",
+    "VNRecognizeTextRequest",
+    "VNRequest",
+    "VNRequestHandler",
+    "VNTypes",
+] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+image = { workspace = true, optional = true }
+ocrs = { workspace = true, optional = true }
+rten = { workspace = true, optional = true }

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -53,6 +53,7 @@ windows = { workspace = true, optional = true, features = [
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+image = { workspace = true, optional = true }
 objc2 = { workspace = true, optional = true }
 objc2-foundation = { workspace = true, optional = true, default-features = false, features = [
     "std",

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -773,7 +773,8 @@ pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
         ));
     }
 
-    let data = NSData::with_bytes(bytes);
+    let ocr_bytes = prepare_macos_ocr_bytes(bytes, &cfg)?;
+    let data = NSData::with_bytes(ocr_bytes.as_ref());
     let options = NSDictionary::<VNImageOption, AnyObject>::from_slices::<VNImageOption>(&[], &[]);
     let request = VNRecognizeTextRequest::new();
     request.setRecognitionLevel(VNRequestTextRecognitionLevel::Fast);
@@ -808,6 +809,53 @@ pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
         text.push_str(&candidate.string().to_string());
     }
     Ok(text)
+}
+
+#[cfg(all(feature = "ocr", target_os = "macos"))]
+fn prepare_macos_ocr_bytes<'a>(
+    bytes: &'a [u8],
+    cfg: &ImageOcrConfig,
+) -> Result<std::borrow::Cow<'a, [u8]>, String> {
+    use image::{GenericImageView, ImageFormat, ImageReader};
+    use std::{borrow::Cow, io::Cursor};
+
+    let reader = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|e| format!("could not inspect image: {e}"))?;
+    let (width, height) = reader
+        .into_dimensions()
+        .map_err(|e| format!("could not read image dimensions: {e}"))?;
+    let pixels = u64::from(width).saturating_mul(u64::from(height));
+    if pixels > cfg.max_pixels {
+        return Err(format!(
+            "image has {pixels} pixels; limit is {}",
+            cfg.max_pixels
+        ));
+    }
+    if cfg.max_edge == 0 || (width <= cfg.max_edge && height <= cfg.max_edge) {
+        return Ok(Cow::Borrowed(bytes));
+    }
+
+    let img = image::load_from_memory(bytes).map_err(|e| format!("could not decode image: {e}"))?;
+    let resized = img.resize(
+        cfg.max_edge,
+        cfg.max_edge,
+        image::imageops::FilterType::Triangle,
+    );
+    let (resized_width, resized_height) = resized.dimensions();
+    let resized_pixels = u64::from(resized_width).saturating_mul(u64::from(resized_height));
+    if resized_pixels > cfg.max_pixels {
+        return Err(format!(
+            "image has {resized_pixels} pixels after resize; limit is {}",
+            cfg.max_pixels
+        ));
+    }
+
+    let mut out = Vec::new();
+    resized
+        .write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
+        .map_err(|e| format!("could not prepare image for macOS OCR: {e}"))?;
+    Ok(Cow::Owned(out))
 }
 
 #[cfg(all(feature = "ocr", target_os = "linux"))]

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -756,7 +756,7 @@ fn scaled_dimensions(width: u32, height: u32, max_edge: u32) -> (u32, u32) {
 
 #[cfg(all(feature = "ocr", target_os = "macos"))]
 pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
-    use objc2::AnyObject;
+    use objc2::{runtime::AnyObject, AnyThread};
     use objc2_foundation::{NSArray, NSData, NSDictionary};
     use objc2_vision::{
         VNImageOption, VNImageRequestHandler, VNRecognizeTextRequest, VNRequestTextRecognitionLevel,
@@ -795,12 +795,13 @@ pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
         return Ok(String::new());
     };
     let mut text = String::new();
-    for observation in observations.iter() {
+    for index in 0..observations.len() {
+        let observation = observations.objectAtIndex(index);
         let candidates = observation.topCandidates(1);
-        let mut iter = candidates.iter();
-        let Some(candidate) = iter.next() else {
+        if candidates.is_empty() {
             continue;
-        };
+        }
+        let candidate = candidates.objectAtIndex(0);
         if !text.is_empty() {
             text.push('\n');
         }

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -610,9 +610,27 @@ fn fetch_image_url_bytes(
     Ok(None)
 }
 
-#[cfg(feature = "ocr")]
+#[cfg(all(feature = "ocr", target_os = "linux"))]
 pub fn ocr_status() -> &'static str {
     "bundled"
+}
+
+#[cfg(all(feature = "ocr", target_os = "windows"))]
+pub fn ocr_status() -> &'static str {
+    "windows"
+}
+
+#[cfg(all(feature = "ocr", target_os = "macos"))]
+pub fn ocr_status() -> &'static str {
+    "macos"
+}
+
+#[cfg(all(
+    feature = "ocr",
+    not(any(target_os = "linux", target_os = "windows", target_os = "macos"))
+))]
+pub fn ocr_status() -> &'static str {
+    "unsupported"
 }
 
 #[cfg(not(feature = "ocr"))]
@@ -620,7 +638,178 @@ pub fn ocr_status() -> &'static str {
     "disabled"
 }
 
-#[cfg(feature = "ocr")]
+#[cfg(all(feature = "ocr", target_os = "windows"))]
+pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
+    use windows::Graphics::Imaging::{
+        BitmapAlphaMode, BitmapDecoder, BitmapInterpolationMode, BitmapPixelFormat,
+        BitmapTransform, ColorManagementMode, ExifOrientationMode,
+    };
+    use windows::Media::Ocr::OcrEngine;
+    use windows::Storage::Streams::{DataWriter, InMemoryRandomAccessStream};
+
+    let cfg = image_ocr_config()?;
+    if matches!(cfg.mode, ImageOcrMode::Off) {
+        return Err("image OCR disabled".to_string());
+    }
+    if bytes.len() as u64 > cfg.max_image_bytes {
+        return Err(format!(
+            "image is larger than {} bytes",
+            cfg.max_image_bytes
+        ));
+    }
+
+    let stream = InMemoryRandomAccessStream::new()
+        .map_err(|e| format!("could not initialize image stream: {e}"))?;
+    let output = stream
+        .GetOutputStreamAt(0)
+        .map_err(|e| format!("could not open image stream: {e}"))?;
+    let writer = DataWriter::CreateDataWriter(&output)
+        .map_err(|e| format!("could not initialize image writer: {e}"))?;
+    writer
+        .WriteBytes(bytes)
+        .map_err(|e| format!("could not write image bytes: {e}"))?;
+    writer
+        .StoreAsync()
+        .map_err(|e| format!("could not store image bytes: {e}"))?
+        .join()
+        .map_err(|e| format!("could not store image bytes: {e}"))?;
+    writer
+        .FlushAsync()
+        .map_err(|e| format!("could not flush image bytes: {e}"))?
+        .join()
+        .map_err(|e| format!("could not flush image bytes: {e}"))?;
+    stream
+        .Seek(0)
+        .map_err(|e| format!("could not rewind image stream: {e}"))?;
+
+    let decoder = BitmapDecoder::CreateAsync(&stream)
+        .map_err(|e| format!("could not decode image: {e}"))?
+        .join()
+        .map_err(|e| format!("could not decode image: {e}"))?;
+    let width = decoder
+        .PixelWidth()
+        .map_err(|e| format!("could not read image width: {e}"))?;
+    let height = decoder
+        .PixelHeight()
+        .map_err(|e| format!("could not read image height: {e}"))?;
+    let pixels = u64::from(width).saturating_mul(u64::from(height));
+    if pixels > cfg.max_pixels {
+        return Err(format!(
+            "image has {pixels} pixels; limit is {}",
+            cfg.max_pixels
+        ));
+    }
+
+    let max_dimension = OcrEngine::MaxImageDimension()
+        .map_err(|e| format!("could not read OCR image limit: {e}"))?
+        .min(cfg.max_edge);
+    let (scaled_width, scaled_height) = scaled_dimensions(width, height, max_dimension);
+    let transform =
+        BitmapTransform::new().map_err(|e| format!("could not initialize image transform: {e}"))?;
+    transform
+        .SetScaledWidth(scaled_width)
+        .map_err(|e| format!("could not set image width: {e}"))?;
+    transform
+        .SetScaledHeight(scaled_height)
+        .map_err(|e| format!("could not set image height: {e}"))?;
+    transform
+        .SetInterpolationMode(BitmapInterpolationMode::Fant)
+        .map_err(|e| format!("could not set image interpolation: {e}"))?;
+
+    let bitmap = decoder
+        .GetSoftwareBitmapTransformedAsync(
+            BitmapPixelFormat::Bgra8,
+            BitmapAlphaMode::Premultiplied,
+            &transform,
+            ExifOrientationMode::RespectExifOrientation,
+            ColorManagementMode::ColorManageToSRgb,
+        )
+        .map_err(|e| format!("could not prepare image bitmap: {e}"))?
+        .join()
+        .map_err(|e| format!("could not prepare image bitmap: {e}"))?;
+    let engine = OcrEngine::TryCreateFromUserProfileLanguages()
+        .map_err(|e| format!("could not initialize Windows OCR: {e}"))?;
+    let result = engine
+        .RecognizeAsync(&bitmap)
+        .map_err(|e| format!("could not start Windows OCR: {e}"))?
+        .join()
+        .map_err(|e| format!("could not OCR image: {e}"))?;
+    result
+        .Text()
+        .map(|text| text.to_string_lossy())
+        .map_err(|e| format!("could not read OCR text: {e}"))
+}
+
+#[cfg(all(feature = "ocr", target_os = "windows"))]
+fn scaled_dimensions(width: u32, height: u32, max_edge: u32) -> (u32, u32) {
+    if max_edge == 0 || (width <= max_edge && height <= max_edge) {
+        return (width.max(1), height.max(1));
+    }
+    if width >= height {
+        let scaled_height = (u64::from(height) * u64::from(max_edge) / u64::from(width)).max(1);
+        (max_edge, scaled_height as u32)
+    } else {
+        let scaled_width = (u64::from(width) * u64::from(max_edge) / u64::from(height)).max(1);
+        (scaled_width as u32, max_edge)
+    }
+}
+
+#[cfg(all(feature = "ocr", target_os = "macos"))]
+pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
+    use objc2::AnyObject;
+    use objc2_foundation::{NSArray, NSData, NSDictionary};
+    use objc2_vision::{
+        VNImageOption, VNImageRequestHandler, VNRecognizeTextRequest, VNRequestTextRecognitionLevel,
+    };
+
+    let cfg = image_ocr_config()?;
+    if matches!(cfg.mode, ImageOcrMode::Off) {
+        return Err("image OCR disabled".to_string());
+    }
+    if bytes.len() as u64 > cfg.max_image_bytes {
+        return Err(format!(
+            "image is larger than {} bytes",
+            cfg.max_image_bytes
+        ));
+    }
+
+    let data = NSData::with_bytes(bytes);
+    let options = NSDictionary::<VNImageOption, AnyObject>::from_slices::<VNImageOption>(&[], &[]);
+    let request = VNRecognizeTextRequest::new();
+    request.setRecognitionLevel(VNRequestTextRecognitionLevel::Fast);
+    request.setAutomaticallyDetectsLanguage(true);
+    request.setUsesLanguageCorrection(false);
+
+    let request_for_handler = request.clone().into_super().into_super();
+    let requests = NSArray::from_retained_slice(&[request_for_handler]);
+    let handler = VNImageRequestHandler::initWithData_options(
+        VNImageRequestHandler::alloc(),
+        &data,
+        &options,
+    );
+    handler
+        .performRequests_error(&requests)
+        .map_err(|e| format!("could not OCR image with macOS Vision: {e}"))?;
+
+    let Some(observations) = request.results() else {
+        return Ok(String::new());
+    };
+    let mut text = String::new();
+    for observation in observations.iter() {
+        let candidates = observation.topCandidates(1);
+        let mut iter = candidates.iter();
+        let Some(candidate) = iter.next() else {
+            continue;
+        };
+        if !text.is_empty() {
+            text.push('\n');
+        }
+        text.push_str(&candidate.string().to_string());
+    }
+    Ok(text)
+}
+
+#[cfg(all(feature = "ocr", target_os = "linux"))]
 pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
     use image::GenericImageView;
     use ocrs::{ImageSource, OcrEngine, OcrEngineParams};
@@ -673,7 +862,7 @@ pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
         .map_err(|e| format!("could not OCR image: {e}"))
 }
 
-#[cfg(feature = "ocr")]
+#[cfg(all(feature = "ocr", target_os = "linux"))]
 fn resize_for_ocr(img: image::DynamicImage, max_edge: u32) -> image::DynamicImage {
     use image::GenericImageView;
 
@@ -682,6 +871,14 @@ fn resize_for_ocr(img: image::DynamicImage, max_edge: u32) -> image::DynamicImag
         return img;
     }
     img.resize(max_edge, max_edge, image::imageops::FilterType::Triangle)
+}
+
+#[cfg(all(
+    feature = "ocr",
+    not(any(target_os = "linux", target_os = "windows", target_os = "macos"))
+))]
+pub fn ocr_image_bytes(_bytes: &[u8]) -> Result<String, String> {
+    Err("image OCR is not supported on this platform".to_string())
 }
 
 #[cfg(not(feature = "ocr"))]
@@ -998,7 +1195,7 @@ mod tests {
         assert!(!ocr_text_has_secret("   \n\t", &[7; 32]));
     }
 
-    #[cfg(feature = "ocr")]
+    #[cfg(all(feature = "ocr", target_os = "linux"))]
     #[test]
     fn resize_for_ocr_caps_long_edge() {
         use image::GenericImageView;
@@ -1010,5 +1207,13 @@ mod tests {
         let img = image::DynamicImage::new_rgb8(1024, 512);
         let resized = resize_for_ocr(img, 2048);
         assert_eq!(resized.dimensions(), (1024, 512));
+    }
+
+    #[cfg(all(feature = "ocr", target_os = "windows"))]
+    #[test]
+    fn windows_scaled_dimensions_cap_long_edge() {
+        assert_eq!(scaled_dimensions(4096, 1024, 2048), (2048, 512));
+        assert_eq!(scaled_dimensions(1024, 512, 2048), (1024, 512));
+        assert_eq!(scaled_dimensions(10, 100, 50), (5, 50));
     }
 }


### PR DESCRIPTION
## Summary
- Use Windows OCR on Windows and Vision OCR on macOS
- Keep bundled RTen/ocrs OCR only on Linux
- Add lightweight Windows/macOS OCR build checks in CI

## Checks
- cargo fmt --all --check
- cargo test --workspace --all-features --locked --quiet
- cargo clippy -p pentect-runtime --features ocr --target x86_64-pc-windows-msvc --all-targets --locked -- -D warnings
- cargo clippy -p pentect-cli --all-targets --locked -- -D warnings
- Windows OCR smoke test: HELLO OCR 1234