### PR TITLE
Fix scan and adapter stability gaps

### DIFF
--- a/crates/pentect-cli/src/extensions_cmd.rs
+++ b/crates/pentect-cli/src/extensions_cmd.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use serde_json::json;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
+use std::process::{Child, ChildStdin, ChildStdout, Command, ExitStatus, Stdio};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -292,21 +292,20 @@ impl AdapterFile {
             .take()
             .ok_or_else(|| format!("{}: stdout", self.name))?;
         let stdout_reader = spawn_adapter_stdout_reader(stdout);
-        if let Some(mut stdin) = child.stdin.take() {
-            if let Err(e) = stdin.write_all(request.as_bytes()) {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = join_adapter_stdout(stdout_reader, &self.name);
-                return Err(format!("{}: {e}", self.name));
-            }
-        }
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| format!("{}: stdin", self.name))?;
+        let stdin_writer = spawn_adapter_stdin_writer(stdin, request.as_bytes().to_vec());
         let status = match wait_for_adapter_child(&mut child, &self.name, self.timeout) {
             Ok(status) => status,
             Err(err) => {
+                let _ = join_adapter_stdin(stdin_writer, &self.name);
                 let _ = join_adapter_stdout(stdout_reader, &self.name);
                 return Err(err);
             }
         };
+        join_adapter_stdin(stdin_writer, &self.name)?;
         let stdout = join_adapter_stdout(stdout_reader, &self.name)?;
         if stdout.len() > MAX_STDOUT_BYTES {
             return Err(format!("{}: output limit", self.name));
@@ -326,6 +325,13 @@ impl AdapterFile {
         }
         Ok(count)
     }
+}
+
+fn spawn_adapter_stdin_writer(
+    mut stdin: ChildStdin,
+    request: Vec<u8>,
+) -> JoinHandle<Result<(), String>> {
+    std::thread::spawn(move || stdin.write_all(&request).map_err(|e| format!("stdin: {e}")))
 }
 
 fn spawn_adapter_stdout_reader(stdout: ChildStdout) -> JoinHandle<Result<Vec<u8>, String>> {
@@ -361,6 +367,13 @@ fn wait_for_adapter_child(
             }
         }
     }
+}
+
+fn join_adapter_stdin(writer: JoinHandle<Result<(), String>>, name: &str) -> Result<(), String> {
+    writer
+        .join()
+        .map_err(|_| format!("{name}: stdin writer panicked"))?
+        .map_err(|e| format!("{name}: {e}"))
 }
 
 fn join_adapter_stdout(

--- a/crates/pentect-cli/src/extensions_cmd.rs
+++ b/crates/pentect-cli/src/extensions_cmd.rs
@@ -2,9 +2,10 @@ use crate::extensions;
 use pentect_core::load_pack;
 use serde::Deserialize;
 use serde_json::json;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 const PENTECT_DIR: &str = ".pentect";
@@ -15,6 +16,7 @@ const EXTENSION_NAME_ENV: &str = "PENTECT_EXTENSION_NAME";
 const EXTENSION_DATA_DIR_ENV: &str = "PENTECT_EXTENSION_DATA_DIR";
 const EXTENSION_CACHE_DIR_ENV: &str = "PENTECT_EXTENSION_CACHE_DIR";
 const EXTENSION_CONFIG_ENV: &str = "PENTECT_EXTENSION_CONFIG";
+const MAX_STDOUT_BYTES: usize = 1024 * 1024;
 
 pub(crate) fn cmd_extensions(args: &[String]) {
     let opts = match ExtensionCmd::parse(args) {
@@ -285,30 +287,35 @@ impl AdapterFile {
             .stdout(Stdio::piped())
             .stderr(Stdio::null());
         let mut child = command.spawn().map_err(|e| format!("{}: {e}", self.name))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| format!("{}: stdout", self.name))?;
+        let stdout_reader = spawn_adapter_stdout_reader(stdout);
         if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(request.as_bytes())
-                .map_err(|e| format!("{}: {e}", self.name))?;
-        }
-        let start = Instant::now();
-        loop {
-            match child.try_wait() {
-                Ok(Some(status)) if status.success() => break,
-                Ok(Some(status)) => return Err(format!("{}: {status}", self.name)),
-                Ok(None) if start.elapsed() >= self.timeout => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(format!("{}: timeout", self.name));
-                }
-                Ok(None) => std::thread::sleep(Duration::from_millis(5)),
-                Err(e) => return Err(format!("{}: {e}", self.name)),
+            if let Err(e) = stdin.write_all(request.as_bytes()) {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = join_adapter_stdout(stdout_reader, &self.name);
+                return Err(format!("{}: {e}", self.name));
             }
         }
-        let output = child
-            .wait_with_output()
-            .map_err(|e| format!("{}: {e}", self.name))?;
+        let status = match wait_for_adapter_child(&mut child, &self.name, self.timeout) {
+            Ok(status) => status,
+            Err(err) => {
+                let _ = join_adapter_stdout(stdout_reader, &self.name);
+                return Err(err);
+            }
+        };
+        let stdout = join_adapter_stdout(stdout_reader, &self.name)?;
+        if stdout.len() > MAX_STDOUT_BYTES {
+            return Err(format!("{}: output limit", self.name));
+        }
+        if !status.success() {
+            return Err(format!("{}: {status}", self.name));
+        }
         let value: serde_json::Value =
-            serde_json::from_slice(&output.stdout).map_err(|e| format!("{}: {e}", self.name))?;
+            serde_json::from_slice(&stdout).map_err(|e| format!("{}: {e}", self.name))?;
         let count = value
             .get("spans")
             .and_then(|spans| spans.as_array())
@@ -319,6 +326,51 @@ impl AdapterFile {
         }
         Ok(count)
     }
+}
+
+fn spawn_adapter_stdout_reader(stdout: ChildStdout) -> JoinHandle<Result<Vec<u8>, String>> {
+    std::thread::spawn(move || {
+        let mut stdout = stdout.take(MAX_STDOUT_BYTES as u64 + 1);
+        let mut out = Vec::new();
+        stdout
+            .read_to_end(&mut out)
+            .map_err(|e| format!("stdout: {e}"))?;
+        Ok(out)
+    })
+}
+
+fn wait_for_adapter_child(
+    child: &mut Child,
+    name: &str,
+    timeout: Duration,
+) -> Result<ExitStatus, String> {
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) if start.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("{name}: timeout"));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(5)),
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("{name}: {e}"));
+            }
+        }
+    }
+}
+
+fn join_adapter_stdout(
+    reader: JoinHandle<Result<Vec<u8>, String>>,
+    name: &str,
+) -> Result<Vec<u8>, String> {
+    reader
+        .join()
+        .map_err(|_| format!("{name}: stdout reader panicked"))?
+        .map_err(|e| format!("{name}: {e}"))
 }
 
 fn adapter_command_from_manifest(command: Option<Vec<String>>) -> Result<Vec<String>, String> {
@@ -563,14 +615,28 @@ impl Check {
 
 fn adapter_program(program: &str, cwd: &Path) -> PathBuf {
     let path = Path::new(program);
-    if path.is_absolute() || !looks_like_path_command(program) {
+    if path.is_absolute() {
         return path.to_path_buf();
     }
-    cwd.join(path)
+    if looks_like_path_command(program) {
+        return cwd.join(path);
+    }
+    adapter_sidecar_program(program).unwrap_or_else(|| path.to_path_buf())
 }
 
 fn looks_like_path_command(program: &str) -> bool {
     program.contains('/') || program.contains('\\')
+}
+
+fn adapter_sidecar_program(program: &str) -> Option<PathBuf> {
+    let dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
+    for name in command_names(program) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 fn find_command(path: &Path) -> Option<PathBuf> {

--- a/crates/pentect-cli/src/scan/engine.rs
+++ b/crates/pentect-cli/src/scan/engine.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 
 const ENGINE_NAME: &str = "pentect";
-const MAX_SCAN_FILE_BYTES: u64 = 1024 * 1024;
+const MAX_SCAN_FILE_BYTES: u64 = 16 * 1024 * 1024;
 
 pub(super) fn scan_files(
     files: Vec<PathBuf>,
@@ -322,10 +322,13 @@ fn scan_file_with_engine(engine: &Engine, path: &Path, binary: BinaryMode) -> Sc
     };
     let kind = infer_kind(path);
     let line_index = LineIndex::new(&data);
-    let result = engine.analyze_spans(Input {
-        kind: kind.clone(),
-        data,
-    });
+    let result = engine.analyze_spans_with_path(
+        Input {
+            kind: kind.clone(),
+            data,
+        },
+        path.to_string_lossy().into_owned(),
+    );
     let hits = result
         .spans
         .iter()

--- a/crates/pentect-core/src/lib.rs
+++ b/crates/pentect-core/src/lib.rs
@@ -81,8 +81,21 @@ pub fn infer_kind(path: &std::path::Path) -> Kind {
         .as_deref()
     {
         Some("json") => Kind::Json,
+        Some("jsonl" | "ndjson") => Kind::Ndjson,
         Some("env") => Kind::Env,
         Some("har") => Kind::Har,
         _ => Kind::Text,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn infer_kind_recognizes_json_lines_files() {
+        assert_eq!(infer_kind(Path::new("events.jsonl")), Kind::Ndjson);
+        assert_eq!(infer_kind(Path::new("events.ndjson")), Kind::Ndjson);
     }
 }

--- a/crates/pentect-core/src/parse/json.rs
+++ b/crates/pentect-core/src/parse/json.rs
@@ -12,10 +12,26 @@ use memchr::memchr2;
 const MAX_DEPTH: usize = 128;
 
 pub fn parse_json_regions(raw: &str) -> Option<Vec<Region>> {
-    parse_json_regions_with(raw, JsonRegionMode::Json)
+    parse_json_regions_with(raw, JsonRegionMode::Json, false)
 }
 
 pub fn parse_ndjson_regions(raw: &str) -> Option<Vec<Region>> {
+    parse_ndjson_regions_with(raw, false)
+}
+
+pub(crate) fn parse_json_analysis_regions(raw: &str) -> Option<Vec<Region>> {
+    parse_json_regions_with(raw, JsonRegionMode::Json, true)
+}
+
+pub(crate) fn parse_ndjson_analysis_regions(raw: &str) -> Option<Vec<Region>> {
+    parse_ndjson_regions_with(raw, true)
+}
+
+pub(crate) fn parse_tool_result_analysis_regions(raw: &str) -> Option<Vec<Region>> {
+    parse_json_regions_with(raw, JsonRegionMode::ToolResult, true)
+}
+
+fn parse_ndjson_regions_with(raw: &str, include_primitives: bool) -> Option<Vec<Region>> {
     let mut out = Vec::new();
     let mut start = 0usize;
     let mut saw_line = false;
@@ -30,7 +46,8 @@ pub fn parse_ndjson_regions(raw: &str) -> Option<Vec<Region>> {
         let line = &raw[start..end];
         if !line.trim().is_empty() {
             saw_line = true;
-            let mut regions = parse_json_regions(line)?;
+            let mut regions =
+                parse_json_regions_with(line, JsonRegionMode::Json, include_primitives)?;
             for region in &mut regions {
                 region.span.start += start;
                 region.span.end += start;
@@ -46,15 +63,20 @@ pub fn parse_ndjson_regions(raw: &str) -> Option<Vec<Region>> {
 }
 
 pub fn parse_tool_result_regions(raw: &str) -> Option<Vec<Region>> {
-    parse_json_regions_with(raw, JsonRegionMode::ToolResult)
+    parse_json_regions_with(raw, JsonRegionMode::ToolResult, false)
 }
 
-fn parse_json_regions_with(raw: &str, mode: JsonRegionMode) -> Option<Vec<Region>> {
+fn parse_json_regions_with(
+    raw: &str,
+    mode: JsonRegionMode,
+    include_primitives: bool,
+) -> Option<Vec<Region>> {
     let mut p = Parser {
         b: raw.as_bytes(),
         i: 0,
         out: Vec::new(),
         mode,
+        include_primitives,
     };
     if p.b.starts_with(&[0xef, 0xbb, 0xbf]) {
         p.i = 3;
@@ -79,6 +101,7 @@ struct Parser<'a> {
     i: usize,
     out: Vec<Region>,
     mode: JsonRegionMode,
+    include_primitives: bool,
 }
 
 impl Parser<'_> {
@@ -121,7 +144,7 @@ impl Parser<'_> {
             b't' => self.literal(b"true"),
             b'f' => self.literal(b"false"),
             b'n' => self.literal(b"null"),
-            _ => self.number(),
+            _ => self.number(key, hints),
         }
     }
 
@@ -262,7 +285,7 @@ impl Parser<'_> {
         }
     }
 
-    fn number(&mut self) -> Option<()> {
+    fn number(&mut self, key: Option<String>, hints: Vec<String>) -> Option<()> {
         let start = self.i;
         if self.b.get(self.i) == Some(&b'-') {
             self.i += 1;
@@ -277,6 +300,18 @@ impl Parser<'_> {
         if self.i == start {
             None
         } else {
+            if self.include_primitives {
+                self.out.push(Region {
+                    span: ByteRange::new(start, self.i),
+                    ctx: Context {
+                        path: None,
+                        key,
+                        hints,
+                        kind: RegionKind::JsonValue,
+                        format: self.format(),
+                    },
+                });
+            }
             Some(())
         }
     }
@@ -398,6 +433,17 @@ mod tests {
             got,
             [(Some("password"), "hunter2"), (Some("token"), "abc123")]
         );
+    }
+
+    #[test]
+    fn analysis_regions_include_numeric_values_with_key_context() {
+        let raw = r#"{"otp":100482,"name":"demo"}"#;
+        let regions = parse_json_analysis_regions(raw).unwrap();
+        let got = regions
+            .iter()
+            .map(|r| (r.ctx.key.as_deref(), &raw[r.span.start..r.span.end]))
+            .collect::<Vec<_>>();
+        assert_eq!(got, [(Some("otp"), "100482"), (Some("name"), "demo")]);
     }
 
     #[test]

--- a/crates/pentect-core/src/parse/mod.rs
+++ b/crates/pentect-core/src/parse/mod.rs
@@ -49,6 +49,15 @@ impl Parser for ToolResultParser {
     }
 }
 
+pub(crate) fn analysis_regions_for_kind(raw: &str, kind: &Kind) -> Option<Vec<Region>> {
+    match kind {
+        Kind::Json | Kind::Har => json::parse_json_analysis_regions(raw),
+        Kind::Ndjson => json::parse_ndjson_analysis_regions(raw),
+        Kind::ToolResult => json::parse_tool_result_analysis_regions(raw),
+        _ => None,
+    }
+}
+
 /// Parses `.env` / KEY=VALUE lines into one region per value, tagged with its
 /// key, so key-anchored detection works on the highest-yield leak format. Keys,
 /// `=`, quotes, comments, and newlines stay outside regions and are preserved.

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -226,12 +226,45 @@ impl Engine {
     }
 
     pub fn analyze_spans(&self, input: Input) -> SpanAnalysisResult {
-        let (ir, fell_back) = self.parse(input);
+        let kind = input.kind.clone();
+        let (mut ir, fell_back) = self.parse(input);
+        self.replace_analysis_regions(&mut ir, &kind, fell_back);
         let (spans, residual) = self.masked_spans(&ir);
         SpanAnalysisResult {
             spans,
             residual,
             parser_fallback: fell_back,
+        }
+    }
+
+    pub fn analyze_spans_with_path(
+        &self,
+        input: Input,
+        path: impl Into<String>,
+    ) -> SpanAnalysisResult {
+        let path = path.into();
+        let kind = input.kind.clone();
+        let (mut ir, fell_back) = self.parse(input);
+        self.replace_analysis_regions(&mut ir, &kind, fell_back);
+        for region in &mut ir.regions {
+            if region.ctx.path.is_none() {
+                region.ctx.path = Some(path.clone());
+            }
+        }
+        let (spans, residual) = self.masked_spans(&ir);
+        SpanAnalysisResult {
+            spans,
+            residual,
+            parser_fallback: fell_back,
+        }
+    }
+
+    fn replace_analysis_regions(&self, ir: &mut Ir, kind: &Kind, fell_back: bool) {
+        if fell_back {
+            return;
+        }
+        if let Some(regions) = crate::parse::analysis_regions_for_kind(&ir.raw, kind) {
+            ir.regions = regions;
         }
     }
 
@@ -927,6 +960,32 @@ mod tests {
         assert!(r.masked.contains("<<PASSWORD_"), "{}", r.masked);
         assert!(r.masked.contains("<<TOKEN_"), "{}", r.masked);
         assert_eq!(restore(&r.masked, &r.recovery).unwrap(), input);
+    }
+
+    #[test]
+    fn analyze_spans_checks_numeric_json_values_without_changing_mask_output() {
+        let input = r#"{"otp":100482,"ok":1}"#;
+        let engine = Engine::with_profile(Profile::Strict);
+        let result = engine.analyze_spans(Input {
+            kind: Kind::Json,
+            data: input.to_string(),
+        });
+        assert!(
+            result.spans.iter().any(|span| span.label == labels::OTP
+                && &input[span.range.start..span.range.end] == "100482"),
+            "{:?}",
+            result.spans
+        );
+
+        let masked = engine.mask(
+            Input {
+                kind: Kind::Json,
+                data: input.to_string(),
+            },
+            &Config::insecure_testing(),
+        );
+        serde_json::from_str::<serde_json::Value>(&masked.masked)
+            .expect("regular JSON masking keeps JSON valid");
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -226,9 +226,7 @@ impl Engine {
     }
 
     pub fn analyze_spans(&self, input: Input) -> SpanAnalysisResult {
-        let kind = input.kind.clone();
-        let (mut ir, fell_back) = self.parse(input);
-        self.replace_analysis_regions(&mut ir, &kind, fell_back);
+        let (ir, fell_back) = self.parse_for_analysis(input);
         let (spans, residual) = self.masked_spans(&ir);
         SpanAnalysisResult {
             spans,
@@ -243,9 +241,7 @@ impl Engine {
         path: impl Into<String>,
     ) -> SpanAnalysisResult {
         let path = path.into();
-        let kind = input.kind.clone();
-        let (mut ir, fell_back) = self.parse(input);
-        self.replace_analysis_regions(&mut ir, &kind, fell_back);
+        let (mut ir, fell_back) = self.parse_for_analysis(input);
         for region in &mut ir.regions {
             if region.ctx.path.is_none() {
                 region.ctx.path = Some(path.clone());
@@ -256,15 +252,6 @@ impl Engine {
             spans,
             residual,
             parser_fallback: fell_back,
-        }
-    }
-
-    fn replace_analysis_regions(&self, ir: &mut Ir, kind: &Kind, fell_back: bool) {
-        if fell_back {
-            return;
-        }
-        if let Some(regions) = crate::parse::analysis_regions_for_kind(&ir.raw, kind) {
-            ir.regions = regions;
         }
     }
 
@@ -475,7 +462,36 @@ impl Engine {
     /// fallback.
     fn parse(&self, input: Input) -> (Ir, bool) {
         let Input { kind, data: raw } = input;
+        self.parse_raw(kind, raw)
+    }
+
+    fn parse_for_analysis(&self, input: Input) -> (Ir, bool) {
+        let Input { kind, data: raw } = input;
         let protected = scan_placeholders(&raw);
+        if let Some(regions) = crate::parse::analysis_regions_for_kind(&raw, &kind) {
+            return (
+                Ir {
+                    raw,
+                    regions,
+                    protected,
+                },
+                false,
+            );
+        }
+        self.parse_raw_with_protected(kind, raw, protected)
+    }
+
+    fn parse_raw(&self, kind: Kind, raw: String) -> (Ir, bool) {
+        let protected = scan_placeholders(&raw);
+        self.parse_raw_with_protected(kind, raw, protected)
+    }
+
+    fn parse_raw_with_protected(
+        &self,
+        kind: Kind,
+        raw: String,
+        protected: Vec<ByteRange>,
+    ) -> (Ir, bool) {
         let (regions, fell_back) = match self.parsers.iter().find(|(k, _)| *k == kind) {
             Some((_, p)) => match p.parse(&raw) {
                 Some(regions) => (regions, false),

--- a/crates/pentect-runtime/src/extension_adapter.rs
+++ b/crates/pentect-runtime/src/extension_adapter.rs
@@ -5,7 +5,7 @@ use pentect_core::{
 use serde::Deserialize;
 use serde_json::json;
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
+use std::process::{Child, ChildStdin, ChildStdout, Command, ExitStatus, Stdio};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -181,29 +181,21 @@ impl ModelAdapter {
             )
         })?;
         let stdout_reader = spawn_adapter_stdout_reader(stdout);
-        {
-            let mut stdin = child.stdin.take().ok_or_else(|| {
-                format!("could not open stdin for extension adapter '{}'", self.name)
-            })?;
-            use std::io::Write as _;
-            if let Err(e) = stdin.write_all(request.as_bytes()) {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = join_adapter_stdout(stdout_reader, &self.name);
-                return Err(format!(
-                    "could not write to extension adapter '{}': {e}",
-                    self.name
-                ));
-            }
-        }
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| format!("could not open stdin for extension adapter '{}'", self.name))?;
+        let stdin_writer = spawn_adapter_stdin_writer(stdin, request.as_bytes().to_vec());
 
         let status = match wait_for_adapter_child(&mut child, &self.name, self.timeout) {
             Ok(status) => status,
             Err(err) => {
+                let _ = join_adapter_stdin(stdin_writer, &self.name);
                 let _ = join_adapter_stdout(stdout_reader, &self.name);
                 return Err(err);
             }
         };
+        join_adapter_stdin(stdin_writer, &self.name)?;
         let stdout = join_adapter_stdout(stdout_reader, &self.name)?;
         if stdout.len() > MAX_STDOUT_BYTES {
             return Err(format!(
@@ -224,6 +216,18 @@ impl ModelAdapter {
             )
         })
     }
+}
+
+fn spawn_adapter_stdin_writer(
+    mut stdin: ChildStdin,
+    request: Vec<u8>,
+) -> JoinHandle<Result<(), String>> {
+    std::thread::spawn(move || {
+        use std::io::Write as _;
+        stdin
+            .write_all(&request)
+            .map_err(|e| format!("could not write adapter stdin: {e}"))
+    })
 }
 
 fn spawn_adapter_stdout_reader(stdout: ChildStdout) -> JoinHandle<Result<Vec<u8>, String>> {
@@ -262,6 +266,13 @@ fn wait_for_adapter_child(
             }
         }
     }
+}
+
+fn join_adapter_stdin(writer: JoinHandle<Result<(), String>>, name: &str) -> Result<(), String> {
+    writer
+        .join()
+        .map_err(|_| format!("extension adapter '{name}' stdin writer panicked"))?
+        .map_err(|e| format!("extension adapter '{name}' {e}"))
 }
 
 fn join_adapter_stdout(

--- a/crates/pentect-runtime/src/extension_adapter.rs
+++ b/crates/pentect-runtime/src/extension_adapter.rs
@@ -5,7 +5,8 @@ use pentect_core::{
 use serde::Deserialize;
 use serde_json::json;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 pub(crate) const ADAPTERS_ENV: &str = "PENTECT_EXTENSION_ADAPTERS";
@@ -91,21 +92,17 @@ impl ModelAdapter {
             .map_err(|e| format!("could not read extension adapter '{}': {e}", path.display()))?;
         let file: AdapterFile = toml::from_str(&src)
             .map_err(|e| format!("extension adapter '{}' is invalid: {e}", path.display()))?;
-        if let Some(schema) = &file.schema {
-            if schema != "pentect.model_adapter.v1" {
-                return Err(format!(
-                    "extension adapter '{}' has unsupported schema: {schema}",
-                    path.display()
-                ));
-            }
+        if file.schema.as_deref() != Some("pentect.model_adapter.v1") {
+            return Err(format!(
+                "extension adapter '{}' requires schema = \"pentect.model_adapter.v1\"",
+                path.display()
+            ));
         }
-        if let Some(kind) = &file.kind {
-            if kind != "model" {
-                return Err(format!(
-                    "extension adapter '{}' has unsupported kind: {kind}",
-                    path.display()
-                ));
-            }
+        if file.kind.as_deref() != Some("model") {
+            return Err(format!(
+                "extension adapter '{}' requires kind = \"model\"",
+                path.display()
+            ));
         }
         let command = adapter_command_from_file(path, file.command)?;
         let name = file
@@ -177,64 +174,104 @@ impl ModelAdapter {
         let mut child = cmd
             .spawn()
             .map_err(|e| format!("could not start extension adapter '{}': {e}", self.name))?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            format!(
+                "could not open stdout for extension adapter '{}'",
+                self.name
+            )
+        })?;
+        let stdout_reader = spawn_adapter_stdout_reader(stdout);
         {
             let mut stdin = child.stdin.take().ok_or_else(|| {
                 format!("could not open stdin for extension adapter '{}'", self.name)
             })?;
             use std::io::Write as _;
-            stdin.write_all(request.as_bytes()).map_err(|e| {
-                format!("could not write to extension adapter '{}': {e}", self.name)
-            })?;
-        }
-
-        let start = Instant::now();
-        loop {
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    if !status.success() {
-                        return Err(format!(
-                            "extension adapter '{}' exited with status {status}",
-                            self.name
-                        ));
-                    }
-                    break;
-                }
-                Ok(None) if start.elapsed() >= self.timeout => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(format!("extension adapter '{}' timed out", self.name));
-                }
-                Ok(None) => std::thread::sleep(Duration::from_millis(5)),
-                Err(e) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(format!(
-                        "could not wait for extension adapter '{}': {e}",
-                        self.name
-                    ));
-                }
+            if let Err(e) = stdin.write_all(request.as_bytes()) {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = join_adapter_stdout(stdout_reader, &self.name);
+                return Err(format!(
+                    "could not write to extension adapter '{}': {e}",
+                    self.name
+                ));
             }
         }
 
-        let output = child.wait_with_output().map_err(|e| {
-            format!(
-                "could not read stdout from extension adapter '{}': {e}",
-                self.name
-            )
-        })?;
-        if output.stdout.len() > MAX_STDOUT_BYTES {
+        let status = match wait_for_adapter_child(&mut child, &self.name, self.timeout) {
+            Ok(status) => status,
+            Err(err) => {
+                let _ = join_adapter_stdout(stdout_reader, &self.name);
+                return Err(err);
+            }
+        };
+        let stdout = join_adapter_stdout(stdout_reader, &self.name)?;
+        if stdout.len() > MAX_STDOUT_BYTES {
             return Err(format!(
                 "extension adapter '{}' returned too much output",
                 self.name
             ));
         }
-        String::from_utf8(output.stdout).map_err(|e| {
+        if !status.success() {
+            return Err(format!(
+                "extension adapter '{}' exited with status {status}",
+                self.name
+            ));
+        }
+        String::from_utf8(stdout).map_err(|e| {
             format!(
                 "extension adapter '{}' returned non-UTF-8 output: {e}",
                 self.name
             )
         })
     }
+}
+
+fn spawn_adapter_stdout_reader(stdout: ChildStdout) -> JoinHandle<Result<Vec<u8>, String>> {
+    std::thread::spawn(move || {
+        use std::io::Read as _;
+        let mut stdout = stdout.take(MAX_STDOUT_BYTES as u64 + 1);
+        let mut out = Vec::new();
+        stdout
+            .read_to_end(&mut out)
+            .map_err(|e| format!("could not read adapter stdout: {e}"))?;
+        Ok(out)
+    })
+}
+
+fn wait_for_adapter_child(
+    child: &mut Child,
+    name: &str,
+    timeout: Duration,
+) -> Result<ExitStatus, String> {
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) if start.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("extension adapter '{name}' timed out"));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(5)),
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "could not wait for extension adapter '{name}': {e}"
+                ));
+            }
+        }
+    }
+}
+
+fn join_adapter_stdout(
+    reader: JoinHandle<Result<Vec<u8>, String>>,
+    name: &str,
+) -> Result<Vec<u8>, String> {
+    reader
+        .join()
+        .map_err(|_| format!("extension adapter '{name}' stdout reader panicked"))?
+        .map_err(|e| format!("extension adapter '{name}' {e}"))
 }
 
 fn apply_adapter_child_env(command: &mut Command, id_or_name: &str) -> Result<(), String> {
@@ -300,14 +337,46 @@ fn adapter_default_name(path: &Path) -> String {
 
 fn adapter_program(program: &str, cwd: &Path) -> PathBuf {
     let path = Path::new(program);
-    if path.is_absolute() || !looks_like_path_command(program) {
+    if path.is_absolute() {
         return path.to_path_buf();
     }
-    cwd.join(path)
+    if looks_like_path_command(program) {
+        return cwd.join(path);
+    }
+    adapter_sidecar_program(program).unwrap_or_else(|| path.to_path_buf())
 }
 
 fn looks_like_path_command(program: &str) -> bool {
     program.contains('/') || program.contains('\\')
+}
+
+fn adapter_sidecar_program(program: &str) -> Option<PathBuf> {
+    let dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
+    for name in command_names(program) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn command_names(name: &str) -> Vec<String> {
+    if Path::new(name).extension().is_some() {
+        return vec![name.to_string()];
+    }
+    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+    pathext
+        .split(';')
+        .filter(|ext| !ext.is_empty())
+        .map(|ext| format!("{name}{ext}"))
+        .collect()
+}
+
+#[cfg(not(windows))]
+fn command_names(name: &str) -> Vec<String> {
+    vec![name.to_string()]
 }
 
 fn extension_id(value: &str) -> String {
@@ -580,6 +649,31 @@ builtin = "pii-ner"
         let err = ModelAdapter::load(&path).unwrap_err();
         std::fs::remove_dir_all(root).unwrap();
         assert!(err.contains("unknown field `builtin`"), "{err}");
+    }
+
+    #[test]
+    fn adapter_manifest_requires_schema_and_kind() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-adapter-requires-schema-kind-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("adapter.toml");
+        std::fs::write(
+            &path,
+            r#"
+name = "bad"
+command = ["pentect-pii-ner"]
+"#,
+        )
+        .unwrap();
+        let err = ModelAdapter::load(&path).unwrap_err();
+        std::fs::remove_dir_all(root).unwrap();
+        assert!(
+            err.contains("requires schema = \"pentect.model_adapter.v1\""),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -1,7 +1,9 @@
 use crate::config::ImageOcrConfig;
 #[cfg(feature = "ocr")]
 use crate::config::{image_ocr_config, ImageOcrMode, ImageRedactionStyle};
+#[cfg(any(feature = "ocr", test))]
 use pentect_core::model::labels;
+#[cfg(any(feature = "ocr", test))]
 use pentect_core::ByteRange;
 use serde_json::Value;
 #[cfg(feature = "ocr")]
@@ -65,6 +67,7 @@ struct RedactedImagePayload {
     mime_type: &'static str,
 }
 
+#[cfg(feature = "ocr")]
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct NormalizedImageRect {
     left: f32,
@@ -73,6 +76,7 @@ struct NormalizedImageRect {
     bottom: f32,
 }
 
+#[cfg(feature = "ocr")]
 #[derive(Clone, Debug)]
 struct ImageTextRegion {
     text: String,
@@ -82,12 +86,17 @@ struct ImageTextRegion {
 #[derive(Clone, Debug)]
 struct ImageSecretFinding {
     labels: Vec<String>,
+    #[cfg(feature = "ocr")]
     rect: Option<NormalizedImageRect>,
+    #[cfg(feature = "ocr")]
     force_black: bool,
+    #[cfg(feature = "ocr")]
     pad_left: bool,
+    #[cfg(feature = "ocr")]
     redact_pixels: bool,
 }
 
+#[cfg(any(feature = "ocr", test))]
 #[derive(Clone, Debug)]
 struct ImageTextSecretHit {
     label: String,
@@ -154,8 +163,8 @@ pub(crate) fn skip_text_masking_for_image_field(key: &str, text: &str) -> bool {
     }
     matches!(
         normalized_json_key(key).as_str(),
-        "data" | "bytes" | "base64" | "content" | "imagedata" | "dataurl"
-    )
+        "data" | "bytes" | "base64" | "imagedata" | "dataurl"
+    ) && looks_like_base64_image_field_value(text)
 }
 
 pub(crate) fn inspect_tool_images_for_secrets(
@@ -716,6 +725,7 @@ impl ImageRedactionState {
     }
 }
 
+#[cfg(feature = "ocr")]
 fn image_regions_text(regions: &[ImageTextRegion]) -> String {
     let mut text = String::new();
     for region in regions {
@@ -1217,6 +1227,7 @@ fn byte_to_char_count(text: &str, byte: usize) -> usize {
     text[..end].chars().count()
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn floor_char_boundary(text: &str, mut byte: usize) -> usize {
     while byte > 0 && !text.is_char_boundary(byte) {
         byte -= 1;
@@ -1224,6 +1235,7 @@ fn floor_char_boundary(text: &str, mut byte: usize) -> usize {
     byte
 }
 
+#[cfg(feature = "ocr")]
 fn assignment_value_range_for_span(text: &str, range: ByteRange) -> Option<ByteRange> {
     if range.start >= text.len() || range.end <= range.start {
         return None;
@@ -1248,6 +1260,7 @@ fn assignment_value_range_for_span(text: &str, range: ByteRange) -> Option<ByteR
     out
 }
 
+#[cfg(feature = "ocr")]
 fn first_sensitive_assignment_value_range(text: &str) -> Option<ByteRange> {
     for (idx, ch) in text.char_indices() {
         if ch != '=' && ch != ':' {
@@ -1262,6 +1275,7 @@ fn first_sensitive_assignment_value_range(text: &str) -> Option<ByteRange> {
     None
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn sensitive_assignment_value_range(
     text: &str,
     line_start: usize,
@@ -1283,6 +1297,7 @@ fn sensitive_assignment_value_range(
     (value_end > value_start).then_some(ByteRange::new(value_start, value_end))
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn text_line_bounds(text: &str, byte: usize) -> (usize, usize) {
     let byte = floor_char_boundary(text, byte.min(text.len()));
     let start = text[..byte].rfind(['\r', '\n']).map_or(0, |idx| idx + 1);
@@ -1292,6 +1307,7 @@ fn text_line_bounds(text: &str, byte: usize) -> (usize, usize) {
     (start, end)
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn trim_ascii_ws_start(text: &str, mut start: usize, end: usize) -> usize {
     start = floor_char_boundary(text, start.min(text.len()));
     let end = floor_char_boundary(text, end.min(text.len()));
@@ -1301,6 +1317,7 @@ fn trim_ascii_ws_start(text: &str, mut start: usize, end: usize) -> usize {
     start
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn trim_ascii_ws_end(text: &str, start: usize, mut end: usize) -> usize {
     let start = floor_char_boundary(text, start.min(text.len()));
     end = floor_char_boundary(text, end.min(text.len()));
@@ -1315,6 +1332,7 @@ fn image_text_secret_labels(text: &str, key: &[u8; 32]) -> Vec<String> {
     labels_from_text_hits(&image_text_secret_hits(text, key))
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn image_text_secret_hits(text: &str, _key: &[u8; 32]) -> Vec<ImageTextSecretHit> {
     if text.trim().is_empty() {
         return Vec::new();
@@ -1346,6 +1364,7 @@ fn image_text_secret_hits(text: &str, _key: &[u8; 32]) -> Vec<ImageTextSecretHit
     hits
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn labels_from_text_hits(hits: &[ImageTextSecretHit]) -> Vec<String> {
     let mut labels = Vec::new();
     for hit in hits {
@@ -1361,6 +1380,7 @@ fn ocr_fragmented_secret_labels(text: &str) -> Vec<String> {
     labels_from_text_hits(&ocr_fragmented_secret_hits(text))
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn ocr_fragmented_secret_hits(text: &str) -> Vec<ImageTextSecretHit> {
     let mut labels = Vec::new();
     for (idx, ch) in text.char_indices() {
@@ -1385,6 +1405,7 @@ fn ocr_fragmented_secret_hits(text: &str) -> Vec<ImageTextSecretHit> {
     labels
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn ocr_fragmented_secret_label(before: &str, after: &str) -> Option<String> {
     let key_tokens = ocr_words(before);
     if !ocr_words_have_sensitive_key(&key_tokens) || !ocr_fragmented_value_has_secret_shape(after) {
@@ -1393,6 +1414,7 @@ fn ocr_fragmented_secret_label(before: &str, after: &str) -> Option<String> {
     Some(ocr_key_label(&key_tokens))
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn bounded_prefix(text: &str, byte_end: usize, max_chars: usize) -> &str {
     let end = byte_end.min(text.len());
     let mut starts = text[..end].char_indices().map(|(idx, _)| idx).rev();
@@ -1400,6 +1422,7 @@ fn bounded_prefix(text: &str, byte_end: usize, max_chars: usize) -> &str {
     &text[start..end]
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn bounded_suffix(text: &str, max_chars: usize) -> &str {
     match text.char_indices().nth(max_chars) {
         Some((idx, _)) => &text[..idx],
@@ -1407,6 +1430,7 @@ fn bounded_suffix(text: &str, max_chars: usize) -> &str {
     }
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn ocr_words(text: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut current = String::new();
@@ -1423,6 +1447,7 @@ fn ocr_words(text: &str) -> Vec<String> {
     out
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn ocr_words_have_sensitive_key(words: &[String]) -> bool {
     let mut has_material = false;
     let mut has_modifier = false;
@@ -1448,6 +1473,7 @@ fn ocr_words_have_sensitive_key(words: &[String]) -> bool {
                 .is_some_and(|word| matches!(word.as_str(), "PASSWORD" | "SECRET" | "TOKEN")))
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn ocr_fragmented_value_has_secret_shape(text: &str) -> bool {
     let mut ascii_alnum = 0usize;
     let mut ascii_alpha = 0usize;
@@ -1472,6 +1498,7 @@ fn ocr_fragmented_value_has_secret_shape(text: &str) -> bool {
     ascii_alnum >= 16 && ascii_alpha >= 4 && ascii_digit >= 4 && longest_run >= 6
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn ocr_key_label(words: &[String]) -> String {
     let mut relevant = words
         .iter()
@@ -1488,6 +1515,7 @@ fn ocr_key_label(words: &[String]) -> String {
     }
 }
 
+#[cfg(feature = "ocr")]
 impl NormalizedImageRect {
     #[cfg(feature = "ocr")]
     fn from_pixels(
@@ -1924,6 +1952,7 @@ fn resize_for_barcode(img: image::DynamicImage, max_edge: u32) -> image::Dynamic
     img.resize(max_edge, max_edge, image::imageops::FilterType::Triangle)
 }
 
+#[cfg(any(feature = "ocr", test))]
 fn image_ocr_secret_engine() -> &'static pentect_core::Engine {
     static ENGINE: std::sync::OnceLock<pentect_core::Engine> = std::sync::OnceLock::new();
     ENGINE.get_or_init(|| pentect_core::Engine::with_profile(pentect_core::Profile::Strict))
@@ -1989,6 +2018,15 @@ fn looks_like_base64_image(text: &str) -> bool {
         return false;
     }
     decode_base64_prefix(&compact).is_some_and(|prefix| image_signature(&prefix).is_some())
+}
+
+fn looks_like_base64_image_field_value(text: &str) -> bool {
+    let compact = compact_base64(text);
+    compact.len() >= 16
+        && compact.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(b, b'+' | b'/' | b'=' | b'-' | b'_' | b'\r' | b'\n')
+        })
 }
 
 fn decode_base64_limited(text: &str, max_bytes: u64) -> Result<Vec<u8>, String> {
@@ -2293,6 +2331,9 @@ fn remote_image_ip_is_private(ip: IpAddr) -> bool {
                 || ip.is_multicast()
         }
         IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4_mapped() {
+                return remote_image_ip_is_private(IpAddr::V4(mapped));
+            }
             ip.is_loopback()
                 || ip.is_unspecified()
                 || ip.is_unique_local()
@@ -2772,19 +2813,6 @@ fn ocr_image_regions_with_config(
 
 #[cfg(not(feature = "ocr"))]
 pub fn ocr_image_bytes(_bytes: &[u8]) -> Result<String, String> {
-    Err("image OCR requires a build with `--features ocr`".to_string())
-}
-
-#[cfg(not(feature = "ocr"))]
-fn ocr_image_bytes_with_config(_bytes: &[u8], _cfg: &ImageOcrConfig) -> Result<String, String> {
-    Err("image OCR requires a build with `--features ocr`".to_string())
-}
-
-#[cfg(not(feature = "ocr"))]
-fn ocr_image_regions_with_config(
-    _bytes: &[u8],
-    _cfg: &ImageOcrConfig,
-) -> Result<Vec<ImageTextRegion>, String> {
     Err("image OCR requires a build with `--features ocr`".to_string())
 }
 
@@ -3525,6 +3553,15 @@ mod tests {
             "169.254.169.254".parse().unwrap()
         ));
         assert!(remote_image_ip_is_private("10.0.0.1".parse().unwrap()));
+        assert!(remote_image_ip_is_private(
+            "::ffff:127.0.0.1".parse().unwrap()
+        ));
+        assert!(remote_image_ip_is_private(
+            "::ffff:10.0.0.1".parse().unwrap()
+        ));
+        assert!(!remote_image_ip_is_private(
+            "::ffff:8.8.8.8".parse().unwrap()
+        ));
         assert!(!remote_image_ip_is_private("8.8.8.8".parse().unwrap()));
     }
 

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -7,7 +7,7 @@ use pentect_core::model::labels;
 use pentect_core::ByteRange;
 use serde_json::Value;
 #[cfg(feature = "ocr")]
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 #[cfg(feature = "ocr")]
 const IMAGE_URL_MAX_REDIRECTS: usize = 5;
@@ -2334,6 +2334,9 @@ fn remote_image_ip_is_private(ip: IpAddr) -> bool {
             if let Some(mapped) = ip.to_ipv4_mapped() {
                 return remote_image_ip_is_private(IpAddr::V4(mapped));
             }
+            if let Some(embedded) = ipv6_embedded_ipv4(ip) {
+                return remote_image_ip_is_private(IpAddr::V4(embedded));
+            }
             ip.is_loopback()
                 || ip.is_unspecified()
                 || ip.is_unique_local()
@@ -2341,6 +2344,26 @@ fn remote_image_ip_is_private(ip: IpAddr) -> bool {
                 || ip.is_multicast()
         }
     }
+}
+
+#[cfg(feature = "ocr")]
+fn ipv6_embedded_ipv4(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    let octets = ip.octets();
+    if octets[..12] == [0; 12] {
+        return Some(Ipv4Addr::new(
+            octets[12], octets[13], octets[14], octets[15],
+        ));
+    }
+    if octets[..12]
+        == [
+            0x00, 0x64, 0xff, 0x9b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]
+    {
+        return Some(Ipv4Addr::new(
+            octets[12], octets[13], octets[14], octets[15],
+        ));
+    }
+    None
 }
 
 #[cfg(not(feature = "ocr"))]
@@ -3559,8 +3582,17 @@ mod tests {
         assert!(remote_image_ip_is_private(
             "::ffff:10.0.0.1".parse().unwrap()
         ));
+        assert!(remote_image_ip_is_private("::127.0.0.1".parse().unwrap()));
+        assert!(remote_image_ip_is_private("::10.0.0.1".parse().unwrap()));
+        assert!(remote_image_ip_is_private(
+            "64:ff9b::a00:1".parse().unwrap()
+        ));
         assert!(!remote_image_ip_is_private(
             "::ffff:8.8.8.8".parse().unwrap()
+        ));
+        assert!(!remote_image_ip_is_private("::8.8.8.8".parse().unwrap()));
+        assert!(!remote_image_ip_is_private(
+            "64:ff9b::808:808".parse().unwrap()
         ));
         assert!(!remote_image_ip_is_private("8.8.8.8".parse().unwrap()));
     }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -2684,16 +2684,25 @@ fn masked_read_display_path(original: &Path) -> PathBuf {
                 return safe_masked_read_path(relative);
             }
         }
-        return PathBuf::from("_external").join(
-            original
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(safe_masked_read_component)
-                .filter(|name| !name.is_empty())
-                .unwrap_or_else(|| "file.txt".to_string()),
-        );
+        return PathBuf::from("_external")
+            .join(masked_read_path_hash(original))
+            .join(
+                original
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(safe_masked_read_component)
+                    .filter(|name| !name.is_empty())
+                    .unwrap_or_else(|| "file.txt".to_string()),
+            );
     }
     safe_masked_read_path(original)
+}
+
+fn masked_read_path_hash(path: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(path.as_os_str().to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    data_encoding::HEXLOWER.encode(&digest[..6])
 }
 
 fn safe_masked_read_path(path: &Path) -> PathBuf {
@@ -2812,6 +2821,11 @@ fn repair_masked_write_after_tool(
         let (path, resolved) = resolved_write_parts(session, path, content)?;
         ensure_local_write_path_within_cwd(&path)?;
         if !path.is_file() {
+            return Ok(false);
+        }
+        let current = std::fs::read_to_string(&path)
+            .map_err(|e| format!("could not read '{}': {e}", path.display()))?;
+        if current != content {
             return Ok(false);
         }
         std::fs::write(&path, resolved)

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -566,19 +566,24 @@ fn local_write_detection_covers_common_powershell_write_forms() {
 
 #[test]
 fn resolve_file_local_write_requires_approval_without_dashboard() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("approval-resolve-needs-dashboard");
+    let _cwd = enter_temp_cwd(&root);
     let approval_session = format!("approval_resolve_needs_dashboard_{}", unix_millis());
 
     let err = approval_decision_for_resolve(&approval_session, &[PathBuf::from(".env.prod")])
         .unwrap_err();
     assert!(err.contains("approval needed"), "{err}");
     let _ = std::fs::remove_dir_all(session_root(&approval_session).unwrap());
+    drop(_cwd);
     let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
 fn forged_unsigned_heartbeat_is_not_alive() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("approval-forged-heartbeat");
+    let _cwd = enter_temp_cwd(&root);
     let session_name = format!("approval_forged_heartbeat_{}", unix_millis());
     let queue = ApprovalQueue::open(&session_name).unwrap();
     let heartbeat = session_root(&session_name)
@@ -597,18 +602,22 @@ fn forged_unsigned_heartbeat_is_not_alive() {
 
     assert!(!queue.dashboard_alive(DASHBOARD_HEARTBEAT_MAX_AGE));
     let _ = std::fs::remove_dir_all(session_root(&session_name).unwrap());
+    drop(_cwd);
     let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
 fn resolve_stdin_local_write_requires_approval_without_dashboard() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("approval-resolve-stdin-needs-dashboard");
+    let _cwd = enter_temp_cwd(&root);
     let approval_session = format!("approval_resolve_stdin_needs_dashboard_{}", unix_millis());
     let input = "OPENAI_API_KEY=<<OPENAI_API_KEY_abcdef0123456789>>\n";
 
     let err = approval_decision_for_resolve_stdin(&approval_session, input).unwrap_err();
     assert!(err.contains("approval needed"), "{err}");
     let _ = std::fs::remove_dir_all(session_root(&approval_session).unwrap());
+    drop(_cwd);
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1147,6 +1147,41 @@ fn write_tool_repairs_masked_file_after_tool() {
 }
 
 #[test]
+fn write_tool_does_not_repair_when_tool_left_existing_file_unchanged() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("capability-write-repair-unchanged");
+    let project = PathBuf::from("target").join(format!(
+        "pentect-write-repair-unchanged-{}-{}",
+        std::process::id(),
+        unix_millis()
+    ));
+    let _ = std::fs::remove_dir_all(&project);
+    std::fs::create_dir_all(&project).unwrap();
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let masked = mask_tool_output(&session, &format!("token={raw}\n")).unwrap();
+    let config = project.join("config.txt");
+    std::fs::write(&config, "token=existing\n").unwrap();
+
+    let input = json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": config.to_string_lossy(),
+            "content": masked
+        },
+        "tool_response": "Write failed"
+    });
+    let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
+    assert_eq!(output, json!({}));
+    let written = std::fs::read_to_string(&config).unwrap();
+    assert_eq!(written, "token=existing\n");
+    assert!(!written.contains(raw), "{written}");
+    let _ = std::fs::remove_dir_all(project);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn write_tool_allows_and_repairs_absolute_file_path() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("capability-write-absolute");
@@ -1661,6 +1696,36 @@ fn posttool_masks_secret_query_inside_image_url() {
     assert!(rendered.contains("<<URL_CREDENTIAL_"), "{rendered}");
     assert!(!rendered.contains(raw), "{rendered}");
     assert!(rendered.contains("screenshot.png?api_key="), "{rendered}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn posttool_masks_text_in_invalid_image_shaped_object() {
+    let (root, session) = empty_session("hook-post-invalid-image-object");
+    write_project_config(
+        &root,
+        "[image]\nocr = \"off\"\nunscanned_images = \"allow\"\n",
+    );
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let input = json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "mcp__browser__screenshot",
+        "tool_response": {
+            "content": [{
+                "type": "image",
+                "content": format!("OPENAI_API_KEY={raw}")
+            }]
+        }
+    });
+    let output = {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _cwd = enter_temp_cwd(&root);
+        handle_hook(HookProvider::Claude, "t", &session, input).unwrap()
+    };
+    let rendered =
+        serde_json::to_string(&output["hookSpecificOutput"]["updatedToolOutput"]).unwrap();
+    assert!(rendered.contains("<<OPENAI_API_KEY_"), "{rendered}");
+    assert!(!rendered.contains(raw), "{rendered}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -2908,6 +2973,49 @@ fn masked_read_copy_path_mirrors_relative_paths() {
             .join("nested")
             .join(".env")
     );
+}
+
+#[test]
+fn masked_read_copy_paths_do_not_collide_for_external_same_basename() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("masked-read-external-collision");
+    let project = root.join("project");
+    let external = root.join("external");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(external.join("one")).unwrap();
+    std::fs::create_dir_all(external.join("two")).unwrap();
+    let first = external.join("one").join(".env");
+    let second = external.join("two").join(".env");
+    std::fs::write(
+        &first,
+        "RUNPOD_API_KEY=rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\n",
+    )
+    .unwrap();
+    std::fs::write(&second, "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n").unwrap();
+
+    let first_masked = {
+        let _cwd = enter_temp_cwd(&project);
+        let session = Session::open_at(&project, "t").unwrap();
+        masked_read_copy(&session, first.to_str().unwrap())
+            .unwrap()
+            .unwrap()
+    };
+    let second_masked = {
+        let _cwd = enter_temp_cwd(&project);
+        let session = Session::open_at(&project, "t").unwrap();
+        masked_read_copy(&session, second.to_str().unwrap())
+            .unwrap()
+            .unwrap()
+    };
+
+    assert_ne!(first_masked, second_masked);
+    assert!(first_masked.starts_with(Path::new(".pentect").join("read").join("_external")));
+    assert!(second_masked.starts_with(Path::new(".pentect").join("read").join("_external")));
+    let first_text = std::fs::read_to_string(project.join(&first_masked)).unwrap();
+    let second_text = std::fs::read_to_string(project.join(&second_masked)).unwrap();
+    assert!(first_text.contains("<<RUNPOD_API_KEY_"), "{first_text}");
+    assert!(second_text.contains("<<OPENAI_API_KEY_"), "{second_text}");
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]


### PR DESCRIPTION
## What changed
- Hardened extension adapter loading and execution: schema/kind are now required, stdout is drained while waiting, output is bounded, and sidecar commands are resolved next to the Pentect executable before PATH.
- Fixed runtime boundary bugs around masked write repair, masked read copy paths, invalid image-shaped text payloads, and IPv4-mapped private image URLs.
- Improved scan coverage by recognizing `.jsonl`/`.ndjson`, passing file path context into scan analysis, scanning numeric JSON values for analysis without breaking JSON masking, and raising the default scan file cap to 16MiB.

## Why
Subagent review found several cases where Pentect could silently miss scan context, hang on extension adapter output, mutate a file after a failed Write tool, or collide masked read previews for external files with the same basename.

## Validation
- `cargo test -p pentect-core`
- `cargo test -p pentect-runtime --no-default-features`
- `cargo test -p pentect-runtime --no-default-features --features ocr`
- `cargo test -p pentect-cli --no-default-features`
- `cargo clippy -p pentect-runtime --no-default-features -- -D warnings`
- `cargo clippy -p pentect-cli --no-default-features --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- Targeted `pentect scan` check for numeric OTP in `.jsonl`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Better support for larger files during scanning.
  * Improved handling of adapter and extension commands for more reliable execution.
  * Added recognition for more log/data file formats.
* **Bug Fixes**
  * Fixed JSON analysis so numeric values are detected more consistently.
  * Improved masking and repair behavior for file writes and external file paths.
  * Strengthened image and network privacy handling, including more accurate address detection.
* **Chores**
  * Added regression coverage for the updated behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->