### PR TITLE
Publish Pi integration as @pentect/pi

### DIFF
--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -1,0 +1,50 @@
+name: Publish Pi
+
+on:
+  push:
+    tags:
+      - "pi-v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-pi-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'EdamAme-x/pentect'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: integrations/pi
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - name: Verify tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node --print "require('./package.json').version")"
+          test "$GITHUB_REF_NAME" = "pi-v$version"
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+      - name: Install
+        run: npm ci --ignore-scripts --no-audit --no-fund
+      - name: Check
+        run: |
+          npm run check
+          npm test
+          npm pack --dry-run
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -10,7 +10,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: publish-pi-${{ github.ref }}
+  group: publish-pi
   cancel-in-progress: false
 
 jobs:
@@ -22,10 +22,11 @@ jobs:
       run:
         working-directory: integrations/pi
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -36,7 +37,27 @@ jobs:
           set -euo pipefail
           version="$(node --print "require('./package.json').version")"
           test "$GITHUB_REF_NAME" = "pi-v$version"
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          test "$GITHUB_SHA" = "$(git rev-parse origin/main)"
+          published="$(npm view @pentect/pi version 2>/dev/null || true)"
+          node - "$published" "$version" <<'NODE'
+          const [published, next] = process.argv.slice(2);
+          const parse = (value) => {
+            if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(value)) {
+              throw new Error(`invalid release version: ${value}`);
+            }
+            return value.split(".").map(Number);
+          };
+          if (published) {
+            const previous = parse(published);
+            const candidate = parse(next);
+            const order = candidate.findIndex((part, index) => part !== previous[index]);
+            if (order < 0 || candidate[order] < previous[order]) {
+              throw new Error(`${next} must be newer than ${published}`);
+            }
+          } else {
+            parse(next);
+          }
+          NODE
       - name: Install
         run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Check
@@ -45,6 +66,4 @@ jobs:
           npm test
           npm pack --dry-run
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --provenance --access public

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -1,0 +1,19 @@
+# @pentect/pi
+
+Pentect protection for Pi.
+
+## Install
+
+Install `pentect`, then run:
+
+```sh
+pi install npm:@pentect/pi
+```
+
+Start Pi normally:
+
+```sh
+pi
+```
+
+Pentect runs behind Pi's existing interface. No separate launcher is required.

--- a/integrations/pi/package-lock.json
+++ b/integrations/pi/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@edamame-x/pentect-pi",
+  "name": "@pentect/pi",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@edamame-x/pentect-pi",
+      "name": "@pentect/pi",
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@edamame-x/pentect-pi",
+  "name": "@pentect/pi",
   "version": "0.0.1",
   "description": "Pentect protection for Pi",
   "type": "module",
@@ -9,6 +9,8 @@
     "url": "git+https://github.com/EdamAme-x/pentect.git",
     "directory": "integrations/pi"
   },
+  "homepage": "https://github.com/EdamAme-x/pentect/tree/main/integrations/pi",
+  "bugs": "https://github.com/EdamAme-x/pentect/issues",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- rename the native Pi package to `@pentect/pi`
- add package-local installation documentation
- publish version-matched `pi-v*` tags through npm trusted publishing
- serialize releases, require the current `main` commit, and reject non-increasing versions

## Verification
- `npm run check`
- `npm test`
- `npm publish --dry-run --access public`
- `actionlint .github/workflows/publish-pi.yml`