### PR TITLE
Improve scan and proxy performance

### DIFF
--- a/crates/pentect-cli/src/exec_proxy.rs
+++ b/crates/pentect-cli/src/exec_proxy.rs
@@ -174,7 +174,7 @@ async fn handle_client(fut: upgrade::UpgradeFut, codex: PathBuf) -> Result<(), S
     let mut backend_rewriter =
         BackendRewriter::new(move |text: &str| mask_exec_output_text(&mut output_masker, text));
 
-    loop {
+    'session: loop {
         tokio::select! {
             frame = ws.read_frame() => {
                 let frame = match frame {
@@ -206,12 +206,13 @@ async fn handle_client(fut: upgrade::UpgradeFut, codex: PathBuf) -> Result<(), S
                 if line.trim().is_empty() {
                     continue;
                 }
-                let line = backend_rewriter.rewrite_line(&line)?;
-                if let Err(e) = ws.write_frame(Frame::text(Payload::Owned(line.into_bytes()))).await {
-                    if is_clean_websocket_close(&e) {
-                        break;
+                for line in backend_rewriter.rewrite_line(&line)? {
+                    if let Err(e) = ws.write_frame(Frame::text(Payload::Owned(line.into_bytes()))).await {
+                        if is_clean_websocket_close(&e) {
+                            break 'session;
+                        }
+                        return Err(format!("websocket write failed: {e}"));
                     }
-                    return Err(format!("websocket write failed: {e}"));
                 }
             }
         }
@@ -223,9 +224,11 @@ async fn handle_client(fut: upgrade::UpgradeFut, codex: PathBuf) -> Result<(), S
 }
 
 fn request_has_auth<B>(req: &Request<B>, auth: &str) -> bool {
-    req.uri()
-        .query()
-        .is_some_and(|query| query.split('&').any(|part| part == format!("token={auth}")))
+    req.uri().query().is_some_and(|query| {
+        query
+            .split('&')
+            .any(|part| part.strip_prefix("token=") == Some(auth))
+    })
 }
 
 fn random_auth_token() -> Result<String, String> {
@@ -355,7 +358,14 @@ where
 
 struct BackendRewriter<F> {
     mask: F,
-    pending_output: BTreeMap<String, String>,
+    pending_output: BTreeMap<String, PendingOutput>,
+    next_output_order: u64,
+}
+
+struct PendingOutput {
+    params: Value,
+    text: String,
+    order: u64,
 }
 
 impl<F> BackendRewriter<F>
@@ -366,13 +376,14 @@ where
         Self {
             mask,
             pending_output: BTreeMap::new(),
+            next_output_order: 0,
         }
     }
 
-    fn rewrite_line(&mut self, line: &str) -> Result<String, String> {
+    fn rewrite_line(&mut self, line: &str) -> Result<Vec<String>, String> {
         let mut value: Value = match serde_json::from_str(line) {
             Ok(value) => value,
-            Err(_) => return Ok(line.to_string()),
+            Err(_) => return Ok(vec![line.to_string()]),
         };
         let method = value
             .get("method")
@@ -400,7 +411,9 @@ where
         }
         if method.as_deref() == Some(PROCESS_OUTPUT_METHOD) {
             if let Some(params) = value.get_mut("params") {
-                self.mask_process_output(params)?;
+                if !self.mask_process_output(params)? {
+                    return Ok(Vec::new());
+                }
             }
         } else if is_process_read_response(&value) {
             if let Some(chunks) = value
@@ -411,30 +424,48 @@ where
                 mask_read_chunks(chunks, &mut self.mask)?;
             }
         }
-        if matches!(method.as_deref(), Some("process/exited" | "process/closed")) {
-            clear_process_pending(&mut self.pending_output, &value);
-        }
+        let mut out = if matches!(method.as_deref(), Some("process/exited" | "process/closed")) {
+            flush_process_pending(&mut self.pending_output, &value, &mut self.mask)?
+        } else {
+            Vec::new()
+        };
         if let Some(error) = value.get_mut("error") {
             mask_json_strings(error, &mut self.mask)?;
         }
-        serde_json::to_string(&value).map_err(|e| e.to_string())
+        out.push(serde_json::to_string(&value).map_err(|e| e.to_string())?);
+        Ok(out)
     }
 
-    fn mask_process_output(&mut self, value: &mut Value) -> Result<(), String> {
+    fn mask_process_output(&mut self, value: &mut Value) -> Result<bool, String> {
         let Some(text) = decoded_chunk_text(value)? else {
-            return Ok(());
+            return Ok(true);
         };
         let key = output_buffer_key(value);
-        let pending = self.pending_output.remove(&key).unwrap_or_default();
-        let combined = format!("{pending}{text}");
+        let pending = self.pending_output.remove(&key);
+        let (mut combined, params, order) = match pending {
+            Some(pending) => (pending.text, pending.params, pending.order),
+            None => {
+                let order = self.next_output_order;
+                self.next_output_order = self.next_output_order.saturating_add(1);
+                (String::new(), value.clone(), order)
+            }
+        };
+        combined.push_str(&text);
         if should_flush_output(&combined) {
             let masked = (self.mask)(&combined)?;
             set_chunk_text(value, &masked);
+            Ok(true)
         } else {
-            self.pending_output.insert(key, combined);
-            set_chunk_text(value, "");
+            self.pending_output.insert(
+                key,
+                PendingOutput {
+                    params,
+                    text: combined,
+                    order,
+                },
+            );
+            Ok(false)
         }
-        Ok(())
     }
 }
 
@@ -516,16 +547,42 @@ fn should_flush_output(text: &str) -> bool {
     text.contains('\n') || text.len() >= OUTPUT_HOLDBACK_BYTES
 }
 
-fn clear_process_pending(pending: &mut BTreeMap<String, String>, value: &Value) {
+fn flush_process_pending<F>(
+    pending: &mut BTreeMap<String, PendingOutput>,
+    value: &Value,
+    mask: &mut F,
+) -> Result<Vec<String>, String>
+where
+    F: FnMut(&str) -> Result<String, String>,
+{
     let Some(process) = value
         .get("params")
         .and_then(|params| params.get("processId"))
         .and_then(Value::as_str)
     else {
-        return;
+        return Ok(Vec::new());
     };
     let prefix = format!("{process}\0");
-    pending.retain(|key, _| !key.starts_with(&prefix));
+    let mut keys = pending
+        .iter()
+        .filter(|(key, _)| key.starts_with(&prefix))
+        .map(|(key, item)| (item.order, key.clone()))
+        .collect::<Vec<_>>();
+    keys.sort_by_key(|(order, _)| *order);
+    let mut out = Vec::new();
+    for (_, key) in keys {
+        let Some(mut item) = pending.remove(&key) else {
+            continue;
+        };
+        let masked = mask(&item.text)?;
+        set_chunk_text(&mut item.params, &masked);
+        let notification = serde_json::json!({
+            "method": PROCESS_OUTPUT_METHOD,
+            "params": item.params,
+        });
+        out.push(serde_json::to_string(&notification).map_err(|e| e.to_string())?);
+    }
+    Ok(out)
 }
 
 fn mask_json_strings<F>(value: &mut Value, mask: &mut F) -> Result<(), String>
@@ -577,6 +634,11 @@ fn exec_proxy_debug() -> bool {
 mod tests {
     use super::*;
 
+    fn single_line(lines: Vec<String>) -> String {
+        assert_eq!(1, lines.len(), "{lines:?}");
+        lines.into_iter().next().unwrap()
+    }
+
     #[test]
     fn backend_notification_masks_output_chunk() {
         let raw = data_encoding::BASE64.encode(b"OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx\n");
@@ -588,7 +650,7 @@ mod tests {
         let mut rewriter = BackendRewriter::new(|text: &str| {
             Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
         });
-        let rewritten = rewriter.rewrite_line(&line).unwrap();
+        let rewritten = single_line(rewriter.rewrite_line(&line).unwrap());
         let value: Value = serde_json::from_str(&rewritten).unwrap();
         let text = decoded_chunk_text(value.get("params").unwrap())
             .unwrap()
@@ -665,7 +727,7 @@ mod tests {
         let mut rewriter = BackendRewriter::new(|text: &str| {
             Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
         });
-        let rewritten = rewriter.rewrite_line(&line).unwrap();
+        let rewritten = single_line(rewriter.rewrite_line(&line).unwrap());
         assert!(!rewritten.contains("sk-abcdef"), "{rewritten}");
         let value: Value = serde_json::from_str(&rewritten).unwrap();
         let chunks = value
@@ -695,19 +757,72 @@ mod tests {
             Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
         });
         let first = rewriter.rewrite_line(&first).unwrap();
-        let first_value: Value = serde_json::from_str(&first).unwrap();
-        assert_eq!(
-            decoded_chunk_text(first_value.get("params").unwrap())
-                .unwrap()
-                .unwrap(),
-            ""
-        );
-        let second = rewriter.rewrite_line(&second).unwrap();
+        assert!(first.is_empty(), "{first:?}");
+        let second = single_line(rewriter.rewrite_line(&second).unwrap());
         let second_value: Value = serde_json::from_str(&second).unwrap();
         let text = decoded_chunk_text(second_value.get("params").unwrap())
             .unwrap()
             .unwrap();
         assert!(text.contains("<<OPENAI_API_KEY_x>>"), "{text}");
+    }
+
+    #[test]
+    fn backend_output_notification_flushes_partial_on_exit() {
+        let output = serde_json::json!({
+            "method": PROCESS_OUTPUT_METHOD,
+            "params": {"processId": "proc-1", "seq": 1, "stream": "stdout", "chunk": data_encoding::BASE64.encode(b"OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx")}
+        })
+        .to_string();
+        let exited = serde_json::json!({
+            "method": "process/exited",
+            "params": {"processId": "proc-1", "exitCode": 0}
+        })
+        .to_string();
+        let mut rewriter = BackendRewriter::new(|text: &str| {
+            Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
+        });
+
+        assert!(rewriter.rewrite_line(&output).unwrap().is_empty());
+        let lines = rewriter.rewrite_line(&exited).unwrap();
+        assert_eq!(2, lines.len(), "{lines:?}");
+        let output_value: Value = serde_json::from_str(&lines[0]).unwrap();
+        let text = decoded_chunk_text(output_value.get("params").unwrap())
+            .unwrap()
+            .unwrap();
+        assert!(text.contains("<<OPENAI_API_KEY_x>>"), "{text}");
+        assert_eq!(
+            serde_json::from_str::<Value>(&lines[1]).unwrap()["method"],
+            "process/exited"
+        );
+    }
+
+    #[test]
+    fn backend_output_exit_flush_preserves_pending_order() {
+        let stdout = serde_json::json!({
+            "method": PROCESS_OUTPUT_METHOD,
+            "params": {"processId": "proc-1", "seq": 1, "stream": "stdout", "chunk": data_encoding::BASE64.encode(b"out")}
+        })
+        .to_string();
+        let stderr = serde_json::json!({
+            "method": PROCESS_OUTPUT_METHOD,
+            "params": {"processId": "proc-1", "seq": 2, "stream": "stderr", "chunk": data_encoding::BASE64.encode(b"err")}
+        })
+        .to_string();
+        let exited = serde_json::json!({
+            "method": "process/exited",
+            "params": {"processId": "proc-1", "exitCode": 0}
+        })
+        .to_string();
+        let mut rewriter = BackendRewriter::new(|text: &str| Ok(text.to_string()));
+
+        assert!(rewriter.rewrite_line(&stdout).unwrap().is_empty());
+        assert!(rewriter.rewrite_line(&stderr).unwrap().is_empty());
+        let lines = rewriter.rewrite_line(&exited).unwrap();
+        assert_eq!(3, lines.len(), "{lines:?}");
+        let first: Value = serde_json::from_str(&lines[0]).unwrap();
+        let second: Value = serde_json::from_str(&lines[1]).unwrap();
+        assert_eq!(first["params"]["stream"], "stdout");
+        assert_eq!(second["params"]["stream"], "stderr");
     }
 
     #[test]
@@ -720,7 +835,7 @@ mod tests {
         let mut rewriter = BackendRewriter::new(|text: &str| {
             Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
         });
-        let rewritten = rewriter.rewrite_line(&line).unwrap();
+        let rewritten = single_line(rewriter.rewrite_line(&line).unwrap());
         assert!(
             !rewritten.contains("sk-abcdefghijklmnopqrstuvwx"),
             "{rewritten}"

--- a/crates/pentect-cli/src/scan.rs
+++ b/crates/pentect-cli/src/scan.rs
@@ -330,6 +330,42 @@ mod tests {
     }
 
     #[test]
+    fn scan_skips_non_regular_paths_without_aborting() {
+        let root = temp_scan_root("pentect-scan-non-regular-skip");
+        let secret = root.join(".env");
+        std::fs::write(
+            &secret,
+            "RUNPOD_API_KEY=rpa_FAKEPENTECTSCAN1234567890abcdef\n",
+        )
+        .unwrap();
+
+        let (results, _) = engine::scan_files_core_for_tests(
+            vec![root.clone(), secret.clone()],
+            Vec::new(),
+            BinaryMode::Skip,
+        )
+        .unwrap();
+        let mut saw_skipped_dir = false;
+        let mut saw_secret_finding = false;
+        for result in results {
+            match result {
+                ScanFile::Skipped(skipped) if skipped.path == root => {
+                    assert_eq!("not a regular file", skipped.reason);
+                    saw_skipped_dir = true;
+                }
+                ScanFile::Finding(file) if file.path == secret => {
+                    saw_secret_finding = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_skipped_dir);
+        assert!(saw_secret_finding);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn extensionless_text_starting_with_mz_is_scanned() {
         let root = temp_scan_root("pentect-scan-extensionless-mz");
         std::fs::write(

--- a/crates/pentect-cli/src/scan/engine.rs
+++ b/crates/pentect-cli/src/scan/engine.rs
@@ -149,8 +149,15 @@ fn precheck_files(
                 skipped.push(SkippedFile::new(path, "missing"));
                 continue;
             }
-            Err(e) => return Err(format!("could not read '{}': {e}", path.display())),
+            Err(_) => {
+                skipped.push(SkippedFile::new(path, "metadata error"));
+                continue;
+            }
         };
+        if !meta.is_file() {
+            skipped.push(SkippedFile::new(path, "not a regular file"));
+            continue;
+        }
         if meta.len() > MAX_SCAN_FILE_BYTES {
             skipped.push(SkippedFile::new(path, "too large"));
             continue;
@@ -294,48 +301,6 @@ impl CoreBackend {
         }
     }
 
-    fn scan_file(&mut self, path: &Path) -> Result<ScanFile, String> {
-        let data = match read_text_file(path, self.binary)? {
-            ReadTextFile::Text(data) => data,
-            ReadTextFile::Skipped(reason) => {
-                return Ok(ScanFile::Skipped(SkippedFile::new(path, reason)));
-            }
-        };
-        let kind = infer_kind(path);
-        self.ensure_engine();
-        let line_index = LineIndex::new(&data);
-        let result = self.engine.as_ref().unwrap().analyze_spans(Input {
-            kind: kind.clone(),
-            data,
-        });
-        let hits = result
-            .spans
-            .iter()
-            .filter(|span| span.category == Category::Secret)
-            .filter_map(|span| hit_from_span(span, &line_index))
-            .collect::<Vec<_>>();
-        let warnings = result
-            .residual
-            .iter()
-            .filter(|note| note.category == Category::Secret)
-            .count();
-        if hits.is_empty() && warnings == 0 {
-            return Ok(ScanFile::Clean(path.to_path_buf()));
-        }
-        Ok(ScanFile::Finding(FileFinding {
-            path: path.to_path_buf(),
-            scope: ScanScope::classify(path),
-            kind,
-            findings: hits.len(),
-            warnings,
-            labels: label_counts(&hits),
-            categories: category_counts(&hits),
-            engines: engine_counts(&hits),
-            parser_fallback: result.parser_fallback,
-            hits,
-        }))
-    }
-
     fn ensure_engine(&mut self) {
         if self.engine.is_some() {
             return;
@@ -346,6 +311,47 @@ impl CoreBackend {
             packs,
         ));
     }
+}
+
+fn scan_file_with_engine(engine: &Engine, path: &Path, binary: BinaryMode) -> ScanFile {
+    let data = match read_text_file(path, binary) {
+        ReadTextFile::Text(data) => data,
+        ReadTextFile::Skipped(reason) => {
+            return ScanFile::Skipped(SkippedFile::new(path, reason));
+        }
+    };
+    let kind = infer_kind(path);
+    let line_index = LineIndex::new(&data);
+    let result = engine.analyze_spans(Input {
+        kind: kind.clone(),
+        data,
+    });
+    let hits = result
+        .spans
+        .iter()
+        .filter(|span| span.category == Category::Secret)
+        .filter_map(|span| hit_from_span(span, &line_index))
+        .collect::<Vec<_>>();
+    let warnings = result
+        .residual
+        .iter()
+        .filter(|note| note.category == Category::Secret)
+        .count();
+    if hits.is_empty() && warnings == 0 {
+        return ScanFile::Clean(path.to_path_buf());
+    }
+    ScanFile::Finding(FileFinding {
+        path: path.to_path_buf(),
+        scope: ScanScope::classify(path),
+        kind,
+        findings: hits.len(),
+        warnings,
+        labels: label_counts(&hits),
+        categories: category_counts(&hits),
+        engines: engine_counts(&hits),
+        parser_fallback: result.parser_fallback,
+        hits,
+    })
 }
 
 impl ScanBackend for CoreBackend {
@@ -366,31 +372,34 @@ impl ScanBackend for CoreBackend {
             .unwrap_or(1)
             .min(8)
             .min(files.len());
+        self.ensure_engine();
+        let Some(engine) = self.engine.as_ref() else {
+            return Err("engine unavailable".to_string());
+        };
         let next = AtomicUsize::new(0);
-        let packs = self.packs.take().unwrap_or_default();
         let (tx, rx) = mpsc::channel();
-        std::thread::scope(|scope| {
+        let out = std::thread::scope(|scope| {
             for _ in 0..workers {
                 let next = &next;
-                let packs = packs.clone();
                 let tx = tx.clone();
                 let binary = self.binary;
-                scope.spawn(move || {
-                    let mut worker = CoreBackend::new(packs, binary);
-                    loop {
-                        let index = next.fetch_add(1, Ordering::Relaxed);
-                        let Some(path) = files.get(index) else {
-                            break;
-                        };
-                        if tx.send(worker.scan_file(path)).is_err() {
-                            break;
-                        }
+                scope.spawn(move || loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(path) = files.get(index) else {
+                        break;
+                    };
+                    if tx
+                        .send(scan_file_with_engine(engine, path, binary))
+                        .is_err()
+                    {
+                        break;
                     }
                 });
             }
             drop(tx);
-            rx.into_iter().collect::<Result<Vec<_>, _>>()
-        })
+            rx.into_iter().collect::<Vec<_>>()
+        });
+        Ok(out)
     }
 }
 
@@ -399,23 +408,24 @@ enum ReadTextFile {
     Skipped(&'static str),
 }
 
-fn read_text_file(path: &Path, binary: BinaryMode) -> Result<ReadTextFile, String> {
-    let bytes =
-        std::fs::read(path).map_err(|e| format!("could not read '{}': {e}", path.display()))?;
+fn read_text_file(path: &Path, binary: BinaryMode) -> ReadTextFile {
+    let Ok(bytes) = std::fs::read(path) else {
+        return ReadTextFile::Skipped("read error");
+    };
     if binary == BinaryMode::Skip && should_sniff_magic(path) {
         if let FileMagic::Binary(reason) = classify(&bytes) {
-            return Ok(ReadTextFile::Skipped(reason));
+            return ReadTextFile::Skipped(reason);
         }
     }
     if binary == BinaryMode::Skip && memchr(0, &bytes).is_some() {
-        return Ok(ReadTextFile::Skipped("binary content"));
+        return ReadTextFile::Skipped("binary content");
     }
     match String::from_utf8(bytes) {
-        Ok(data) => Ok(ReadTextFile::Text(data)),
-        Err(e) if binary == BinaryMode::Text => Ok(ReadTextFile::Text(
-            String::from_utf8_lossy(e.as_bytes()).into_owned(),
-        )),
-        Err(_) => Ok(ReadTextFile::Skipped("invalid utf-8")),
+        Ok(data) => ReadTextFile::Text(data),
+        Err(e) if binary == BinaryMode::Text => {
+            ReadTextFile::Text(String::from_utf8_lossy(e.as_bytes()).into_owned())
+        }
+        Err(_) => ReadTextFile::Skipped("invalid utf-8"),
     }
 }
 

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -142,7 +142,7 @@ fn inspect_image_bytes(
         return;
     }
     inspection.scanned_images += 1;
-    match ocr_image_bytes(bytes) {
+    match ocr_image_bytes_with_config(bytes, cfg) {
         Ok(text) => {
             if ocr_text_has_secret(&text, key) {
                 inspection.secret_images += 1;
@@ -200,7 +200,7 @@ fn ocr_text_has_secret(text: &str, key: &[u8; 32]) -> bool {
     if text.trim().is_empty() {
         return false;
     }
-    let engine = pentect_core::Engine::with_profile(pentect_core::Profile::Strict);
+    let engine = image_ocr_secret_engine();
     let result = engine.mask(
         pentect_core::Input {
             kind: pentect_core::Kind::Text,
@@ -209,6 +209,11 @@ fn ocr_text_has_secret(text: &str, key: &[u8; 32]) -> bool {
         &pentect_core::Config::new(*key),
     );
     result.summary.masked_count > 0
+}
+
+fn image_ocr_secret_engine() -> &'static pentect_core::Engine {
+    static ENGINE: std::sync::OnceLock<pentect_core::Engine> = std::sync::OnceLock::new();
+    ENGINE.get_or_init(|| pentect_core::Engine::with_profile(pentect_core::Profile::Strict))
 }
 
 fn object_marks_image(map: &serde_json::Map<String, Value>) -> bool {
@@ -640,6 +645,12 @@ pub fn ocr_status() -> &'static str {
 
 #[cfg(all(feature = "ocr", target_os = "windows"))]
 pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
+    let cfg = image_ocr_config()?;
+    ocr_image_bytes_with_config(bytes, &cfg)
+}
+
+#[cfg(all(feature = "ocr", target_os = "windows"))]
+fn ocr_image_bytes_with_config(bytes: &[u8], cfg: &ImageOcrConfig) -> Result<String, String> {
     use windows::Graphics::Imaging::{
         BitmapAlphaMode, BitmapDecoder, BitmapInterpolationMode, BitmapPixelFormat,
         BitmapTransform, ColorManagementMode, ExifOrientationMode,
@@ -647,7 +658,6 @@ pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
     use windows::Media::Ocr::OcrEngine;
     use windows::Storage::Streams::{DataWriter, InMemoryRandomAccessStream};
 
-    let cfg = image_ocr_config()?;
     if matches!(cfg.mode, ImageOcrMode::Off) {
         return Err("image OCR disabled".to_string());
     }
@@ -756,13 +766,18 @@ fn scaled_dimensions(width: u32, height: u32, max_edge: u32) -> (u32, u32) {
 
 #[cfg(all(feature = "ocr", target_os = "macos"))]
 pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
+    let cfg = image_ocr_config()?;
+    ocr_image_bytes_with_config(bytes, &cfg)
+}
+
+#[cfg(all(feature = "ocr", target_os = "macos"))]
+fn ocr_image_bytes_with_config(bytes: &[u8], cfg: &ImageOcrConfig) -> Result<String, String> {
     use objc2::{runtime::AnyObject, AnyThread};
     use objc2_foundation::{NSArray, NSData, NSDictionary};
     use objc2_vision::{
         VNImageOption, VNImageRequestHandler, VNRecognizeTextRequest, VNRequestTextRecognitionLevel,
     };
 
-    let cfg = image_ocr_config()?;
     if matches!(cfg.mode, ImageOcrMode::Off) {
         return Err("image OCR disabled".to_string());
     }
@@ -773,7 +788,7 @@ pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
         ));
     }
 
-    let ocr_bytes = prepare_macos_ocr_bytes(bytes, &cfg)?;
+    let ocr_bytes = prepare_macos_ocr_bytes(bytes, cfg)?;
     let data = NSData::with_bytes(ocr_bytes.as_ref());
     let options = NSDictionary::<VNImageOption, AnyObject>::from_slices::<VNImageOption>(&[], &[]);
     let request = VNRecognizeTextRequest::new();
@@ -860,6 +875,12 @@ fn prepare_macos_ocr_bytes<'a>(
 
 #[cfg(all(feature = "ocr", target_os = "linux"))]
 pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
+    let cfg = image_ocr_config()?;
+    ocr_image_bytes_with_config(bytes, &cfg)
+}
+
+#[cfg(all(feature = "ocr", target_os = "linux"))]
+fn ocr_image_bytes_with_config(bytes: &[u8], cfg: &ImageOcrConfig) -> Result<String, String> {
     use image::GenericImageView;
     use ocrs::{ImageSource, OcrEngine, OcrEngineParams};
     use rten::Model;
@@ -867,7 +888,6 @@ pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
 
     static ENGINE: OnceLock<Result<OcrEngine, String>> = OnceLock::new();
 
-    let cfg = image_ocr_config()?;
     if matches!(cfg.mode, ImageOcrMode::Off) {
         return Err("image OCR disabled".to_string());
     }
@@ -930,8 +950,21 @@ pub fn ocr_image_bytes(_bytes: &[u8]) -> Result<String, String> {
     Err("image OCR is not supported on this platform".to_string())
 }
 
+#[cfg(all(
+    feature = "ocr",
+    not(any(target_os = "linux", target_os = "windows", target_os = "macos"))
+))]
+fn ocr_image_bytes_with_config(_bytes: &[u8], _cfg: &ImageOcrConfig) -> Result<String, String> {
+    Err("image OCR is not supported on this platform".to_string())
+}
+
 #[cfg(not(feature = "ocr"))]
 pub fn ocr_image_bytes(_bytes: &[u8]) -> Result<String, String> {
+    Err("image OCR requires a build with `--features ocr`".to_string())
+}
+
+#[cfg(not(feature = "ocr"))]
+fn ocr_image_bytes_with_config(_bytes: &[u8], _cfg: &ImageOcrConfig) -> Result<String, String> {
     Err("image OCR requires a build with `--features ocr`".to_string())
 }
 


### PR DESCRIPTION
## Summary
- share one scan engine across worker threads instead of rebuilding it per worker
- keep scans running when individual paths are unreadable or non-regular
- preserve Codex exec proxy output that was held for split-secret masking and flush it safely on process exit
- reuse OCR secret-detection state and avoid rereading image OCR config inside the inspection loop

## Validation
- cargo test --workspace --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- target/release/pentect.exe scan crates/pentect-cli/src crates/pentect-runtime/src --no-fail --json

## Notes
Release scan timing on this machine: about 1.09s for crates/pentect-cli/src plus crates/pentect-runtime/src, and about 0.59s for the three touched source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scans now continue past unreadable, missing, or non-regular paths instead of stopping early.
  * OCR checks now use the same scan settings consistently, improving detection reliability.
  * Process output is now delivered more accurately, including buffered partial output on exit and preserving output order.
  * Secret-like values are masked more reliably in error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->