### PR TITLE
Keep OCR image redaction local and fast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +1985,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,12 +2025,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-vision"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfc194758a2d5d7540b1ad283bfb9ca318ec608991892326e95b428230b2689b"
 dependencies = [
  "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2148,6 +2195,7 @@ dependencies = [
  "image",
  "jiff",
  "objc2",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-vision",
  "ocrs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,19 +1996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,17 +2012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "objc2-vision"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,7 +2019,6 @@ checksum = "bfc194758a2d5d7540b1ad283bfb9ca318ec608991892326e95b428230b2689b"
 dependencies = [
  "objc2",
  "objc2-core-foundation",
- "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2195,7 +2170,7 @@ dependencies = [
  "image",
  "jiff",
  "objc2",
- "objc2-core-graphics",
+ "objc2-core-foundation",
  "objc2-foundation",
  "objc2-vision",
  "ocrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,5 @@ tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }
 windows = "0.62.2"
 objc2 = { version = "0.6.3", default-features = false }
 objc2-foundation = { version = "0.3.2", default-features = false }
-objc2-core-graphics = { version = "0.3.2", default-features = false }
+objc2-core-foundation = { version = "0.3.2", default-features = false }
 objc2-vision = { version = "0.3.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,5 @@ tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }
 windows = "0.62.2"
 objc2 = { version = "0.6.3", default-features = false }
 objc2-foundation = { version = "0.3.2", default-features = false }
+objc2-core-graphics = { version = "0.3.2", default-features = false }
 objc2-vision = { version = "0.3.2", default-features = false }

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -20,7 +20,7 @@ native-ocr = [
     "dep:windows",
     "dep:objc2",
     "dep:objc2-foundation",
-    "dep:objc2-core-graphics",
+    "dep:objc2-core-foundation",
     "dep:objc2-vision",
 ]
 bundled-ocr = ["dep:image", "dep:ocrs", "dep:rten"]
@@ -67,12 +67,11 @@ objc2-foundation = { workspace = true, optional = true, default-features = false
     "NSObject",
     "NSString",
 ] }
-objc2-core-graphics = { workspace = true, optional = true, default-features = false, features = [
-    "CGGeometry",
+objc2-core-foundation = { workspace = true, optional = true, default-features = false, features = [
+    "CFCGTypes",
 ] }
 objc2-vision = { workspace = true, optional = true, default-features = false, features = [
     "objc2-core-foundation",
-    "objc2-core-graphics",
     "std",
     "VNObservation",
     "VNRecognizeTextRequest",

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -20,6 +20,7 @@ native-ocr = [
     "dep:windows",
     "dep:objc2",
     "dep:objc2-foundation",
+    "dep:objc2-core-graphics",
     "dep:objc2-vision",
 ]
 bundled-ocr = ["dep:image", "dep:ocrs", "dep:rten"]
@@ -66,7 +67,12 @@ objc2-foundation = { workspace = true, optional = true, default-features = false
     "NSObject",
     "NSString",
 ] }
+objc2-core-graphics = { workspace = true, optional = true, default-features = false, features = [
+    "CGGeometry",
+] }
 objc2-vision = { workspace = true, optional = true, default-features = false, features = [
+    "objc2-core-foundation",
+    "objc2-core-graphics",
     "std",
     "VNObservation",
     "VNRecognizeTextRequest",

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -858,16 +858,14 @@ impl NormalizedImageRect {
     }
 
     #[cfg(all(feature = "ocr", target_os = "macos"))]
-    fn from_macos_vision_rect(rect: objc2_core_graphics::CGRect) -> Option<Self> {
-        use objc2_core_graphics::{CGRectGetHeight, CGRectGetMinX, CGRectGetMinY, CGRectGetWidth};
-
-        let left = CGRectGetMinX(rect) as f32;
-        let width = CGRectGetWidth(rect) as f32;
-        let height = CGRectGetHeight(rect) as f32;
+    fn from_macos_vision_rect(rect: objc2_core_foundation::CGRect) -> Option<Self> {
+        let left = rect.origin.x as f32;
+        let width = rect.size.width as f32;
+        let height = rect.size.height as f32;
         if width <= 0.0 || height <= 0.0 {
             return None;
         }
-        let bottom_from_vision = CGRectGetMinY(rect) as f32;
+        let bottom_from_vision = rect.origin.y as f32;
         let top = 1.0 - bottom_from_vision - height;
         Self::new(left, top, left + width, top + height)
     }

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -857,6 +857,21 @@ impl NormalizedImageRect {
         )
     }
 
+    #[cfg(all(feature = "ocr", target_os = "macos"))]
+    fn from_macos_vision_rect(rect: objc2_core_graphics::CGRect) -> Option<Self> {
+        use objc2_core_graphics::{CGRectGetHeight, CGRectGetMinX, CGRectGetMinY, CGRectGetWidth};
+
+        let left = CGRectGetMinX(rect) as f32;
+        let width = CGRectGetWidth(rect) as f32;
+        let height = CGRectGetHeight(rect) as f32;
+        if width <= 0.0 || height <= 0.0 {
+            return None;
+        }
+        let bottom_from_vision = CGRectGetMinY(rect) as f32;
+        let top = 1.0 - bottom_from_vision - height;
+        Self::new(left, top, left + width, top + height)
+    }
+
     #[cfg(feature = "ocr")]
     fn new(left: f32, top: f32, right: f32, bottom: f32) -> Option<Self> {
         if !left.is_finite() || !top.is_finite() || !right.is_finite() || !bottom.is_finite() {
@@ -1072,11 +1087,27 @@ fn fill_rect(
     height: u32,
     color: image::Rgba<u8>,
 ) {
-    let right = left.saturating_add(width).min(image.width());
-    let bottom = top.saturating_add(height).min(image.height());
+    let image_width = image.width() as usize;
+    let image_height = image.height() as usize;
+    let left = left.min(image.width()) as usize;
+    let top = top.min(image.height()) as usize;
+    let right = left.saturating_add(width as usize).min(image_width);
+    let bottom = top.saturating_add(height as usize).min(image_height);
+    if right <= left || bottom <= top {
+        return;
+    }
+    let row_stride = image_width.saturating_mul(4);
+    let row_left = left.saturating_mul(4);
+    let row_right = right.saturating_mul(4);
+    let data = image.as_mut();
     for y in top..bottom {
-        for x in left..right {
-            image.put_pixel(x, y, color);
+        let row_start = y.saturating_mul(row_stride).saturating_add(row_left);
+        let row_end = y.saturating_mul(row_stride).saturating_add(row_right);
+        let Some(row) = data.get_mut(row_start..row_end) else {
+            continue;
+        };
+        for pixel in row.chunks_exact_mut(4) {
+            pixel.copy_from_slice(&color.0);
         }
     }
 }
@@ -1796,7 +1827,9 @@ fn ocr_image_regions_with_config(
         if text.trim().is_empty() {
             continue;
         }
-        regions.push(ImageTextRegion { text, rect: None });
+        let rect =
+            NormalizedImageRect::from_macos_vision_rect(unsafe { observation.boundingBox() });
+        regions.push(ImageTextRegion { text, rect });
     }
     Ok(regions)
 }


### PR DESCRIPTION
## Summary
- keep macOS Vision OCR redaction local by using observation bounding boxes
- speed up default black image redaction with row-buffer fills instead of per-pixel put calls
- keep QR/barcode black redaction behavior unchanged

## Verification
- cargo test -p pentect-runtime image_ocr::tests --features ocr --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo build -p pentect-cli --release --locked
- local Claude hook E2E: black/blur preserve non-secret image regions and redact only the secret row
