### PR TITLE
Add runtime-free official privacy extensions

### DIFF
--- a/crates/pentect-cli/src/extensions.rs
+++ b/crates/pentect-cli/src/extensions.rs
@@ -295,41 +295,58 @@ fn extension_paths_for_named(name: &str, _create: bool) -> Result<ExtensionPaths
     validate_extension_name(name)?;
     let project_dir = extensions_root().join(name);
     let official_dir = official_extensions_root().join(name);
-    let dir = if project_dir.exists() {
-        project_dir
-    } else if official_dir.exists() {
-        official_dir.clone()
+
+    if project_dir.is_dir() {
+        let paths = extension_paths_in_dir(&project_dir)?;
+        if !paths.is_empty() {
+            return Ok(paths);
+        }
+    }
+
+    if official_dir.is_dir() {
+        let paths = extension_paths_in_dir(&official_dir)?;
+        if !paths.is_empty() {
+            return Ok(paths);
+        }
+    }
+
+    let remote_error = if remote_extensions_enabled() {
+        match remote_extension_paths_for_name(name) {
+            Ok(paths) if !paths.is_empty() => return Ok(paths),
+            Ok(_) => None,
+            Err(e) => Some(e),
+        }
     } else {
-        let remote_error = if remote_extensions_enabled() {
-            match remote_extension_paths_for_name(name) {
-                Ok(paths) if !paths.is_empty() => return Ok(paths),
-                Ok(_) => None,
-                Err(e) => Some(e),
-            }
+        None
+    };
+    if project_dir.is_dir() || official_dir.is_dir() {
+        let suggestion_dir = if project_dir.is_dir() {
+            &project_dir
         } else {
-            None
+            &official_dir
         };
         let mut message = format!(
-            "extension '{name}' was not found at '{}' or '{}'",
-            project_dir.display(),
-            official_dir.display()
+            "extension '{name}' has no configs or adapters; add '{}', '{}', '{}', or '{}'",
+            suggestion_dir.join(EXTENSION_CONFIG_FILE).display(),
+            suggestion_dir.join(EXTENSION_CONFIGS_DIR).display(),
+            suggestion_dir.join("adapter.toml").display(),
+            suggestion_dir.join("adapters").display()
         );
         if let Some(error) = remote_error {
             message.push_str(&format!("; remote lookup failed: {error}"));
         }
         bail!(message);
-    };
-    let paths = extension_paths_in_dir(&dir)?;
-    if paths.is_empty() {
-        bail!(
-            "extension '{name}' has no configs or adapters; add '{}', '{}', '{}', or '{}'",
-            dir.join(EXTENSION_CONFIG_FILE).display(),
-            dir.join(EXTENSION_CONFIGS_DIR).display(),
-            dir.join("adapter.toml").display(),
-            dir.join("adapters").display()
-        );
     }
-    Ok(paths)
+
+    let mut message = format!(
+        "extension '{name}' was not found at '{}' or '{}'",
+        project_dir.display(),
+        official_dir.display()
+    );
+    if let Some(error) = remote_error {
+        message.push_str(&format!("; remote lookup failed: {error}"));
+    }
+    bail!(message)
 }
 
 fn extension_paths_for_url(url: &str) -> Result<ExtensionPaths> {
@@ -743,6 +760,68 @@ mod tests {
         assert!(normalize_github_extension_url("https://example.com/company/config.toml").is_err());
         assert!(
             normalize_github_extension_url("https://raw.githubusercontent.com/owner/repo").is_err()
+        );
+    }
+
+    #[test]
+    fn empty_project_extension_does_not_shadow_official_extension() {
+        let name = format!("shadow-test-{}", std::process::id());
+        let project = PathBuf::from(".pentect").join("extensions").join(&name);
+        let official = PathBuf::from("extensions").join(&name);
+        let _ = std::fs::remove_dir_all(&project);
+        let _ = std::fs::remove_dir_all(&official);
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&official).unwrap();
+        std::fs::write(official.join("config.toml"), "").unwrap();
+
+        let paths = extension_paths_for_named(&name, true).unwrap();
+        let expected = official.join("config.toml").canonicalize().unwrap();
+
+        let _ = std::fs::remove_dir_all(&project);
+        let _ = std::fs::remove_dir_all(&official);
+
+        assert_eq!(paths.config_paths, vec![expected]);
+        assert!(paths.adapter_paths.is_empty());
+    }
+
+    #[test]
+    fn official_runtime_free_extensions_mask_contextual_pii() {
+        let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .unwrap();
+        let opf = repo.join("extensions").join("openai-privacy-filter");
+        let packs = load_config_packs_from_specs(vec![opf.display().to_string()], true).unwrap();
+        let engine = pentect_core::Engine::with_profile_and_packs(
+            pentect_core::Profile::Strict,
+            packs,
+            false,
+        );
+        let raw = concat!(
+            "full_name: Ada Lovelace\n",
+            "company: Contoso Corporation\n",
+            "住所: 東京都千代田区丸の内1丁目\n",
+            "notes: Grace Hopper appears here without a field\n"
+        );
+        let masked = engine
+            .mask(
+                pentect_core::Input::text(raw),
+                &pentect_core::Config::insecure_testing(),
+            )
+            .masked;
+
+        assert!(masked.contains("<<PERSON_NAME_"), "{masked}");
+        assert!(masked.contains("<<ORGANIZATION_"), "{masked}");
+        assert!(masked.contains("<<JP_ADDRESS_"), "{masked}");
+        assert!(!masked.contains("full_name: Ada Lovelace"), "{masked}");
+        assert!(!masked.contains("company: Contoso Corporation"), "{masked}");
+        assert!(
+            !masked.contains("住所: 東京都千代田区丸の内1丁目"),
+            "{masked}"
+        );
+        assert!(
+            masked.contains("notes: Grace Hopper appears here without a field"),
+            "{masked}"
         );
     }
 

--- a/crates/pentect-cli/src/extensions_cmd.rs
+++ b/crates/pentect-cli/src/extensions_cmd.rs
@@ -685,4 +685,22 @@ mod tests {
         assert_eq!(rows[0].configs, 1);
         assert_eq!(rows[0].adapters, 0);
     }
+
+    #[test]
+    fn list_extensions_includes_official_runtime_free_configs() {
+        let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .unwrap();
+        let rows = extension_rows_in(repo.join("extensions"), "official").unwrap();
+        let names = rows
+            .iter()
+            .filter(|row| row.source == "official")
+            .map(|row| row.name.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert!(names.contains("openai-privacy-filter"), "{names:?}");
+        assert!(names.contains("ner-lite"), "{names:?}");
+        assert!(names.contains("jp-pii"), "{names:?}");
+    }
 }

--- a/extensions/jp-pii/config.toml
+++ b/extensions/jp-pii/config.toml
@@ -1,0 +1,34 @@
+# Runtime-free Japanese PII extension.
+# Rules are key/context-gated to avoid broad Japanese prose masking.
+
+[[detector]]
+pattern = '(?:氏名|名前|お名前|担当者|顧客名|利用者名)\s*[:：=]\s*"?([\p{Han}\p{Hiragana}\p{Katakana}ー々]{2,12}(?:[ 　][\p{Han}\p{Hiragana}\p{Katakana}ー々]{1,12})?)"?'
+prefilter = ["氏名", "名前", "お名前", "担当者", "顧客名", "利用者名"]
+category = "pii"
+label = "JP_PERSON_NAME"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?:会社名|法人名|組織名|勤務先)\s*[:：=]\s*"?((?:株式会社|合同会社|有限会社)[\p{Han}\p{Hiragana}\p{Katakana}A-Za-z0-9ー・ 　]{2,40}|[\p{Han}\p{Hiragana}\p{Katakana}A-Za-z0-9ー・ 　]{2,40}(?:株式会社|合同会社|有限会社))"?'
+prefilter = ["会社名", "法人名", "組織名", "勤務先", "株式会社", "合同会社", "有限会社"]
+category = "pii"
+label = "JP_ORGANIZATION"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?:住所|所在地|送付先|配送先)\s*[:：=]\s*"?(?:〒\s*[0-9０-９]{3}-?[0-9０-９]{4}[ 　]*)?((?:東京都|北海道|(?:京都|大阪)府|[\p{Han}]{2,3}県)[\p{Han}\p{Hiragana}\p{Katakana}0-9０-９ー丁目番地号\-－の 　]{4,80})"?'
+prefilter = ["住所", "所在地", "送付先", "配送先"]
+category = "pii"
+label = "JP_ADDRESS"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?:生年月日|誕生日)\s*[:：=]\s*"?([0-9０-９]{4}年[0-9０-９]{1,2}月[0-9０-９]{1,2}日|[0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2})"?'
+prefilter = ["生年月日", "誕生日"]
+category = "pii"
+label = "JP_DATE_OF_BIRTH"
+confidence = "medium"
+capture = 1

--- a/extensions/ner-lite/config.toml
+++ b/extensions/ner-lite/config.toml
@@ -1,0 +1,34 @@
+# Runtime-free, context-gated NER-style PII.
+# No bare person/org guessing: every rule needs an explicit field/key context.
+
+[[detector]]
+pattern = '(?i)\b(?:full[ _-]?name|legal[ _-]?name|display[ _-]?name|customer[ _-]?name|patient[ _-]?name|recipient[ _-]?name|contact[ _-]?name|person[ _-]?name)\b\s*[:=]\s*"?([A-Za-z][A-Za-z.-]{1,31}(?:[ \t]+[A-Za-z][A-Za-z.-]{1,31}){1,3})"?'
+prefilter = ["name"]
+category = "pii"
+label = "PERSON_NAME"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?i)\b(?:company|organization|organisation|employer|vendor|customer|client|legal[ _-]?entity)\b\s*[:=]\s*"?([A-Za-z0-9&., -]{2,80}\b(?:Corporation|Corp\.?|Company|Co\.|Limited|Ltd\.?|LLC|Inc\.?|GmbH|SAS|Pte\. Ltd\.|K\.K\.))"?'
+prefilter = ["company", "organization", "organisation", "employer", "vendor", "customer", "client", "entity"]
+category = "pii"
+label = "ORGANIZATION"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?i)\b(?:street[ _-]?address|address|shipping[ _-]?address|billing[ _-]?address|home[ _-]?address)\b\s*[:=]\s*"?([0-9]{1,6}[A-Za-z0-9 .,#/-]{5,120}\b(?:Street|St\.|Avenue|Ave\.|Road|Rd\.|Boulevard|Blvd\.|Lane|Ln\.|Drive|Dr\.|Way|Court|Ct\.|Place|Pl\.|Suite|Ste\.|Apt\.|Apartment)\b[A-Za-z0-9 .,#/-]{0,80})"?'
+prefilter = ["address", "street", "shipping", "billing"]
+category = "pii"
+label = "STREET_ADDRESS"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?i)\b(?:date[ _-]?of[ _-]?birth|birth[ _-]?date|dob)\b\s*[:=]\s*"?([0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2}|[0-9]{1,2}[-/][0-9]{1,2}[-/][0-9]{2,4})"?'
+prefilter = ["birth", "dob"]
+category = "pii"
+label = "DATE_OF_BIRTH"
+confidence = "medium"
+capture = 1

--- a/extensions/openai-privacy-filter/config.toml
+++ b/extensions/openai-privacy-filter/config.toml
@@ -1,0 +1,67 @@
+# Runtime-free privacy filter for agent/tool text.
+# This bundles conservative NER-style PII rules without requiring Python, Node,
+# a model server, or OS-specific OCR/NER components.
+
+[[detector]]
+pattern = '(?i)\b(?:full[ _-]?name|legal[ _-]?name|display[ _-]?name|customer[ _-]?name|patient[ _-]?name|recipient[ _-]?name|contact[ _-]?name|person[ _-]?name)\b\s*[:=]\s*"?([A-Za-z][A-Za-z.-]{1,31}(?:[ \t]+[A-Za-z][A-Za-z.-]{1,31}){1,3})"?'
+prefilter = ["name"]
+category = "pii"
+label = "PERSON_NAME"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?i)\b(?:company|organization|organisation|employer|vendor|customer|client|legal[ _-]?entity)\b\s*[:=]\s*"?([A-Za-z0-9&., -]{2,80}\b(?:Corporation|Corp\.?|Company|Co\.|Limited|Ltd\.?|LLC|Inc\.?|GmbH|SAS|Pte\. Ltd\.|K\.K\.))"?'
+prefilter = ["company", "organization", "organisation", "employer", "vendor", "customer", "client", "entity"]
+category = "pii"
+label = "ORGANIZATION"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?i)\b(?:street[ _-]?address|address|shipping[ _-]?address|billing[ _-]?address|home[ _-]?address)\b\s*[:=]\s*"?([0-9]{1,6}[A-Za-z0-9 .,#/-]{5,120}\b(?:Street|St\.|Avenue|Ave\.|Road|Rd\.|Boulevard|Blvd\.|Lane|Ln\.|Drive|Dr\.|Way|Court|Ct\.|Place|Pl\.|Suite|Ste\.|Apt\.|Apartment)\b[A-Za-z0-9 .,#/-]{0,80})"?'
+prefilter = ["address", "street", "shipping", "billing"]
+category = "pii"
+label = "STREET_ADDRESS"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?i)\b(?:date[ _-]?of[ _-]?birth|birth[ _-]?date|dob)\b\s*[:=]\s*"?([0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2}|[0-9]{1,2}[-/][0-9]{1,2}[-/][0-9]{2,4})"?'
+prefilter = ["birth", "dob"]
+category = "pii"
+label = "DATE_OF_BIRTH"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?:氏名|名前|お名前|担当者|顧客名|利用者名)\s*[:：=]\s*"?([\p{Han}\p{Hiragana}\p{Katakana}ー々]{2,12}(?:[ 　][\p{Han}\p{Hiragana}\p{Katakana}ー々]{1,12})?)"?'
+prefilter = ["氏名", "名前", "お名前", "担当者", "顧客名", "利用者名"]
+category = "pii"
+label = "JP_PERSON_NAME"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?:会社名|法人名|組織名|勤務先)\s*[:：=]\s*"?((?:株式会社|合同会社|有限会社)[\p{Han}\p{Hiragana}\p{Katakana}A-Za-z0-9ー・ 　]{2,40}|[\p{Han}\p{Hiragana}\p{Katakana}A-Za-z0-9ー・ 　]{2,40}(?:株式会社|合同会社|有限会社))"?'
+prefilter = ["会社名", "法人名", "組織名", "勤務先", "株式会社", "合同会社", "有限会社"]
+category = "pii"
+label = "JP_ORGANIZATION"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?:住所|所在地|送付先|配送先)\s*[:：=]\s*"?(?:〒\s*[0-9０-９]{3}-?[0-9０-９]{4}[ 　]*)?((?:東京都|北海道|(?:京都|大阪)府|[\p{Han}]{2,3}県)[\p{Han}\p{Hiragana}\p{Katakana}0-9０-９ー丁目番地号\-－の 　]{4,80})"?'
+prefilter = ["住所", "所在地", "送付先", "配送先"]
+category = "pii"
+label = "JP_ADDRESS"
+confidence = "medium"
+capture = 1
+
+[[detector]]
+pattern = '(?:生年月日|誕生日)\s*[:：=]\s*"?([0-9０-９]{4}年[0-9０-９]{1,2}月[0-9０-９]{1,2}日|[0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2})"?'
+prefilter = ["生年月日", "誕生日"]
+category = "pii"
+label = "JP_DATE_OF_BIRTH"
+confidence = "medium"
+capture = 1


### PR DESCRIPTION
## Summary
- add official runtime-free extensions: openai-privacy-filter, ner-lite, jp-pii
- keep rules context-gated to avoid bare NER-style overmasking
- allow empty project extension dirs to fall back to official extensions

## Test
- cargo fmt --all -- --check
- cargo test -p pentect-cli extensions --locked
- cargo run -p pentect-cli --locked -- extensions list
- cargo clippy -p pentect-cli -p pentect-runtime --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new privacy/PII detection options for Japanese data, lightweight NER-style fields, and a runtime-free privacy filter.
  * Included these new extensions in the available extension list.

* **Bug Fixes**
  * Improved extension discovery so an empty local extension folder no longer hides a matching official extension.
  * Made extension lookup errors clearer when no valid configuration is found, with more helpful guidance on what’s missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->