### PR TITLE
Namespace generated secret environment bindings

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -39,11 +39,11 @@ const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
     "Pentect agent contract:\n",
     "- Use normal shell commands. Pentect routes stdout/stderr through its protected runner and masks tool results.\n",
     "- You may read, fetch, transform, store, sync, and use user-authorized secrets. Pentect is the safety layer; raw secret values must not reach chat.\n",
-    "- Prefer generated environment variables for secret values already seen through Pentect. Do not make helper scripts reopen a secret source when an equivalent environment binding is available.\n",
-    "- When a source has not been seen yet, read it once with a normal protected command. Then use its assignment name or generated `PENTECT_...` environment variable in later commands.\n",
-    "- Masked handles like `<<NAME_hash>>` work only in this running Pentect-launched session. Use `$env:NAME`/`$env:PENTECT_NAME_hash` on PowerShell or `$NAME`/`$PENTECT_NAME_hash` on Unix.\n",
+    "- Prefer Pentect-generated `PENTECT_<LABEL>_<HASH>` environment variables for secret values already seen through Pentect. Do not make helper scripts reopen a secret source when an equivalent environment binding is available.\n",
+    "- When a source has not been seen yet, read it once with a normal protected command. Then use the generated `PENTECT_...` environment variable in later commands.\n",
+    "- Masked handles like `<<NAME_hash>>` work only in this running Pentect-launched session. Use `$env:PENTECT_NAME_hash` on PowerShell or `$PENTECT_NAME_hash` on Unix.\n",
     "- `pentect view '<handle>'` shows only label, hash, and length. Use handles or generated env vars instead of printing raw values.\n",
-    "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:NAME`; on Unix use POSIX commands and `$NAME`.\n",
+    "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:PENTECT_...`; on Unix use POSIX commands and `$PENTECT_...`.\n",
     "- MCP, browser, plugin, and connector tools may retrieve and use user-authorized secrets. Pentect masks tool text output when the host supports replacement; otherwise it stops unsafe output.\n",
     "- Default builds check image output with OS OCR on Windows/macOS and bundled OCR on Linux.\n",
     "- For user-requested storage, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
@@ -4011,15 +4011,13 @@ mod tests {
         assert!(rendered.contains("--enable\nunified_exec"), "{rendered}");
         assert!(rendered.contains("protected runner"), "{rendered}");
         assert!(rendered.contains("tool results"), "{rendered}");
-        assert!(
-            rendered.contains("generated environment variables"),
-            "{rendered}"
-        );
+        assert!(rendered.contains("PENTECT_<LABEL>_<HASH>"), "{rendered}");
         assert!(rendered.contains("read it once"), "{rendered}");
         assert!(rendered.contains("helper scripts"), "{rendered}");
         assert!(!rendered.contains("cat .env"), "{rendered}");
         assert!(rendered.contains("Masked handles"), "{rendered}");
-        assert!(rendered.contains("$env:NAME"), "{rendered}");
+        assert!(rendered.contains("$env:PENTECT_NAME_hash"), "{rendered}");
+        assert!(!rendered.contains("$env:NAME"), "{rendered}");
         assert!(rendered.contains("user-authorized secrets"), "{rendered}");
         assert!(
             rendered.contains("Pentect is the safety layer"),
@@ -4123,14 +4121,12 @@ mod tests {
         assert!(rendered.contains("Use normal shell commands"), "{rendered}");
         assert!(rendered.contains("protected runner"), "{rendered}");
         assert!(rendered.contains("tool results"), "{rendered}");
-        assert!(
-            rendered.contains("generated environment variables"),
-            "{rendered}"
-        );
+        assert!(rendered.contains("PENTECT_<LABEL>_<HASH>"), "{rendered}");
         assert!(rendered.contains("read it once"), "{rendered}");
         assert!(rendered.contains("helper scripts"), "{rendered}");
         assert!(!rendered.contains("cat .env"), "{rendered}");
-        assert!(rendered.contains("$env:NAME"), "{rendered}");
+        assert!(rendered.contains("$env:PENTECT_NAME_hash"), "{rendered}");
+        assert!(!rendered.contains("$env:NAME"), "{rendered}");
         assert!(rendered.contains("user-authorized secrets"), "{rendered}");
         assert!(
             rendered.contains("Pentect is the safety layer"),

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -737,74 +737,8 @@ pub(crate) fn env_alias_recovery(masked: &str, key: &[u8; 32]) -> Recovery {
 }
 
 fn reusable_env_aliases(text: &str) -> Vec<(String, String)> {
-    let mut out = reusable_assignment_env_aliases(text);
-    out.extend(reusable_inline_assignment_env_aliases(text));
-    out.extend(reusable_handle_env_aliases(text));
-    out
-}
-
-fn reusable_assignment_env_aliases(text: &str) -> Vec<(String, String)> {
-    let mut out = Vec::new();
-    for line in text.lines() {
-        let trimmed = line.trim();
-        let Some((key, value)) = trimmed
-            .strip_prefix("export ")
-            .unwrap_or(trimmed)
-            .split_once('=')
-        else {
-            continue;
-        };
-        if !is_env_name(key) {
-            continue;
-        }
-        let handle = value
-            .trim()
-            .trim_matches('"')
-            .trim_matches('\'')
-            .trim_end_matches(';');
-        if is_reusable_placeholder(handle) {
-            out.push((key.to_string(), handle.to_string()));
-        }
-    }
-    out
-}
-
-fn reusable_inline_assignment_env_aliases(text: &str) -> Vec<(String, String)> {
-    reusable_placeholders_with_spans(text)
-        .into_iter()
-        .filter_map(|(handle, start, end)| {
-            let key = inline_assignment_key_before_handle(text, start)?;
-            inline_assignment_handle_boundary_ok(text, end).then_some((key, handle))
-        })
-        .collect()
-}
-
-fn inline_assignment_key_before_handle(text: &str, handle_start: usize) -> Option<String> {
-    let before = text.get(..handle_start)?;
-    let line_start = before
-        .rfind(['\r', '\n'])
-        .map(|index| index + 1)
-        .unwrap_or(0);
-    let line_before = before.get(line_start..)?.trim_end();
-    let assignment_left = line_before.strip_suffix('=')?.trim_end();
-    let key_end = assignment_left.len();
-    let key_start = assignment_left
-        .char_indices()
-        .rev()
-        .find(|(_, ch)| !is_env_name_char(*ch))
-        .map(|(index, ch)| index + ch.len_utf8())
-        .unwrap_or(0);
-    let key = assignment_left.get(key_start..key_end)?;
-    is_env_name(key).then(|| key.to_string())
-}
-
-fn inline_assignment_handle_boundary_ok(text: &str, handle_end: usize) -> bool {
-    let Some(rest) = text.get(handle_end..) else {
-        return true;
-    };
-    rest.chars()
-        .next()
-        .is_none_or(|ch| !is_env_name_char(ch) && ch != '<')
+    // Generated names must not shadow source or parent environment variables.
+    reusable_handle_env_aliases(text)
 }
 
 fn reusable_handle_env_aliases(text: &str) -> Vec<(String, String)> {
@@ -829,27 +763,6 @@ fn reusable_placeholders(text: &str) -> Vec<String> {
                     out.push(handle.to_string());
                 }
                 i = close + 2;
-                continue;
-            }
-        }
-        i += 1;
-    }
-    out
-}
-
-fn reusable_placeholders_with_spans(text: &str) -> Vec<(String, usize, usize)> {
-    let mut out = Vec::new();
-    let bytes = text.as_bytes();
-    let mut i = 0usize;
-    while i + 1 < bytes.len() {
-        if bytes[i] == b'<' && bytes[i + 1] == b'<' {
-            if let Some(close) = find_from(bytes, i + 2, b">>") {
-                let end = close + 2;
-                let handle = &text[i..end];
-                if is_reusable_placeholder(handle) {
-                    out.push((handle.to_string(), i, end));
-                }
-                i = end;
                 continue;
             }
         }
@@ -974,10 +887,6 @@ fn placeholder_label(value: &str) -> Option<&str> {
 
 fn is_env_name(name: &str) -> bool {
     !name.is_empty() && !name.as_bytes()[0].is_ascii_digit() && name.bytes().all(is_env_name_byte)
-}
-
-fn is_env_name_char(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || ch == '_'
 }
 
 fn redact_env_derivative_lines(text: &str) -> String {

--- a/crates/pentect-runtime/src/memory_store.rs
+++ b/crates/pentect-runtime/src/memory_store.rs
@@ -713,9 +713,12 @@ mod tests {
             })
             .collect();
         assert!(alias_records.iter().any(|(name, handle)| {
-            name == "OPENAI_API_KEY"
+            name.starts_with("PENTECT_OPENAI_API_KEY_")
                 && snapshot.recovery.resolve(handle) == "sk-ABCDEFGHIJKLMNOPQRSTUVWX"
         }));
+        assert!(!alias_records
+            .iter()
+            .any(|(name, _)| name == "OPENAI_API_KEY"));
     }
 
     #[test]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -814,25 +814,25 @@ fn prompt_masked_env_is_available_to_exec_proxy_without_visible_pentect_exec() {
     std::env::set_var(ENV_TOKEN, token);
 
     let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
-    let prompt = mask_prompt_text_into_active_memory_store(&format!(
-        "OPENAI_API_KEY={raw} use it from $env:OPENAI_API_KEY"
-    ))
-    .unwrap()
-    .unwrap();
+    let prompt = mask_prompt_text_into_active_memory_store(&format!("OPENAI_API_KEY={raw}"))
+        .unwrap()
+        .unwrap();
     assert!(!prompt.contains(raw), "{prompt}");
     assert!(prompt.contains("OPENAI_API_KEY=<<"), "{prompt}");
+    let env_name =
+        pentect_env_name_for_handle(&masked_handle_from_assignment(&prompt, "OPENAI_API_KEY"));
 
     let argv_mode = if cfg!(windows) {
         vec![
             "powershell".to_string(),
             "-Command".to_string(),
-            "Write-Output $env:OPENAI_API_KEY".to_string(),
+            format!("Write-Output $env:{env_name}"),
         ]
     } else {
         vec![
             "sh".to_string(),
             "-c".to_string(),
-            "printf '%s' \"$OPENAI_API_KEY\"".to_string(),
+            format!("printf '%s' \"${env_name}\""),
         ]
     };
     let session = Session::open_capability("default").unwrap();
@@ -841,7 +841,7 @@ fn prompt_masked_env_is_available_to_exec_proxy_without_visible_pentect_exec() {
     assert!(
         overlays
             .iter()
-            .any(|(name, value)| name == "OPENAI_API_KEY" && value == raw),
+            .any(|(name, value)| name == &env_name && value == raw),
         "{overlays:?}"
     );
 }
@@ -874,18 +874,24 @@ fn prompt_masking_uses_strict_input_detection_for_env_lines_in_prose() {
 }
 
 #[test]
-fn exec_capability_env_overlays_parent_environment_when_referenced() {
+fn exec_capability_env_does_not_shadow_parent_environment() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("env-overlay");
     let session = Session::open_capability_at(&root, "t").unwrap();
     let value = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
-    let _masked = mask_tool_output(&session, &format!("RUNPOD_API_KEY={value}\n")).unwrap();
+    let masked = mask_tool_output(&session, &format!("RUNPOD_API_KEY={value}\n")).unwrap();
     let store = MemoryStore::for_session(&session);
+    let env_name =
+        pentect_env_name_for_handle(&masked_handle_from_assignment(&masked, "RUNPOD_API_KEY"));
     std::env::set_var("RUNPOD_API_KEY", "parent-value");
     let mode = if cfg!(windows) {
-        ExecMode::Shell("Write-Output $env:RUNPOD_API_KEY".to_string())
+        ExecMode::Shell(format!(
+            "Write-Output $env:RUNPOD_API_KEY; Write-Output $env:{env_name}"
+        ))
     } else {
-        ExecMode::Shell("printf '%s' \"$RUNPOD_API_KEY\"".to_string())
+        ExecMode::Shell(format!(
+            "printf '%s\\n%s' \"$RUNPOD_API_KEY\" \"${env_name}\""
+        ))
     };
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
@@ -897,7 +903,7 @@ fn exec_capability_env_overlays_parent_environment_when_referenced() {
     let output = output.unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains(value), "{stdout}");
-    assert!(!stdout.contains("parent-value"), "{stdout}");
+    assert!(stdout.contains("parent-value"), "{stdout}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -945,35 +951,41 @@ fn exec_auto_binds_masked_env_output_in_running_session() {
     assert!(masked.contains("NOTE=<<SECRET_"), "{masked}");
     let runpod_handle = masked_handle_from_assignment(&masked, "RUNPOD_API_KEY");
     let runpod_pentect_env = pentect_env_name_for_handle(&runpod_handle);
+    let test_secret_env =
+        pentect_env_name_for_handle(&masked_handle_from_assignment(&masked, "TEST_SECRET"));
+    let note_env = pentect_env_name_for_handle(&masked_handle_from_assignment(&masked, "NOTE"));
 
     let store = MemoryStore::for_session(&session);
     let env = store.auto_env_bindings().unwrap();
-    assert!(
-        env.iter().any(|(name, value)| name == "RUNPOD_API_KEY"
-            && value == "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"),
-        "{env:?}"
-    );
-    assert!(
-        env.iter()
-            .any(|(name, value)| name == "TEST_SECRET" && value == "114514810"),
-        "{env:?}"
-    );
-    assert!(
-        env.iter()
-            .any(|(name, value)| name == "NOTE" && value == "hello world"),
-        "{env:?}"
-    );
     assert!(
         env.iter().any(|(name, value)| name == &runpod_pentect_env
             && value == "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"),
         "{env:?}"
     );
+    assert!(
+        env.iter()
+            .any(|(name, value)| name == &test_secret_env && value == "114514810"),
+        "{env:?}"
+    );
+    assert!(
+        env.iter()
+            .any(|(name, value)| name == &note_env && value == "hello world"),
+        "{env:?}"
+    );
+    assert!(
+        !env.iter()
+            .any(|(name, _)| matches!(name.as_str(), "RUNPOD_API_KEY" | "TEST_SECRET" | "NOTE")),
+        "{env:?}"
+    );
 
     let command = if cfg!(windows) {
-        "Write-Output $env:RUNPOD_API_KEY; Write-Output $env:TEST_SECRET; Write-Output $env:NOTE"
-            .to_string()
+        format!(
+            "Write-Output $env:{runpod_pentect_env}; Write-Output $env:{test_secret_env}; Write-Output $env:{note_env}"
+        )
     } else {
-        "printf '%s\n%s\n%s\n' \"$RUNPOD_API_KEY\" \"$TEST_SECRET\" \"$NOTE\"".to_string()
+        format!(
+            "printf '%s\\n%s\\n%s\\n' \"${runpod_pentect_env}\" \"${test_secret_env}\" \"${note_env}\""
+        )
     };
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
@@ -1002,8 +1014,10 @@ fn exec_only_injects_referenced_capability_env() {
     let session = Session::open_capability_at(&root, "t").unwrap();
     let output =
         "RUNPOD_API_KEY=rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\nTEST_SECRET=114514810\n";
-    let _masked = mask_tool_output(&session, output).unwrap();
+    let masked = mask_tool_output(&session, output).unwrap();
     let store = MemoryStore::for_session(&session);
+    let env_name =
+        pentect_env_name_for_handle(&masked_handle_from_assignment(&masked, "RUNPOD_API_KEY"));
 
     let none = requested_env_bindings(
         &store,
@@ -1019,14 +1033,14 @@ fn exec_only_injects_referenced_capability_env() {
     let one = requested_env_bindings(
         &store,
         &ExecMode::Shell(if cfg!(windows) {
-            "Write-Output $env:RUNPOD_API_KEY".to_string()
+            format!("Write-Output $env:{env_name}")
         } else {
-            "printf '%s' \"$RUNPOD_API_KEY\"".to_string()
+            format!("printf '%s' \"${env_name}\"")
         }),
     )
     .unwrap();
     assert_eq!(one.len(), 1, "{one:?}");
-    assert_eq!(one[0].0, "RUNPOD_API_KEY");
+    assert_eq!(one[0].0, env_name);
     assert_eq!(one[0].1, "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef");
     let _ = std::fs::remove_dir_all(root);
 }
@@ -1036,16 +1050,18 @@ fn exec_injects_powershell_env_provider_references() {
     let root = temp_root("capability-env-provider");
     let session = Session::open_capability_at(&root, "t").unwrap();
     let value = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
-    let _masked = mask_tool_output(&session, &format!("OPENAI_API_KEY={value}\n")).unwrap();
+    let masked = mask_tool_output(&session, &format!("OPENAI_API_KEY={value}\n")).unwrap();
     let store = MemoryStore::for_session(&session);
+    let env_name =
+        pentect_env_name_for_handle(&masked_handle_from_assignment(&masked, "OPENAI_API_KEY"));
     let env = requested_env_bindings(
         &store,
-        &ExecMode::Shell("Test-Path Env:OPENAI_API_KEY".to_string()),
+        &ExecMode::Shell(format!("Test-Path Env:{env_name}")),
     )
     .unwrap();
     assert!(
         env.iter()
-            .any(|(name, found)| name == "OPENAI_API_KEY" && found == value),
+            .any(|(name, found)| name == &env_name && found == value),
         "{env:?}"
     );
     let _ = std::fs::remove_dir_all(root);
@@ -1067,12 +1083,13 @@ fn auto_env_bindings_do_not_override_baseline_environment() {
     let env = store.auto_env_bindings().unwrap();
     assert!(
         !env.iter()
-            .any(|(name, _)| name.eq_ignore_ascii_case("PATH")),
+            .any(|(name, _)| matches!(name.as_str(), "PATH" | "DUMMY_SECRET")),
         "{env:?}"
     );
     assert!(
         env.iter()
-            .any(|(name, value)| name == "DUMMY_SECRET" && value == "sk-YYYYYYYYYYYYYYYYYYYY"),
+            .any(|(name, value)| name.starts_with("PENTECT_OPENAI_API_KEY_")
+                && value == "sk-YYYYYYYYYYYYYYYYYYYY"),
         "{env:?}"
     );
     let _ = std::fs::remove_dir_all(root);


### PR DESCRIPTION
## Summary
- expose recovered secrets only through generated PENTECT_<LABEL>_<HASH> environment names
- stop shadowing source and parent environment variables
- align the Codex and Claude agent contract with the namespaced bindings

## Verification
- cargo test -p pentect-runtime --no-default-features env -- --test-threads=1
- cargo test -p pentect-cli --no-default-features model_visible_pentect_contract
- cargo clippy -p pentect-runtime -p pentect-cli --all-targets --no-default-features -- -D warnings
- cargo fmt --all
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment references now use Pentect-generated variable names for improved masking consistency.
  * PowerShell and Unix command guidance now supports only Pentect-generated environment variable formats.

* **Bug Fixes**
  * Prevented original environment variable names from being automatically exposed or injected.
  * Preserved parent environment values without unintentionally shadowing them.
  * Improved environment alias recovery and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->