### PR TITLE
Make secret environment prefix configurable

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -35,20 +35,25 @@ pub(crate) type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 /// Refuse oversized input rather than emit partially-masked output (a masked
 /// head plus a raw tail would leak the tail).
 const MAX_INPUT_BYTES: usize = 32 * 1024 * 1024;
-const PENTECT_CONTRACT_INSTRUCTIONS: &str = concat!(
-    "Pentect agent contract:\n",
-    "- Use normal shell commands. Pentect routes stdout/stderr through its protected runner and masks tool results.\n",
-    "- You may read, fetch, transform, store, sync, and use user-authorized secrets. Pentect is the safety layer; raw secret values must not reach chat.\n",
-    "- Prefer Pentect-generated `PENTECT_<LABEL>_<HASH>` environment variables for secret values already seen through Pentect. Do not make helper scripts reopen a secret source when an equivalent environment binding is available.\n",
-    "- When a source has not been seen yet, read it once with a normal protected command. Then use the generated `PENTECT_...` environment variable in later commands.\n",
-    "- Masked handles like `<<NAME_hash>>` work only in this running Pentect-launched session. Use `$env:PENTECT_NAME_hash` on PowerShell or `$PENTECT_NAME_hash` on Unix.\n",
-    "- `pentect view '<handle>'` shows only label, hash, and length. Use handles or generated env vars instead of printing raw values.\n",
-    "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:PENTECT_...`; on Unix use POSIX commands and `$PENTECT_...`.\n",
-    "- MCP, browser, plugin, and connector tools may retrieve and use user-authorized secrets. Pentect masks tool text output when the host supports replacement; otherwise it stops unsafe output.\n",
-    "- Default builds check image output with OS OCR on Windows/macOS and bundled OCR on Linux.\n",
-    "- For user-requested storage, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
-    "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
-);
+fn pentect_contract_instructions(environment_prefix: &str) -> String {
+    format!(
+        concat!(
+            "Pentect agent contract:\n",
+            "- Use normal shell commands. Pentect routes stdout/stderr through its protected runner and masks tool results.\n",
+            "- You may read, fetch, transform, store, sync, and use user-authorized secrets. Pentect is the safety layer; raw secret values must not reach chat.\n",
+            "- Prefer Pentect-generated `{environment_prefix}<LABEL>_<HASH>` environment variables for secret values already seen through Pentect. Do not make helper scripts reopen a secret source when an equivalent environment binding is available.\n",
+            "- When a source has not been seen yet, read it once with a normal protected command. Then use the generated `{environment_prefix}...` environment variable in later commands.\n",
+            "- Masked handles like `<<NAME_hash>>` work only in this running Pentect-launched session. Use `$env:{environment_prefix}NAME_hash` on PowerShell or `${environment_prefix}NAME_hash` on Unix.\n",
+            "- `pentect view '<handle>'` shows only label, hash, and length. Use handles or generated env vars instead of printing raw values.\n",
+            "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:{environment_prefix}...`; on Unix use POSIX commands and `${environment_prefix}...`.\n",
+            "- MCP, browser, plugin, and connector tools may retrieve and use user-authorized secrets. Pentect masks tool text output when the host supports replacement; otherwise it stops unsafe output.\n",
+            "- Default builds check image output with OS OCR on Windows/macOS and bundled OCR on Linux.\n",
+            "- For user-requested storage, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
+            "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
+        ),
+        environment_prefix = environment_prefix
+    )
+}
 const PENTECT_BIN_ENV: &str = "PENTECT_BIN";
 const PENTECT_AGENT_LAUNCHED_ENV: &str = "PENTECT_AGENT_LAUNCHED";
 const PENTECT_MEMORY_STORE_ADDR_ENV: &str = "PENTECT_MEMORY_STORE_ADDR";
@@ -796,6 +801,8 @@ impl AgentToolOpts {
 
 fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
     let configs = codex_hook_config_args(pentect, opts.session.as_deref())?;
+    let contract =
+        pentect_contract_instructions(&pentect_agent::load_environment_variable_prefix()?);
     let status_line_enabled = status_line_enabled_by_config()?;
     if opts.dry_run {
         if codex_uses_unverified_headless_hook_path(&opts.tool_args) {
@@ -803,7 +810,10 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
                 "[pentect] note: headless Codex may skip hooks; use interactive `pentect codex` for protected tool use."
             );
         }
-        print_dry_run(&opts.command, &codex_args(&configs, &opts.tool_args));
+        print_dry_run(
+            &opts.command,
+            &codex_args(&configs, &opts.tool_args, &contract),
+        );
         return Ok(success_status());
     }
     if codex_uses_unverified_headless_hook_path(&opts.tool_args) && !opts.allow_unverified_hooks {
@@ -856,13 +866,14 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
             cmd.env(app_server_proxy::PENTECT_CODEX_APP_SERVER_PROXY_ENV, "1");
             let proxy = app_server_proxy::AppServerProxyGuard::start(
                 &opts.command,
-                codex_app_server_args(&configs, &opts.tool_args),
+                codex_app_server_args(&configs, &opts.tool_args, &contract),
             )?;
-            let args = codex_args_with_remote(&configs, &opts.tool_args, Some(proxy.url()));
+            let args =
+                codex_args_with_remote(&configs, &opts.tool_args, Some(proxy.url()), &contract);
             cmd.args(args);
             return run_interactive_command_with_guard(cmd, &opts.command, proxy);
         } else {
-            codex_args(&configs, &opts.tool_args)
+            codex_args(&configs, &opts.tool_args, &contract)
         };
     cmd.args(codex_args);
     run_interactive_command(cmd, &opts.command)
@@ -870,7 +881,9 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
 
 fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
     let settings = claude_settings_json(pentect, opts.session.as_deref());
-    let args = claude_args(&settings, &opts.tool_args);
+    let contract =
+        pentect_contract_instructions(&pentect_agent::load_environment_variable_prefix()?);
+    let args = claude_args(&settings, &opts.tool_args, &contract);
     if opts.dry_run {
         print_dry_run(&opts.command, &args);
         return Ok(success_status());
@@ -908,6 +921,8 @@ fn run_bridge_agent(
         }
     };
     let integration = TempAgentIntegration::create(kind)?;
+    let contract =
+        pentect_contract_instructions(&pentect_agent::load_environment_variable_prefix()?);
     let mut args = Vec::new();
     if tool == AgentTool::Pi {
         args.push("--extension".to_string());
@@ -933,7 +948,7 @@ fn run_bridge_agent(
     apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()));
     apply_memory_store_env(&mut cmd, Some(&memory_store));
     apply_status_line_env(&mut cmd, status_line_enabled);
-    cmd.env("PENTECT_AGENT_CONTRACT", PENTECT_CONTRACT_INSTRUCTIONS);
+    cmd.env("PENTECT_AGENT_CONTRACT", contract);
     if tool == AgentTool::OpenCode {
         let existing = std::env::var("OPENCODE_CONFIG_CONTENT").ok();
         let config = agent_integrations::opencode_config_with_plugin(
@@ -2702,14 +2717,15 @@ fn apply_extension_env(
     Ok(())
 }
 
-fn codex_args(configs: &[String], tool_args: &[String]) -> Vec<String> {
-    codex_args_with_remote(configs, tool_args, None)
+fn codex_args(configs: &[String], tool_args: &[String], contract: &str) -> Vec<String> {
+    codex_args_with_remote(configs, tool_args, None, contract)
 }
 
 fn codex_args_with_remote(
     configs: &[String],
     tool_args: &[String],
     remote: Option<&str>,
+    contract: &str,
 ) -> Vec<String> {
     let mut args = Vec::with_capacity(configs.len() * 2 + 5 + tool_args.len());
     if !codex_args_disable_unified_exec(tool_args) && !codex_args_enable_unified_exec(tool_args) {
@@ -2721,10 +2737,7 @@ fn codex_args_with_remote(
         args.push(config.clone());
     }
     args.push("--config".to_string());
-    args.push(format!(
-        "developer_instructions={}",
-        toml_string(PENTECT_CONTRACT_INSTRUCTIONS)
-    ));
+    args.push(format!("developer_instructions={}", toml_string(contract)));
     if let Some(remote) = remote {
         args.push("--remote".to_string());
         args.push(remote.to_string());
@@ -2733,7 +2746,7 @@ fn codex_args_with_remote(
     args
 }
 
-fn codex_app_server_args(configs: &[String], tool_args: &[String]) -> Vec<String> {
+fn codex_app_server_args(configs: &[String], tool_args: &[String], contract: &str) -> Vec<String> {
     let mut args = Vec::with_capacity(configs.len() * 2 + 5);
     if !codex_args_disable_unified_exec(tool_args) && !codex_args_enable_unified_exec(tool_args) {
         args.push("--enable".to_string());
@@ -2744,10 +2757,7 @@ fn codex_app_server_args(configs: &[String], tool_args: &[String]) -> Vec<String
         args.push(config.clone());
     }
     args.push("--config".to_string());
-    args.push(format!(
-        "developer_instructions={}",
-        toml_string(PENTECT_CONTRACT_INSTRUCTIONS)
-    ));
+    args.push(format!("developer_instructions={}", toml_string(contract)));
     for (flag, value) in codex_root_config_args(tool_args) {
         args.push(flag);
         if let Some(value) = value {
@@ -2902,12 +2912,12 @@ fn codex_args_feature_value(args: &[String], flag: &str, feature: &str) -> bool 
     false
 }
 
-fn claude_args(settings: &str, tool_args: &[String]) -> Vec<String> {
+fn claude_args(settings: &str, tool_args: &[String], contract: &str) -> Vec<String> {
     let mut args = vec![
         "--settings".to_string(),
         settings.to_string(),
         "--append-system-prompt".to_string(),
-        PENTECT_CONTRACT_INSTRUCTIONS.to_string(),
+        contract.to_string(),
     ];
     args.extend(tool_args.iter().cloned());
     args
@@ -3863,10 +3873,12 @@ mod tests {
 
     #[test]
     fn codex_args_place_remote_before_prompt() {
+        let contract = pentect_contract_instructions("PENTECT_");
         let args = codex_args_with_remote(
             &["features.hooks=true".to_string()],
             &["hello".to_string()],
             Some("ws://127.0.0.1:12345"),
+            &contract,
         );
         let remote = args.iter().position(|arg| arg == "--remote").unwrap();
         let prompt = args.iter().position(|arg| arg == "hello").unwrap();
@@ -3893,6 +3905,7 @@ mod tests {
 
     #[test]
     fn codex_app_server_args_keep_pentect_and_root_config_only() {
+        let contract = pentect_contract_instructions("PENTECT_");
         let args = codex_app_server_args(
             &["features.hooks=true".to_string()],
             &[
@@ -3902,6 +3915,7 @@ mod tests {
                 "model_reasoning_effort=\"high\"".to_string(),
                 "hello".to_string(),
             ],
+            &contract,
         );
         assert!(args.contains(&"--enable".to_string()), "{args:?}");
         assert!(args.contains(&"unified_exec".to_string()), "{args:?}");
@@ -4002,7 +4016,12 @@ mod tests {
 
     #[test]
     fn codex_args_inject_model_visible_pentect_contract() {
-        let args = codex_args(&["features.hooks=true".to_string()], &["hello".to_string()]);
+        let contract = pentect_contract_instructions("PENTECT_");
+        let args = codex_args(
+            &["features.hooks=true".to_string()],
+            &["hello".to_string()],
+            &contract,
+        );
         let rendered = args.join("\n");
         assert!(!args.contains(&"--dangerously-bypass-hook-trust".to_string()));
         assert!(rendered.contains("developer_instructions="), "{rendered}");
@@ -4105,7 +4124,8 @@ mod tests {
             "exec".to_string(),
             "hello".to_string(),
         ];
-        let args = codex_args(&[], &tool_args);
+        let contract = pentect_contract_instructions("PENTECT_");
+        let args = codex_args(&[], &tool_args, &contract);
         let rendered = args.join("\n");
         assert!(!codex_unified_exec_proxy_enabled(&tool_args));
         assert!(!rendered.contains("--enable\nunified_exec"), "{rendered}");
@@ -4114,7 +4134,8 @@ mod tests {
 
     #[test]
     fn claude_args_inject_model_visible_pentect_contract() {
-        let args = claude_args("{}", &["hello".to_string()]);
+        let contract = pentect_contract_instructions("PENTECT_");
+        let args = claude_args("{}", &["hello".to_string()], &contract);
         let rendered = args.join("\n");
         assert!(rendered.contains("--append-system-prompt"), "{rendered}");
         assert!(rendered.contains("Pentect agent contract"), "{rendered}");
@@ -4155,6 +4176,15 @@ mod tests {
             !rendered.contains("pentect exec \"pentect exec"),
             "{rendered}"
         );
+    }
+
+    #[test]
+    fn agent_contract_uses_configured_environment_prefix() {
+        let rendered = pentect_contract_instructions("SAFE_");
+        assert!(rendered.contains("SAFE_<LABEL>_<HASH>"), "{rendered}");
+        assert!(rendered.contains("$env:SAFE_NAME_hash"), "{rendered}");
+        assert!(rendered.contains("$SAFE_NAME_hash"), "{rendered}");
+        assert!(!rendered.contains("PENTECT_NAME_hash"), "{rendered}");
     }
 
     #[test]

--- a/crates/pentect-cli/tests/process_host.rs
+++ b/crates/pentect-cli/tests/process_host.rs
@@ -70,6 +70,44 @@ fn concurrent_up_keeps_one_persistent_host() {
 }
 
 #[test]
+fn codex_dry_run_uses_project_environment_prefix() {
+    let root = test_root();
+    let config_dir = root.join(".pentect");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.toml"),
+        "[environment]\nprefix = \"SAFE_\"\n",
+    )
+    .unwrap();
+    let _cleanup = Cleanup {
+        root: root.clone(),
+        host_pid: None,
+        command_pids: Vec::new(),
+    };
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+    command
+        .args(["codex", "--dry-run"])
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for name in PRIVATE_ENV {
+        command.env_remove(name);
+    }
+    let output = command.output().unwrap();
+    assert!(output.status.success(), "{:?}", output.status);
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(rendered.contains("SAFE_<LABEL>_<HASH>"), "{rendered}");
+    assert!(rendered.contains("$env:SAFE_NAME_hash"), "{rendered}");
+    assert!(!rendered.contains("PENTECT_NAME_hash"), "{rendered}");
+}
+
+#[test]
 fn log_hosts_while_running_but_help_does_not() {
     let root = test_root();
     std::fs::create_dir_all(&root).unwrap();

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 const PENTECT_DIR: &str = ".pentect";
 const CONFIG_FILE: &str = "config.toml";
+const DEFAULT_ENVIRONMENT_PREFIX: &str = "PENTECT_";
 const DEFAULT_IMAGE_OCR_MAX_EDGE: u32 = 2_048;
 const DEFAULT_IMAGE_OCR_MAX_PIXELS: u64 = 64_000_000;
 const DEFAULT_IMAGE_MAX_IMAGES: usize = 64;
@@ -78,6 +79,20 @@ pub(crate) fn image_ocr_config() -> Result<ImageOcrConfig, String> {
     let project = read_image_ocr_config(project_config_path())?;
     let global = read_image_ocr_config(global_config_path()?)?;
     Ok(merge_image_ocr_config(project, global))
+}
+
+#[cfg(not(test))]
+pub(crate) fn environment_variable_prefix() -> Result<String, String> {
+    let project = read_environment_variable_prefix(project_config_path())?;
+    let global = read_environment_variable_prefix(global_config_path()?)?;
+    Ok(project
+        .or(global)
+        .unwrap_or_else(|| DEFAULT_ENVIRONMENT_PREFIX.to_string()))
+}
+
+#[cfg(test)]
+pub(crate) fn environment_variable_prefix() -> Result<String, String> {
+    Ok(DEFAULT_ENVIRONMENT_PREFIX.to_string())
 }
 
 #[cfg(not(test))]
@@ -263,6 +278,55 @@ fn read_file_pointer_manager_save(path: PathBuf) -> Result<Option<bool>, String>
         .parse::<toml::Value>()
         .map_err(|e| format!("could not parse '{}': {e}", path.display()))?;
     file_pointer_manager_save_value(&value)
+}
+
+fn read_environment_variable_prefix(path: PathBuf) -> Result<Option<String>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let src = fs::read_to_string(&path)
+        .map_err(|e| format!("could not read '{}': {e}", path.display()))?;
+    if src.trim().is_empty() {
+        return Ok(None);
+    }
+    let value = src
+        .parse::<toml::Value>()
+        .map_err(|e| format!("could not parse '{}': {e}", path.display()))?;
+    environment_variable_prefix_value(&value)
+}
+
+fn environment_variable_prefix_value(value: &toml::Value) -> Result<Option<String>, String> {
+    let Some(raw) = value.get("environment") else {
+        return Ok(None);
+    };
+    let Some(table) = raw.as_table() else {
+        return Err("environment config must be a table".to_string());
+    };
+    let Some(raw) = table.get("prefix") else {
+        return Ok(None);
+    };
+    let Some(prefix) = raw.as_str() else {
+        return Err("environment.prefix must be a string".to_string());
+    };
+    validate_environment_variable_prefix(prefix)?;
+    Ok(Some(prefix.to_string()))
+}
+
+fn validate_environment_variable_prefix(prefix: &str) -> Result<(), String> {
+    if prefix.is_empty() {
+        return Ok(());
+    }
+    let bytes = prefix.as_bytes();
+    if bytes[0].is_ascii_digit()
+        || !bytes
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+    {
+        return Err(
+            "environment.prefix must be empty or an ASCII environment-name prefix".to_string(),
+        );
+    }
+    Ok(())
 }
 
 fn file_pointer_manager_save_value(value: &toml::Value) -> Result<Option<bool>, String> {
@@ -615,6 +679,55 @@ unknown_min_bytes = 32
         assert_eq!(partial.max_inflate_bytes, Some(None));
         assert_eq!(partial.mask_unknown, Some(true));
         assert_eq!(partial.unknown_min_bytes, Some(32));
+    }
+
+    #[test]
+    fn environment_prefix_accepts_namespaced_and_empty_values() {
+        let value = "[environment]\nprefix = \"SAFE_\""
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(
+            environment_variable_prefix_value(&value).unwrap(),
+            Some("SAFE_".to_string())
+        );
+
+        let value = "[environment]\nprefix = \"\""
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(
+            environment_variable_prefix_value(&value).unwrap(),
+            Some(String::new())
+        );
+    }
+
+    #[test]
+    fn environment_prefix_rejects_invalid_environment_names() {
+        for prefix in ["9SAFE_", "SAFE-", "秘密_"] {
+            let value = format!("[environment]\nprefix = {prefix:?}")
+                .parse::<toml::Value>()
+                .unwrap();
+            assert!(environment_variable_prefix_value(&value).is_err());
+        }
+    }
+
+    #[test]
+    fn environment_prefix_reads_config_file() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-environment-prefix-config-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("config.toml");
+        std::fs::write(&path, "[environment]\nprefix = \"SAFE_\"\n").unwrap();
+        assert_eq!(
+            read_environment_variable_prefix(path).unwrap(),
+            Some("SAFE_".to_string())
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 const PENTECT_DIR: &str = ".pentect";
 const CONFIG_FILE: &str = "config.toml";
 const DEFAULT_ENVIRONMENT_PREFIX: &str = "PENTECT_";
+const MAX_ENVIRONMENT_PREFIX_BYTES: usize = 64;
 const DEFAULT_IMAGE_OCR_MAX_EDGE: u32 = 2_048;
 const DEFAULT_IMAGE_OCR_MAX_PIXELS: u64 = 64_000_000;
 const DEFAULT_IMAGE_MAX_IMAGES: usize = 64;
@@ -85,9 +86,7 @@ pub(crate) fn image_ocr_config() -> Result<ImageOcrConfig, String> {
 pub(crate) fn environment_variable_prefix() -> Result<String, String> {
     let project = read_environment_variable_prefix(project_config_path())?;
     let global = read_environment_variable_prefix(global_config_path()?)?;
-    Ok(project
-        .or(global)
-        .unwrap_or_else(|| DEFAULT_ENVIRONMENT_PREFIX.to_string()))
+    Ok(effective_environment_variable_prefix(project, global))
 }
 
 #[cfg(test)]
@@ -313,6 +312,11 @@ fn environment_variable_prefix_value(value: &toml::Value) -> Result<Option<Strin
 }
 
 fn validate_environment_variable_prefix(prefix: &str) -> Result<(), String> {
+    if prefix.len() > MAX_ENVIRONMENT_PREFIX_BYTES {
+        return Err(format!(
+            "environment.prefix must be at most {MAX_ENVIRONMENT_PREFIX_BYTES} ASCII bytes"
+        ));
+    }
     if prefix.is_empty() {
         return Ok(());
     }
@@ -327,6 +331,15 @@ fn validate_environment_variable_prefix(prefix: &str) -> Result<(), String> {
         );
     }
     Ok(())
+}
+
+fn effective_environment_variable_prefix(
+    project: Option<String>,
+    global: Option<String>,
+) -> String {
+    project
+        .or(global)
+        .unwrap_or_else(|| DEFAULT_ENVIRONMENT_PREFIX.to_string())
 }
 
 fn file_pointer_manager_save_value(value: &toml::Value) -> Result<Option<bool>, String> {
@@ -702,12 +715,36 @@ unknown_min_bytes = 32
 
     #[test]
     fn environment_prefix_rejects_invalid_environment_names() {
-        for prefix in ["9SAFE_", "SAFE-", "秘密_"] {
+        let too_long = "A".repeat(MAX_ENVIRONMENT_PREFIX_BYTES + 1);
+        for prefix in ["9SAFE_", "SAFE-", "秘密_", &too_long] {
             let value = format!("[environment]\nprefix = {prefix:?}")
                 .parse::<toml::Value>()
                 .unwrap();
             assert!(environment_variable_prefix_value(&value).is_err());
         }
+    }
+
+    #[test]
+    fn environment_prefix_prefers_project_then_global_then_default() {
+        assert_eq!(
+            effective_environment_variable_prefix(
+                Some("PROJECT_".to_string()),
+                Some("GLOBAL_".to_string())
+            ),
+            "PROJECT_"
+        );
+        assert_eq!(
+            effective_environment_variable_prefix(None, Some("GLOBAL_".to_string())),
+            "GLOBAL_"
+        );
+        assert_eq!(
+            effective_environment_variable_prefix(None, None),
+            "PENTECT_"
+        );
+        assert_eq!(
+            effective_environment_variable_prefix(Some(String::new()), Some("GLOBAL_".to_string())),
+            ""
+        );
     }
 
     #[test]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -2158,8 +2158,12 @@ impl ShellInputProtector {
 
     fn prepare_paste(&mut self, text: &str) -> Result<ProtectedPaste, String> {
         let masked = self.masker.mask_text(text, live_output_kind(text))?;
-        let (visible, bindings) =
-            replace_masked_handles_with_env_refs(&masked, &self.store, self.syntax)?;
+        let (visible, bindings) = replace_masked_handles_with_env_refs(
+            &masked,
+            &self.store,
+            self.syntax,
+            self.masker.environment_prefix(),
+        )?;
         if bindings.is_empty() {
             return Ok(ProtectedPaste {
                 child: text.to_string(),
@@ -2245,6 +2249,7 @@ fn replace_masked_handles_with_env_refs(
     masked: &str,
     store: &MemoryStore,
     syntax: ShellSyntax,
+    environment_prefix: &str,
 ) -> Result<(String, Vec<ShellEnvBinding>), String> {
     let handles = masked_handles_in_text(masked);
     if handles.is_empty() {
@@ -2256,7 +2261,7 @@ fn replace_masked_handles_with_env_refs(
         let Ok(parts) = parse_placeholder(&handle) else {
             continue;
         };
-        let name = format!("PENTECT_{}_{}", parts.label, parts.hash);
+        let name = format!("{environment_prefix}{}_{}", parts.label, parts.hash);
         let mut value = store.resolve_all(&handle).map_err(|e| e.to_string())?;
         if value == handle {
             value.zeroize();

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -112,6 +112,10 @@ pub fn load_decode_config(profile: Profile) -> Result<pentect_core::DecodeConfig
     config::decode_config(profile)
 }
 
+pub fn load_environment_variable_prefix() -> Result<String, String> {
+    config::environment_variable_prefix()
+}
+
 pub fn mask_input_into_active_memory_store(
     input: Input,
     profile: Profile,
@@ -145,7 +149,8 @@ fn mask_input_into_memory_store_client(
     let key = client.key().map_err(|e| e.to_string())?;
     let result = masking::mask_read_input_with_profile(key, input, profile, packs)?;
     let mut recovery = result.recovery.clone();
-    recovery.extend_same_key(env_alias_recovery(&result.masked, &key));
+    let prefix = config::environment_variable_prefix()?;
+    recovery.extend_same_key(env_alias_recovery(&result.masked, &key, &prefix));
     client
         .add_recovery(&key, &recovery)
         .map_err(|e| e.to_string())?;
@@ -3558,7 +3563,8 @@ fn masked_read_copy(session: &Session, path_text: &str) -> Result<Option<PathBuf
     }
     activity_log::record_mask_result("read", &result, Some(path));
     let mut recovery = result.recovery.clone();
-    recovery.extend_same_key(env_alias_recovery(&result.masked, &session.key));
+    let prefix = config::environment_variable_prefix()?;
+    recovery.extend_same_key(env_alias_recovery(&result.masked, &session.key, &prefix));
     MemoryStore::for_session(session)
         .add_recovery(recovery)
         .map_err(|e| e.to_string())?;

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -86,6 +86,10 @@ impl OutputMasker {
         self.masked_count
     }
 
+    pub(crate) fn environment_prefix(&self) -> &str {
+        &self.environment_prefix
+    }
+
     pub(crate) fn flush(&mut self) -> Result<(), String> {
         if !self.pending.is_empty() {
             let next = Recovery::empty_for_key(&self.store.session.key);

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -34,6 +34,7 @@ pub(crate) struct OutputMasker {
     store: MemoryStore,
     engine: &'static Engine,
     model_adapters: ModelAdapters,
+    environment_prefix: String,
     mode: OutputMaskerMode,
     pending: Recovery,
     masked_count: u64,
@@ -58,6 +59,7 @@ impl OutputMasker {
             store,
             engine: tool_boundary_engine()?,
             model_adapters: ModelAdapters::from_env()?,
+            environment_prefix: config::environment_variable_prefix()?,
             mode: OutputMaskerMode::Shared,
             pending: Recovery::empty_for_key(&key),
             masked_count: 0,
@@ -72,6 +74,7 @@ impl OutputMasker {
             store,
             engine: tool_boundary_engine()?,
             model_adapters: ModelAdapters::from_env()?,
+            environment_prefix: config::environment_variable_prefix()?,
             mode: OutputMaskerMode::Deferred { remask_recoveries },
             pending: Recovery::empty_for_key(&key),
             masked_count: 0,
@@ -119,7 +122,11 @@ impl OutputMasker {
         self.add_masked_count(result.summary.masked_count);
         let masked = compact_local_home_paths(&result.masked);
         let mut recovery = result.recovery;
-        recovery.extend_same_key(env_alias_recovery(&masked, &self.store.session.key));
+        recovery.extend_same_key(env_alias_recovery(
+            &masked,
+            &self.store.session.key,
+            &self.environment_prefix,
+        ));
         self.record_recovery(recovery)?;
         Ok(masked)
     }
@@ -164,7 +171,11 @@ impl OutputMasker {
             }
         }
         let masked = compact_local_home_paths(&masked);
-        recovery.extend_same_key(env_alias_recovery(&masked, &self.store.session.key));
+        recovery.extend_same_key(env_alias_recovery(
+            &masked,
+            &self.store.session.key,
+            &self.environment_prefix,
+        ));
         self.record_recovery(recovery)?;
         Ok(masked)
     }
@@ -279,7 +290,11 @@ impl OutputMasker {
         self.add_masked_count(result.summary.masked_count);
         let masked = compact_local_home_paths(&result.masked);
         let mut recovery = result.recovery;
-        recovery.extend_same_key(env_alias_recovery(&masked, &self.store.session.key));
+        recovery.extend_same_key(env_alias_recovery(
+            &masked,
+            &self.store.session.key,
+            &self.environment_prefix,
+        ));
         self.record_recovery(recovery)?;
         Ok(masked)
     }
@@ -712,15 +727,15 @@ fn looks_like_sensitive_env_output(text: &str) -> bool {
 }
 
 #[cfg(test)]
-pub(crate) fn first_reusable_env_name(masked: &str) -> Option<String> {
-    reusable_env_aliases(masked)
+pub(crate) fn first_reusable_env_name(masked: &str, prefix: &str) -> Option<String> {
+    reusable_env_aliases(masked, prefix)
         .into_iter()
         .next()
         .map(|(name, _)| name)
 }
 
-pub(crate) fn env_alias_recovery(masked: &str, key: &[u8; 32]) -> Recovery {
-    let aliases = reusable_env_aliases(masked);
+pub(crate) fn env_alias_recovery(masked: &str, key: &[u8; 32], prefix: &str) -> Recovery {
+    let aliases = reusable_env_aliases(masked, prefix);
     if aliases.is_empty() {
         return Recovery::empty_for_key(key);
     }
@@ -736,16 +751,16 @@ pub(crate) fn env_alias_recovery(masked: &str, key: &[u8; 32]) -> Recovery {
     Recovery::seal(map, key)
 }
 
-fn reusable_env_aliases(text: &str) -> Vec<(String, String)> {
+fn reusable_env_aliases(text: &str, prefix: &str) -> Vec<(String, String)> {
     // Generated names must not shadow source or parent environment variables.
-    reusable_handle_env_aliases(text)
+    reusable_handle_env_aliases(text, prefix)
 }
 
-fn reusable_handle_env_aliases(text: &str) -> Vec<(String, String)> {
+fn reusable_handle_env_aliases(text: &str, prefix: &str) -> Vec<(String, String)> {
     reusable_placeholders(text)
         .into_iter()
         .filter_map(|handle| {
-            let name = env_name_for_handle(&handle)?;
+            let name = env_name_for_handle(&handle, prefix)?;
             Some((name, handle))
         })
         .collect()
@@ -771,9 +786,9 @@ fn reusable_placeholders(text: &str) -> Vec<String> {
     out
 }
 
-fn env_name_for_handle(handle: &str) -> Option<String> {
+fn env_name_for_handle(handle: &str, prefix: &str) -> Option<String> {
     let core = placeholder_core(handle)?;
-    Some(format!("PENTECT_{core}"))
+    Some(format!("{prefix}{core}"))
 }
 
 fn env_alias_placeholder(key: &[u8; 32], name: &str, handle: &str) -> String {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -233,6 +233,30 @@ fn shell_secret_paste_replaces_visible_value_with_env_ref() {
 }
 
 #[test]
+fn shell_secret_paste_uses_explicit_environment_prefix() {
+    let (root, session) = empty_session("shell-paste-custom-prefix");
+    let store = MemoryStore::for_session(&session);
+    let mut masker = OutputMasker::new_shared(store.clone()).unwrap();
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let masked = masker
+        .mask_text(&format!("Authorization: Bearer {raw}"), Kind::Text)
+        .unwrap();
+    let (visible, mut bindings) =
+        replace_masked_handles_with_env_refs(&masked, &store, ShellSyntax::current(), "SAFE_")
+            .unwrap();
+    assert!(!visible.contains(raw), "{visible}");
+    assert!(visible.contains("SAFE_OPENAI_API_KEY_"), "{visible}");
+    assert!(!visible.contains("PENTECT_OPENAI_API_KEY_"), "{visible}");
+    assert!(bindings
+        .iter()
+        .any(|binding| binding.name.starts_with("SAFE_OPENAI_API_KEY_") && binding.value == raw));
+    for binding in &mut bindings {
+        binding.value.zeroize();
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn pty_echo_suppressor_removes_injected_env_prefix_only() {
     let suppressor = PtyEchoSuppressor::default();
     suppressor.push("$env:PENTECT_TOKEN='raw-secret'; ".to_string());

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1009,6 +1009,30 @@ fn exec_auto_binds_masked_env_output_in_running_session() {
 }
 
 #[test]
+fn env_alias_recovery_uses_explicit_prefix() {
+    let key = [7u8; 32];
+    let masked = "OPENAI_API_KEY=<<OPENAI_API_KEY_0123456789abcdef>>\n";
+    let recovery = env_alias_recovery(masked, &key, "SAFE_");
+    let aliases: Vec<_> = recovery
+        .placeholders()
+        .into_iter()
+        .filter(|placeholder| masking::is_env_alias_placeholder(placeholder))
+        .filter_map(|placeholder| {
+            let record = recovery.resolve(&placeholder);
+            masking::decode_env_alias_record(&record)
+                .map(|(name, handle)| (name.to_string(), handle.to_string()))
+        })
+        .collect();
+    assert_eq!(
+        aliases,
+        vec![(
+            "SAFE_OPENAI_API_KEY_0123456789abcdef".to_string(),
+            "<<OPENAI_API_KEY_0123456789abcdef>>".to_string()
+        )]
+    );
+}
+
+#[test]
 fn exec_only_injects_referenced_capability_env() {
     let root = temp_root("capability-env-least");
     let session = Session::open_capability_at(&root, "t").unwrap();
@@ -2657,7 +2681,10 @@ fn derived_redactions_do_not_claim_to_be_reusable_handles() {
     let (root, session) = empty_session("exec-derived-no-hint");
     let masked = mask_tool_output(&session, "PREFIX_32=rpa_FAKE\n").unwrap();
     assert_eq!(masked, "PREFIX_32=<<REDACTED_DERIVED>>\n");
-    assert!(first_reusable_env_name(&masked).is_none(), "{masked}");
+    assert!(
+        first_reusable_env_name(&masked, "PENTECT_").is_none(),
+        "{masked}"
+    );
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -3,6 +3,9 @@
 extensions = []
 # extension data: .pentect/extensions-data/<extension-id>
 
+[environment]
+prefix = "PENTECT_"
+
 [log]
 share = true
 


### PR DESCRIPTION
## Summary
- add [environment].prefix with project-over-global precedence and PENTECT_ default
- use the configured prefix for generated in-memory secret bindings
- keep Codex, Claude, OpenCode, and Pi agent contracts aligned with the configured name
- validate environment-name syntax while allowing an explicit empty prefix

## Verification
- cargo test -p pentect-runtime --no-default-features environment_prefix -- --test-threads=1
- cargo test -p pentect-runtime --no-default-features env_alias_recovery_uses_explicit_prefix -- --test-threads=1
- cargo test -p pentect-cli --no-default-features agent_contract_uses_configured_environment_prefix -- --test-threads=1
- cargo clippy -p pentect-runtime -p pentect-cli --all-targets --no-default-features -- -D warnings
- pentect codex --dry-run with [environment] prefix = SAFE_
- cargo fmt --all
- git diff --check