### PR TITLE
Protect headless agent input and output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +813,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -2010,6 +2032,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,6 +2323,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "crossterm",
+ "ctrlc",
  "data-encoding",
  "fastwebsockets",
  "getrandom 0.2.17",
@@ -2498,7 +2533,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.28.0",
  "serial2",
  "shared_library",
  "shell-words",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -41,6 +41,7 @@ data-encoding.workspace = true
 getrandom = { workspace = true }
 reqwest = { workspace = true }
 sysinfo = { version = "0.37.2", default-features = false, features = ["system"] }
+ctrlc = "3.4"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = [

--- a/crates/pentect-cli/src/app_server_proxy.rs
+++ b/crates/pentect-cli/src/app_server_proxy.rs
@@ -271,11 +271,11 @@ fn terminate_windows_process_tree(root: SupervisedProcess) {
             sysinfo::ProcessRefreshKind::nothing(),
         );
         let root_process = system.process(root.pid);
-        let root_matches = root_process.is_some_and(|process| {
-            root.start_time
-                .is_none_or(|start_time| start_time == process.start_time())
-        });
-        let root_reused = root.start_time.is_some() && root_process.is_some() && !root_matches;
+        let root_matches = root
+            .start_time
+            .zip(root_process)
+            .is_some_and(|(start_time, process)| start_time == process.start_time());
+        let root_reused = root.start_time.is_none() || (root_process.is_some() && !root_matches);
         let mut targets = system
             .processes()
             .iter()
@@ -688,13 +688,13 @@ fn rewrite_server_binary_payload<F>(
 where
     F: FnMut(&str) -> Result<String, String>,
 {
-    if let Ok(text) = std::str::from_utf8(payload) {
-        return rewrite_server_text_frame_for_display(text, clean_command_display, mask)
-            .map(String::into_bytes);
-    }
     if image_payload(payload) {
         return pentect_agent::redact_image_bytes_into_active_memory_store(payload)
             .map(|redacted| redacted.unwrap_or_else(|| payload.to_vec()));
+    }
+    if let Ok(text) = std::str::from_utf8(payload) {
+        return rewrite_server_text_frame_for_display(text, clean_command_display, mask)
+            .map(String::into_bytes);
     }
     Err("app-server binary output cannot be protected".to_string())
 }

--- a/crates/pentect-cli/src/app_server_proxy.rs
+++ b/crates/pentect-cli/src/app_server_proxy.rs
@@ -21,6 +21,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::process::{Child, Command};
 use tokio::sync::oneshot;
+use zeroize::Zeroize;
 
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(8);
 pub(crate) const PENTECT_CODEX_APP_SERVER_PROXY_ENV: &str = "PENTECT_CODEX_APP_SERVER_PROXY";
@@ -92,6 +93,7 @@ async fn run_proxy(
     let backend_addr = reserve_loopback_addr()?;
     let backend_url = format!("ws://{backend_addr}");
     let mut backend = start_codex_app_server(&codex, &backend_url, app_server_args)?;
+    let _backend_supervisor = AppServerProcessSupervisor::new(&backend);
     if let Err(e) = wait_for_ready(backend_addr, &mut backend).await {
         stop_child(&mut backend).await;
         return Err(e);
@@ -116,6 +118,12 @@ async fn run_proxy(
     loop {
         tokio::select! {
             _ = &mut shutdown_rx => break,
+            status = backend.wait() => {
+                return Err(match status {
+                    Ok(status) => format!("codex app-server exited: {status}"),
+                    Err(error) => format!("could not wait for codex app-server: {error}"),
+                });
+            }
             accepted = listener.accept() => {
                 let (stream, _) = match accepted {
                     Ok(accepted) => accepted,
@@ -161,8 +169,194 @@ fn start_codex_app_server(
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    cmd.kill_on_drop(true);
+    #[cfg(unix)]
+    cmd.process_group(0);
     cmd.spawn()
         .map_err(|e| format!("could not start codex app-server: {e}"))
+}
+
+#[cfg(windows)]
+struct AppServerProcessSupervisor {
+    job: windows_sys::Win32::Foundation::HANDLE,
+    root: Option<SupervisedProcess>,
+}
+
+#[cfg(windows)]
+#[derive(Clone, Copy)]
+struct SupervisedProcess {
+    pid: sysinfo::Pid,
+    start_time: Option<u64>,
+}
+
+#[cfg(windows)]
+impl AppServerProcessSupervisor {
+    fn new(child: &Child) -> Self {
+        use windows_sys::Win32::System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+
+        let root = child.id().map(|pid| {
+            let pid = sysinfo::Pid::from_u32(pid);
+            let mut system = sysinfo::System::new();
+            system.refresh_processes_specifics(
+                sysinfo::ProcessesToUpdate::Some(&[pid]),
+                true,
+                sysinfo::ProcessRefreshKind::nothing(),
+            );
+            SupervisedProcess {
+                pid,
+                start_time: system.process(pid).map(sysinfo::Process::start_time),
+            }
+        });
+        let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if job.is_null() {
+            return Self { job, root };
+        }
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                std::ptr::from_ref(&limits).cast(),
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        } != 0;
+        let assigned = configured
+            && child.raw_handle().is_some_and(|process| unsafe {
+                AssignProcessToJobObject(job, process.cast()) != 0
+            });
+        if assigned {
+            Self { job, root }
+        } else {
+            unsafe {
+                let _ = windows_sys::Win32::Foundation::CloseHandle(job);
+            }
+            Self {
+                job: std::ptr::null_mut(),
+                root,
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for AppServerProcessSupervisor {
+    fn drop(&mut self) {
+        if !self.job.is_null() {
+            unsafe {
+                let _ = windows_sys::Win32::Foundation::CloseHandle(self.job);
+            }
+            self.job = std::ptr::null_mut();
+        }
+        let Some(root) = self.root.take() else {
+            return;
+        };
+        terminate_windows_process_tree(root);
+    }
+}
+
+#[cfg(windows)]
+fn terminate_windows_process_tree(root: SupervisedProcess) {
+    use std::thread;
+
+    for _ in 0..4 {
+        let mut system = sysinfo::System::new();
+        system.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::All,
+            true,
+            sysinfo::ProcessRefreshKind::nothing(),
+        );
+        let root_process = system.process(root.pid);
+        let root_matches = root_process.is_some_and(|process| {
+            root.start_time
+                .is_none_or(|start_time| start_time == process.start_time())
+        });
+        let root_reused = root.start_time.is_some() && root_process.is_some() && !root_matches;
+        let mut targets = system
+            .processes()
+            .iter()
+            .filter_map(|(pid, _)| {
+                ((root_matches && *pid == root.pid)
+                    || (!root_reused
+                        && windows_process_descends_from(*pid, root.pid, system.processes())))
+                .then_some(*pid)
+            })
+            .filter(|pid| pid.as_u32() > 1 && pid.as_u32() != std::process::id())
+            .collect::<Vec<_>>();
+        if targets.is_empty() {
+            break;
+        }
+        targets.sort_unstable_by_key(|pid| std::cmp::Reverse(pid.as_u32()));
+        for pid in targets {
+            if let Some(process) = system.process(pid) {
+                let _ = process.kill();
+            }
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(windows)]
+fn windows_process_descends_from(
+    mut pid: sysinfo::Pid,
+    root: sysinfo::Pid,
+    processes: &std::collections::HashMap<sysinfo::Pid, sysinfo::Process>,
+) -> bool {
+    if pid == root {
+        return false;
+    }
+    for _ in 0..64 {
+        let Some(parent) = processes.get(&pid).and_then(sysinfo::Process::parent) else {
+            return false;
+        };
+        if parent == root {
+            return true;
+        }
+        if parent == pid {
+            return false;
+        }
+        pid = parent;
+    }
+    false
+}
+
+#[cfg(unix)]
+struct AppServerProcessSupervisor {
+    process_group: Option<i32>,
+}
+
+#[cfg(unix)]
+impl AppServerProcessSupervisor {
+    fn new(child: &Child) -> Self {
+        Self {
+            process_group: child.id().and_then(|pid| i32::try_from(pid).ok()),
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for AppServerProcessSupervisor {
+    fn drop(&mut self) {
+        if let Some(process_group) = self.process_group.take() {
+            unsafe {
+                let _ = libc::kill(-process_group, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+struct AppServerProcessSupervisor;
+
+#[cfg(not(any(unix, windows)))]
+impl AppServerProcessSupervisor {
+    fn new(_child: &Child) -> Self {
+        Self
+    }
 }
 
 async fn wait_for_ready(addr: SocketAddr, child: &mut Child) -> Result<(), String> {
@@ -476,6 +670,9 @@ where
         Err(_) => return mask(text),
     };
     redact_images(&mut value)?;
+    if clean_command_display {
+        suppress_partial_json_deltas(&mut value);
+    }
     mask_app_server_display_strings(&mut value, None, clean_command_display, mask)?;
     if clean_command_display {
         prefer_command_action_display(&mut value);
@@ -491,10 +688,24 @@ fn rewrite_server_binary_payload<F>(
 where
     F: FnMut(&str) -> Result<String, String>,
 {
-    let Ok(text) = std::str::from_utf8(payload) else {
-        return Ok(payload.to_vec());
-    };
-    rewrite_server_text_frame_for_display(text, clean_command_display, mask).map(String::into_bytes)
+    if let Ok(text) = std::str::from_utf8(payload) {
+        return rewrite_server_text_frame_for_display(text, clean_command_display, mask)
+            .map(String::into_bytes);
+    }
+    if image_payload(payload) {
+        return pentect_agent::redact_image_bytes_into_active_memory_store(payload)
+            .map(|redacted| redacted.unwrap_or_else(|| payload.to_vec()));
+    }
+    Err("app-server binary output cannot be protected".to_string())
+}
+
+fn image_payload(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"\x89PNG\r\n\x1a\n")
+        || bytes.starts_with(&[0xff, 0xd8, 0xff])
+        || bytes.starts_with(b"GIF87a")
+        || bytes.starts_with(b"GIF89a")
+        || bytes.starts_with(b"BM")
+        || (bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WEBP"))
 }
 
 fn redact_app_server_images(value: &mut Value) -> Result<(), String> {
@@ -524,7 +735,9 @@ where
                     debug_app_server_display_clean(key, before_len, before_len, false);
                 }
             }
-            if key.is_some_and(maskable_app_server_text_key) {
+            if !looks_like_image_payload_string(text)
+                && !key.is_some_and(|key| safe_protocol_path(key, text))
+            {
                 let masked = mask(text)?;
                 if masked != *text {
                     *text = masked;
@@ -732,6 +945,117 @@ fn maskable_app_server_text_key(key: &str) -> bool {
     )
 }
 
+fn safe_protocol_path(key: &str, text: &str) -> bool {
+    use pentect_core::OverMaskGuard;
+
+    if !matches!(key, "path" | "cwd") {
+        return false;
+    }
+    let candidate = text
+        .strip_prefix("file:///")
+        .or_else(|| text.strip_prefix("file://"))
+        .unwrap_or(text);
+    !text.contains(['?', '#', '\r', '\n']) && pentect_core::ShapeGuard::builtin().benign(candidate)
+}
+
+fn looks_like_image_payload_string(text: &str) -> bool {
+    text.trim_start()
+        .get(..11)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:image/"))
+}
+
+fn suppress_partial_json_deltas(value: &mut Value) -> bool {
+    if !json_has_partial_event_marker(value) {
+        return false;
+    }
+    clear_partial_json_payload(value, None)
+}
+
+fn json_has_partial_event_marker(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            object.iter().any(|(key, value)| {
+                matches!(key.as_str(), "type" | "event" | "method")
+                    && value.as_str().is_some_and(|text| {
+                        let lower = text.to_ascii_lowercase();
+                        lower == "stream_event"
+                            || lower
+                                .rsplit(['/', '_'])
+                                .next()
+                                .is_some_and(|part| part.ends_with("delta"))
+                    })
+            }) || object.values().any(json_has_partial_event_marker)
+        }
+        Value::Array(values) => values.iter().any(json_has_partial_event_marker),
+        _ => false,
+    }
+}
+
+fn clear_partial_json_payload(value: &mut Value, key: Option<&str>) -> bool {
+    match value {
+        Value::Object(object) => {
+            let mut changed = false;
+            for (key, value) in object {
+                changed |= clear_partial_json_payload(value, Some(key));
+            }
+            changed
+        }
+        Value::Array(values) => {
+            let mut changed = false;
+            for value in values {
+                changed |= clear_partial_json_payload(value, key);
+            }
+            changed
+        }
+        Value::String(text) if !key.is_some_and(partial_json_metadata_key) => {
+            text.zeroize();
+            text.clear();
+            true
+        }
+        _ => false,
+    }
+}
+
+fn partial_json_metadata_key(key: &str) -> bool {
+    matches!(
+        key,
+        "type"
+            | "event"
+            | "method"
+            | "jsonrpc"
+            | "id"
+            | "requestId"
+            | "request_id"
+            | "responseId"
+            | "response_id"
+            | "sessionId"
+            | "session_id"
+            | "threadId"
+            | "thread_id"
+            | "turnId"
+            | "turn_id"
+            | "itemId"
+            | "item_id"
+            | "messageId"
+            | "message_id"
+            | "toolUseId"
+            | "tool_use_id"
+            | "callId"
+            | "call_id"
+            | "parentId"
+            | "parent_id"
+            | "uuid"
+            | "status"
+            | "phase"
+            | "timestamp"
+            | "createdAt"
+            | "created_at"
+            | "updatedAt"
+            | "updated_at"
+            | "version"
+    )
+}
+
 fn mask_output_text(
     masker: &mut pentect_agent::ActiveToolOutputMasker,
     text: &str,
@@ -763,11 +1087,13 @@ mod tests {
     fn server_frame_masks_nested_strings() {
         let raw = serde_json::json!({
             "method": "item/completed",
+            "session_id": "sk-abcdefghijklmnopqrstuvwx",
             "params": {
                 "item": {
                     "content": [
                         {"text": "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx"}
-                    ]
+                    ],
+                    "output": {"value": "sk-abcdefghijklmnopqrstuvwx"}
                 }
             }
         })
@@ -776,8 +1102,17 @@ mod tests {
             Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
         })
         .unwrap();
-        assert!(!masked.contains("sk-abcdefghijklmnopqrstuvwx"), "{masked}");
         assert!(masked.contains("<<OPENAI_API_KEY_x>>"), "{masked}");
+        let value: Value = serde_json::from_str(&masked).unwrap();
+        assert_eq!(value["session_id"], "<<OPENAI_API_KEY_x>>");
+        assert_eq!(
+            value["params"]["item"]["content"][0]["text"],
+            "OPENAI_API_KEY=<<OPENAI_API_KEY_x>>"
+        );
+        assert_eq!(
+            value["params"]["item"]["output"]["value"],
+            "<<OPENAI_API_KEY_x>>"
+        );
     }
 
     #[test]
@@ -812,14 +1147,17 @@ mod tests {
     }
 
     #[test]
-    fn server_frame_masks_command_execution_delta() {
+    fn server_frame_suppresses_partial_command_output() {
         let raw = serde_json::json!({
             "method": "item/commandExecution/outputDelta",
             "params": {
                 "threadId": "thread-1",
                 "turnId": "turn-1",
                 "itemId": "item-1",
-                "delta": "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx"
+                "delta": {
+                    "type": "text_delta",
+                    "text": "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx"
+                }
             }
         })
         .to_string();
@@ -828,7 +1166,9 @@ mod tests {
         })
         .unwrap();
         assert!(!masked.contains("sk-abcdefghijklmnopqrstuvwx"), "{masked}");
-        assert!(masked.contains("<<OPENAI_API_KEY_x>>"), "{masked}");
+        let value: Value = serde_json::from_str(&masked).unwrap();
+        assert_eq!(value["params"]["delta"]["type"], "text_delta");
+        assert_eq!(value["params"]["delta"]["text"], "");
     }
 
     #[test]
@@ -973,16 +1313,16 @@ mod tests {
     }
 
     #[test]
-    fn server_binary_frame_leaves_non_utf8_payload() {
+    fn server_binary_frame_rejects_unknown_non_utf8_payload() {
         let raw = [0xff, 0x00, 0x80];
-        let masked =
+        let error =
             rewrite_server_binary_payload(
                 &raw,
                 true,
                 &mut |_| Ok("<<SHOULD_NOT_RUN>>".to_string()),
             )
-            .unwrap();
-        assert_eq!(masked, raw);
+            .unwrap_err();
+        assert_eq!(error, "app-server binary output cannot be protected");
     }
 
     #[test]
@@ -1017,6 +1357,21 @@ mod tests {
         assert!(masked.contains("<<OPENAI_API_KEY_x>>"), "{masked}");
         assert!(!masked.contains("<<LOCAL_PATH_x>>"), "{masked}");
         assert!(!masked.contains("<<LOCAL_URI_x>>"), "{masked}");
+    }
+
+    #[test]
+    fn server_frame_scans_metadata_keys_that_do_not_contain_real_paths() {
+        let raw = serde_json::json!({
+            "id": "sk-abcdefghijklmnopqrstuvwx",
+            "path": "Authorization: Bearer sk-abcdefghijklmnopqrstuvwx"
+        })
+        .to_string();
+        let masked = rewrite_server_text_frame(&raw, &mut |text| {
+            Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
+        })
+        .unwrap();
+        assert!(!masked.contains("sk-abcdefghijklmnopqrstuvwx"), "{masked}");
+        assert_eq!(masked.matches("<<OPENAI_API_KEY_x>>").count(), 2);
     }
 
     #[test]

--- a/crates/pentect-cli/src/headless.rs
+++ b/crates/pentect-cli/src/headless.rs
@@ -1,0 +1,2006 @@
+use std::io::{self, BufRead, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc, Arc,
+};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use zeroize::Zeroize;
+
+const MAX_HEADLESS_INPUT_BYTES: usize = 32 * 1024 * 1024;
+const MAX_HEADLESS_IMAGE_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_HEADLESS_OUTPUT_BYTES: usize = 32 * 1024 * 1024;
+const MAX_HEADLESS_OUTPUT_RECORD_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AgentKind {
+    Codex,
+    Claude,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) enum InputMode {
+    #[default]
+    Buffered,
+    JsonLines,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) enum OutputMode {
+    #[default]
+    Text,
+    JsonRecords,
+}
+
+#[derive(Default)]
+pub(crate) struct ProtectedImageFiles {
+    root: Option<PathBuf>,
+    next_file: usize,
+}
+
+impl ProtectedImageFiles {
+    fn protect_path(&mut self, value: &str) -> Result<String, String> {
+        let path = Path::new(value);
+        let size = std::fs::metadata(path)
+            .map_err(|error| format!("could not inspect image '{}': {error}", path.display()))?
+            .len();
+        if size > MAX_HEADLESS_IMAGE_BYTES {
+            return Err(format!(
+                "image '{}' exceeds {MAX_HEADLESS_IMAGE_BYTES} bytes",
+                path.display()
+            ));
+        }
+        let mut bytes = std::fs::read(path)
+            .map_err(|error| format!("could not read image '{}': {error}", path.display()))?;
+        let redaction = pentect_agent::redact_image_bytes_into_active_memory_store(&bytes);
+        bytes.zeroize();
+        let Some(mut redacted) = redaction? else {
+            return Ok(value.to_string());
+        };
+        let output = self.output_path(path, &redacted)?;
+        let write_result = write_private_file(&output, &redacted);
+        redacted.zeroize();
+        write_result?;
+        Ok(output.to_string_lossy().into_owned())
+    }
+
+    fn output_path(&mut self, source: &Path, bytes: &[u8]) -> Result<PathBuf, String> {
+        let root = match &self.root {
+            Some(root) => root.clone(),
+            None => {
+                let mut nonce = [0u8; 16];
+                getrandom::getrandom(&mut nonce)
+                    .map_err(|error| format!("could not create protected image path: {error}"))?;
+                let root = std::env::temp_dir().join(format!(
+                    "pentect-images-{}-{}",
+                    std::process::id(),
+                    data_encoding::HEXLOWER.encode(&nonce)
+                ));
+                nonce.zeroize();
+                std::fs::create_dir(&root).map_err(|error| {
+                    format!("could not create protected image directory: {error}")
+                })?;
+                set_private_directory_permissions(&root)?;
+                self.root = Some(root.clone());
+                root
+            }
+        };
+        self.next_file += 1;
+        let extension = image_extension(bytes).unwrap_or_else(|| {
+            source
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .filter(|extension| {
+                    !extension.is_empty()
+                        && extension.len() <= 10
+                        && extension
+                            .chars()
+                            .all(|character| character.is_ascii_alphanumeric())
+                })
+                .unwrap_or("png")
+        });
+        Ok(root.join(format!("image-{}.{extension}", self.next_file)))
+    }
+}
+
+fn image_extension(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        Some("png")
+    } else if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        Some("jpg")
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some("gif")
+    } else if bytes.starts_with(b"BM") {
+        Some("bmp")
+    } else if bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WEBP") {
+        Some("webp")
+    } else {
+        None
+    }
+}
+
+impl Drop for ProtectedImageFiles {
+    fn drop(&mut self) {
+        if let Some(root) = self.root.take() {
+            remove_private_directory(&root);
+        }
+    }
+}
+
+fn remove_private_directory(root: &Path) {
+    for delay in [0, 10, 25, 50] {
+        if delay > 0 {
+            thread::sleep(Duration::from_millis(delay));
+        }
+        match std::fs::remove_dir_all(root) {
+            Ok(()) => return,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return,
+            Err(_) => {}
+        }
+    }
+}
+
+pub(crate) fn protect_codex_image_args(
+    args: &[String],
+) -> Result<(Vec<String>, ProtectedImageFiles), String> {
+    let mut protected = args.to_vec();
+    let mut files = ProtectedImageFiles::default();
+    rewrite_codex_image_values(&mut protected, &mut |value| {
+        let mut rewritten = Vec::new();
+        for path in value.split(',') {
+            rewritten.push(files.protect_path(path)?);
+        }
+        Ok(rewritten.join(","))
+    })?;
+    Ok((protected, files))
+}
+
+fn rewrite_codex_image_values<F>(args: &mut [String], rewrite: &mut F) -> Result<(), String>
+where
+    F: FnMut(&str) -> Result<String, String>,
+{
+    let mut index = 0usize;
+    while index < args.len() {
+        if args[index] == "--" {
+            break;
+        }
+        if let Some(value) = args[index]
+            .strip_prefix("--image=")
+            .or_else(|| args[index].strip_prefix("-i="))
+        {
+            let prefix = args[index]
+                .split_once('=')
+                .map(|(prefix, _)| prefix)
+                .unwrap_or("-i");
+            args[index] = format!("{prefix}={}", rewrite(value)?);
+            index += 1;
+            continue;
+        }
+        if matches!(args[index].as_str(), "-i" | "--image") {
+            index += 1;
+            while index < args.len()
+                && args[index] != "--"
+                && !args[index].starts_with('-')
+                && !is_codex_command(&args[index])
+            {
+                args[index] = rewrite(&args[index])?;
+                index += 1;
+            }
+            continue;
+        }
+        index += 1;
+    }
+    Ok(())
+}
+
+fn write_private_file(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| format!("could not create protected image: {error}"))?;
+    file.write_all(bytes)
+        .map_err(|error| format!("could not write protected image: {error}"))
+}
+
+#[cfg(unix)]
+fn set_private_directory_permissions(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .map_err(|error| format!("could not protect image directory: {error}"))
+}
+
+#[cfg(not(unix))]
+fn set_private_directory_permissions(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(windows)]
+struct HeadlessProcessSupervisor {
+    job: windows_sys::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+impl HeadlessProcessSupervisor {
+    fn new(child: &Child) -> Self {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+
+        let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if job.is_null() {
+            return Self { job };
+        }
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                std::ptr::from_ref(&limits).cast(),
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        } != 0;
+        let assigned = configured
+            && unsafe { AssignProcessToJobObject(job, child.as_raw_handle().cast()) } != 0;
+        if assigned {
+            Self { job }
+        } else {
+            unsafe {
+                let _ = windows_sys::Win32::Foundation::CloseHandle(job);
+            }
+            Self {
+                job: std::ptr::null_mut(),
+            }
+        }
+    }
+
+    fn terminate(&mut self) -> bool {
+        use windows_sys::Win32::{Foundation::CloseHandle, System::JobObjects::TerminateJobObject};
+
+        if self.job.is_null() {
+            return false;
+        }
+        let terminated = unsafe { TerminateJobObject(self.job, 1) != 0 };
+        unsafe {
+            let _ = CloseHandle(self.job);
+        }
+        self.job = std::ptr::null_mut();
+        terminated
+    }
+}
+
+#[cfg(windows)]
+impl Drop for HeadlessProcessSupervisor {
+    fn drop(&mut self) {
+        let _ = self.terminate();
+    }
+}
+
+#[cfg(not(windows))]
+struct HeadlessProcessSupervisor;
+
+#[cfg(not(windows))]
+impl HeadlessProcessSupervisor {
+    fn new(_child: &Child) -> Self {
+        Self
+    }
+
+    fn terminate(&mut self) -> bool {
+        false
+    }
+}
+
+pub(crate) fn protect_prompt_args(
+    agent: AgentKind,
+    args: &[String],
+) -> Result<Vec<String>, String> {
+    rewrite_prompt_args_with(agent, args, &mut |text| {
+        pentect_agent::mask_prompt_text_into_active_memory_store(text)
+    })
+}
+
+pub(crate) fn claude_input_mode(args: &[String]) -> InputMode {
+    for (index, arg) in args.iter().enumerate() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--input-format"
+            && args
+                .get(index + 1)
+                .is_some_and(|value| value == "stream-json")
+        {
+            return InputMode::JsonLines;
+        }
+        if arg == "--input-format=stream-json" {
+            return InputMode::JsonLines;
+        }
+    }
+    InputMode::Buffered
+}
+
+pub(crate) fn codex_output_mode(args: &[String]) -> OutputMode {
+    if args
+        .iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| arg == "--json")
+    {
+        OutputMode::JsonRecords
+    } else {
+        OutputMode::Text
+    }
+}
+
+pub(crate) fn claude_output_mode(args: &[String]) -> OutputMode {
+    for (index, arg) in args.iter().enumerate() {
+        if arg == "--" {
+            break;
+        }
+        let value = if arg == "--output-format" {
+            args.get(index + 1).map(String::as_str)
+        } else {
+            arg.strip_prefix("--output-format=")
+        };
+        if value.is_some_and(|value| matches!(value, "json" | "stream-json")) {
+            return OutputMode::JsonRecords;
+        }
+    }
+    OutputMode::Text
+}
+
+pub(crate) fn claude_uses_partial_output(args: &[String]) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| arg == "--include-partial-messages")
+}
+
+pub(crate) fn protect_stdin(
+    agent: AgentKind,
+    args: &[String],
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+) -> bool {
+    match agent {
+        AgentKind::Codex => {
+            codex_reads_prompt_from_stdin(args)
+                || (!stdin_is_terminal && codex_accepts_prompt_input(args))
+        }
+        AgentKind::Claude => {
+            claude_reads_prompt_from_stdin(args, stdin_is_terminal, stdout_is_terminal)
+        }
+    }
+}
+
+pub(crate) fn run_noninteractive_command(
+    cmd: &mut Command,
+    display: &Path,
+    input_mode: InputMode,
+    output_mode: OutputMode,
+    protect_stdin: bool,
+) -> Result<ExitStatus, String> {
+    let protected_stdin = protect_stdin;
+    let buffered_stdin = if protected_stdin && input_mode == InputMode::Buffered {
+        Some(read_masked_buffered_stdin()?)
+    } else {
+        None
+    };
+    let streaming_masker = if protected_stdin && input_mode == InputMode::JsonLines {
+        Some(pentect_agent::ActiveToolOutputMasker::new()?)
+    } else {
+        None
+    };
+    if protected_stdin {
+        cmd.stdin(Stdio::piped());
+    } else {
+        cmd.stdin(Stdio::inherit());
+    }
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let interrupt_cancelled = Arc::clone(&cancelled);
+    ctrlc::set_handler(move || interrupt_cancelled.store(true, Ordering::Release))
+        .map_err(|error| format!("could not install interrupt handler: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    let mut child = cmd
+        .spawn()
+        .map_err(|error| format!("could not start '{}': {error}", display.display()))?;
+    let mut process_supervisor = HeadlessProcessSupervisor::new(&child);
+    let supervised_root = crate::capture_supervised_root_pid(Some(child.id()));
+    let mut streaming_stdin = None;
+    let mut stdin_thread = None;
+    if protected_stdin {
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| format!("could not open '{}' stdin", display.display()))?;
+        if let Some(buffered) = buffered_stdin {
+            let cancelled = Arc::clone(&cancelled);
+            stdin_thread = Some(thread::spawn(move || {
+                let result = write_buffered_stdin(stdin, buffered);
+                if result.is_err() {
+                    cancelled.store(true, Ordering::Release);
+                }
+                result
+            }));
+        } else {
+            let (sender, receiver) = mpsc::sync_channel(1);
+            let input_cancelled = Arc::clone(&cancelled);
+            stdin_thread = Some(thread::spawn(move || {
+                read_json_lines(sender, input_cancelled)
+            }));
+            streaming_stdin = Some((
+                stdin,
+                streaming_masker.ok_or_else(|| "prompt masker is unavailable".to_string())?,
+                receiver,
+            ));
+        }
+    }
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| format!("could not open '{}' stdout", display.display()))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| format!("could not open '{}' stderr", display.display()))?;
+    let stdout_cancelled = Arc::clone(&cancelled);
+    let stdout_thread = thread::spawn(move || {
+        let output = io::stdout();
+        let framing = if output_mode == OutputMode::Text {
+            OutputFraming::Whole
+        } else {
+            OutputFraming::Records
+        };
+        proxy_output(
+            stdout,
+            output.lock(),
+            stdout_cancelled,
+            true,
+            output_mode,
+            framing,
+        )
+    });
+    let stderr_cancelled = Arc::clone(&cancelled);
+    let stderr_thread = thread::spawn(move || {
+        let output = io::stderr();
+        proxy_output(
+            stderr,
+            output.lock(),
+            stderr_cancelled,
+            true,
+            OutputMode::Text,
+            OutputFraming::Whole,
+        )
+    });
+
+    let mut early_status = None;
+    let streaming_input_error = if let Some((mut stdin, mut masker, receiver)) = streaming_stdin {
+        loop {
+            if cancelled.load(Ordering::Acquire) {
+                break None;
+            }
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    early_status = Some(status);
+                    break None;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    cancelled.store(true, Ordering::Release);
+                    break Some(format!(
+                        "could not wait for '{}': {error}",
+                        display.display()
+                    ));
+                }
+            }
+            match receiver.recv_timeout(Duration::from_millis(10)) {
+                Ok(Ok(mut line)) => {
+                    let result = mask_and_write_json_prompt(&line, &mut stdin, &mut masker)
+                        .and_then(|()| {
+                            stdin
+                                .flush()
+                                .map_err(|error| format!("could not flush agent stdin: {error}"))
+                        });
+                    line.zeroize();
+                    if let Err(error) = result {
+                        cancelled.store(true, Ordering::Release);
+                        break Some(error);
+                    }
+                }
+                Ok(Err(error)) => {
+                    cancelled.store(true, Ordering::Release);
+                    break Some(error);
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => break None,
+            }
+        }
+    } else {
+        None
+    };
+
+    let status = if let Some(status) = early_status {
+        terminate_headless_processes(&mut process_supervisor, supervised_root);
+        status
+    } else {
+        loop {
+            if cancelled.load(Ordering::Acquire) {
+                terminate_headless_processes(&mut process_supervisor, supervised_root);
+                let _ = child.kill();
+                let status = child
+                    .wait()
+                    .map_err(|error| format!("could not stop '{}': {error}", display.display()))?;
+                break status;
+            }
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|error| format!("could not wait for '{}': {error}", display.display()))?
+            {
+                terminate_headless_processes(&mut process_supervisor, supervised_root);
+                break status;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    };
+    join_output(stdout_thread, "stdout")?;
+    join_output(stderr_thread, "stderr")?;
+    if let Some(stdin_thread) = stdin_thread {
+        join_input(stdin_thread)?;
+    }
+    if let Some(error) = streaming_input_error {
+        return Err(error);
+    }
+    Ok(status)
+}
+
+fn terminate_headless_processes(
+    supervisor: &mut HeadlessProcessSupervisor,
+    root: Option<crate::SupervisedRoot>,
+) {
+    if !supervisor.terminate() {
+        terminate_cancelled_processes(root);
+    }
+}
+
+#[cfg(windows)]
+fn terminate_cancelled_processes(root: Option<crate::SupervisedRoot>) {
+    if let Some(root) = root {
+        crate::terminate_supervised_processes(root);
+    }
+}
+
+#[cfg(unix)]
+fn terminate_cancelled_processes(root: Option<crate::SupervisedRoot>) {
+    if let Some(root) = root {
+        unsafe {
+            let _ = libc::kill(-(root.pid.as_u32() as i32), libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn terminate_cancelled_processes(_root: Option<crate::SupervisedRoot>) {}
+
+fn proxy_output(
+    mut reader: impl Read,
+    mut writer: impl Write,
+    cancelled: Arc<AtomicBool>,
+    detect_new_secrets: bool,
+    output_mode: OutputMode,
+    framing: OutputFraming,
+) -> Result<(), String> {
+    let mut masker = match HeadlessOutputMasker::new(detect_new_secrets, output_mode, framing) {
+        Ok(masker) => masker,
+        Err(error) => {
+            drain_sensitive(&mut reader);
+            cancelled.store(true, Ordering::Release);
+            return Err(error);
+        }
+    };
+    let mut buffer = [0u8; 8192];
+    let mut output_open = true;
+    let mut first_error = None;
+    loop {
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(error) => {
+                buffer.zeroize();
+                cancelled.store(true, Ordering::Release);
+                return Err(format!("could not read agent output: {error}"));
+            }
+        };
+        if first_error.is_some() {
+            buffer[..read].zeroize();
+            continue;
+        }
+        let mut masked = match masker.push(&buffer[..read]) {
+            Ok(masked) => masked,
+            Err(error) => {
+                buffer[..read].zeroize();
+                cancelled.store(true, Ordering::Release);
+                first_error = Some(error);
+                continue;
+            }
+        };
+        buffer[..read].zeroize();
+        if output_open {
+            match writer.write_all(&masked).and_then(|()| writer.flush()) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {
+                    output_open = false;
+                    cancelled.store(true, Ordering::Release);
+                }
+                Err(error) => {
+                    output_open = false;
+                    cancelled.store(true, Ordering::Release);
+                    first_error = Some(format!("could not write agent output: {error}"));
+                }
+            }
+        }
+        masked.zeroize();
+    }
+    buffer.zeroize();
+    if let Some(error) = first_error {
+        return Err(error);
+    }
+    let mut tail = masker.finish()?;
+    let tail_result = if output_open {
+        match writer.write_all(&tail).and_then(|()| writer.flush()) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+            Err(error) => Err(format!("could not write agent output: {error}")),
+        }
+    } else {
+        Ok(())
+    };
+    tail.zeroize();
+    tail_result
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OutputFraming {
+    Whole,
+    Records,
+}
+
+struct HeadlessOutputMasker {
+    detector: Option<pentect_agent::ActiveToolOutputMasker>,
+    remasker: pentect_agent::ActiveTerminalOutputRemasker,
+    pending: Vec<u8>,
+    output_mode: OutputMode,
+    framing: OutputFraming,
+}
+
+impl HeadlessOutputMasker {
+    fn new(
+        detect_new_secrets: bool,
+        output_mode: OutputMode,
+        framing: OutputFraming,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            detector: detect_new_secrets
+                .then(pentect_agent::ActiveToolOutputMasker::new)
+                .transpose()?,
+            remasker: pentect_agent::ActiveTerminalOutputRemasker::new()?,
+            pending: Vec::new(),
+            output_mode,
+            framing,
+        })
+    }
+
+    fn push(&mut self, bytes: &[u8]) -> Result<Vec<u8>, String> {
+        self.pending.extend_from_slice(bytes);
+        if self.framing == OutputFraming::Whole {
+            if self.pending.len() > MAX_HEADLESS_OUTPUT_BYTES {
+                self.pending.zeroize();
+                self.pending.clear();
+                return Err(format!(
+                    "agent output exceeds {MAX_HEADLESS_OUTPUT_BYTES} bytes"
+                ));
+            }
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut start = 0usize;
+        while let Some(relative) = memchr::memchr2(b'\n', b'\r', &self.pending[start..]) {
+            let end = start + relative + 1;
+            let mut record = self.pending[start..end].to_vec();
+            let masked = self.mask_record(&record);
+            record.zeroize();
+            let masked = match masked {
+                Ok(masked) => masked,
+                Err(error) => {
+                    self.pending.zeroize();
+                    self.pending.clear();
+                    out.zeroize();
+                    return Err(error);
+                }
+            };
+            out.extend(masked);
+            start = end;
+        }
+        if start > 0 {
+            let remaining = self.pending.len() - start;
+            self.pending.copy_within(start.., 0);
+            self.pending[remaining..].zeroize();
+            self.pending.truncate(remaining);
+        }
+        if self.pending.len() > MAX_HEADLESS_OUTPUT_RECORD_BYTES {
+            self.pending.zeroize();
+            self.pending.clear();
+            out.zeroize();
+            return Err(format!(
+                "agent output record exceeds {MAX_HEADLESS_OUTPUT_RECORD_BYTES} bytes"
+            ));
+        }
+        Ok(out)
+    }
+
+    fn finish(&mut self) -> Result<Vec<u8>, String> {
+        let mut out = Vec::new();
+        if !self.pending.is_empty() {
+            let mut record = std::mem::take(&mut self.pending);
+            let masked = self.mask_record(&record);
+            record.zeroize();
+            match masked {
+                Ok(masked) => out.extend(masked),
+                Err(error) => {
+                    out.zeroize();
+                    return Err(error);
+                }
+            }
+        }
+        out.extend(self.remasker.finish()?);
+        Ok(out)
+    }
+
+    fn mask_record(&mut self, record: &[u8]) -> Result<Vec<u8>, String> {
+        let text = std::str::from_utf8(record)
+            .map_err(|_| "agent output must be UTF-8 text so Pentect can protect it".to_string())?;
+        let Some(detector) = &mut self.detector else {
+            return self.remasker.push(record);
+        };
+        if self.output_mode == OutputMode::Text && benign_identifier_metadata_record(record) {
+            return self.remasker.push(record);
+        }
+        if self.output_mode == OutputMode::JsonRecords {
+            return mask_json_record(record, detector, &mut self.remasker);
+        }
+        let Some(mut masked) = detector.mask_tool_output(text)? else {
+            return self.remasker.push(record);
+        };
+        let result = self.remasker.push(masked.as_bytes());
+        masked.zeroize();
+        result
+    }
+}
+
+fn benign_identifier_metadata_record(record: &[u8]) -> bool {
+    use pentect_core::OverMaskGuard;
+
+    let Ok(text) = std::str::from_utf8(record) else {
+        return false;
+    };
+    let Some((key, value)) = text.trim().split_once(':') else {
+        return false;
+    };
+    let tokens = key
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect::<Vec<_>>();
+    if !tokens
+        .iter()
+        .any(|token| matches!(token.as_str(), "id" | "uuid" | "hash" | "sha"))
+        || tokens.iter().any(|token| {
+            matches!(
+                token.as_str(),
+                "secret" | "token" | "key" | "password" | "credential" | "auth" | "cookie"
+            )
+        })
+    {
+        return false;
+    }
+    pentect_core::ShapeGuard::builtin().benign(value.trim())
+}
+
+impl Drop for HeadlessOutputMasker {
+    fn drop(&mut self) {
+        self.pending.zeroize();
+    }
+}
+
+fn mask_json_record(
+    record: &[u8],
+    detector: &mut pentect_agent::ActiveToolOutputMasker,
+    remasker: &mut pentect_agent::ActiveTerminalOutputRemasker,
+) -> Result<Vec<u8>, String> {
+    let body_len = record
+        .iter()
+        .rposition(|byte| !matches!(byte, b'\r' | b'\n'))
+        .map_or(0, |index| index + 1);
+    let (body, ending) = record.split_at(body_len);
+    if body.iter().all(u8::is_ascii_whitespace) {
+        return remasker.push(record);
+    }
+    let mut value: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|error| format!("agent JSON output is invalid: {error}"))?;
+    let suppressed = suppress_partial_json_deltas(&mut value);
+    let changed = mask_json_value(&mut value, true, &mut |text| {
+        detector.mask_tool_output(text)
+    });
+    let changed = match changed {
+        Ok(changed) => suppressed || changed,
+        Err(error) => {
+            zeroize_json_strings(&mut value);
+            return Err(error);
+        }
+    };
+    if !changed {
+        zeroize_json_strings(&mut value);
+        return remasker.push(record);
+    }
+    let encoded = serde_json::to_vec(&value);
+    zeroize_json_strings(&mut value);
+    let mut masked = encoded
+        .map_err(|error| format!("could not encode protected agent JSON output: {error}"))?;
+    masked.extend_from_slice(ending);
+    let result = remasker.push(&masked);
+    masked.zeroize();
+    result
+}
+
+fn mask_json_value<F>(
+    value: &mut serde_json::Value,
+    scan_string: bool,
+    mask: &mut F,
+) -> Result<bool, String>
+where
+    F: FnMut(&str) -> Result<Option<String>, String>,
+{
+    match value {
+        serde_json::Value::Object(object) => {
+            let mut changed = false;
+            for (key, value) in object {
+                let scan_child = !value.as_str().is_some_and(looks_like_image_payload_string)
+                    && !value
+                        .as_str()
+                        .is_some_and(|text| safe_protocol_path(key, text));
+                changed |= mask_json_value(value, scan_child, mask)?;
+            }
+            Ok(changed)
+        }
+        serde_json::Value::Array(values) => {
+            let mut changed = false;
+            for value in values {
+                changed |= mask_json_value(value, scan_string, mask)?;
+            }
+            Ok(changed)
+        }
+        serde_json::Value::String(text) if scan_string => {
+            let Some(masked) = mask(text)? else {
+                return Ok(false);
+            };
+            if masked == *text {
+                return Ok(false);
+            }
+            text.zeroize();
+            *text = masked;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn safe_protocol_path(key: &str, text: &str) -> bool {
+    use pentect_core::OverMaskGuard;
+
+    if !matches!(key, "path" | "cwd") {
+        return false;
+    }
+    let candidate = text
+        .strip_prefix("file:///")
+        .or_else(|| text.strip_prefix("file://"))
+        .unwrap_or(text);
+    !text.contains(['?', '#', '\r', '\n']) && pentect_core::ShapeGuard::builtin().benign(candidate)
+}
+
+fn looks_like_image_payload_string(text: &str) -> bool {
+    text.trim_start()
+        .get(..11)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:image/"))
+}
+
+fn suppress_partial_json_deltas(value: &mut serde_json::Value) -> bool {
+    if !json_has_partial_event_marker(value) {
+        return false;
+    }
+    clear_partial_json_payload(value, None)
+}
+
+fn json_has_partial_event_marker(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(object) => {
+            object.iter().any(|(key, value)| {
+                matches!(key.as_str(), "type" | "event" | "method")
+                    && value.as_str().is_some_and(|text| {
+                        let lower = text.to_ascii_lowercase();
+                        lower == "stream_event"
+                            || lower
+                                .rsplit(['/', '_'])
+                                .next()
+                                .is_some_and(|part| part.ends_with("delta"))
+                    })
+            }) || object.values().any(json_has_partial_event_marker)
+        }
+        serde_json::Value::Array(values) => values.iter().any(json_has_partial_event_marker),
+        _ => false,
+    }
+}
+
+fn clear_partial_json_payload(value: &mut serde_json::Value, key: Option<&str>) -> bool {
+    match value {
+        serde_json::Value::Object(object) => {
+            let mut changed = false;
+            for (key, value) in object {
+                changed |= clear_partial_json_payload(value, Some(key));
+            }
+            changed
+        }
+        serde_json::Value::Array(values) => {
+            let mut changed = false;
+            for value in values {
+                changed |= clear_partial_json_payload(value, key);
+            }
+            changed
+        }
+        serde_json::Value::String(text) if !key.is_some_and(partial_json_metadata_key) => {
+            text.zeroize();
+            text.clear();
+            true
+        }
+        _ => false,
+    }
+}
+
+fn partial_json_metadata_key(key: &str) -> bool {
+    matches!(
+        key,
+        "type"
+            | "event"
+            | "method"
+            | "jsonrpc"
+            | "id"
+            | "request_id"
+            | "response_id"
+            | "session_id"
+            | "thread_id"
+            | "turn_id"
+            | "item_id"
+            | "message_id"
+            | "tool_use_id"
+            | "call_id"
+            | "parent_id"
+            | "uuid"
+            | "status"
+            | "phase"
+            | "timestamp"
+            | "created_at"
+            | "updated_at"
+            | "version"
+    )
+}
+
+fn zeroize_json_strings(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for value in object.values_mut() {
+                zeroize_json_strings(value);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                zeroize_json_strings(value);
+            }
+        }
+        serde_json::Value::String(text) => text.zeroize(),
+        _ => {}
+    }
+}
+
+fn drain_sensitive(reader: &mut impl Read) {
+    let mut buffer = [0u8; 8192];
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) | Err(_) => break,
+            Ok(read) => buffer[..read].zeroize(),
+        }
+    }
+    buffer.zeroize();
+}
+
+fn read_masked_buffered_stdin() -> Result<Vec<u8>, String> {
+    let mut input = Vec::new();
+    if let Err(error) = io::stdin()
+        .take((MAX_HEADLESS_INPUT_BYTES + 1) as u64)
+        .read_to_end(&mut input)
+    {
+        input.zeroize();
+        return Err(format!("could not read agent stdin: {error}"));
+    }
+    if input.len() > MAX_HEADLESS_INPUT_BYTES {
+        input.zeroize();
+        return Err(format!(
+            "agent stdin exceeds {MAX_HEADLESS_INPUT_BYTES} bytes"
+        ));
+    }
+    let mut masked = Vec::with_capacity(input.len());
+    let result = pentect_agent::ActiveToolOutputMasker::new()
+        .and_then(|mut masker| mask_and_write_prompt(&input, &mut masked, &mut masker));
+    input.zeroize();
+    match result {
+        Ok(()) => Ok(masked),
+        Err(error) => {
+            masked.zeroize();
+            Err(error)
+        }
+    }
+}
+
+fn write_buffered_stdin(mut child_stdin: impl Write, mut buffered: Vec<u8>) -> Result<(), String> {
+    let result = child_stdin
+        .write_all(&buffered)
+        .and_then(|()| child_stdin.flush())
+        .map_err(|error| format!("could not write agent stdin: {error}"));
+    buffered.zeroize();
+    result
+}
+
+fn read_json_lines(
+    sender: mpsc::SyncSender<Result<Vec<u8>, String>>,
+    cancelled: Arc<AtomicBool>,
+) -> Result<(), String> {
+    let stdin = io::stdin();
+    let mut reader = io::BufReader::new(stdin.lock());
+    let mut total = 0usize;
+    let mut line = Vec::new();
+    loop {
+        if cancelled.load(Ordering::Acquire) {
+            break;
+        }
+        line.clear();
+        let mut read = match reader.read_until(b'\n', &mut line) {
+            Ok(read) => read,
+            Err(error) => {
+                line.zeroize();
+                let _ = sender.send(Err(format!("could not read agent stdin: {error}")));
+                return Ok(());
+            }
+        };
+        if read == 0 {
+            break;
+        }
+        if utf16le_line_needs_trailing_byte(&line) {
+            let mut trailing = [0u8; 1];
+            if let Err(error) = reader.read_exact(&mut trailing) {
+                line.zeroize();
+                trailing.zeroize();
+                let _ = sender.send(Err(format!(
+                    "could not complete agent UTF-16 stdin line: {error}"
+                )));
+                return Ok(());
+            }
+            line.push(trailing[0]);
+            trailing.zeroize();
+            read += 1;
+        }
+        total = total.saturating_add(read);
+        if total > MAX_HEADLESS_INPUT_BYTES {
+            line.zeroize();
+            let _ = sender.send(Err(format!(
+                "agent stdin exceeds {MAX_HEADLESS_INPUT_BYTES} bytes"
+            )));
+            return Ok(());
+        }
+        let next = std::mem::take(&mut line);
+        if let Err(error) = sender.send(Ok(next)) {
+            if let Ok(mut unsent) = error.0 {
+                unsent.zeroize();
+            }
+            break;
+        }
+    }
+    line.zeroize();
+    Ok(())
+}
+
+fn mask_and_write_json_prompt(
+    input: &[u8],
+    output: &mut impl Write,
+    masker: &mut pentect_agent::ActiveToolOutputMasker,
+) -> Result<(), String> {
+    let mut decoded = decode_agent_input(input)?;
+    let body_len = decoded
+        .as_bytes()
+        .iter()
+        .rposition(|byte| !matches!(byte, b'\r' | b'\n'))
+        .map_or(0, |index| index + 1);
+    let parsed = serde_json::from_slice(&decoded.as_bytes()[..body_len]);
+    let mut value: serde_json::Value = match parsed {
+        Ok(value) => value,
+        Err(error) => {
+            decoded.zeroize();
+            return Err(format!("agent JSON input is invalid: {error}"));
+        }
+    };
+    let changed = mask_json_value(&mut value, true, &mut |text| masker.mask_prompt_text(text));
+    let changed = match changed {
+        Ok(changed) => changed,
+        Err(error) => {
+            zeroize_json_strings(&mut value);
+            decoded.zeroize();
+            return Err(error);
+        }
+    };
+    if !changed {
+        zeroize_json_strings(&mut value);
+        let result = output
+            .write_all(decoded.as_bytes())
+            .map_err(|error| format!("could not write agent stdin: {error}"));
+        decoded.zeroize();
+        return result;
+    }
+    let encoded = serde_json::to_vec(&value);
+    zeroize_json_strings(&mut value);
+    let mut masked =
+        encoded.map_err(|error| format!("could not encode protected agent JSON input: {error}"))?;
+    masked.extend_from_slice(&decoded.as_bytes()[body_len..]);
+    decoded.zeroize();
+    let result = output
+        .write_all(&masked)
+        .map_err(|error| format!("could not write agent stdin: {error}"));
+    masked.zeroize();
+    result
+}
+
+fn mask_and_write_prompt(
+    input: &[u8],
+    output: &mut impl Write,
+    masker: &mut pentect_agent::ActiveToolOutputMasker,
+) -> Result<(), String> {
+    let mut text = decode_agent_input(input)?;
+    let masked_result = masker.mask_prompt_text(&text);
+    let mut masked = match masked_result {
+        Ok(masked) => masked,
+        Err(error) => {
+            text.zeroize();
+            return Err(error);
+        }
+    };
+    let bytes = masked.as_deref().unwrap_or(&text).as_bytes();
+    let result = output
+        .write_all(bytes)
+        .map_err(|error| format!("could not write agent stdin: {error}"));
+    if let Some(masked) = masked.as_mut() {
+        masked.zeroize();
+    }
+    text.zeroize();
+    result
+}
+
+fn decode_agent_input(input: &[u8]) -> Result<String, String> {
+    let (bytes, little_endian) = if let Some(bytes) = input.strip_prefix(&[0xff, 0xfe]) {
+        (bytes, Some(true))
+    } else if let Some(bytes) = input.strip_prefix(&[0xfe, 0xff]) {
+        (bytes, Some(false))
+    } else if looks_like_utf16(input, true) {
+        (input, Some(true))
+    } else if looks_like_utf16(input, false) {
+        (input, Some(false))
+    } else {
+        let text = std::str::from_utf8(input)
+            .map_err(|_| "agent stdin must be UTF-8 or UTF-16 text".to_string())?;
+        return Ok(text.strip_prefix('\u{feff}').unwrap_or(text).to_string());
+    };
+    if !bytes.len().is_multiple_of(2) {
+        return Err("agent UTF-16 stdin has an incomplete code unit".to_string());
+    }
+    let little_endian = little_endian.unwrap_or(true);
+    let mut units = bytes
+        .chunks_exact(2)
+        .map(|pair| {
+            if little_endian {
+                u16::from_le_bytes([pair[0], pair[1]])
+            } else {
+                u16::from_be_bytes([pair[0], pair[1]])
+            }
+        })
+        .collect::<Vec<_>>();
+    let decoded = String::from_utf16(&units)
+        .map_err(|_| "agent stdin contains invalid UTF-16 text".to_string());
+    units.zeroize();
+    decoded
+}
+
+fn looks_like_utf16(bytes: &[u8], little_endian: bool) -> bool {
+    if bytes.len() < 4 || !bytes.len().is_multiple_of(2) {
+        return false;
+    }
+    let (expected_zeroes, other_zeroes) =
+        bytes
+            .chunks_exact(2)
+            .fold((0usize, 0usize), |(expected, other), pair| {
+                let (expected_byte, other_byte) = if little_endian {
+                    (pair[1], pair[0])
+                } else {
+                    (pair[0], pair[1])
+                };
+                (
+                    expected + usize::from(expected_byte == 0),
+                    other + usize::from(other_byte == 0),
+                )
+            });
+    let units = bytes.len() / 2;
+    expected_zeroes * 4 >= units * 3 && other_zeroes * 8 <= units
+}
+
+fn utf16le_line_needs_trailing_byte(bytes: &[u8]) -> bool {
+    if bytes.len() < 3 || bytes.len().is_multiple_of(2) || bytes.last() != Some(&b'\n') {
+        return false;
+    }
+    bytes.starts_with(&[0xff, 0xfe]) || looks_like_utf16(&bytes[..bytes.len() - 1], true)
+}
+
+fn join_input(thread: JoinHandle<Result<(), String>>) -> Result<(), String> {
+    if !thread.is_finished() {
+        return Ok(());
+    }
+    thread
+        .join()
+        .map_err(|_| "agent stdin thread panicked".to_string())?
+}
+
+fn join_output(thread: JoinHandle<Result<(), String>>, stream: &str) -> Result<(), String> {
+    thread
+        .join()
+        .map_err(|_| format!("agent {stream} thread panicked"))?
+}
+
+fn rewrite_prompt_args_with<F>(
+    agent: AgentKind,
+    args: &[String],
+    mask: &mut F,
+) -> Result<Vec<String>, String>
+where
+    F: FnMut(&str) -> Result<Option<String>, String>,
+{
+    let positional_prompt = match agent {
+        AgentKind::Codex => codex_prompt_index(args),
+        AgentKind::Claude => claude_prompt_index(args),
+    };
+    let mut rewritten = args.to_vec();
+    if let Some(index) = positional_prompt.filter(|index| rewritten[*index] != "-") {
+        rewrite_prompt_value(&mut rewritten[index], mask)?;
+    }
+    if agent == AgentKind::Claude {
+        let mut index = 0usize;
+        while index < rewritten.len() {
+            let arg = rewritten[index].as_str();
+            if claude_prompt_option(arg) {
+                if let Some(value) = rewritten.get_mut(index + 1) {
+                    rewrite_prompt_value(value, mask)?;
+                }
+                index += 2;
+                continue;
+            }
+            if let Some((prefix, value)) = claude_inline_prompt_option(arg) {
+                let mut rewritten_value = value.to_string();
+                rewrite_prompt_value(&mut rewritten_value, mask)?;
+                rewritten[index] = format!("{prefix}={rewritten_value}");
+            }
+            index += 1;
+        }
+    }
+    Ok(rewritten)
+}
+
+fn rewrite_prompt_value<F>(value: &mut String, mask: &mut F) -> Result<(), String>
+where
+    F: FnMut(&str) -> Result<Option<String>, String>,
+{
+    if let Some(masked) = mask(value)? {
+        *value = masked;
+    }
+    Ok(())
+}
+
+fn claude_prompt_option(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--append-system-prompt" | "--system-prompt" | "--agents"
+    )
+}
+
+fn claude_inline_prompt_option(arg: &str) -> Option<(&str, &str)> {
+    let (name, value) = arg.split_once('=')?;
+    claude_prompt_option(name).then_some((name, value))
+}
+
+fn codex_prompt_index(args: &[String]) -> Option<usize> {
+    let root = codex_root_positional_indices(args);
+    let first = *root.first()?;
+    match args[first].as_str() {
+        "exec" | "e" => codex_exec_prompt_index(args, first + 1),
+        "review" => positional_indices(args, first + 1, codex_option_kind)
+            .last()
+            .copied(),
+        "resume" | "fork" => codex_session_prompt_index(args, first + 1),
+        command if is_codex_command(command) => None,
+        _ => Some(first),
+    }
+}
+
+fn codex_exec_prompt_index(args: &[String], start: usize) -> Option<usize> {
+    let positionals = positional_indices(args, start, codex_option_kind);
+    let first = *positionals.first()?;
+    match args[first].as_str() {
+        "review" => positionals.get(1..)?.last().copied(),
+        "resume" => codex_session_prompt_index(args, first + 1),
+        "help" => None,
+        _ => positionals.last().copied(),
+    }
+}
+
+fn codex_session_prompt_index(args: &[String], start: usize) -> Option<usize> {
+    let positionals = positional_indices(args, start, codex_session_option_kind);
+    if positionals.len() >= 2 || (positionals.len() == 1 && has_flag(args, start, "--last")) {
+        positionals.last().copied()
+    } else {
+        None
+    }
+}
+
+fn codex_reads_prompt_from_stdin(args: &[String]) -> bool {
+    let root = codex_root_positional_indices(args);
+    let Some(first) = root.first().copied() else {
+        return false;
+    };
+    match args[first].as_str() {
+        "exec" | "e" => {
+            let positionals = positional_indices(args, first + 1, codex_option_kind);
+            match positionals.first().map(|index| args[*index].as_str()) {
+                None => true,
+                Some("review") | Some("resume") => {
+                    positionals.last().is_some_and(|index| args[*index] == "-")
+                }
+                Some("help") => false,
+                Some(_) => positionals.last().is_some_and(|index| args[*index] == "-"),
+            }
+        }
+        "review" => root.last().is_some_and(|index| args[*index] == "-"),
+        _ => false,
+    }
+}
+
+fn codex_accepts_prompt_input(args: &[String]) -> bool {
+    let root = codex_root_positional_indices(args);
+    root.first()
+        .is_some_and(|index| matches!(args[*index].as_str(), "exec" | "e" | "review"))
+}
+
+fn claude_prompt_index(args: &[String]) -> Option<usize> {
+    let positionals = positional_indices(args, 0, claude_option_kind);
+    let first = *positionals.first()?;
+    (!is_claude_command(&args[first])).then_some(first)
+}
+
+fn claude_reads_prompt_from_stdin(
+    args: &[String],
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+) -> bool {
+    let positionals = positional_indices(args, 0, claude_option_kind);
+    if positionals
+        .first()
+        .is_some_and(|index| is_claude_command(&args[*index]))
+    {
+        return false;
+    }
+    !stdin_is_terminal
+        || (claude_prompt_index(args).is_none()
+            && (args
+                .iter()
+                .any(|arg| matches!(arg.as_str(), "-p" | "--print"))
+                || !stdout_is_terminal))
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum OptionKind {
+    Flag,
+    Value,
+    Variadic,
+}
+
+fn codex_root_positional_indices(args: &[String]) -> Vec<usize> {
+    let mut out = Vec::new();
+    let mut index = 0usize;
+    while index < args.len() {
+        let arg = args[index].as_str();
+        if arg == "--" {
+            out.extend(index + 1..args.len());
+            break;
+        }
+        if arg == "-" || !arg.starts_with('-') {
+            out.push(index);
+            index += 1;
+            continue;
+        }
+        if arg.contains('=') {
+            index += 1;
+            continue;
+        }
+        if matches!(arg, "-i" | "--image") {
+            index += 1;
+            while index < args.len()
+                && !args[index].starts_with('-')
+                && !is_codex_command(&args[index])
+            {
+                index += 1;
+            }
+            continue;
+        }
+        index += match codex_option_kind(arg) {
+            OptionKind::Flag => 1,
+            OptionKind::Value | OptionKind::Variadic => 2,
+        };
+    }
+    out
+}
+
+fn positional_indices(
+    args: &[String],
+    start: usize,
+    option_kind: fn(&str) -> OptionKind,
+) -> Vec<usize> {
+    // These adapters preserve operational values such as model names, paths,
+    // and session IDs while isolating the model-visible positional argument.
+    let mut out = Vec::new();
+    let mut index = start;
+    while index < args.len() {
+        let arg = args[index].as_str();
+        if arg == "--" {
+            out.extend(index + 1..args.len());
+            break;
+        }
+        if arg == "-" || !arg.starts_with('-') {
+            out.push(index);
+            index += 1;
+            continue;
+        }
+        if arg.contains('=') {
+            index += 1;
+            continue;
+        }
+        match option_kind(arg) {
+            OptionKind::Flag => index += 1,
+            OptionKind::Value => index += 2,
+            OptionKind::Variadic => {
+                index += 1;
+                while index < args.len() && !args[index].starts_with('-') {
+                    index += 1;
+                }
+            }
+        }
+    }
+    out
+}
+
+fn codex_option_kind(arg: &str) -> OptionKind {
+    if matches!(arg, "-i" | "--image") {
+        return OptionKind::Variadic;
+    }
+    if matches!(
+        arg,
+        "-c" | "--config"
+            | "--enable"
+            | "--disable"
+            | "-m"
+            | "--model"
+            | "--local-provider"
+            | "-p"
+            | "--profile"
+            | "-s"
+            | "--sandbox"
+            | "-a"
+            | "--ask-for-approval"
+            | "-C"
+            | "--cd"
+            | "--add-dir"
+            | "--output-schema"
+            | "--color"
+            | "-o"
+            | "--output-last-message"
+            | "--base"
+            | "--commit"
+            | "--title"
+            | "--remote"
+            | "--remote-auth-token-env"
+    ) {
+        OptionKind::Value
+    } else {
+        OptionKind::Flag
+    }
+}
+
+fn codex_session_option_kind(arg: &str) -> OptionKind {
+    if matches!(arg, "-i" | "--image") {
+        OptionKind::Value
+    } else {
+        codex_option_kind(arg)
+    }
+}
+
+fn claude_option_kind(arg: &str) -> OptionKind {
+    if matches!(
+        arg,
+        "--add-dir"
+            | "--allowedTools"
+            | "--allowed-tools"
+            | "--betas"
+            | "--disallowedTools"
+            | "--disallowed-tools"
+            | "--file"
+            | "--mcp-config"
+            | "--tools"
+    ) {
+        return OptionKind::Variadic;
+    }
+    if matches!(
+        arg,
+        "--agent"
+            | "--agents"
+            | "--append-system-prompt"
+            | "-d"
+            | "--debug"
+            | "--debug-file"
+            | "--effort"
+            | "--fallback-model"
+            | "--from-pr"
+            | "--input-format"
+            | "--json-schema"
+            | "--max-budget-usd"
+            | "--model"
+            | "-n"
+            | "--name"
+            | "--output-format"
+            | "--permission-mode"
+            | "--plugin-dir"
+            | "--plugin-url"
+            | "--prompt-suggestions"
+            | "--remote-control"
+            | "--remote-control-session-name-prefix"
+            | "-r"
+            | "--resume"
+            | "--session-id"
+            | "--setting-sources"
+            | "--settings"
+            | "--system-prompt"
+            | "--worktree"
+            | "-w"
+    ) {
+        OptionKind::Value
+    } else {
+        OptionKind::Flag
+    }
+}
+
+fn has_flag(args: &[String], start: usize, flag: &str) -> bool {
+    args.iter().skip(start).any(|arg| arg == flag)
+}
+
+pub(crate) fn is_codex_command(value: &str) -> bool {
+    matches!(
+        value,
+        "exec"
+            | "e"
+            | "review"
+            | "login"
+            | "logout"
+            | "mcp"
+            | "plugin"
+            | "mcp-server"
+            | "app-server"
+            | "remote-control"
+            | "app"
+            | "completion"
+            | "update"
+            | "debug"
+            | "apply"
+            | "resume"
+            | "archive"
+            | "delete"
+            | "unarchive"
+            | "fork"
+            | "doctor"
+            | "sandbox"
+            | "features"
+            | "cloud"
+            | "help"
+    )
+}
+
+fn is_claude_command(value: &str) -> bool {
+    matches!(
+        value,
+        "agents"
+            | "auth"
+            | "auto-mode"
+            | "doctor"
+            | "gateway"
+            | "install"
+            | "mcp"
+            | "plugin"
+            | "plugins"
+            | "project"
+            | "setup-token"
+            | "ultrareview"
+            | "update"
+            | "upgrade"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rewrite(agent: AgentKind, args: &[&str]) -> Vec<String> {
+        let args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
+        rewrite_prompt_args_with(agent, &args, &mut |text| {
+            Ok(Some(text.replace("raw-secret", "<<SECRET_test>>")))
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn codex_exec_masks_only_prompt() {
+        let args = rewrite(
+            AgentKind::Codex,
+            &["--model", "raw-secret-model", "exec", "use raw-secret"],
+        );
+        assert_eq!(args[1], "raw-secret-model");
+        assert_eq!(args[3], "use <<SECRET_test>>");
+    }
+
+    #[test]
+    fn codex_short_approval_option_keeps_value_and_masks_prompt() {
+        let args = rewrite(AgentKind::Codex, &["-a", "never", "exec", "use raw-secret"]);
+        assert_eq!(args[1], "never");
+        assert_eq!(args[3], "use <<SECRET_test>>");
+    }
+
+    #[test]
+    fn codex_images_are_rewritten_without_touching_the_prompt() {
+        let mut args = vec![
+            "-i".to_string(),
+            "first.png,second.png".to_string(),
+            "exec".to_string(),
+            "--image=third.png".to_string(),
+            "-i".to_string(),
+            "fourth.png".to_string(),
+            "fifth.png".to_string(),
+            "--".to_string(),
+            "use raw-secret".to_string(),
+        ];
+        rewrite_codex_image_values(&mut args, &mut |value| Ok(format!("safe-{value}"))).unwrap();
+        assert_eq!(args[1], "safe-first.png,second.png");
+        assert_eq!(args[3], "--image=safe-third.png");
+        assert_eq!(args[5], "safe-fourth.png");
+        assert_eq!(args[6], "safe-fifth.png");
+        assert_eq!(args[8], "use raw-secret");
+
+        let masked = rewrite(
+            AgentKind::Codex,
+            &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
+        assert_eq!(masked[8], "use <<SECRET_test>>");
+        assert_eq!(image_extension(b"\x89PNG\r\n\x1a\nrest"), Some("png"));
+        assert_eq!(image_extension(b"\xff\xd8\xffrest"), Some("jpg"));
+    }
+
+    #[test]
+    fn codex_exec_stdin_marker_is_preserved() {
+        let args = rewrite(AgentKind::Codex, &["exec", "-"]);
+        assert_eq!(args, ["exec", "-"]);
+    }
+
+    #[test]
+    fn codex_resume_keeps_session_and_masks_prompt() {
+        let args = rewrite(
+            AgentKind::Codex,
+            &["exec", "resume", "raw-secret-session", "use raw-secret"],
+        );
+        assert_eq!(args[2], "raw-secret-session");
+        assert_eq!(args[3], "use <<SECRET_test>>");
+    }
+
+    #[test]
+    fn codex_root_resume_and_fork_mask_only_prompt() {
+        for command in ["resume", "fork"] {
+            let args = rewrite(
+                AgentKind::Codex,
+                &[command, "raw-secret-session", "use raw-secret"],
+            );
+            assert_eq!(args[1], "raw-secret-session");
+            assert_eq!(args[2], "use <<SECRET_test>>");
+
+            let args = rewrite(AgentKind::Codex, &[command, "--last", "use raw-secret"]);
+            assert_eq!(args[2], "use <<SECRET_test>>");
+        }
+    }
+
+    #[test]
+    fn codex_review_masks_custom_instructions() {
+        let args = rewrite(
+            AgentKind::Codex,
+            &["review", "--base", "main", "find raw-secret"],
+        );
+        assert_eq!(args[2], "main");
+        assert_eq!(args[3], "find <<SECRET_test>>");
+    }
+
+    #[test]
+    fn claude_print_masks_prompt_and_keeps_option_values() {
+        let args = rewrite(
+            AgentKind::Claude,
+            &["-p", "--model", "raw-secret-model", "use raw-secret"],
+        );
+        assert_eq!(args[2], "raw-secret-model");
+        assert_eq!(args[3], "use <<SECRET_test>>");
+    }
+
+    #[test]
+    fn claude_commands_are_not_treated_as_prompts() {
+        let args = rewrite(AgentKind::Claude, &["doctor", "raw-secret"]);
+        assert_eq!(args, ["doctor", "raw-secret"]);
+    }
+
+    #[test]
+    fn claude_single_value_options_do_not_consume_prompt() {
+        for option in ["--plugin-dir", "--remote-control-session-name-prefix"] {
+            let args = rewrite(
+                AgentKind::Claude,
+                &["-p", option, "raw-secret-option", "use raw-secret"],
+            );
+            assert_eq!(args[2], "raw-secret-option");
+            assert_eq!(args[3], "use <<SECRET_test>>");
+        }
+    }
+
+    #[test]
+    fn claude_masks_model_visible_option_values() {
+        let args = rewrite(
+            AgentKind::Claude,
+            &[
+                "-p",
+                "--system-prompt=keep raw-secret private",
+                "--append-system-prompt",
+                "also raw-secret",
+                "answer raw-secret",
+            ],
+        );
+        assert_eq!(args[1], "--system-prompt=keep <<SECRET_test>> private");
+        assert_eq!(args[3], "also <<SECRET_test>>");
+        assert_eq!(args[4], "answer <<SECRET_test>>");
+    }
+
+    #[test]
+    fn claude_stream_json_selects_line_mode() {
+        assert_eq!(
+            claude_input_mode(&["-p".into(), "--input-format=stream-json".into()]),
+            InputMode::JsonLines
+        );
+        assert_eq!(
+            claude_input_mode(&["-p".into(), "--input-format".into(), "stream-json".into()]),
+            InputMode::JsonLines
+        );
+    }
+
+    #[test]
+    fn machine_readable_output_modes_are_detected() {
+        assert_eq!(
+            codex_output_mode(&["exec".into(), "--json".into()]),
+            OutputMode::JsonRecords
+        );
+        assert_eq!(
+            claude_output_mode(&["-p".into(), "--output-format=json".into()]),
+            OutputMode::JsonRecords
+        );
+        assert_eq!(
+            claude_output_mode(&["-p".into(), "--output-format".into(), "stream-json".into()]),
+            OutputMode::JsonRecords
+        );
+        assert!(claude_uses_partial_output(&[
+            "-p".into(),
+            "--include-partial-messages".into()
+        ]));
+        assert!(!claude_uses_partial_output(&["-p".into()]));
+        assert_eq!(
+            codex_output_mode(&["exec".into(), "--".into(), "--json".into()]),
+            OutputMode::Text
+        );
+        assert_eq!(
+            claude_output_mode(&["-p".into(), "--".into(), "--output-format=json".into()]),
+            OutputMode::Text
+        );
+        assert!(!claude_uses_partial_output(&[
+            "-p".into(),
+            "--".into(),
+            "--include-partial-messages".into()
+        ]));
+    }
+
+    #[test]
+    fn agent_input_decodes_powershell_utf16() {
+        let text = "{\"type\":\"user\"}\r\n";
+        let mut little = text
+            .encode_utf16()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>();
+        assert_eq!(decode_agent_input(&little).unwrap(), text);
+        little.splice(0..0, [0xff, 0xfe]);
+        assert_eq!(decode_agent_input(&little).unwrap(), text);
+
+        let mut partial = text
+            .encode_utf16()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>();
+        assert_eq!(partial.pop(), Some(0));
+        assert!(utf16le_line_needs_trailing_byte(&partial));
+        little.zeroize();
+        partial.zeroize();
+    }
+
+    #[test]
+    fn structured_output_masks_every_secret_bearing_string() {
+        let mut value = serde_json::json!({
+            "type": "result",
+            "session_id": "raw-secret-session",
+            "result": "answer raw-secret",
+            "message": {"content": [{"text": "tool raw-secret"}]},
+            "item": {"command": "use raw-secret", "arguments": "raw-secret"}
+        });
+        let changed = mask_json_value(&mut value, true, &mut |text| {
+            Ok(Some(text.replace("raw-secret", "<<SECRET_test>>")))
+        })
+        .unwrap();
+        assert!(changed);
+        assert_eq!(value["session_id"], "<<SECRET_test>>-session");
+        assert_eq!(value["result"], "answer <<SECRET_test>>");
+        assert_eq!(
+            value["message"]["content"][0]["text"],
+            "tool <<SECRET_test>>"
+        );
+        assert_eq!(value["item"]["command"], "use <<SECRET_test>>");
+        assert_eq!(value["item"]["arguments"], "<<SECRET_test>>");
+        zeroize_json_strings(&mut value);
+    }
+
+    #[test]
+    fn structured_output_suppresses_partial_deltas() {
+        let mut value = serde_json::json!({
+            "method": "item/agentMessage/delta",
+            "params": {
+                "thread_id": "thread-1",
+                "delta": {
+                    "type": "text_delta",
+                    "text": "sk-proj-part-one"
+                }
+            }
+        });
+        assert!(suppress_partial_json_deltas(&mut value));
+        assert_eq!(value["method"], "item/agentMessage/delta");
+        assert_eq!(value["params"]["thread_id"], "thread-1");
+        assert_eq!(value["params"]["delta"]["type"], "text_delta");
+        assert_eq!(value["params"]["delta"]["text"], "");
+        zeroize_json_strings(&mut value);
+    }
+
+    #[test]
+    fn protocol_path_bypass_requires_a_real_path_shape() {
+        assert!(safe_protocol_path("cwd", r"C:\Users\yun40\Desktop\pentect"));
+        assert!(safe_protocol_path(
+            "path",
+            "file:///C:/Users/yun40/Desktop/pentect"
+        ));
+        assert!(!safe_protocol_path(
+            "path",
+            "Authorization: Bearer sk-proj-secret"
+        ));
+        assert!(!safe_protocol_path("id", r"C:\Users\yun40\Desktop\pentect"));
+    }
+
+    #[test]
+    fn diagnostic_identifier_metadata_is_not_treated_as_a_secret() {
+        assert!(benign_identifier_metadata_record(
+            b"session id: 019f6998-e305-7e81-85de-0a403ecf167e\n"
+        ));
+        assert!(!benign_identifier_metadata_record(
+            b"private key id: 019f6998-e305-7e81-85de-0a403ecf167e\n"
+        ));
+        assert!(!benign_identifier_metadata_record(
+            b"API_TOKEN=sk-proj-PENTECTSyntheticOnly1234567890\n"
+        ));
+    }
+
+    #[test]
+    fn text_output_waits_for_the_complete_response() {
+        let mut masker = HeadlessOutputMasker::new(false, OutputMode::Text, OutputFraming::Whole)
+            .expect("headless output masker");
+        assert!(masker.push(b"first\n").unwrap().is_empty());
+        assert!(masker.push(b"second").unwrap().is_empty());
+        assert_eq!(masker.finish().unwrap(), b"first\nsecond");
+
+        let mut records =
+            HeadlessOutputMasker::new(false, OutputMode::Text, OutputFraming::Records)
+                .expect("headless output masker");
+        assert_eq!(records.push(b"first\nsecond").unwrap(), b"first\n");
+        assert_eq!(records.finish().unwrap(), b"second");
+    }
+
+    #[test]
+    fn stdin_is_protected_for_headless_agent_input() {
+        assert!(protect_stdin(
+            AgentKind::Codex,
+            &["exec".into(), "--json".into()],
+            true,
+            true
+        ));
+        assert!(protect_stdin(
+            AgentKind::Claude,
+            &["-p".into(), "--output-format".into(), "json".into()],
+            true,
+            true
+        ));
+        assert!(protect_stdin(AgentKind::Claude, &[], false, true));
+        assert!(protect_stdin(AgentKind::Claude, &[], true, false));
+        assert!(protect_stdin(
+            AgentKind::Claude,
+            &["-p".into(), "hello".into()],
+            false,
+            true
+        ));
+        assert!(!protect_stdin(
+            AgentKind::Claude,
+            &["-p".into(), "hello".into()],
+            true,
+            true
+        ));
+        assert!(protect_stdin(
+            AgentKind::Codex,
+            &["exec".into(), "hello".into()],
+            false,
+            true
+        ));
+        assert!(!protect_stdin(
+            AgentKind::Claude,
+            &["doctor".into()],
+            false,
+            false
+        ));
+    }
+}

--- a/crates/pentect-cli/src/headless.rs
+++ b/crates/pentect-cli/src/headless.rs
@@ -44,17 +44,26 @@ pub(crate) struct ProtectedImageFiles {
 impl ProtectedImageFiles {
     fn protect_path(&mut self, value: &str) -> Result<String, String> {
         let path = Path::new(value);
-        let size = std::fs::metadata(path)
-            .map_err(|error| format!("could not inspect image '{}': {error}", path.display()))?
-            .len();
-        if size > MAX_HEADLESS_IMAGE_BYTES {
+        let file = std::fs::File::open(path)
+            .map_err(|error| format!("could not read image '{}': {error}", path.display()))?;
+        let mut bytes = Vec::new();
+        if let Err(error) = file
+            .take(MAX_HEADLESS_IMAGE_BYTES + 1)
+            .read_to_end(&mut bytes)
+        {
+            bytes.zeroize();
+            return Err(format!(
+                "could not read image '{}': {error}",
+                path.display()
+            ));
+        }
+        if bytes.len() as u64 > MAX_HEADLESS_IMAGE_BYTES {
+            bytes.zeroize();
             return Err(format!(
                 "image '{}' exceeds {MAX_HEADLESS_IMAGE_BYTES} bytes",
                 path.display()
             ));
         }
-        let mut bytes = std::fs::read(path)
-            .map_err(|error| format!("could not read image '{}': {error}", path.display()))?;
         let redaction = pentect_agent::redact_image_bytes_into_active_memory_store(&bytes);
         bytes.zeroize();
         let Some(mut redacted) = redaction? else {
@@ -606,8 +615,8 @@ fn proxy_output(
     let mut masker = match HeadlessOutputMasker::new(detect_new_secrets, output_mode, framing) {
         Ok(masker) => masker,
         Err(error) => {
-            drain_sensitive(&mut reader);
             cancelled.store(true, Ordering::Release);
+            drain_sensitive(&mut reader);
             return Err(error);
         }
     };
@@ -840,12 +849,19 @@ fn mask_json_record(
     }
     let mut value: serde_json::Value = serde_json::from_slice(body)
         .map_err(|error| format!("agent JSON output is invalid: {error}"))?;
+    let images_changed = match redact_json_images(&mut value) {
+        Ok(changed) => changed,
+        Err(error) => {
+            zeroize_json_strings(&mut value);
+            return Err(error);
+        }
+    };
     let suppressed = suppress_partial_json_deltas(&mut value);
     let changed = mask_json_value(&mut value, true, &mut |text| {
         detector.mask_tool_output(text)
     });
     let changed = match changed {
-        Ok(changed) => suppressed || changed,
+        Ok(changed) => images_changed || suppressed || changed,
         Err(error) => {
             zeroize_json_strings(&mut value);
             return Err(error);
@@ -863,6 +879,15 @@ fn mask_json_record(
     let result = remasker.push(&masked);
     masked.zeroize();
     result
+}
+
+fn redact_json_images(value: &mut serde_json::Value) -> Result<bool, String> {
+    let Some(updated) = pentect_agent::redact_tool_images_into_active_memory_store(value)? else {
+        return Ok(false);
+    };
+    zeroize_json_strings(value);
+    *value = updated;
+    Ok(true)
 }
 
 fn mask_json_value<F>(
@@ -1148,9 +1173,17 @@ fn mask_and_write_json_prompt(
             return Err(format!("agent JSON input is invalid: {error}"));
         }
     };
+    let images_changed = match redact_json_images(&mut value) {
+        Ok(changed) => changed,
+        Err(error) => {
+            zeroize_json_strings(&mut value);
+            decoded.zeroize();
+            return Err(error);
+        }
+    };
     let changed = mask_json_value(&mut value, true, &mut |text| masker.mask_prompt_text(text));
     let changed = match changed {
-        Ok(changed) => changed,
+        Ok(changed) => images_changed || changed,
         Err(error) => {
             zeroize_json_strings(&mut value);
             decoded.zeroize();

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1303,11 +1303,11 @@ pub(crate) fn terminate_supervised_processes(root: SupervisedRoot) {
             sysinfo::ProcessRefreshKind::nothing(),
         );
         let root_process = system.process(root.pid);
-        let root_matches = root_process.is_some_and(|process| {
-            root.start_time
-                .is_none_or(|start_time| start_time == process.start_time())
-        });
-        let root_reused = root.start_time.is_some() && root_process.is_some() && !root_matches;
+        let root_matches = root
+            .start_time
+            .zip(root_process)
+            .is_some_and(|(start_time, process)| start_time == process.start_time());
+        let root_reused = root.start_time.is_none() || (root_process.is_some() && !root_matches);
         let mut targets = system
             .processes()
             .iter()
@@ -3048,6 +3048,7 @@ fn canonical_json_value(value: &Value) -> Value {
 fn codex_headless_agent_command(tool_args: &[String]) -> bool {
     if tool_args
         .iter()
+        .take_while(|arg| arg.as_str() != "--")
         .any(|arg| matches!(arg.as_str(), "--help" | "-h" | "--version" | "-V"))
     {
         return false;
@@ -4184,6 +4185,11 @@ mod tests {
             "-a".to_string(),
             "never".to_string(),
             "exec".to_string()
+        ]));
+        assert!(codex_headless_agent_command(&[
+            "exec".to_string(),
+            "--".to_string(),
+            "--help".to_string()
         ]));
     }
 

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -7,6 +7,7 @@ mod eval;
 mod exec_proxy;
 mod extensions;
 mod extensions_cmd;
+mod headless;
 mod input;
 mod scan;
 mod terminal;
@@ -355,11 +356,6 @@ fn agent_tool_extensions(opts: &AgentToolOpts) -> Result<extensions::ActiveExten
     extensions::active_from_specs(opts.extensions.clone(), true).map_err(|e| e.to_string())
 }
 
-fn blocked_headless_codex_error() -> String {
-    "headless Codex may skip hooks. Use interactive `pentect codex` for protected tool use."
-        .to_string()
-}
-
 /// Read stdin as bytes (no panic on binary), cap the size, then delegate
 /// interpretation to the injected input adapter.
 fn read_stdin_capped(reader: &dyn InputAdapter) -> Result<String, String> {
@@ -684,7 +680,6 @@ struct AgentToolOpts {
     command: PathBuf,
     extensions: Vec<String>,
     dry_run: bool,
-    allow_unverified_hooks: bool,
     codex_app_server_proxy_disabled: bool,
     tool_args: Vec<String>,
 }
@@ -698,7 +693,6 @@ impl AgentToolOpts {
             .unwrap_or_else(|| PathBuf::from(tool.default_command()));
         let mut extensions = Vec::new();
         let mut dry_run = false;
-        let mut allow_unverified_hooks = false;
         let mut codex_app_server_proxy_disabled = false;
         let mut tool_args = Vec::new();
         let mut i = 2;
@@ -741,19 +735,12 @@ impl AgentToolOpts {
                     dry_run = true;
                     i += 1;
                 }
-                "--allow-unverified-hooks" => {
-                    allow_unverified_hooks = true;
-                    i += 1;
-                }
                 "--no-app-server-proxy" if tool == AgentTool::Codex => {
                     codex_app_server_proxy_disabled = true;
                     i += 1;
                 }
                 "--prompt-proxy" | "--no-prompt-proxy" => {
-                    return Err(
-                        "prompt proxy is currently disabled/TODO; Pentect now protects tool boundaries via agent hooks only"
-                            .to_string(),
-                    );
+                    return Err("prompt protection is automatic".to_string());
                 }
                 _ => {
                     tool_args.extend(args[i..].iter().cloned());
@@ -767,7 +754,6 @@ impl AgentToolOpts {
             command,
             extensions,
             dry_run,
-            allow_unverified_hooks,
             codex_app_server_proxy_disabled,
             tool_args,
         })
@@ -780,24 +766,7 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
         &pentect_agent::load_environment_variable_prefix()?,
     );
     let status_line_enabled = status_line_enabled_by_config()?;
-    if opts.dry_run {
-        if codex_uses_unverified_headless_hook_path(&opts.tool_args) {
-            eprintln!(
-                "[pentect] note: headless Codex may skip hooks; use interactive `pentect codex` for protected tool use."
-            );
-        }
-        print_dry_run(
-            &opts.command,
-            &codex_args(&configs, &opts.tool_args, &contract),
-        );
-        return Ok(success_status());
-    }
-    if codex_uses_unverified_headless_hook_path(&opts.tool_args) && !opts.allow_unverified_hooks {
-        return Err(blocked_headless_codex_error());
-    }
     let active_extensions = agent_tool_extensions(opts)?;
-    let mut cmd = Command::new(&opts.command);
-    apply_extension_env(&mut cmd, &active_extensions)?;
     let memory_store = start_memory_store(pentect)?;
     let _parent_env = agent_parent_env_guard(
         pentect,
@@ -805,7 +774,29 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
         status_line_enabled,
         &active_extensions,
     )?;
-    let exec_proxy = if codex_unified_exec_proxy_enabled(&opts.tool_args) {
+    let tool_args = headless::protect_prompt_args(headless::AgentKind::Codex, &opts.tool_args)?;
+    let headless_command = codex_headless_agent_command(&tool_args);
+    let (tool_args, _protected_images) = if headless_command && !opts.dry_run {
+        headless::protect_codex_image_args(&tool_args)?
+    } else {
+        (tool_args, headless::ProtectedImageFiles::default())
+    };
+    let app_server_enabled = !headless_command
+        && codex_app_server_proxy_enabled(&tool_args, opts.codex_app_server_proxy_disabled)?;
+    let protect_stdin = headless::protect_stdin(
+        headless::AgentKind::Codex,
+        &tool_args,
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+    );
+    let output_mode = headless::codex_output_mode(&tool_args);
+    if opts.dry_run {
+        print_dry_run(&opts.command, &codex_args(&configs, &tool_args, &contract));
+        return Ok(success_status());
+    }
+    let mut cmd = Command::new(&opts.command);
+    apply_extension_env(&mut cmd, &active_extensions)?;
+    let exec_proxy = if codex_unified_exec_proxy_enabled(&tool_args) {
         Some(exec_proxy::ExecProxyGuard::start(&opts.command)?)
     } else {
         None
@@ -833,41 +824,48 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
         .as_ref()
         .map(|exec_proxy| CodexEnvironmentOverlayGuard::install(exec_proxy.url()))
         .transpose()?;
-    let codex_args =
-        if codex_app_server_proxy_enabled(&opts.tool_args, opts.codex_app_server_proxy_disabled)? {
-            let _app_server_proxy_env = EnvVarGuard::set_optional([(
-                app_server_proxy::PENTECT_CODEX_APP_SERVER_PROXY_ENV,
-                Some(OsString::from("1")),
-            )]);
-            cmd.env(app_server_proxy::PENTECT_CODEX_APP_SERVER_PROXY_ENV, "1");
-            let proxy = app_server_proxy::AppServerProxyGuard::start(
-                &opts.command,
-                codex_app_server_args(&configs, &opts.tool_args, &contract),
-            )?;
-            let args =
-                codex_args_with_remote(&configs, &opts.tool_args, Some(proxy.url()), &contract);
-            cmd.args(args);
-            return run_interactive_command_with_guard(cmd, &opts.command, proxy);
-        } else {
-            codex_args(&configs, &opts.tool_args, &contract)
-        };
+    let codex_args = if app_server_enabled {
+        let _app_server_proxy_env = EnvVarGuard::set_optional([(
+            app_server_proxy::PENTECT_CODEX_APP_SERVER_PROXY_ENV,
+            Some(OsString::from("1")),
+        )]);
+        cmd.env(app_server_proxy::PENTECT_CODEX_APP_SERVER_PROXY_ENV, "1");
+        let proxy = app_server_proxy::AppServerProxyGuard::start(
+            &opts.command,
+            codex_app_server_args(&configs, &tool_args, &contract),
+        )?;
+        let args = codex_args_with_remote(&configs, &tool_args, Some(proxy.url()), &contract);
+        cmd.args(args);
+        return run_interactive_command_with_guard(
+            cmd,
+            &opts.command,
+            headless::InputMode::Buffered,
+            output_mode,
+            protect_stdin,
+            proxy,
+        );
+    } else {
+        codex_args(&configs, &tool_args, &contract)
+    };
     cmd.args(codex_args);
-    run_interactive_command(cmd, &opts.command)
+    run_interactive_command(
+        cmd,
+        &opts.command,
+        headless::InputMode::Buffered,
+        output_mode,
+        protect_stdin,
+    )
 }
 
 fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
+    if headless::claude_uses_partial_output(&opts.tool_args) {
+        return Err("Claude partial output cannot be protected".to_string());
+    }
     let settings = claude_settings_json(pentect, opts.session.as_deref());
     let contract = pentect_agent::agent_contract_instructions(
         &pentect_agent::load_environment_variable_prefix()?,
     );
-    let args = claude_args(&settings, &opts.tool_args, &contract);
-    if opts.dry_run {
-        print_dry_run(&opts.command, &args);
-        return Ok(success_status());
-    }
     let active_extensions = agent_tool_extensions(opts)?;
-    let mut cmd = Command::new(&opts.command);
-    apply_extension_env(&mut cmd, &active_extensions)?;
     let memory_store = start_memory_store(pentect)?;
     let status_line_enabled = status_line_enabled_by_config()?;
     let _parent_env = agent_parent_env_guard(
@@ -876,11 +874,27 @@ fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::Exit
         status_line_enabled,
         &active_extensions,
     )?;
+    let tool_args = headless::protect_prompt_args(headless::AgentKind::Claude, &opts.tool_args)?;
+    let input_mode = headless::claude_input_mode(&tool_args);
+    let output_mode = headless::claude_output_mode(&tool_args);
+    let protect_stdin = headless::protect_stdin(
+        headless::AgentKind::Claude,
+        &tool_args,
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+    );
+    let args = claude_args(&settings, &tool_args, &contract);
+    if opts.dry_run {
+        print_dry_run(&opts.command, &args);
+        return Ok(success_status());
+    }
+    let mut cmd = Command::new(&opts.command);
+    apply_extension_env(&mut cmd, &active_extensions)?;
     apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()));
     apply_memory_store_env(&mut cmd, Some(&memory_store));
     apply_status_line_env(&mut cmd, status_line_enabled);
     cmd.args(&args);
-    run_interactive_command(cmd, &opts.command)
+    run_interactive_command(cmd, &opts.command, input_mode, output_mode, protect_stdin)
 }
 
 fn run_bridge_agent(
@@ -920,49 +934,50 @@ fn run_bridge_agent(
         agent_integrations::opencode_config_with_plugin(existing.as_deref(), integration.path())?;
     cmd.env("OPENCODE_CONFIG_CONTENT", config);
     cmd.args(args);
-    run_interactive_command_with_guard(cmd, &opts.command, (integration, memory_store))
+    run_interactive_command_with_guard(
+        cmd,
+        &opts.command,
+        headless::InputMode::Buffered,
+        headless::OutputMode::Text,
+        !std::io::stdin().is_terminal(),
+        (integration, memory_store),
+    )
 }
 
 fn run_interactive_command(
     mut cmd: Command,
     display: &Path,
+    input_mode: headless::InputMode,
+    output_mode: headless::OutputMode,
+    protect_stdin: bool,
 ) -> Result<std::process::ExitStatus, String> {
-    run_interactive_command_inner(&mut cmd, display)
+    run_interactive_command_inner(&mut cmd, display, input_mode, output_mode, protect_stdin)
 }
 
 fn run_interactive_command_with_guard<G>(
     mut cmd: Command,
     display: &Path,
+    input_mode: headless::InputMode,
+    output_mode: headless::OutputMode,
+    protect_stdin: bool,
     _guard: G,
 ) -> Result<std::process::ExitStatus, String> {
-    run_interactive_command_inner(&mut cmd, display)
+    run_interactive_command_inner(&mut cmd, display, input_mode, output_mode, protect_stdin)
 }
 
 fn run_interactive_command_inner(
     cmd: &mut Command,
     display: &Path,
+    input_mode: headless::InputMode,
+    output_mode: headless::OutputMode,
+    protect_stdin: bool,
 ) -> Result<std::process::ExitStatus, String> {
     if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
         let mut terminal_guard = terminal::TuiSessionGuard::enter();
         let status = run_interactive_command_pty(cmd, display, &mut terminal_guard);
         return status;
     }
-    let mut child = match cmd.spawn() {
-        Ok(child) => child,
-        Err(e) => return Err(format!("could not start '{}': {e}", display.display())),
-    };
-    // Set this after spawn so child TUIs still receive Ctrl+C; the parent
-    // stays alive long enough to restore terminal state after the child exits.
-    let ctrl_c_guard = terminal::IgnoreCtrlCGuard::new();
-    let status = match child.wait() {
-        Ok(status) => status,
-        Err(e) => {
-            drop(ctrl_c_guard);
-            return Err(format!("could not wait for '{}': {e}", display.display()));
-        }
-    };
-    drop(ctrl_c_guard);
-    Ok(status)
+    headless::run_noninteractive_command(cmd, display, input_mode, output_mode, protect_stdin)
 }
 
 fn run_interactive_command_pty(
@@ -1235,7 +1250,6 @@ impl Drop for PtyProcessSupervisor {
     }
 }
 
-#[cfg(windows)]
 fn process_descends_from(
     mut pid: sysinfo::Pid,
     root: sysinfo::Pid,
@@ -1257,13 +1271,17 @@ fn process_descends_from(
 }
 
 #[derive(Clone, Copy)]
-struct SupervisedRoot {
-    pid: sysinfo::Pid,
+pub(crate) struct SupervisedRoot {
+    pub(crate) pid: sysinfo::Pid,
     start_time: Option<u64>,
 }
 
 fn capture_supervised_root(child: &dyn PtyChild) -> Option<SupervisedRoot> {
-    let pid = child.process_id().map(sysinfo::Pid::from_u32)?;
+    capture_supervised_root_pid(child.process_id())
+}
+
+pub(crate) fn capture_supervised_root_pid(pid: Option<u32>) -> Option<SupervisedRoot> {
+    let pid = pid.map(sysinfo::Pid::from_u32)?;
     let mut system = sysinfo::System::new();
     system.refresh_processes_specifics(
         sysinfo::ProcessesToUpdate::Some(&[pid]),
@@ -1276,7 +1294,7 @@ fn capture_supervised_root(child: &dyn PtyChild) -> Option<SupervisedRoot> {
     })
 }
 
-fn terminate_supervised_processes(root: SupervisedRoot) {
+pub(crate) fn terminate_supervised_processes(root: SupervisedRoot) {
     for _ in 0..4 {
         let mut system = sysinfo::System::new();
         system.refresh_processes_specifics(
@@ -1284,10 +1302,12 @@ fn terminate_supervised_processes(root: SupervisedRoot) {
             true,
             sysinfo::ProcessRefreshKind::nothing(),
         );
-        let root_matches = system
-            .process(root.pid)
-            .is_some_and(|process| root.start_time == Some(process.start_time()));
-        let root_reused = system.process(root.pid).is_some() && !root_matches;
+        let root_process = system.process(root.pid);
+        let root_matches = root_process.is_some_and(|process| {
+            root.start_time
+                .is_none_or(|start_time| start_time == process.start_time())
+        });
+        let root_reused = root.start_time.is_some() && root_process.is_some() && !root_matches;
         let mut targets = system
             .processes()
             .iter()
@@ -1328,7 +1348,6 @@ fn is_supervised_process(
     if pid == root.pid {
         return false;
     }
-    #[cfg(windows)]
     if !_root_reused && process_descends_from(pid, root.pid, _processes) {
         return true;
     }
@@ -3026,7 +3045,7 @@ fn canonical_json_value(value: &Value) -> Value {
     }
 }
 
-fn codex_uses_unverified_headless_hook_path(tool_args: &[String]) -> bool {
+fn codex_headless_agent_command(tool_args: &[String]) -> bool {
     if tool_args
         .iter()
         .any(|arg| matches!(arg.as_str(), "--help" | "-h" | "--version" | "-V"))
@@ -3045,6 +3064,16 @@ fn codex_first_positional(args: &[String]) -> Option<&str> {
         let arg = args[i].as_str();
         if arg == "--" {
             return args.get(i + 1).map(String::as_str);
+        }
+        if matches!(arg, "-i" | "--image") {
+            i += 1;
+            while i < args.len() && !args[i].starts_with('-') {
+                if headless::is_codex_command(&args[i]) {
+                    return Some(args[i].as_str());
+                }
+                i += 1;
+            }
+            continue;
         }
         if arg.starts_with("--") {
             i += if codex_long_option_takes_value(arg) {
@@ -3092,7 +3121,7 @@ fn codex_long_option_takes_value(arg: &str) -> bool {
 }
 
 fn codex_short_option_takes_value(arg: &str) -> bool {
-    matches!(arg, "-m" | "-c" | "-p" | "-s" | "-C" | "-o")
+    matches!(arg, "-m" | "-c" | "-p" | "-s" | "-a" | "-C" | "-o")
 }
 
 fn claude_settings_json(agent: &Path, session: Option<&str>) -> String {
@@ -3592,21 +3621,6 @@ mod tests {
     }
 
     #[test]
-    fn agent_tool_parse_accepts_unverified_hook_escape_hatch() {
-        let args = vec![
-            "pentect".to_string(),
-            "codex".to_string(),
-            "--allow-unverified-hooks".to_string(),
-            "--".to_string(),
-            "exec".to_string(),
-            "do something".to_string(),
-        ];
-        let opts = AgentToolOpts::parse(AgentTool::Codex, &args).unwrap();
-        assert!(opts.allow_unverified_hooks);
-        assert_eq!(opts.tool_args, vec!["exec", "do something"]);
-    }
-
-    #[test]
     fn agent_tool_parse_consumes_codex_app_server_proxy_toggle() {
         let args = vec![
             "pentect".to_string(),
@@ -3641,7 +3655,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_tool_parse_rejects_prompt_proxy_for_all_agents() {
+    fn agent_tool_parse_reports_automatic_prompt_protection() {
         for tool in [AgentTool::Codex, AgentTool::Claude, AgentTool::OpenCode] {
             let args = vec![
                 "pentect".to_string(),
@@ -3649,7 +3663,7 @@ mod tests {
                 "--prompt-proxy".to_string(),
             ];
             let err = AgentToolOpts::parse(tool, &args).unwrap_err();
-            assert!(err.contains("disabled/TODO"), "{tool:?}: {err}");
+            assert!(err.contains("protection is automatic"), "{tool:?}: {err}");
         }
     }
 
@@ -3661,15 +3675,9 @@ mod tests {
 
     #[test]
     fn codex_metadata_commands_do_not_need_verified_hooks() {
-        assert!(!codex_uses_unverified_headless_hook_path(&[
-            "--version".to_string()
-        ]));
-        assert!(!codex_uses_unverified_headless_hook_path(&[
-            "--help".to_string()
-        ]));
-        assert!(!codex_uses_unverified_headless_hook_path(&[
-            "help".to_string()
-        ]));
+        assert!(!codex_headless_agent_command(&["--version".to_string()]));
+        assert!(!codex_headless_agent_command(&["--help".to_string()]));
+        assert!(!codex_headless_agent_command(&["help".to_string()]));
     }
 
     #[test]
@@ -4144,11 +4152,9 @@ mod tests {
 
     #[test]
     fn codex_interactive_invocations_do_not_need_headless_hook_guard() {
-        assert!(!codex_uses_unverified_headless_hook_path(&Vec::new()));
-        assert!(!codex_uses_unverified_headless_hook_path(&[
-            "review this".to_string()
-        ]));
-        assert!(!codex_uses_unverified_headless_hook_path(&[
+        assert!(!codex_headless_agent_command(&Vec::new()));
+        assert!(!codex_headless_agent_command(&["review this".to_string()]));
+        assert!(!codex_headless_agent_command(&[
             "--model".to_string(),
             "gpt-5.5".to_string(),
             "Run a command".to_string()
@@ -4157,25 +4163,26 @@ mod tests {
 
     #[test]
     fn codex_headless_commands_need_verified_hooks() {
-        assert!(codex_uses_unverified_headless_hook_path(&[
-            "exec".to_string()
-        ]));
-        assert!(codex_uses_unverified_headless_hook_path(&["e".to_string()]));
-        assert!(codex_uses_unverified_headless_hook_path(&[
-            "review".to_string()
-        ]));
-        assert!(codex_uses_unverified_headless_hook_path(&[
+        assert!(codex_headless_agent_command(&["exec".to_string()]));
+        assert!(codex_headless_agent_command(&["e".to_string()]));
+        assert!(codex_headless_agent_command(&["review".to_string()]));
+        assert!(codex_headless_agent_command(&[
             "--model".to_string(),
             "gpt-5.5".to_string(),
             "exec".to_string()
         ]));
-        assert!(codex_uses_unverified_headless_hook_path(&[
+        assert!(codex_headless_agent_command(&[
             "--".to_string(),
             "exec".to_string()
         ]));
-        assert!(codex_uses_unverified_headless_hook_path(&[
+        assert!(codex_headless_agent_command(&[
             "--enable".to_string(),
             "foo".to_string(),
+            "exec".to_string()
+        ]));
+        assert!(codex_headless_agent_command(&[
+            "-a".to_string(),
+            "never".to_string(),
             "exec".to_string()
         ]));
     }

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -529,7 +529,7 @@ fn merge_image_ocr_config(
         unscanned_images: project
             .unscanned_images
             .or(global.unscanned_images)
-            .unwrap_or(UnscannedImagePolicy::Allow),
+            .unwrap_or(UnscannedImagePolicy::Block),
     }
 }
 
@@ -853,6 +853,7 @@ unknown_min_bytes = 32
         assert_eq!(cfg.max_seconds, 20);
         assert_eq!(cfg.max_image_bytes, 64 * 1024 * 1024);
         assert_eq!(cfg.fetch_seconds, 8);
+        assert_eq!(cfg.unscanned_images, UnscannedImagePolicy::Block);
     }
 
     #[test]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -261,8 +261,8 @@ fn first_image_data_url(value: &Value) -> Option<&str> {
         Value::String(text)
             if text
                 .trim_start()
-                .to_ascii_lowercase()
-                .starts_with("data:image/") =>
+                .get(.."data:image/".len())
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:image/")) =>
         {
             Some(text)
         }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -233,6 +233,54 @@ pub fn redact_tool_images_into_active_memory_store(value: &Value) -> Result<Opti
     )))
 }
 
+pub fn redact_image_bytes_into_active_memory_store(
+    bytes: &[u8],
+) -> Result<Option<Vec<u8>>, String> {
+    let mut encoded = data_encoding::BASE64.encode(bytes);
+    let mut value = Value::String(format!("data:image/png;base64,{encoded}"));
+    encoded.zeroize();
+    let redaction = redact_tool_images_into_active_memory_store(&value);
+    zeroize_value_strings(&mut value);
+    let Some(mut updated) = redaction? else {
+        return Ok(None);
+    };
+    let data_url = first_image_data_url(&updated)
+        .ok_or_else(|| "protected image payload is missing".to_string())?;
+    let (_, payload) = data_url
+        .split_once(',')
+        .ok_or_else(|| "protected image payload is invalid".to_string())?;
+    let decoded = data_encoding::BASE64
+        .decode(payload.as_bytes())
+        .map_err(|_| "protected image payload is invalid".to_string());
+    zeroize_value_strings(&mut updated);
+    decoded.map(Some)
+}
+
+fn first_image_data_url(value: &Value) -> Option<&str> {
+    match value {
+        Value::String(text)
+            if text
+                .trim_start()
+                .to_ascii_lowercase()
+                .starts_with("data:image/") =>
+        {
+            Some(text)
+        }
+        Value::Array(values) => values.iter().find_map(first_image_data_url),
+        Value::Object(object) => object.values().find_map(first_image_data_url),
+        _ => None,
+    }
+}
+
+fn zeroize_value_strings(value: &mut Value) {
+    match value {
+        Value::String(text) => text.zeroize(),
+        Value::Array(values) => values.iter_mut().for_each(zeroize_value_strings),
+        Value::Object(object) => object.values_mut().for_each(zeroize_value_strings),
+        _ => {}
+    }
+}
+
 pub fn resolve_text_from_active_memory_store(text: &str) -> Result<Option<String>, String> {
     if MemoryStoreClient::from_env().is_none() {
         return Ok(None);


### PR DESCRIPTION
## What changed
- protect Codex and Claude headless prompt arguments and piped input before child startup
- mask text and structured agent output while preserving valid JSON records
- proxy Codex app-server output, redact images, suppress partial deltas, and reject unprotected binary frames
- supervise child process trees and clean redacted image files

## Why
Headless commands and app-server traffic could bypass the interactive prompt boundary, expose split output, or leave child processes behind. Protection now covers those paths without changing the normal agent command surface.

## Validation
- `cargo test -p pentect-cli --no-default-features --bin pentect --locked -- --test-threads=1` (166 passed)
- `cargo clippy -p pentect-cli --all-targets --locked -- -D warnings`
- `cargo build -p pentect-cli --locked`
- Codex prompt + piped-input E2E: exit 0, expected response, no raw value in stdout/stderr
- Claude stream-json E2E: exit 0, 7 valid JSON records, expected response, no raw value in stdout/stderr
- Codex image E2E: exit 0, OCR path active, no temporary image directory left

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protected headless execution for Codex and Claude, including prompt, input, output, and image handling.
  * Added automatic protection for sensitive data passed through commands and streamed JSON output.
  * Added support for redacting raw image bytes while preserving usable protected images.
  * Added improved process supervision and Ctrl-C handling.

* **Bug Fixes**
  * Improved masking of nested content and metadata while preserving safe paths and image data.
  * Rejected unsupported binary payloads and suppressed incomplete command-output updates.
  * Removed the prompt-protection bypass option; protection is now automatic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->