### PR TITLE
Add Codex app-server proxy

### DIFF
--- a/crates/pentect-cli/src/app_server_proxy.rs
+++ b/crates/pentect-cli/src/app_server_proxy.rs
@@ -49,7 +49,9 @@ impl AppServerProxyGuard {
                 }
             };
             runtime.block_on(async move {
+                let ready_err_tx = ready_tx.clone();
                 if let Err(e) = run_proxy(codex, app_server_args, ready_tx, shutdown_rx).await {
+                    let _ = ready_err_tx.send(Err(e.clone()));
                     eprintln!("[pentect] app-server proxy stopped: {e}");
                 }
             });
@@ -89,21 +91,38 @@ async fn run_proxy(
     let backend_addr = reserve_loopback_addr()?;
     let backend_url = format!("ws://{backend_addr}");
     let mut backend = start_codex_app_server(&codex, &backend_url, app_server_args)?;
-    wait_for_ready(backend_addr, &mut backend).await?;
+    if let Err(e) = wait_for_ready(backend_addr, &mut backend).await {
+        stop_child(&mut backend).await;
+        return Err(e);
+    }
 
-    let listener = TcpListener::bind(("127.0.0.1", 0))
-        .await
-        .map_err(|e| format!("could not bind app-server proxy: {e}"))?;
-    let proxy_addr = listener
-        .local_addr()
-        .map_err(|e| format!("could not read app-server proxy addr: {e}"))?;
+    let listener = match TcpListener::bind(("127.0.0.1", 0)).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            stop_child(&mut backend).await;
+            return Err(format!("could not bind app-server proxy: {e}"));
+        }
+    };
+    let proxy_addr = match listener.local_addr() {
+        Ok(addr) => addr,
+        Err(e) => {
+            stop_child(&mut backend).await;
+            return Err(format!("could not read app-server proxy addr: {e}"));
+        }
+    };
     let _ = ready_tx.send(Ok(format!("ws://{proxy_addr}")));
 
     loop {
         tokio::select! {
             _ = &mut shutdown_rx => break,
             accepted = listener.accept() => {
-                let (stream, _) = accepted.map_err(|e| format!("app-server proxy accept failed: {e}"))?;
+                let (stream, _) = match accepted {
+                    Ok(accepted) => accepted,
+                    Err(e) => {
+                        stop_child(&mut backend).await;
+                        return Err(format!("app-server proxy accept failed: {e}"));
+                    }
+                };
                 tokio::spawn(async move {
                     let io = TokioIo::new(stream);
                     let service = service_fn(move |req| proxy_upgrade(req, backend_addr));
@@ -116,8 +135,7 @@ async fn run_proxy(
         }
     }
 
-    let _ = backend.kill().await;
-    let _ = backend.wait().await;
+    stop_child(&mut backend).await;
     Ok(())
 }
 
@@ -155,12 +173,22 @@ async fn wait_for_ready(addr: SocketAddr, child: &mut Child) -> Result<(), Strin
         {
             return Err(format!("codex app-server exited before ready: {status}"));
         }
-        if ready_probe(addr).await.unwrap_or(false) {
+        if let Ok(Ok(true)) =
+            tokio::time::timeout(Duration::from_millis(500), ready_probe(addr)).await
+        {
             return Ok(());
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
     Err("codex app-server did not become ready within 8 seconds".to_string())
+}
+
+async fn stop_child(child: &mut Child) {
+    if child.try_wait().ok().flatten().is_some() {
+        return;
+    }
+    let _ = child.kill().await;
+    let _ = child.wait().await;
 }
 
 async fn ready_probe(addr: SocketAddr) -> Result<bool, String> {

--- a/crates/pentect-cli/src/app_server_proxy.rs
+++ b/crates/pentect-cli/src/app_server_proxy.rs
@@ -1,0 +1,444 @@
+use fastwebsockets::handshake;
+use fastwebsockets::upgrade;
+use fastwebsockets::{Frame, OpCode, Payload, WebSocketError};
+use http_body_util::Empty;
+use hyper::body::{Bytes, Incoming};
+use hyper::header::{CONNECTION, UPGRADE};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use serde_json::Value;
+use std::future::Future;
+use std::io::ErrorKind;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::process::{Child, Command};
+use tokio::sync::oneshot;
+
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(8);
+
+pub(crate) struct AppServerProxyGuard {
+    url: String,
+    shutdown: Option<oneshot::Sender<()>>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl AppServerProxyGuard {
+    pub(crate) fn start(codex: &Path, app_server_args: Vec<String>) -> Result<Self, String> {
+        let codex = codex.to_path_buf();
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let thread = thread::spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(e) => {
+                    let _ = ready_tx.send(Err(format!(
+                        "could not start app-server proxy runtime: {e}"
+                    )));
+                    return;
+                }
+            };
+            runtime.block_on(async move {
+                if let Err(e) = run_proxy(codex, app_server_args, ready_tx, shutdown_rx).await {
+                    eprintln!("[pentect] app-server proxy stopped: {e}");
+                }
+            });
+        });
+        let url = ready_rx
+            .recv_timeout(STARTUP_TIMEOUT)
+            .map_err(|_| "app-server proxy did not start within 8 seconds".to_string())??;
+        Ok(Self {
+            url,
+            shutdown: Some(shutdown_tx),
+            thread: Some(thread),
+        })
+    }
+
+    pub(crate) fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl Drop for AppServerProxyGuard {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+async fn run_proxy(
+    codex: PathBuf,
+    app_server_args: Vec<String>,
+    ready_tx: mpsc::Sender<Result<String, String>>,
+    mut shutdown_rx: oneshot::Receiver<()>,
+) -> Result<(), String> {
+    let backend_addr = reserve_loopback_addr()?;
+    let backend_url = format!("ws://{backend_addr}");
+    let mut backend = start_codex_app_server(&codex, &backend_url, app_server_args)?;
+    wait_for_ready(backend_addr, &mut backend).await?;
+
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .map_err(|e| format!("could not bind app-server proxy: {e}"))?;
+    let proxy_addr = listener
+        .local_addr()
+        .map_err(|e| format!("could not read app-server proxy addr: {e}"))?;
+    let _ = ready_tx.send(Ok(format!("ws://{proxy_addr}")));
+
+    loop {
+        tokio::select! {
+            _ = &mut shutdown_rx => break,
+            accepted = listener.accept() => {
+                let (stream, _) = accepted.map_err(|e| format!("app-server proxy accept failed: {e}"))?;
+                tokio::spawn(async move {
+                    let io = TokioIo::new(stream);
+                    let service = service_fn(move |req| proxy_upgrade(req, backend_addr));
+                    let conn = http1::Builder::new().serve_connection(io, service).with_upgrades();
+                    if let Err(e) = conn.await {
+                        eprintln!("[pentect] app-server proxy connection failed: {e}");
+                    }
+                });
+            }
+        }
+    }
+
+    let _ = backend.kill().await;
+    let _ = backend.wait().await;
+    Ok(())
+}
+
+fn reserve_loopback_addr() -> Result<SocketAddr, String> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .map_err(|e| format!("could not reserve app-server port: {e}"))?;
+    listener
+        .local_addr()
+        .map_err(|e| format!("could not read reserved app-server port: {e}"))
+}
+
+fn start_codex_app_server(
+    codex: &Path,
+    backend_url: &str,
+    app_server_args: Vec<String>,
+) -> Result<Child, String> {
+    let mut cmd = Command::new(codex);
+    cmd.arg("app-server")
+        .arg("--listen")
+        .arg(backend_url)
+        .args(app_server_args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    cmd.spawn()
+        .map_err(|e| format!("could not start codex app-server: {e}"))
+}
+
+async fn wait_for_ready(addr: SocketAddr, child: &mut Child) -> Result<(), String> {
+    let start = Instant::now();
+    while start.elapsed() < STARTUP_TIMEOUT {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| format!("could not inspect codex app-server: {e}"))?
+        {
+            return Err(format!("codex app-server exited before ready: {status}"));
+        }
+        if ready_probe(addr).await.unwrap_or(false) {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    Err("codex app-server did not become ready within 8 seconds".to_string())
+}
+
+async fn ready_probe(addr: SocketAddr) -> Result<bool, String> {
+    let mut stream = TcpStream::connect(addr)
+        .await
+        .map_err(|e| format!("ready connect failed: {e}"))?;
+    let req = format!("GET /readyz HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(req.as_bytes())
+        .await
+        .map_err(|e| format!("ready write failed: {e}"))?;
+    let mut buf = [0u8; 64];
+    let n = stream
+        .read(&mut buf)
+        .await
+        .map_err(|e| format!("ready read failed: {e}"))?;
+    Ok(buf[..n].starts_with(b"HTTP/1.1 200") || buf[..n].starts_with(b"HTTP/1.0 200"))
+}
+
+async fn proxy_upgrade(
+    mut req: Request<Incoming>,
+    backend_addr: SocketAddr,
+) -> Result<Response<Empty<Bytes>>, WebSocketError> {
+    if req.uri().path() == "/readyz" || req.uri().path() == "/healthz" {
+        let mut response = Response::new(Empty::new());
+        *response.status_mut() = StatusCode::OK;
+        return Ok(response);
+    }
+    let (response, fut) = upgrade::upgrade(&mut req)?;
+    tokio::spawn(async move {
+        if let Err(e) = handle_client(fut, backend_addr).await {
+            eprintln!("[pentect] app-server proxy session failed: {e}");
+        }
+    });
+    Ok(response)
+}
+
+async fn handle_client(fut: upgrade::UpgradeFut, backend_addr: SocketAddr) -> Result<(), String> {
+    let mut client = fastwebsockets::FragmentCollector::new(
+        fut.await
+            .map_err(|e| format!("websocket upgrade failed: {e}"))?,
+    );
+    let mut backend = connect_backend(backend_addr).await?;
+    let mut output_masker = pentect_agent::ActiveToolOutputMasker::new()?;
+
+    loop {
+        tokio::select! {
+            frame = client.read_frame() => {
+                let frame = match frame {
+                    Ok(frame) => frame,
+                    Err(e) if is_clean_websocket_close(&e) => break,
+                    Err(e) => return Err(format!("client websocket read failed: {e}")),
+                };
+                match frame.opcode {
+                    OpCode::Close => break,
+                    OpCode::Text | OpCode::Binary => {
+                        backend.write_frame(frame).await
+                            .map_err(|e| format!("backend websocket write failed: {e}"))?;
+                    }
+                    _ => {}
+                }
+            }
+            frame = backend.read_frame() => {
+                let frame = match frame {
+                    Ok(frame) => frame,
+                    Err(e) if is_clean_websocket_close(&e) => break,
+                    Err(e) => return Err(format!("backend websocket read failed: {e}")),
+                };
+                match frame.opcode {
+                    OpCode::Close => break,
+                    OpCode::Text => {
+                        let payload = Vec::<u8>::from(frame.payload);
+                        let text = std::str::from_utf8(&payload)
+                            .map_err(|e| format!("codex app-server sent non-utf8 text frame: {e}"))?;
+                        let text = rewrite_server_text_frame(text, &mut |text| mask_output_text(&mut output_masker, text))?;
+                        client.write_frame(Frame::text(Payload::Owned(text.into_bytes()))).await
+                            .map_err(|e| format!("client websocket write failed: {e}"))?;
+                    }
+                    OpCode::Binary => {
+                        client.write_frame(frame).await
+                            .map_err(|e| format!("client websocket write failed: {e}"))?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+struct SpawnExecutor;
+
+impl<Fut> hyper::rt::Executor<Fut> for SpawnExecutor
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    fn execute(&self, fut: Fut) {
+        tokio::task::spawn(fut);
+    }
+}
+
+async fn connect_backend(
+    addr: SocketAddr,
+) -> Result<fastwebsockets::FragmentCollector<TokioIo<hyper::upgrade::Upgraded>>, String> {
+    let stream = TcpStream::connect(addr)
+        .await
+        .map_err(|e| format!("could not connect to codex app-server: {e}"))?;
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("http://{addr}/"))
+        .header("Host", addr.to_string())
+        .header(UPGRADE, "websocket")
+        .header(CONNECTION, "upgrade")
+        .header(
+            "Sec-WebSocket-Key",
+            fastwebsockets::handshake::generate_key(),
+        )
+        .header("Sec-WebSocket-Version", "13")
+        .body(Empty::<Bytes>::new())
+        .map_err(|e| format!("could not build websocket request: {e}"))?;
+    let (ws, _) = handshake::client(&SpawnExecutor, req, stream)
+        .await
+        .map_err(|e| format!("codex app-server websocket handshake failed: {e}"))?;
+    Ok(fastwebsockets::FragmentCollector::new(ws))
+}
+
+fn rewrite_server_text_frame<F>(text: &str, mask: &mut F) -> Result<String, String>
+where
+    F: FnMut(&str) -> Result<String, String>,
+{
+    let mut value: Value = match serde_json::from_str(text) {
+        Ok(value) => value,
+        Err(_) => return mask(text),
+    };
+    mask_app_server_display_strings(&mut value, None, mask)?;
+    serde_json::to_string(&value).map_err(|e| e.to_string())
+}
+
+fn mask_app_server_display_strings<F>(
+    value: &mut Value,
+    key: Option<&str>,
+    mask: &mut F,
+) -> Result<(), String>
+where
+    F: FnMut(&str) -> Result<String, String>,
+{
+    match value {
+        Value::String(text) => {
+            if key.is_some_and(maskable_app_server_text_key) {
+                let masked = mask(text)?;
+                if masked != *text {
+                    *text = masked;
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                mask_app_server_display_strings(value, key, mask)?;
+            }
+        }
+        Value::Object(object) => {
+            for (key, value) in object {
+                mask_app_server_display_strings(value, Some(key), mask)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn maskable_app_server_text_key(key: &str) -> bool {
+    matches!(
+        key,
+        "text"
+            | "message"
+            | "preview"
+            | "summary"
+            | "content"
+            | "output"
+            | "stdout"
+            | "stderr"
+            | "command"
+            | "reason"
+            | "detail"
+            | "details"
+            | "error"
+    )
+}
+
+fn mask_output_text(
+    masker: &mut pentect_agent::ActiveToolOutputMasker,
+    text: &str,
+) -> Result<String, String> {
+    Ok(masker
+        .mask_tool_output(text)?
+        .unwrap_or_else(|| text.to_string()))
+}
+
+fn is_clean_websocket_close(error: &WebSocketError) -> bool {
+    match error {
+        WebSocketError::ConnectionClosed | WebSocketError::UnexpectedEOF => true,
+        WebSocketError::IoError(error) => matches!(
+            error.kind(),
+            ErrorKind::ConnectionAborted
+                | ErrorKind::ConnectionReset
+                | ErrorKind::BrokenPipe
+                | ErrorKind::UnexpectedEof
+        ),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_frame_masks_nested_strings() {
+        let raw = serde_json::json!({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "content": [
+                        {"text": "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx"}
+                    ]
+                }
+            }
+        })
+        .to_string();
+        let masked = rewrite_server_text_frame(&raw, &mut |text| {
+            Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
+        })
+        .unwrap();
+        assert!(!masked.contains("sk-abcdefghijklmnopqrstuvwx"), "{masked}");
+        assert!(masked.contains("<<OPENAI_API_KEY_x>>"), "{masked}");
+    }
+
+    #[test]
+    fn server_frame_masks_plain_text_when_not_json() {
+        let masked = rewrite_server_text_frame("token sk-abcdefghijklmnopqrstuvwx", &mut |text| {
+            Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
+        })
+        .unwrap();
+        assert_eq!(masked, "token <<OPENAI_API_KEY_x>>");
+    }
+
+    #[test]
+    fn server_frame_does_not_mask_protocol_paths() {
+        let raw = serde_json::json!({
+            "id": 1,
+            "result": {
+                "thread": {
+                    "cwd": "C:\\Users\\yun40\\Desktop\\pentect",
+                    "path": "file:///C:/Users/yun40/Desktop/pentect"
+                },
+                "preview": "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx"
+            }
+        })
+        .to_string();
+        let masked = rewrite_server_text_frame(&raw, &mut |text| {
+            Ok(text
+                .replace("C:\\Users\\yun40\\Desktop\\pentect", "<<LOCAL_PATH_x>>")
+                .replace("file:///C:/Users/yun40/Desktop/pentect", "<<LOCAL_URI_x>>")
+                .replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
+        })
+        .unwrap();
+        assert!(
+            masked.contains("C:\\\\Users\\\\yun40\\\\Desktop\\\\pentect"),
+            "{masked}"
+        );
+        assert!(
+            masked.contains("file:///C:/Users/yun40/Desktop/pentect"),
+            "{masked}"
+        );
+        assert!(!masked.contains("sk-abcdefghijklmnopqrstuvwx"), "{masked}");
+        assert!(masked.contains("<<OPENAI_API_KEY_x>>"), "{masked}");
+        assert!(!masked.contains("<<LOCAL_PATH_x>>"), "{masked}");
+        assert!(!masked.contains("<<LOCAL_URI_x>>"), "{masked}");
+    }
+}

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1,5 +1,6 @@
 //! Pentect CLI: local secret masking boundary for AI agents.
 
+mod app_server_proxy;
 mod doctor;
 mod eval;
 mod exec_proxy;
@@ -541,6 +542,7 @@ struct AgentToolOpts {
     extensions: Vec<String>,
     dry_run: bool,
     allow_unverified_hooks: bool,
+    codex_app_server_proxy_disabled: bool,
     tool_args: Vec<String>,
 }
 
@@ -554,6 +556,7 @@ impl AgentToolOpts {
         let mut extensions = Vec::new();
         let mut dry_run = false;
         let mut allow_unverified_hooks = false;
+        let mut codex_app_server_proxy_disabled = false;
         let mut tool_args = Vec::new();
         let mut i = 2;
         while i < args.len() {
@@ -599,6 +602,10 @@ impl AgentToolOpts {
                     allow_unverified_hooks = true;
                     i += 1;
                 }
+                "--no-app-server-proxy" if tool == AgentTool::Codex => {
+                    codex_app_server_proxy_disabled = true;
+                    i += 1;
+                }
                 "--prompt-proxy" | "--no-prompt-proxy" => {
                     return Err(
                         "prompt proxy is currently disabled/TODO; Pentect now protects tool boundaries via agent hooks only"
@@ -618,6 +625,7 @@ impl AgentToolOpts {
             extensions,
             dry_run,
             allow_unverified_hooks,
+            codex_app_server_proxy_disabled,
             tool_args,
         })
     }
@@ -642,6 +650,12 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
     let mut cmd = Command::new(&opts.command);
     apply_extension_env(&mut cmd, &active_extensions)?;
     let in_memory_manager = start_in_memory_manager(pentect)?;
+    let pack_env = active_extensions
+        .pack_env_value()
+        .map_err(|e| e.to_string())?;
+    let adapter_env = active_extensions
+        .adapter_env_value()
+        .map_err(|e| e.to_string())?;
     let _parent_env = EnvVarGuard::set_optional([
         (
             PENTECT_IN_MEMORY_MANAGER_ADDR_ENV,
@@ -651,24 +665,36 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
             PENTECT_IN_MEMORY_MANAGER_TOKEN_ENV,
             Some(OsString::from(in_memory_manager.token.as_str())),
         ),
+        (PENTECT_BIN_ENV, Some(pentect.as_os_str().to_os_string())),
         (
-            extensions::PACKS_ENV,
-            active_extensions
-                .pack_env_value()
-                .map_err(|e| e.to_string())?,
+            PENTECT_AGENT_LAUNCHED_ENV,
+            Some(OsString::from(in_memory_manager.token.as_str())),
         ),
+        (PENTECT_AGENT_AUTO_APPROVE_ENV, Some(OsString::from("1"))),
         (
-            extensions::ADAPTERS_ENV,
-            active_extensions
-                .adapter_env_value()
-                .map_err(|e| e.to_string())?,
+            PENTECT_STATUS_LINE_ENV,
+            Some(OsString::from(if status_line_enabled { "1" } else { "0" })),
         ),
+        (extensions::PACKS_ENV, pack_env),
+        (extensions::ADAPTERS_ENV, adapter_env),
     ]);
     let exec_proxy = if codex_unified_exec_proxy_enabled(&opts.tool_args) {
         Some(exec_proxy::ExecProxyGuard::start(&opts.command)?)
     } else {
         None
     };
+    let _exec_proxy_env = exec_proxy.as_ref().map(|exec_proxy| {
+        EnvVarGuard::set_optional([
+            (
+                "CODEX_EXEC_SERVER_URL",
+                Some(OsString::from(exec_proxy.url())),
+            ),
+            (
+                exec_proxy::PENTECT_CODEX_EXEC_PROXY_ENV,
+                Some(OsString::from("1")),
+            ),
+        ])
+    });
     apply_pentect_env(&mut cmd, pentect, Some(in_memory_manager.token.as_str()));
     apply_agent_auto_approve_env(&mut cmd);
     apply_in_memory_manager_env(&mut cmd, Some(&in_memory_manager));
@@ -681,7 +707,19 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
         .as_ref()
         .map(|exec_proxy| CodexEnvironmentOverlayGuard::install(exec_proxy.url()))
         .transpose()?;
-    cmd.args(codex_args(&configs, &opts.tool_args));
+    let codex_args =
+        if codex_app_server_proxy_enabled(&opts.tool_args, opts.codex_app_server_proxy_disabled)? {
+            let proxy = app_server_proxy::AppServerProxyGuard::start(
+                &opts.command,
+                codex_app_server_args(&configs, &opts.tool_args),
+            )?;
+            let args = codex_args_with_remote(&configs, &opts.tool_args, Some(proxy.url()));
+            cmd.args(args);
+            return run_interactive_command_with_guard(cmd, &opts.command, proxy);
+        } else {
+            codex_args(&configs, &opts.tool_args)
+        };
+    cmd.args(codex_args);
     run_interactive_command(cmd, &opts.command)
 }
 
@@ -706,6 +744,21 @@ fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::Exit
 
 fn run_interactive_command(
     mut cmd: Command,
+    display: &Path,
+) -> Result<std::process::ExitStatus, String> {
+    run_interactive_command_inner(&mut cmd, display)
+}
+
+fn run_interactive_command_with_guard<G>(
+    mut cmd: Command,
+    display: &Path,
+    _guard: G,
+) -> Result<std::process::ExitStatus, String> {
+    run_interactive_command_inner(&mut cmd, display)
+}
+
+fn run_interactive_command_inner(
+    cmd: &mut Command,
     display: &Path,
 ) -> Result<std::process::ExitStatus, String> {
     let mut terminal_guard = terminal::TuiSessionGuard::enter();
@@ -1077,6 +1130,14 @@ fn apply_extension_env(
 }
 
 fn codex_args(configs: &[String], tool_args: &[String]) -> Vec<String> {
+    codex_args_with_remote(configs, tool_args, None)
+}
+
+fn codex_args_with_remote(
+    configs: &[String],
+    tool_args: &[String],
+    remote: Option<&str>,
+) -> Vec<String> {
     let mut args = Vec::with_capacity(configs.len() * 2 + 5 + tool_args.len());
     if !codex_args_disable_unified_exec(tool_args) && !codex_args_enable_unified_exec(tool_args) {
         args.push("--enable".to_string());
@@ -1091,8 +1152,79 @@ fn codex_args(configs: &[String], tool_args: &[String]) -> Vec<String> {
         "developer_instructions={}",
         toml_string(PENTECT_CONTRACT_INSTRUCTIONS)
     ));
+    if let Some(remote) = remote {
+        args.push("--remote".to_string());
+        args.push(remote.to_string());
+    }
     args.extend(tool_args.iter().cloned());
     args
+}
+
+fn codex_app_server_args(configs: &[String], tool_args: &[String]) -> Vec<String> {
+    let mut args = Vec::with_capacity(configs.len() * 2 + 5);
+    if !codex_args_disable_unified_exec(tool_args) && !codex_args_enable_unified_exec(tool_args) {
+        args.push("--enable".to_string());
+        args.push("unified_exec".to_string());
+    }
+    for config in configs {
+        args.push("--config".to_string());
+        args.push(config.clone());
+    }
+    args.push("--config".to_string());
+    args.push(format!(
+        "developer_instructions={}",
+        toml_string(PENTECT_CONTRACT_INSTRUCTIONS)
+    ));
+    for (flag, value) in codex_root_config_args(tool_args) {
+        args.push(flag);
+        if let Some(value) = value {
+            args.push(value);
+        }
+    }
+    args
+}
+
+fn codex_root_config_args(args: &[String]) -> Vec<(String, Option<String>)> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        if arg == "--" {
+            break;
+        }
+        match arg {
+            "-c" | "--config" | "--enable" | "--disable" => {
+                if let Some(value) = args.get(i + 1) {
+                    out.push((arg.to_string(), Some(value.clone())));
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            "--strict-config" => {
+                out.push((arg.to_string(), None));
+                i += 1;
+            }
+            _ if arg.starts_with("--config=")
+                || arg.starts_with("--enable=")
+                || arg.starts_with("--disable=") =>
+            {
+                out.push((arg.to_string(), None));
+                i += 1;
+            }
+            _ if arg.starts_with('-') => {
+                i += if codex_long_option_takes_value(arg) || codex_short_option_takes_value(arg) {
+                    2
+                } else {
+                    1
+                };
+            }
+            _ => {
+                break;
+            }
+        }
+    }
+    out
 }
 
 fn codex_args_enable_unified_exec(args: &[String]) -> bool {
@@ -1105,6 +1237,75 @@ fn codex_args_disable_unified_exec(args: &[String]) -> bool {
 
 fn codex_unified_exec_proxy_enabled(args: &[String]) -> bool {
     !codex_args_disable_unified_exec(args)
+}
+
+fn codex_app_server_proxy_enabled(args: &[String], disabled: bool) -> Result<bool, String> {
+    if disabled {
+        return Ok(false);
+    }
+    if codex_metadata_only_args(args) {
+        return Ok(false);
+    }
+    if codex_args_remote_value(args).is_some() {
+        return Err(
+            "`pentect codex` owns Codex --remote; remove --remote or pass --no-app-server-proxy"
+                .to_string(),
+        );
+    }
+    let path = Path::new(PENTECT_DIR).join(PENTECT_CONFIG_FILE);
+    if !path.exists() {
+        return Ok(true);
+    }
+    let src = std::fs::read_to_string(&path)
+        .map_err(|e| format!("could not read '{}': {e}", path.display()))?;
+    if src.trim().is_empty() {
+        return Ok(true);
+    }
+    let value = src
+        .parse::<toml::Value>()
+        .map_err(|e| format!("could not parse '{}': {e}", path.display()))?;
+    Ok(codex_app_server_proxy_config_value(&value)?.unwrap_or(true))
+}
+
+fn codex_app_server_proxy_config_value(value: &toml::Value) -> Result<Option<bool>, String> {
+    let Some(raw) = value.get("agent") else {
+        return Ok(None);
+    };
+    let Some(table) = raw.as_table() else {
+        return Err("agent config must be a table".to_string());
+    };
+    if let Some(raw) = table.get("codex_app_server_proxy") {
+        return status_line_config_bool(raw, "agent.codex_app_server_proxy").map(Some);
+    }
+    Ok(None)
+}
+
+fn codex_args_remote_value(args: &[String]) -> Option<&str> {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        if arg == "--" {
+            return None;
+        }
+        if arg == "--remote" {
+            return args.get(i + 1).map(String::as_str);
+        }
+        if let Some(value) = arg.strip_prefix("--remote=") {
+            return Some(value);
+        }
+        i += if codex_long_option_takes_value(arg) {
+            2
+        } else {
+            1
+        };
+    }
+    None
+}
+
+fn codex_metadata_only_args(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.as_str(), "--help" | "-h" | "--version" | "-V"))
+        || matches!(codex_first_positional(args), Some("help"))
 }
 
 fn codex_args_feature_value(args: &[String], flag: &str, feature: &str) -> bool {
@@ -1844,6 +2045,19 @@ mod tests {
     }
 
     #[test]
+    fn agent_tool_parse_consumes_codex_app_server_proxy_toggle() {
+        let args = vec![
+            "pentect".to_string(),
+            "codex".to_string(),
+            "--no-app-server-proxy".to_string(),
+            "hello".to_string(),
+        ];
+        let opts = AgentToolOpts::parse(AgentTool::Codex, &args).unwrap();
+        assert!(opts.codex_app_server_proxy_disabled);
+        assert_eq!(opts.tool_args, vec!["hello"]);
+    }
+
+    #[test]
     fn agent_tool_parse_consumes_extensions_before_tool_args() {
         let args = vec![
             "pentect".to_string(),
@@ -2028,6 +2242,61 @@ mod tests {
             .and_then(|(_, value)| value)
             .unwrap();
         assert_eq!(disabled, std::ffi::OsStr::new("0"));
+    }
+
+    #[test]
+    fn codex_args_place_remote_before_prompt() {
+        let args = codex_args_with_remote(
+            &["features.hooks=true".to_string()],
+            &["hello".to_string()],
+            Some("ws://127.0.0.1:12345"),
+        );
+        let remote = args.iter().position(|arg| arg == "--remote").unwrap();
+        let prompt = args.iter().position(|arg| arg == "hello").unwrap();
+        assert!(remote < prompt, "{args:?}");
+        assert_eq!(args[remote + 1], "ws://127.0.0.1:12345");
+    }
+
+    #[test]
+    fn codex_app_server_args_keep_pentect_and_root_config_only() {
+        let args = codex_app_server_args(
+            &["features.hooks=true".to_string()],
+            &[
+                "-m".to_string(),
+                "gpt-5.3-codex".to_string(),
+                "--config".to_string(),
+                "model_reasoning_effort=\"high\"".to_string(),
+                "hello".to_string(),
+            ],
+        );
+        assert!(args.contains(&"--enable".to_string()), "{args:?}");
+        assert!(args.contains(&"unified_exec".to_string()), "{args:?}");
+        assert!(
+            args.contains(&"features.hooks=true".to_string()),
+            "{args:?}"
+        );
+        assert!(
+            args.contains(&"model_reasoning_effort=\"high\"".to_string()),
+            "{args:?}"
+        );
+        assert!(!args.contains(&"-m".to_string()), "{args:?}");
+        assert!(!args.contains(&"hello".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn codex_app_server_proxy_config_defaults_and_can_disable() {
+        let empty = ""
+            .parse::<toml::Value>()
+            .unwrap_or(toml::Value::Table(Default::default()));
+        assert_eq!(codex_app_server_proxy_config_value(&empty).unwrap(), None);
+
+        let value = "[agent]\ncodex_app_server_proxy = false"
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(
+            codex_app_server_proxy_config_value(&value).unwrap(),
+            Some(false)
+        );
     }
 
     #[test]

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1293,7 +1293,7 @@ fn codex_args_remote_value(args: &[String]) -> Option<&str> {
         if let Some(value) = arg.strip_prefix("--remote=") {
             return Some(value);
         }
-        i += if codex_long_option_takes_value(arg) {
+        i += if codex_long_option_takes_value(arg) || codex_short_option_takes_value(arg) {
             2
         } else {
             1
@@ -2255,6 +2255,23 @@ mod tests {
         let prompt = args.iter().position(|arg| arg == "hello").unwrap();
         assert!(remote < prompt, "{args:?}");
         assert_eq!(args[remote + 1], "ws://127.0.0.1:12345");
+    }
+
+    #[test]
+    fn codex_remote_scan_skips_short_option_values() {
+        assert_eq!(
+            codex_args_remote_value(&["-m".to_string(), "--remote".to_string()]),
+            None
+        );
+        assert_eq!(
+            codex_args_remote_value(&[
+                "-m".to_string(),
+                "gpt-5.5".to_string(),
+                "--remote".to_string(),
+                "ws://127.0.0.1:12345".to_string()
+            ]),
+            Some("ws://127.0.0.1:12345")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- launch Codex through a local app-server WebSocket proxy for interactive pentect codex
- pass Pentect hook/contract/env state to the app-server process, not just the front TUI
- mask app-server display text while preserving protocol fields such as cwd/path

## Verification
- cargo test --workspace --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- tmux smoke: 	arget\\debug\\pentect.exe codex --no-alt-screen showed the normal Codex TUI via proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Codex app server proxy support for local, browser-based connections.
  * Introduced a `--no-app-server-proxy` option to disable this behavior.

* **Bug Fixes**
  * Improved handling of Codex `--remote` arguments to avoid conflicts.
  * Added clearer validation when proxy mode can’t be used, with guidance to adjust command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->