### PR TITLE
Release @pentect/pi 0.0.2

### DIFF
--- a/integrations/pi/package-lock.json
+++ b/integrations/pi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pentect/pi",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pentect/pi",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.80.7"

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pentect/pi",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pentect protection for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump `@pentect/pi` to `0.0.2`
- verify the OIDC tag publishing path

## Verification
- `npm run check`
- `npm test`
- `npm publish --dry-run --access public`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integration package version from 0.0.1 to 0.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->