### PR TITLE
Add QR and barcode scanning for image secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +408,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codepage-437"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40c1169585d8d08e5675a39f2fc056cd19a258fc4cba5e3bbf4a9c1026de535"
+dependencies = [
+ "csv",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +474,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -552,6 +587,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1253,6 +1309,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,6 +1882,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +1920,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2029,6 +2155,7 @@ dependencies = [
  "pentect-core",
  "reqwest",
  "rten",
+ "rxing",
  "serde",
  "serde_json",
  "sha2",
@@ -2840,6 +2967,33 @@ dependencies = [
  "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rxing"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c3638471fd7805cbe68a058c8963df913e0737fb96a12ef53fed02c1c38103"
+dependencies = [
+ "chrono",
+ "codepage-437",
+ "encoding_rs",
+ "num",
+ "once_cell",
+ "regex",
+ "rxing-one-d-proc-derive",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "rxing-one-d-proc-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60210e9957500c26eb21f4c4e11c7b14efa90768e1b81ec6df0e4d7dfb2ad52"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3721,6 +3875,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ phonenumber = "0.3"
 prost = "0.14"
 pdf-extract = "0.10.0"
 image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "webp", "bmp", "gif"] }
+rxing = { version = "0.9.1", default-features = false, features = ["decoders", "full_barcode_format_support", "multi_barcode_readers", "encoding_rs"] }
 ocrs = "0.12.2"
 rten = { version = "0.24.0", default-features = false, features = ["rten_format"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -14,7 +14,8 @@ path = "src/main.rs"
 [features]
 default = ["pdf", "ocr"]
 pdf = ["dep:pdf-extract"]
-ocr = ["dep:reqwest", "native-ocr", "bundled-ocr"]
+ocr = ["dep:reqwest", "native-ocr", "bundled-ocr", "barcode"]
+barcode = ["dep:image", "dep:rxing"]
 native-ocr = [
     "dep:windows",
     "dep:objc2",
@@ -30,6 +31,8 @@ axum = { workspace = true }
 data-encoding = { workspace = true }
 pdf-extract = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+image = { workspace = true, optional = true }
+rxing = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }
@@ -53,7 +56,6 @@ windows = { workspace = true, optional = true, features = [
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-image = { workspace = true, optional = true }
 objc2 = { workspace = true, optional = true }
 objc2-foundation = { workspace = true, optional = true, default-features = false, features = [
     "std",
@@ -74,6 +76,8 @@ objc2-vision = { workspace = true, optional = true, default-features = false, fe
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-image = { workspace = true, optional = true }
 ocrs = { workspace = true, optional = true }
 rten = { workspace = true, optional = true }
+
+[dev-dependencies]
+rxing = { workspace = true, features = ["encoders"] }

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -142,6 +142,13 @@ fn inspect_image_bytes(
         return;
     }
     inspection.scanned_images += 1;
+    if image_barcode_texts(bytes, cfg)
+        .iter()
+        .any(|text| ocr_text_has_secret(text, key))
+    {
+        inspection.secret_images += 1;
+        return;
+    }
     match ocr_image_bytes_with_config(bytes, cfg) {
         Ok(text) => {
             if ocr_text_has_secret(&text, key) {
@@ -209,6 +216,54 @@ fn ocr_text_has_secret(text: &str, key: &[u8; 32]) -> bool {
         &pentect_core::Config::new(*key),
     );
     result.summary.masked_count > 0
+}
+
+#[cfg(feature = "ocr")]
+fn image_barcode_texts(bytes: &[u8], cfg: &ImageOcrConfig) -> Vec<String> {
+    use image::GenericImageView;
+
+    if matches!(cfg.mode, ImageOcrMode::Off) {
+        return Vec::new();
+    }
+    let Ok(mut image) = image::load_from_memory(bytes) else {
+        return Vec::new();
+    };
+    let (width, height) = image.dimensions();
+    let pixels = u64::from(width).saturating_mul(u64::from(height));
+    if pixels > cfg.max_pixels {
+        return Vec::new();
+    }
+    image = resize_for_barcode(image, cfg.max_edge);
+    let luma = image.into_luma8();
+    let (width, height) = luma.dimensions();
+    let Ok(results) = rxing::helpers::detect_multiple_in_luma(luma.into_raw(), width, height)
+    else {
+        return Vec::new();
+    };
+    let mut texts = Vec::new();
+    for result in results {
+        let text = result.getText();
+        if !text.trim().is_empty() && !texts.iter().any(|seen| seen == text) {
+            texts.push(text.to_string());
+        }
+    }
+    texts
+}
+
+#[cfg(not(feature = "ocr"))]
+fn image_barcode_texts(_bytes: &[u8], _cfg: &ImageOcrConfig) -> Vec<String> {
+    Vec::new()
+}
+
+#[cfg(feature = "ocr")]
+fn resize_for_barcode(img: image::DynamicImage, max_edge: u32) -> image::DynamicImage {
+    use image::GenericImageView;
+
+    let (width, height) = img.dimensions();
+    if max_edge == 0 || (width <= max_edge && height <= max_edge) {
+        return img;
+    }
+    img.resize(max_edge, max_edge, image::imageops::FilterType::Triangle)
 }
 
 fn image_ocr_secret_engine() -> &'static pentect_core::Engine {
@@ -987,6 +1042,31 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "ocr")]
+    fn qr_png(payload: &str) -> Vec<u8> {
+        use image::{GrayImage, ImageFormat, Luma};
+        use rxing::{BarcodeFormat, Writer};
+        use std::io::Cursor;
+
+        let writer = rxing::qrcode::QRCodeWriter {};
+        let matrix = writer
+            .encode(payload, &BarcodeFormat::QR_CODE, 192, 192)
+            .unwrap();
+        let mut img = GrayImage::from_pixel(matrix.getWidth(), matrix.getHeight(), Luma([255]));
+        for y in 0..matrix.getHeight() {
+            for x in 0..matrix.getWidth() {
+                if matrix.get(x, y) {
+                    img.put_pixel(x, y, Luma([0]));
+                }
+            }
+        }
+        let mut out = Vec::new();
+        image::DynamicImage::ImageLuma8(img)
+            .write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
+            .unwrap();
+        out
+    }
+
     #[test]
     fn data_url_image_payload_is_decoded() {
         let png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
@@ -1043,6 +1123,35 @@ mod tests {
         );
         let inspection = inspect_tool_images_for_secrets(&value, &[7; 32], &test_config()).unwrap();
         assert_eq!(inspection.scanned_images, 1);
+        assert_eq!(inspection.unscanned_images, 0);
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn qr_image_secret_is_detected() {
+        let payload = "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+        let png = qr_png(payload);
+        let value = serde_json::json!(format!(
+            "data:image/png;base64,{}",
+            data_encoding::BASE64.encode(&png)
+        ));
+        let inspection = inspect_tool_images_for_secrets(&value, &[7; 32], &test_config()).unwrap();
+        assert_eq!(inspection.scanned_images, 1);
+        assert_eq!(inspection.secret_images, 1);
+        assert_eq!(inspection.unscanned_images, 0);
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn qr_image_plain_text_is_not_secret() {
+        let png = qr_png("hello from pentect qr");
+        let value = serde_json::json!(format!(
+            "data:image/png;base64,{}",
+            data_encoding::BASE64.encode(&png)
+        ));
+        let inspection = inspect_tool_images_for_secrets(&value, &[7; 32], &test_config()).unwrap();
+        assert_eq!(inspection.scanned_images, 1);
+        assert_eq!(inspection.secret_images, 0);
         assert_eq!(inspection.unscanned_images, 0);
     }
 


### PR DESCRIPTION
## Summary
- decode QR/barcode text during image inspection
- run decoded text through the existing Pentect secret engine
- add QR regression tests for secret and benign payloads

## Tests
- cargo test -p pentect-runtime image_ocr --features ocr --locked
- cargo test --workspace --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo build --release -p pentect-cli --locked
- pentect doctor