### PR TITLE
Use extension config files

### DIFF
--- a/crates/pentect-cli/src/extensions.rs
+++ b/crates/pentect-cli/src/extensions.rs
@@ -6,13 +6,15 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-pub(crate) const PACKS_ENV: &str = "PENTECT_EXTENSION_PACKS";
+pub(crate) const CONFIGS_ENV: &str = "PENTECT_EXTENSION_CONFIGS";
 pub(crate) const ADAPTERS_ENV: &str = "PENTECT_EXTENSION_ADAPTERS";
 
 const PENTECT_DIR: &str = ".pentect";
 const EXTENSIONS_DIR: &str = "extensions";
 const EXTENSIONS_CACHE_DIR: &str = "extension-cache";
-const CONFIG_FILE: &str = "config.toml";
+const PENTECT_CONFIG_FILE: &str = "config.toml";
+const EXTENSION_CONFIG_FILE: &str = "config.toml";
+const EXTENSION_CONFIGS_DIR: &str = "configs";
 const OFFICIAL_EXTENSIONS_DIR: &str = "extensions";
 const DEFAULT_REMOTE_EXTENSIONS_BASE: &str =
     "https://raw.githubusercontent.com/EdamAme-x/pentect/main/extensions";
@@ -21,26 +23,26 @@ const REMOTE_EXTENSION_CACHE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 
 #[derive(Debug, Default)]
 pub(crate) struct ActiveExtensions {
-    pack_paths: Vec<PathBuf>,
+    config_paths: Vec<PathBuf>,
     adapter_paths: Vec<PathBuf>,
 }
 
 impl ActiveExtensions {
-    pub(crate) fn pack_paths(&self) -> &[PathBuf] {
-        &self.pack_paths
+    pub(crate) fn config_paths(&self) -> &[PathBuf] {
+        &self.config_paths
     }
 
     pub(crate) fn adapter_paths(&self) -> &[PathBuf] {
         &self.adapter_paths
     }
 
-    pub(crate) fn pack_env_value(&self) -> Result<Option<OsString>> {
-        if self.pack_paths.is_empty() {
+    pub(crate) fn config_env_value(&self) -> Result<Option<OsString>> {
+        if self.config_paths.is_empty() {
             return Ok(None);
         }
-        std::env::join_paths(&self.pack_paths)
+        std::env::join_paths(&self.config_paths)
             .map(Some)
-            .context("could not encode extension pack paths")
+            .context("could not encode extension config paths")
     }
 
     pub(crate) fn adapter_env_value(&self) -> Result<Option<OsString>> {
@@ -185,36 +187,37 @@ pub(crate) fn active_from_explicit_specs(
     specs: Vec<String>,
     create_named: bool,
 ) -> Result<ActiveExtensions> {
-    let (pack_paths, adapter_paths) = extension_paths_for_specs(&specs, create_named)?;
+    let (config_paths, adapter_paths) = extension_paths_for_specs(&specs, create_named)?;
     Ok(ActiveExtensions {
-        pack_paths,
+        config_paths,
         adapter_paths,
     })
 }
 
-pub(crate) fn load_packs_from_args(args: &[String], create_named: bool) -> Result<Vec<Pack>> {
-    load_packs_from_specs(collect_from_args(args)?, create_named)
+pub(crate) fn load_config_packs_from_args(
+    args: &[String],
+    create_named: bool,
+) -> Result<Vec<Pack>> {
+    load_config_packs_from_specs(collect_from_args(args)?, create_named)
 }
 
-pub(crate) fn load_packs_from_specs(
+pub(crate) fn load_config_packs_from_specs(
     explicit_specs: Vec<String>,
     create_named: bool,
 ) -> Result<Vec<Pack>> {
     let active = active_from_specs(explicit_specs, create_named)?;
     let mut packs = Vec::new();
     if !active.adapter_paths.is_empty() {
-        bail!(
-            "model adapter extensions are only used by agent tool-boundary commands; use a rules pack for this command"
-        );
+        bail!("model adapter extensions are only used by agent tool-boundary commands");
     }
-    for path in active.pack_paths {
+    for path in active.config_paths {
         let display = path.display();
         let src = std::fs::read_to_string(&path)
-            .with_context(|| format!("could not read extension pack '{display}'"))?;
+            .with_context(|| format!("could not read extension config '{display}'"))?;
         let pack =
-            load_pack(&src).map_err(|e| anyhow!("extension pack '{display}' is invalid: {e}"))?;
+            load_pack(&src).map_err(|e| anyhow!("extension config '{display}' is invalid: {e}"))?;
         if !pack.disable.is_empty() {
-            bail!("extension pack '{display}' may add detectors but must not disable built-ins");
+            bail!("extension config '{display}' may add detectors but must not disable built-ins");
         }
         packs.push(pack);
     }
@@ -222,7 +225,7 @@ pub(crate) fn load_packs_from_specs(
 }
 
 fn config_specs() -> Result<Vec<String>> {
-    let path = PathBuf::from(PENTECT_DIR).join(CONFIG_FILE);
+    let path = PathBuf::from(PENTECT_DIR).join(PENTECT_CONFIG_FILE);
     if !path.exists() {
         return Ok(Vec::new());
     }
@@ -258,33 +261,33 @@ fn extension_paths_for_specs(
     specs: &[String],
     create_named: bool,
 ) -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
-    let mut packs = Vec::new();
+    let mut configs = Vec::new();
     let mut adapters = Vec::new();
     for spec in specs {
         if is_url_spec(spec) {
             let found = extension_paths_for_url(spec)?;
-            packs.extend(found.pack_paths);
+            configs.extend(found.config_paths);
             adapters.extend(found.adapter_paths);
         } else if is_path_spec(spec) {
             let found = extension_paths_for_path(Path::new(spec))?;
-            packs.extend(found.pack_paths);
+            configs.extend(found.config_paths);
             adapters.extend(found.adapter_paths);
         } else {
             let found = extension_paths_for_named(spec, create_named)?;
-            packs.extend(found.pack_paths);
+            configs.extend(found.config_paths);
             adapters.extend(found.adapter_paths);
         }
     }
-    packs.sort();
-    packs.dedup();
+    configs.sort();
+    configs.dedup();
     adapters.sort();
     adapters.dedup();
-    Ok((packs, adapters))
+    Ok((configs, adapters))
 }
 
 #[derive(Debug, Default)]
 struct ExtensionPaths {
-    pack_paths: Vec<PathBuf>,
+    config_paths: Vec<PathBuf>,
     adapter_paths: Vec<PathBuf>,
 }
 
@@ -319,9 +322,9 @@ fn extension_paths_for_named(name: &str, _create: bool) -> Result<ExtensionPaths
     let paths = extension_paths_in_dir(&dir)?;
     if paths.is_empty() {
         bail!(
-            "extension '{name}' has no packs or adapters; add '{}', '{}', '{}', or '{}'",
-            dir.join("pack.toml").display(),
-            dir.join("packs").display(),
+            "extension '{name}' has no configs or adapters; add '{}', '{}', '{}', or '{}'",
+            dir.join(EXTENSION_CONFIG_FILE).display(),
+            dir.join(EXTENSION_CONFIGS_DIR).display(),
             dir.join("adapter.toml").display(),
             dir.join("adapters").display()
         );
@@ -338,7 +341,7 @@ fn extension_paths_for_url(url: &str) -> Result<ExtensionPaths> {
         if looks_like_adapter_url(&normalized) {
             paths.adapter_paths.push(file);
         } else {
-            paths.pack_paths.push(file);
+            paths.config_paths.push(file);
         }
         return Ok(paths);
     }
@@ -348,14 +351,14 @@ fn extension_paths_for_url(url: &str) -> Result<ExtensionPaths> {
 fn extension_paths_for_path(path: &Path) -> Result<ExtensionPaths> {
     if path.is_file() {
         if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
-            bail!("extension pack must be a .toml file: {}", path.display());
+            bail!("extension config must be a .toml file: {}", path.display());
         }
         let mut paths = ExtensionPaths::default();
         let file = canonical_file(path)?;
         if looks_like_adapter_file(path) {
             paths.adapter_paths.push(file);
         } else {
-            paths.pack_paths.push(file);
+            paths.config_paths.push(file);
         }
         return Ok(paths);
     }
@@ -367,13 +370,13 @@ fn extension_paths_for_path(path: &Path) -> Result<ExtensionPaths> {
 
 fn extension_paths_in_dir(dir: &Path) -> Result<ExtensionPaths> {
     let mut paths = ExtensionPaths::default();
-    let pack = dir.join("pack.toml");
-    if pack.exists() {
-        paths.pack_paths.push(canonical_file(&pack)?);
+    let config = dir.join(EXTENSION_CONFIG_FILE);
+    if config.exists() {
+        paths.config_paths.push(canonical_file(&config)?);
     }
-    let packs_dir = dir.join("packs");
-    if packs_dir.exists() {
-        paths.pack_paths.extend(toml_files_in_dir(&packs_dir)?);
+    let configs_dir = dir.join(EXTENSION_CONFIGS_DIR);
+    if configs_dir.exists() {
+        paths.config_paths.extend(toml_files_in_dir(&configs_dir)?);
     }
     let adapter = dir.join("adapter.toml");
     if adapter.exists() {
@@ -385,14 +388,14 @@ fn extension_paths_in_dir(dir: &Path) -> Result<ExtensionPaths> {
             .adapter_paths
             .extend(toml_files_in_dir(&adapters_dir)?);
     }
-    paths.pack_paths.sort();
+    paths.config_paths.sort();
     paths.adapter_paths.sort();
     Ok(paths)
 }
 
 impl ExtensionPaths {
     fn is_empty(&self) -> bool {
-        self.pack_paths.is_empty() && self.adapter_paths.is_empty()
+        self.config_paths.is_empty() && self.adapter_paths.is_empty()
     }
 }
 
@@ -471,10 +474,12 @@ fn remote_extension_paths_for_name(name: &str) -> Result<ExtensionPaths> {
 
 fn remote_extension_paths_for_base_url(base_url: &str) -> Result<ExtensionPaths> {
     let mut paths = ExtensionPaths::default();
-    if let Some(pack) =
-        fetch_remote_extension_file(&format!("{}/pack.toml", base_url.trim_end_matches('/')))?
-    {
-        paths.pack_paths.push(pack);
+    if let Some(config) = fetch_remote_extension_file(&format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        EXTENSION_CONFIG_FILE
+    ))? {
+        paths.config_paths.push(config);
     }
     if let Some(adapter) =
         fetch_remote_extension_file(&format!("{}/adapter.toml", base_url.trim_end_matches('/')))?
@@ -482,7 +487,7 @@ fn remote_extension_paths_for_base_url(base_url: &str) -> Result<ExtensionPaths>
         paths.adapter_paths.push(adapter);
     }
     if paths.is_empty() {
-        bail!("remote extension has no pack.toml or adapter.toml: {base_url}");
+        bail!("remote extension has no config.toml or adapter.toml: {base_url}");
     }
     Ok(paths)
 }
@@ -716,10 +721,10 @@ mod tests {
     fn github_extension_urls_normalize_to_raw_urls() {
         assert_eq!(
             normalize_github_extension_url(
-                "https://github.com/EdamAme-x/pentect/blob/main/extensions/company/pack.toml"
+                "https://github.com/EdamAme-x/pentect/blob/main/extensions/company/config.toml"
             )
             .unwrap(),
-            "https://raw.githubusercontent.com/EdamAme-x/pentect/main/extensions/company/pack.toml"
+            "https://raw.githubusercontent.com/EdamAme-x/pentect/main/extensions/company/config.toml"
         );
         assert_eq!(
             normalize_github_extension_url(
@@ -730,30 +735,30 @@ mod tests {
         );
         assert_eq!(
             normalize_github_extension_url(
-                "https://raw.githubusercontent.com/EdamAme-x/pentect/main/extensions/company/pack.toml"
+                "https://raw.githubusercontent.com/EdamAme-x/pentect/main/extensions/company/config.toml"
             )
             .unwrap(),
-            "https://raw.githubusercontent.com/EdamAme-x/pentect/main/extensions/company/pack.toml"
+            "https://raw.githubusercontent.com/EdamAme-x/pentect/main/extensions/company/config.toml"
         );
-        assert!(normalize_github_extension_url("https://example.com/company/pack.toml").is_err());
+        assert!(normalize_github_extension_url("https://example.com/company/config.toml").is_err());
         assert!(
             normalize_github_extension_url("https://raw.githubusercontent.com/owner/repo").is_err()
         );
     }
 
     #[test]
-    fn directory_extensions_can_contain_packs_and_adapters() {
+    fn directory_extensions_can_contain_configs_and_adapters() {
         let root =
             std::env::temp_dir().join(format!("pentect-extension-paths-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir(&root).unwrap();
-        std::fs::write(root.join("pack.toml"), "").unwrap();
+        std::fs::write(root.join("config.toml"), "").unwrap();
         std::fs::write(root.join("adapter.toml"), "").unwrap();
 
         let paths = extension_paths_for_path(&root).unwrap();
         assert_eq!(
-            paths.pack_paths,
-            vec![root.join("pack.toml").canonicalize().unwrap()]
+            paths.config_paths,
+            vec![root.join("config.toml").canonicalize().unwrap()]
         );
         assert_eq!(
             paths.adapter_paths,
@@ -771,7 +776,7 @@ mod tests {
         std::fs::create_dir(&root).unwrap();
         std::fs::write(root.join("adapter.toml"), "").unwrap();
 
-        let err = match load_packs_from_specs(vec![root.display().to_string()], true) {
+        let err = match load_config_packs_from_specs(vec![root.display().to_string()], true) {
             Ok(_) => panic!("expected adapter-only extension to be rejected"),
             Err(err) => err.to_string(),
         };

--- a/crates/pentect-cli/src/extensions_cmd.rs
+++ b/crates/pentect-cli/src/extensions_cmd.rs
@@ -95,7 +95,7 @@ fn list_extensions(json_output: bool) -> Result<(), String> {
                     "name": row.name,
                     "source": row.source,
                     "status": row.status(),
-                    "packs": row.packs,
+                    "configs": row.configs,
                     "adapters": row.adapters,
                 })).collect::<Vec<_>>()
             })
@@ -108,11 +108,11 @@ fn list_extensions(json_output: bool) -> Result<(), String> {
     }
     for row in rows {
         println!(
-            "{}: {} {} packs={} adapters={}",
+            "{}: {} {} configs={} adapters={}",
             row.name,
             row.source,
             row.status(),
-            row.packs,
+            row.configs,
             row.adapters
         );
     }
@@ -125,9 +125,9 @@ fn inspect_extension(spec: &str, json_output: bool) -> Result<(), String> {
         println!("{}", active_json(&active));
         return Ok(());
     }
-    println!("packs: {}", active.pack_paths().len());
-    for path in active.pack_paths() {
-        println!("pack: {}", display_path(path));
+    println!("configs: {}", active.config_paths().len());
+    for path in active.config_paths() {
+        println!("config: {}", display_path(path));
     }
     println!("adapters: {}", active.adapter_paths().len());
     for path in active.adapter_paths() {
@@ -139,7 +139,7 @@ fn inspect_extension(spec: &str, json_output: bool) -> Result<(), String> {
 fn test_extension(spec: &str, json_output: bool) -> Result<(), String> {
     let active = active_for_one(spec)?;
     let mut checks = Vec::new();
-    for path in active.pack_paths() {
+    for path in active.config_paths() {
         checks.push(test_pack(path));
     }
     for path in active.adapter_paths() {
@@ -177,7 +177,7 @@ fn active_for_one(spec: &str) -> Result<extensions::ActiveExtensions, String> {
 
 fn active_json(active: &extensions::ActiveExtensions) -> String {
     json!({
-        "packs": active.pack_paths().iter().map(|path| display_path(path)).collect::<Vec<_>>(),
+        "configs": active.config_paths().iter().map(|path| display_path(path)).collect::<Vec<_>>(),
         "adapters": active.adapter_paths().iter().map(|path| display_path(path)).collect::<Vec<_>>(),
     })
     .to_string()
@@ -186,11 +186,11 @@ fn active_json(active: &extensions::ActiveExtensions) -> String {
 fn test_pack(path: &Path) -> Check {
     let src = match std::fs::read_to_string(path) {
         Ok(src) => src,
-        Err(e) => return Check::fail("pack", e.to_string()),
+        Err(e) => return Check::fail("config", e.to_string()),
     };
     match load_pack(&src) {
-        Ok(_) => Check::ok("pack", display_path(path)),
-        Err(e) => Check::fail("pack", e),
+        Ok(_) => Check::ok("config", display_path(path)),
+        Err(e) => Check::fail("config", e),
     }
 }
 
@@ -443,13 +443,13 @@ fn safe_adapter_env_names() -> &'static [&'static str] {
 struct ExtensionRow {
     name: String,
     source: &'static str,
-    packs: usize,
+    configs: usize,
     adapters: usize,
 }
 
 impl ExtensionRow {
     fn status(&self) -> &'static str {
-        if self.packs == 0 && self.adapters == 0 {
+        if self.configs == 0 && self.adapters == 0 {
             "empty"
         } else {
             "ok"
@@ -498,10 +498,13 @@ fn extension_rows_in(root: PathBuf, source: &'static str) -> Result<Vec<Extensio
             .unwrap_or("")
             .to_string();
         let active = active_for_one(&path.to_string_lossy())?;
+        if active.config_paths().is_empty() && active.adapter_paths().is_empty() {
+            continue;
+        }
         rows.push(ExtensionRow {
             name,
             source,
-            packs: active.pack_paths().len(),
+            configs: active.config_paths().len(),
             adapters: active.adapter_paths().len(),
         });
     }
@@ -663,5 +666,23 @@ mod tests {
                 .is_some_and(|path| path.ends_with(".pentect/extensions-data/my-ext/config.toml")),
             "{envs:?}"
         );
+    }
+
+    #[test]
+    fn list_extensions_skips_empty_dirs() {
+        let root =
+            std::env::temp_dir().join(format!("pentect-extension-list-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("empty")).unwrap();
+        std::fs::create_dir_all(root.join("rules")).unwrap();
+        std::fs::write(root.join("rules").join("config.toml"), "").unwrap();
+
+        let rows = extension_rows_in(root.clone(), "official").unwrap();
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "rules");
+        assert_eq!(rows[0].configs, 1);
+        assert_eq!(rows[0].adapters, 0);
     }
 }

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -188,11 +188,11 @@ fn cmd_agent_from(start: usize, args: &[String]) {
         Ok(active) => active,
         Err(e) => die(&e),
     };
-    if let Some(value) = match active_extensions.pack_env_value() {
+    if let Some(value) = match active_extensions.config_env_value() {
         Ok(value) => value,
         Err(e) => die(&e),
     } {
-        std::env::set_var(extensions::PACKS_ENV, value);
+        std::env::set_var(extensions::CONFIGS_ENV, value);
     }
     if let Some(value) = match active_extensions.adapter_env_value() {
         Ok(value) => value,
@@ -363,7 +363,7 @@ fn cmd_read(args: &[String]) {
         Err(e) => die(&e),
     };
     let kind = opts.kind.unwrap_or_else(|| infer_kind(&opts.path));
-    let packs = match extensions::load_packs_from_specs(opts.extensions.clone(), true) {
+    let packs = match extensions::load_config_packs_from_specs(opts.extensions.clone(), true) {
         Ok(packs) => packs,
         Err(e) => die(&e),
     };
@@ -650,8 +650,8 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
     let mut cmd = Command::new(&opts.command);
     apply_extension_env(&mut cmd, &active_extensions)?;
     let in_memory_manager = start_in_memory_manager(pentect)?;
-    let pack_env = active_extensions
-        .pack_env_value()
+    let config_env = active_extensions
+        .config_env_value()
         .map_err(|e| e.to_string())?;
     let adapter_env = active_extensions
         .adapter_env_value()
@@ -675,7 +675,7 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
             PENTECT_STATUS_LINE_ENV,
             Some(OsString::from(if status_line_enabled { "1" } else { "0" })),
         ),
-        (extensions::PACKS_ENV, pack_env),
+        (extensions::CONFIGS_ENV, config_env),
         (extensions::ADAPTERS_ENV, adapter_env),
     ]);
     let exec_proxy = if codex_unified_exec_proxy_enabled(&opts.tool_args) {
@@ -1120,8 +1120,8 @@ fn apply_extension_env(
     cmd: &mut Command,
     active: &extensions::ActiveExtensions,
 ) -> Result<(), String> {
-    if let Some(value) = active.pack_env_value().map_err(|e| e.to_string())? {
-        cmd.env(extensions::PACKS_ENV, value);
+    if let Some(value) = active.config_env_value().map_err(|e| e.to_string())? {
+        cmd.env(extensions::CONFIGS_ENV, value);
     }
     if let Some(value) = active.adapter_env_value().map_err(|e| e.to_string())? {
         cmd.env(extensions::ADAPTERS_ENV, value);
@@ -1864,7 +1864,7 @@ fn load_packs(args: &[String]) -> Result<Vec<Pack>, String> {
         let pack = load_pack(&src).map_err(|e| format!("pack '{display}' is invalid: {e}"))?;
         packs.push(pack);
     }
-    packs.extend(extensions::load_packs_from_args(args, true).map_err(|e| e.to_string())?);
+    packs.extend(extensions::load_config_packs_from_args(args, true).map_err(|e| e.to_string())?);
     Ok(packs)
 }
 

--- a/crates/pentect-cli/src/scan.rs
+++ b/crates/pentect-cli/src/scan.rs
@@ -223,12 +223,12 @@ mod tests {
     }
 
     #[test]
-    fn scan_applies_extension_packs() {
+    fn scan_applies_extension_configs() {
         let root = temp_scan_root("pentect-scan-extension-pack");
         let ext = root.join("ext");
         std::fs::create_dir(&ext).unwrap();
         std::fs::write(
-            ext.join("pack.toml"),
+            ext.join("config.toml"),
             r#"[[detector]]
 pattern = 'ACME-[0-9]{8}'
 category = "secret"

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -13,7 +13,7 @@ use std::sync::OnceLock;
 
 const ENV_ALIAS_LABEL: &str = "PENTECT_ENV_ALIAS";
 const ENV_ALIAS_RECORD_PREFIX: &str = "\u{1f}pentect-env\0";
-const EXTENSION_PACKS_ENV: &str = "PENTECT_EXTENSION_PACKS";
+const EXTENSION_CONFIGS_ENV: &str = "PENTECT_EXTENSION_CONFIGS";
 const BATCH_DELIMITERS: [&str; 4] = [
     "\u{1f}pentect-batch-0\u{1e}",
     "\u{1f}pentect-batch-1\u{1d}",
@@ -520,10 +520,10 @@ fn build_tool_boundary_engine() -> Result<Engine, String> {
         .standard_stack(Profile::Strict.knobs())
         .parser(Kind::ToolResult, Box::new(ToolResultParser))
         .detector(Box::new(SensitiveKeyDetector));
-    for pack in extension_packs_from_env()? {
+    for config_pack in extension_configs_from_env()? {
         builder = builder
-            .detector(Box::new(pack.rules))
-            .disable_labels(pack.disable);
+            .detector(Box::new(config_pack.rules))
+            .disable_labels(config_pack.disable);
     }
     Ok(builder
         .policy(Box::new(ProfilePolicy::new(Profile::Strict)))
@@ -531,36 +531,39 @@ fn build_tool_boundary_engine() -> Result<Engine, String> {
         .build())
 }
 
-fn extension_packs_from_env() -> Result<Vec<pentect_core::Pack>, String> {
+fn extension_configs_from_env() -> Result<Vec<pentect_core::Pack>, String> {
     static CACHE: OnceLock<Result<Vec<pentect_core::Pack>, String>> = OnceLock::new();
-    CACHE.get_or_init(load_extension_packs_from_env).clone()
+    CACHE.get_or_init(load_extension_configs_from_env).clone()
 }
 
-fn load_extension_packs_from_env() -> Result<Vec<pentect_core::Pack>, String> {
-    let Some(value) = std::env::var_os(EXTENSION_PACKS_ENV) else {
+fn load_extension_configs_from_env() -> Result<Vec<pentect_core::Pack>, String> {
+    let Some(value) = std::env::var_os(EXTENSION_CONFIGS_ENV) else {
         return Ok(Vec::new());
     };
-    let mut packs = Vec::new();
+    let mut config_packs = Vec::new();
     for path in std::env::split_paths(&value) {
         if path.as_os_str().is_empty() {
             continue;
         }
         if !path.is_file() {
-            return Err(format!("extension pack does not exist: {}", path.display()));
-        }
-        let src = std::fs::read_to_string(&path)
-            .map_err(|e| format!("could not read extension pack '{}': {e}", path.display()))?;
-        let pack = load_pack(&src)
-            .map_err(|e| format!("extension pack '{}' is invalid: {e}", path.display()))?;
-        if !pack.disable.is_empty() {
             return Err(format!(
-                "extension pack '{}' may add detectors but must not disable built-ins",
+                "extension config does not exist: {}",
                 path.display()
             ));
         }
-        packs.push(pack);
+        let src = std::fs::read_to_string(&path)
+            .map_err(|e| format!("could not read extension config '{}': {e}", path.display()))?;
+        let config_pack = load_pack(&src)
+            .map_err(|e| format!("extension config '{}' is invalid: {e}", path.display()))?;
+        if !config_pack.disable.is_empty() {
+            return Err(format!(
+                "extension config '{}' may add detectors but must not disable built-ins",
+                path.display()
+            ));
+        }
+        config_packs.push(config_pack);
     }
-    Ok(packs)
+    Ok(config_packs)
 }
 
 #[cfg(test)]

--- a/extensions/.gitkeep
+++ b/extensions/.gitkeep
@@ -1,0 +1,1 @@
+# Official extensions live in subdirectories.


### PR DESCRIPTION
## Summary
- keep ./extensions in git without adding placeholder extension packs
- use extension config.toml/configs instead of pack.toml/packs for named extensions
- hide empty extension directories from extensions list

## Test
- cargo test -p pentect-cli extensions --locked
- cargo fmt --all -- --check
- cargo clippy -p pentect-cli -p pentect-runtime --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked
- cargo run -p pentect-cli --locked -- extensions list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed extension terminology from “packs” to “configs” across the CLI and runtime experience.
  * Updated extension discovery to recognize `config.toml` and `configs/` paths.
  * Adjusted extension listing and inspection output to show config-based names and paths.

* **Bug Fixes**
  * Improved handling of empty extension directories so they no longer appear in results.
  * Updated error messages and validation feedback to match the new config naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->