### PR TITLE
Show scan progress and speed up file checks

### DIFF
--- a/crates/pentect-cli/src/scan.rs
+++ b/crates/pentect-cli/src/scan.rs
@@ -1,6 +1,7 @@
 mod engine;
 mod file_magic;
 mod options;
+mod progress;
 mod report;
 mod rules;
 mod walk;
@@ -8,6 +9,7 @@ mod walk;
 use crate::{die, load_packs};
 use engine::{scan_files, ScanFile};
 use options::{BinaryMode, ScanOpts};
+use progress::ScanProgress;
 use report::{print_report, report_json, ScanReport};
 use std::io::Write;
 use walk::collect_scan_roots;
@@ -57,6 +59,7 @@ fn run_scan_with_engine(
         Vec<std::path::PathBuf>,
         Vec<pentect_core::Pack>,
         BinaryMode,
+        ScanProgress,
     ) -> Result<(Vec<ScanFile>, String), String>,
 ) -> Result<ScanReport, String> {
     let mut report = ScanReport {
@@ -64,13 +67,23 @@ fn run_scan_with_engine(
         engine: "pentect".to_string(),
         ..ScanReport::default()
     };
-    let files = collect_scan_roots(
+    let progress = ScanProgress::for_stderr();
+    progress.start("walk", None);
+    let files = match collect_scan_roots(
         &opts.paths,
         &opts.excludes,
         opts.gitignore,
         &mut report.skipped,
-    )?;
-    let (results, engine) = scanner(files, packs, opts.binary)?;
+    ) {
+        Ok(files) => files,
+        Err(error) => {
+            progress.finish();
+            return Err(error);
+        }
+    };
+    let scanned = scanner(files, packs, opts.binary, progress.clone());
+    progress.finish();
+    let (results, engine) = scanned?;
     report.engine = engine;
     for result in results {
         match result {
@@ -384,6 +397,7 @@ label = "ACME_CASE"
             vec![root.clone(), secret.clone()],
             Vec::new(),
             BinaryMode::Skip,
+            ScanProgress::disabled(),
         )
         .unwrap();
         let mut saw_skipped_dir = false;

--- a/crates/pentect-cli/src/scan/engine.rs
+++ b/crates/pentect-cli/src/scan/engine.rs
@@ -10,10 +10,13 @@ use pentect_core::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc;
+use std::sync::{mpsc, Condvar, Mutex};
 
 const ENGINE_NAME: &str = "pentect";
 const MAX_SCAN_FILE_BYTES: u64 = 16 * 1024 * 1024;
+const RESULT_BATCH_SIZE: usize = 256;
+const LARGE_FILE_BYTES: usize = 1024 * 1024;
+const LARGE_FILE_CONCURRENCY: usize = 2;
 
 pub(super) fn scan_files(
     files: Vec<PathBuf>,
@@ -55,8 +58,12 @@ trait ScanBackend {
     fn binary_mode(&self) -> Option<BinaryMode> {
         None
     }
-    fn scan(&mut self, files: &[PathBuf], progress: &ScanProgress)
-        -> Result<Vec<ScanFile>, String>;
+    fn scan(
+        &mut self,
+        files: &[PathBuf],
+        progress: &ScanProgress,
+        retain_hits: bool,
+    ) -> Result<Vec<ScanFile>, String>;
 }
 
 struct ScanPipeline {
@@ -105,7 +112,7 @@ impl ScanPipeline {
             progress.start("scan", Some(eligible.len()));
             out.extend(
                 backend
-                    .scan(&eligible, progress)
+                    .scan(&eligible, progress, false)
                     .map_err(|e| format!("{}: {e}", backend.name()))?,
             );
             return Ok((out, self.name.to_string()));
@@ -119,7 +126,7 @@ impl ScanPipeline {
             let backend_name = backend.name();
             progress.start("scan", Some(eligible.len()));
             for result in backend
-                .scan(&eligible, progress)
+                .scan(&eligible, progress, true)
                 .map_err(|e| format!("{backend_name}: {e}"))?
             {
                 match result {
@@ -177,7 +184,7 @@ fn precheck_files(
     let workers = worker_count(files.len());
     let next = AtomicUsize::new(0);
     let (tx, rx) = mpsc::channel();
-    let batches = std::thread::scope(|scope| {
+    let (eligible, skipped) = std::thread::scope(|scope| {
         for _ in 0..workers {
             let next = &next;
             let tx = tx.clone();
@@ -194,19 +201,28 @@ fn precheck_files(
                         Err(file) => skipped.push(file),
                     }
                     progress.advance();
+                    if eligible.len() + skipped.len() >= RESULT_BATCH_SIZE
+                        && tx
+                            .send((std::mem::take(&mut eligible), std::mem::take(&mut skipped)))
+                            .is_err()
+                    {
+                        return;
+                    }
                 }
-                let _ = tx.send((eligible, skipped));
+                if !eligible.is_empty() || !skipped.is_empty() {
+                    let _ = tx.send((eligible, skipped));
+                }
             });
         }
         drop(tx);
-        rx.into_iter().collect::<Vec<_>>()
+        let mut eligible = Vec::new();
+        let mut skipped = Vec::new();
+        for (mut batch_eligible, mut batch_skipped) in rx {
+            eligible.append(&mut batch_eligible);
+            skipped.append(&mut batch_skipped);
+        }
+        (eligible, skipped)
     });
-    let mut eligible = Vec::new();
-    let mut skipped = Vec::new();
-    for (mut batch_eligible, mut batch_skipped) in batches {
-        eligible.append(&mut batch_eligible);
-        skipped.append(&mut batch_skipped);
-    }
     Ok((eligible, skipped))
 }
 
@@ -389,13 +405,22 @@ impl CoreBackend {
     }
 }
 
-fn scan_file_with_engine(engine: &Engine, path: &Path, binary: BinaryMode) -> ScanFile {
+fn scan_file_with_limits(
+    engine: &Engine,
+    path: &Path,
+    binary: BinaryMode,
+    large_files: &LargeFileLimiter,
+    retain_hits: bool,
+) -> ScanFile {
     let data = match read_text_file(path, binary) {
         ReadTextFile::Text(data) => data,
         ReadTextFile::Skipped(reason) => {
             return ScanFile::Skipped(SkippedFile::new(path, reason));
         }
     };
+    // Detectors can temporarily expand text several times. Keep small files
+    // fully parallel while bounding the peak created by large inputs.
+    let _large_file_permit = large_files.acquire(data.len());
     let kind = infer_kind(path);
     let line_index = LineIndex::new(&data);
     let result = engine.analyze_spans_with_path(
@@ -419,15 +444,20 @@ fn scan_file_with_engine(engine: &Engine, path: &Path, binary: BinaryMode) -> Sc
     if hits.is_empty() && warnings == 0 {
         return ScanFile::Clean(path.to_path_buf());
     }
+    let findings = hits.len();
+    let labels = label_counts(&hits);
+    let categories = category_counts(&hits);
+    let engines = engine_counts(&hits);
+    let hits = if retain_hits { hits } else { Vec::new() };
     ScanFile::Finding(FileFinding {
         path: path.to_path_buf(),
         scope: ScanScope::classify(path),
         kind,
-        findings: hits.len(),
+        findings,
         warnings,
-        labels: label_counts(&hits),
-        categories: category_counts(&hits),
-        engines: engine_counts(&hits),
+        labels,
+        categories,
+        engines,
         parser_fallback: result.parser_fallback,
         hits,
     })
@@ -446,6 +476,7 @@ impl ScanBackend for CoreBackend {
         &mut self,
         files: &[PathBuf],
         progress: &ScanProgress,
+        retain_hits: bool,
     ) -> Result<Vec<ScanFile>, String> {
         if files.is_empty() {
             return Ok(Vec::new());
@@ -456,12 +487,14 @@ impl ScanBackend for CoreBackend {
             return Err("engine unavailable".to_string());
         };
         let next = AtomicUsize::new(0);
+        let large_files = LargeFileLimiter::new(LARGE_FILE_CONCURRENCY);
         let (tx, rx) = mpsc::channel();
         let out = std::thread::scope(|scope| {
             for _ in 0..workers {
                 let next = &next;
                 let tx = tx.clone();
                 let binary = self.binary;
+                let large_files = &large_files;
                 scope.spawn(move || {
                     let mut batch = Vec::new();
                     loop {
@@ -469,16 +502,77 @@ impl ScanBackend for CoreBackend {
                         let Some(path) = files.get(index) else {
                             break;
                         };
-                        batch.push(scan_file_with_engine(engine, path, binary));
+                        batch.push(scan_file_with_limits(
+                            engine,
+                            path,
+                            binary,
+                            large_files,
+                            retain_hits,
+                        ));
                         progress.advance();
+                        if batch.len() >= RESULT_BATCH_SIZE
+                            && tx.send(std::mem::take(&mut batch)).is_err()
+                        {
+                            return;
+                        }
                     }
-                    let _ = tx.send(batch);
+                    if !batch.is_empty() {
+                        let _ = tx.send(batch);
+                    }
                 });
             }
             drop(tx);
             rx.into_iter().flatten().collect::<Vec<_>>()
         });
         Ok(out)
+    }
+}
+
+struct LargeFileLimiter {
+    available: Mutex<usize>,
+    ready: Condvar,
+}
+
+impl LargeFileLimiter {
+    fn new(permits: usize) -> Self {
+        Self {
+            available: Mutex::new(permits.max(1)),
+            ready: Condvar::new(),
+        }
+    }
+
+    fn acquire(&self, bytes: usize) -> Option<LargeFilePermit<'_>> {
+        if bytes < LARGE_FILE_BYTES {
+            return None;
+        }
+        let mut available = self
+            .available
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while *available == 0 {
+            available = self
+                .ready
+                .wait(available)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        *available -= 1;
+        Some(LargeFilePermit { limiter: self })
+    }
+}
+
+struct LargeFilePermit<'a> {
+    limiter: &'a LargeFileLimiter,
+}
+
+impl Drop for LargeFilePermit<'_> {
+    fn drop(&mut self) {
+        let mut available = self
+            .limiter
+            .available
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *available += 1;
+        self.limiter.ready.notify_one();
     }
 }
 

--- a/crates/pentect-cli/src/scan/engine.rs
+++ b/crates/pentect-cli/src/scan/engine.rs
@@ -1,5 +1,6 @@
 use super::file_magic::{classify, FileMagic};
 use super::options::BinaryMode;
+use super::progress::ScanProgress;
 use super::report::{FileFinding, ScanScope, SkippedFile};
 use super::walk::ignored_file_reason;
 use memchr::memchr;
@@ -18,12 +19,13 @@ pub(super) fn scan_files(
     files: Vec<PathBuf>,
     packs: Vec<pentect_core::Pack>,
     binary: BinaryMode,
+    progress: ScanProgress,
 ) -> Result<(Vec<ScanFile>, String), String> {
     #[cfg(not(test))]
     let decode = pentect_agent::load_decode_config(Profile::Strict)?;
     #[cfg(test)]
     let decode = DecodeConfig::default();
-    ScanPipeline::pentect(packs, binary, decode)?.scan(files)
+    ScanPipeline::pentect(packs, binary, decode)?.scan(files, &progress)
 }
 
 #[cfg(test)]
@@ -31,8 +33,9 @@ pub(super) fn scan_files_core_for_tests(
     files: Vec<PathBuf>,
     packs: Vec<pentect_core::Pack>,
     binary: BinaryMode,
+    progress: ScanProgress,
 ) -> Result<(Vec<ScanFile>, String), String> {
-    ScanPipeline::core_for_tests(packs, binary).scan(files)
+    ScanPipeline::core_for_tests(packs, binary).scan(files, &progress)
 }
 
 #[derive(Clone, Debug)]
@@ -52,7 +55,8 @@ trait ScanBackend {
     fn binary_mode(&self) -> Option<BinaryMode> {
         None
     }
-    fn scan(&mut self, files: &[PathBuf]) -> Result<Vec<ScanFile>, String>;
+    fn scan(&mut self, files: &[PathBuf], progress: &ScanProgress)
+        -> Result<Vec<ScanFile>, String>;
 }
 
 struct ScanPipeline {
@@ -84,20 +88,38 @@ impl ScanPipeline {
         }
     }
 
-    fn scan(&mut self, files: Vec<PathBuf>) -> Result<(Vec<ScanFile>, String), String> {
-        let (eligible, skipped) = precheck_files(&files, self.binary_mode())?;
+    fn scan(
+        &mut self,
+        files: Vec<PathBuf>,
+        progress: &ScanProgress,
+    ) -> Result<(Vec<ScanFile>, String), String> {
+        progress.start("check", Some(files.len()));
+        let (eligible, skipped) = precheck_files(&files, self.binary_mode(), progress)?;
         let mut out = skipped
             .into_iter()
             .map(ScanFile::Skipped)
             .collect::<Vec<_>>();
+
+        if self.backends.len() == 1 {
+            let backend = &mut self.backends[0];
+            progress.start("scan", Some(eligible.len()));
+            out.extend(
+                backend
+                    .scan(&eligible, progress)
+                    .map_err(|e| format!("{}: {e}", backend.name()))?,
+            );
+            return Ok((out, self.name.to_string()));
+        }
+
         let mut scanned_paths = BTreeSet::new();
         let mut skipped_paths = BTreeMap::new();
         let mut findings = FindingSet::default();
 
         for backend in &mut self.backends {
             let backend_name = backend.name();
+            progress.start("scan", Some(eligible.len()));
             for result in backend
-                .scan(&eligible)
+                .scan(&eligible, progress)
                 .map_err(|e| format!("{backend_name}: {e}"))?
             {
                 match result {
@@ -147,38 +169,75 @@ impl ScanPipeline {
 fn precheck_files(
     files: &[PathBuf],
     binary: BinaryMode,
+    progress: &ScanProgress,
 ) -> Result<(Vec<PathBuf>, Vec<SkippedFile>), String> {
+    if files.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let workers = worker_count(files.len());
+    let next = AtomicUsize::new(0);
+    let (tx, rx) = mpsc::channel();
+    let batches = std::thread::scope(|scope| {
+        for _ in 0..workers {
+            let next = &next;
+            let tx = tx.clone();
+            scope.spawn(move || {
+                let mut eligible = Vec::new();
+                let mut skipped = Vec::new();
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(path) = files.get(index) else {
+                        break;
+                    };
+                    match precheck_file(path, binary) {
+                        Ok(path) => eligible.push(path),
+                        Err(file) => skipped.push(file),
+                    }
+                    progress.advance();
+                }
+                let _ = tx.send((eligible, skipped));
+            });
+        }
+        drop(tx);
+        rx.into_iter().collect::<Vec<_>>()
+    });
     let mut eligible = Vec::new();
     let mut skipped = Vec::new();
-    for path in files {
-        if binary == BinaryMode::Skip {
-            if let Some(reason) = ignored_file_reason(path) {
-                skipped.push(SkippedFile::new(path, reason));
-                continue;
-            }
-        }
-        let meta = match std::fs::metadata(path) {
-            Ok(meta) => meta,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                skipped.push(SkippedFile::new(path, "missing"));
-                continue;
-            }
-            Err(_) => {
-                skipped.push(SkippedFile::new(path, "metadata error"));
-                continue;
-            }
-        };
-        if !meta.is_file() {
-            skipped.push(SkippedFile::new(path, "not a regular file"));
-            continue;
-        }
-        if meta.len() > MAX_SCAN_FILE_BYTES {
-            skipped.push(SkippedFile::new(path, "too large"));
-            continue;
-        }
-        eligible.push(path.clone());
+    for (mut batch_eligible, mut batch_skipped) in batches {
+        eligible.append(&mut batch_eligible);
+        skipped.append(&mut batch_skipped);
     }
     Ok((eligible, skipped))
+}
+
+fn precheck_file(path: &Path, binary: BinaryMode) -> Result<PathBuf, SkippedFile> {
+    if binary == BinaryMode::Skip {
+        if let Some(reason) = ignored_file_reason(path) {
+            return Err(SkippedFile::new(path, reason));
+        }
+    }
+    let meta = match std::fs::metadata(path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SkippedFile::new(path, "missing"));
+        }
+        Err(_) => return Err(SkippedFile::new(path, "metadata error")),
+    };
+    if !meta.is_file() {
+        return Err(SkippedFile::new(path, "not a regular file"));
+    }
+    if meta.len() > MAX_SCAN_FILE_BYTES {
+        return Err(SkippedFile::new(path, "too large"));
+    }
+    Ok(path.to_path_buf())
+}
+
+fn worker_count(file_count: usize) -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .min(8)
+        .min(file_count)
 }
 
 fn should_sniff_magic(path: &Path) -> bool {
@@ -383,15 +442,15 @@ impl ScanBackend for CoreBackend {
         Some(self.binary)
     }
 
-    fn scan(&mut self, files: &[PathBuf]) -> Result<Vec<ScanFile>, String> {
+    fn scan(
+        &mut self,
+        files: &[PathBuf],
+        progress: &ScanProgress,
+    ) -> Result<Vec<ScanFile>, String> {
         if files.is_empty() {
             return Ok(Vec::new());
         }
-        let workers = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1)
-            .min(8)
-            .min(files.len());
+        let workers = worker_count(files.len());
         self.ensure_engine();
         let Some(engine) = self.engine.as_ref() else {
             return Err("engine unavailable".to_string());
@@ -403,21 +462,21 @@ impl ScanBackend for CoreBackend {
                 let next = &next;
                 let tx = tx.clone();
                 let binary = self.binary;
-                scope.spawn(move || loop {
-                    let index = next.fetch_add(1, Ordering::Relaxed);
-                    let Some(path) = files.get(index) else {
-                        break;
-                    };
-                    if tx
-                        .send(scan_file_with_engine(engine, path, binary))
-                        .is_err()
-                    {
-                        break;
+                scope.spawn(move || {
+                    let mut batch = Vec::new();
+                    loop {
+                        let index = next.fetch_add(1, Ordering::Relaxed);
+                        let Some(path) = files.get(index) else {
+                            break;
+                        };
+                        batch.push(scan_file_with_engine(engine, path, binary));
+                        progress.advance();
                     }
+                    let _ = tx.send(batch);
                 });
             }
             drop(tx);
-            rx.into_iter().collect::<Vec<_>>()
+            rx.into_iter().flatten().collect::<Vec<_>>()
         });
         Ok(out)
     }

--- a/crates/pentect-cli/src/scan/progress.rs
+++ b/crates/pentect-cli/src/scan/progress.rs
@@ -1,9 +1,8 @@
 use std::io::{IsTerminal, Write};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-const DRAW_EVERY: usize = 256;
 const DRAW_INTERVAL: Duration = Duration::from_millis(200);
 
 #[derive(Clone)]
@@ -14,13 +13,14 @@ pub(super) struct ScanProgress {
 struct ProgressInner {
     completed: AtomicUsize,
     total: AtomicUsize,
+    started_at: Instant,
+    last_draw_ms: AtomicU64,
     state: Mutex<ProgressState>,
 }
 
 struct ProgressState {
     phase: &'static str,
     width: usize,
-    last_draw: Instant,
     active: bool,
 }
 
@@ -33,10 +33,11 @@ impl ScanProgress {
             inner: Some(Arc::new(ProgressInner {
                 completed: AtomicUsize::new(0),
                 total: AtomicUsize::new(0),
+                started_at: Instant::now(),
+                last_draw_ms: AtomicU64::new(0),
                 state: Mutex::new(ProgressState {
                     phase: "walk",
                     width: 0,
-                    last_draw: Instant::now(),
                     active: false,
                 }),
             })),
@@ -53,11 +54,13 @@ impl ScanProgress {
         };
         inner.completed.store(0, Ordering::Relaxed);
         inner.total.store(total.unwrap_or(0), Ordering::Relaxed);
+        inner
+            .last_draw_ms
+            .store(elapsed_ms(inner), Ordering::Relaxed);
         let Ok(mut state) = inner.state.lock() else {
             return;
         };
         state.phase = phase;
-        state.last_draw = Instant::now();
         state.active = true;
         draw(inner, &mut state);
     }
@@ -68,16 +71,21 @@ impl ScanProgress {
         };
         let completed = inner.completed.fetch_add(1, Ordering::Relaxed) + 1;
         let total = inner.total.load(Ordering::Relaxed);
-        if completed != total && !completed.is_multiple_of(DRAW_EVERY) {
-            return;
+        if completed != total {
+            let now = elapsed_ms(inner);
+            let previous = inner.last_draw_ms.load(Ordering::Relaxed);
+            if now.saturating_sub(previous) < DRAW_INTERVAL.as_millis() as u64
+                || inner
+                    .last_draw_ms
+                    .compare_exchange(previous, now, Ordering::Relaxed, Ordering::Relaxed)
+                    .is_err()
+            {
+                return;
+            }
         }
         let Ok(mut state) = inner.state.try_lock() else {
             return;
         };
-        if completed != total && state.last_draw.elapsed() < DRAW_INTERVAL {
-            return;
-        }
-        state.last_draw = Instant::now();
         draw(inner, &mut state);
     }
 
@@ -89,11 +97,20 @@ impl ScanProgress {
             return;
         };
         if state.active {
+            draw(inner, &mut state);
             eprintln!();
             state.active = false;
             state.width = 0;
         }
     }
+}
+
+fn elapsed_ms(inner: &ProgressInner) -> u64 {
+    inner
+        .started_at
+        .elapsed()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
 }
 
 fn draw(inner: &ProgressInner, state: &mut ProgressState) {

--- a/crates/pentect-cli/src/scan/progress.rs
+++ b/crates/pentect-cli/src/scan/progress.rs
@@ -1,0 +1,126 @@
+use std::io::{IsTerminal, Write};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const DRAW_EVERY: usize = 256;
+const DRAW_INTERVAL: Duration = Duration::from_millis(200);
+
+#[derive(Clone)]
+pub(super) struct ScanProgress {
+    inner: Option<Arc<ProgressInner>>,
+}
+
+struct ProgressInner {
+    completed: AtomicUsize,
+    total: AtomicUsize,
+    state: Mutex<ProgressState>,
+}
+
+struct ProgressState {
+    phase: &'static str,
+    width: usize,
+    last_draw: Instant,
+    active: bool,
+}
+
+impl ScanProgress {
+    pub(super) fn for_stderr() -> Self {
+        if !std::io::stderr().is_terminal() {
+            return Self::disabled();
+        }
+        Self {
+            inner: Some(Arc::new(ProgressInner {
+                completed: AtomicUsize::new(0),
+                total: AtomicUsize::new(0),
+                state: Mutex::new(ProgressState {
+                    phase: "walk",
+                    width: 0,
+                    last_draw: Instant::now(),
+                    active: false,
+                }),
+            })),
+        }
+    }
+
+    pub(super) fn disabled() -> Self {
+        Self { inner: None }
+    }
+
+    pub(super) fn start(&self, phase: &'static str, total: Option<usize>) {
+        let Some(inner) = &self.inner else {
+            return;
+        };
+        inner.completed.store(0, Ordering::Relaxed);
+        inner.total.store(total.unwrap_or(0), Ordering::Relaxed);
+        let Ok(mut state) = inner.state.lock() else {
+            return;
+        };
+        state.phase = phase;
+        state.last_draw = Instant::now();
+        state.active = true;
+        draw(inner, &mut state);
+    }
+
+    pub(super) fn advance(&self) {
+        let Some(inner) = &self.inner else {
+            return;
+        };
+        let completed = inner.completed.fetch_add(1, Ordering::Relaxed) + 1;
+        let total = inner.total.load(Ordering::Relaxed);
+        if completed != total && !completed.is_multiple_of(DRAW_EVERY) {
+            return;
+        }
+        let Ok(mut state) = inner.state.try_lock() else {
+            return;
+        };
+        if completed != total && state.last_draw.elapsed() < DRAW_INTERVAL {
+            return;
+        }
+        state.last_draw = Instant::now();
+        draw(inner, &mut state);
+    }
+
+    pub(super) fn finish(&self) {
+        let Some(inner) = &self.inner else {
+            return;
+        };
+        let Ok(mut state) = inner.state.lock() else {
+            return;
+        };
+        if state.active {
+            eprintln!();
+            state.active = false;
+            state.width = 0;
+        }
+    }
+}
+
+fn draw(inner: &ProgressInner, state: &mut ProgressState) {
+    let completed = inner.completed.load(Ordering::Relaxed);
+    let total = inner.total.load(Ordering::Relaxed);
+    let line = render_line(state.phase, completed, total);
+    let padding = " ".repeat(state.width.saturating_sub(line.len()));
+    eprint!("\r{line}{padding}");
+    let _ = std::io::stderr().flush();
+    state.width = line.len();
+}
+
+fn render_line(phase: &str, completed: usize, total: usize) -> String {
+    if total == 0 {
+        format!("[pentect] {phase}")
+    } else {
+        format!("[pentect] {phase} {completed}/{total}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_line_is_compact() {
+        assert_eq!(render_line("walk", 0, 0), "[pentect] walk");
+        assert_eq!(render_line("scan", 42, 100), "[pentect] scan 42/100");
+    }
+}

--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -260,9 +260,11 @@ fn has_extension(path: &Path, extensions: &[&str]) -> bool {
     path.extension()
         .and_then(|ext| ext.to_str())
         .is_some_and(|ext| {
-            extensions
-                .iter()
-                .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+            extensions.binary_search(&ext).is_ok()
+                || (ext.bytes().any(|byte| byte.is_ascii_uppercase())
+                    && extensions
+                        .iter()
+                        .any(|candidate| ext.eq_ignore_ascii_case(candidate)))
         })
 }
 
@@ -381,5 +383,22 @@ mod tests {
         std::fs::write(root.join(".pentectignore"), "ignored.env\n").unwrap();
         assert!(has_pentectignore(&root, &[]));
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn ignored_extensions_are_sorted_and_case_insensitive() {
+        assert!(IGNORED_FILE_EXTENSIONS.is_sorted());
+        assert!(has_extension(
+            Path::new("artifact.exe"),
+            IGNORED_FILE_EXTENSIONS
+        ));
+        assert!(has_extension(
+            Path::new("artifact.EXE"),
+            IGNORED_FILE_EXTENSIONS
+        ));
+        assert!(!has_extension(
+            Path::new("source.rs"),
+            IGNORED_FILE_EXTENSIONS
+        ));
     }
 }

--- a/crates/pentect-cli/tests/scan_progress.rs
+++ b/crates/pentect-cli/tests/scan_progress.rs
@@ -80,6 +80,7 @@ fn scan_shows_progress_in_a_terminal() {
     assert_eq!(status.exit_code(), 0, "{output:?}");
     assert!(output.contains("[pentect] walk"), "{output:?}");
     assert!(output.contains("[pentect] scan 0/1"), "{output:?}");
+    assert!(output.contains("[pentect] scan 1/1"), "{output:?}");
     assert!(output.contains("pentect scan engine=pentect"), "{output:?}");
 
     let _ = std::fs::remove_dir_all(root);

--- a/crates/pentect-cli/tests/scan_progress.rs
+++ b/crates/pentect-cli/tests/scan_progress.rs
@@ -1,0 +1,100 @@
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use std::io::{Read, Write};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+#[test]
+fn scan_shows_progress_in_a_terminal() {
+    let root = std::env::temp_dir().join(format!(
+        "pentect-scan-progress-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("clean.txt"), "ordinary text\n").unwrap();
+
+    let pty = native_pty_system();
+    let pair = pty
+        .openpty(PtySize {
+            rows: 24,
+            cols: 100,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_pentect"));
+    command.args(["scan", "--no-fail"]);
+    command.arg(&root);
+    let mut child = pair.slave.spawn_command(command).unwrap();
+    drop(pair.slave);
+
+    let output = Arc::new(Mutex::new(String::new()));
+    let reader = pair.master.try_clone_reader().unwrap();
+    let writer = Arc::new(Mutex::new(pair.master.take_writer().unwrap()));
+    let reader_output = output.clone();
+    let reader_writer = writer.clone();
+    let reader_thread = std::thread::spawn(move || {
+        let mut reader = reader;
+        let mut buffer = [0u8; 4096];
+        let mut dsr_state = 0usize;
+        while let Ok(read) = reader.read(&mut buffer) {
+            if read == 0 {
+                break;
+            }
+            reader_output
+                .lock()
+                .unwrap()
+                .push_str(&String::from_utf8_lossy(&buffer[..read]));
+            for byte in &buffer[..read] {
+                if observe_dsr(&mut dsr_state, *byte) {
+                    let mut writer = reader_writer.lock().unwrap();
+                    writer.write_all(b"\x1b[1;1R").unwrap();
+                    writer.flush().unwrap();
+                }
+            }
+        }
+    });
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            panic!("scan did not exit: {:?}", output.lock().unwrap());
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    drop(pair.master);
+    let reader_deadline = Instant::now() + Duration::from_secs(5);
+    while !reader_thread.is_finished() && Instant::now() < reader_deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(reader_thread.is_finished(), "PTY reader did not reach EOF");
+    reader_thread.join().unwrap();
+    let output = output.lock().unwrap().clone();
+
+    assert_eq!(status.exit_code(), 0, "{output:?}");
+    assert!(output.contains("[pentect] walk"), "{output:?}");
+    assert!(output.contains("[pentect] scan 0/1"), "{output:?}");
+    assert!(output.contains("pentect scan engine=pentect"), "{output:?}");
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+fn observe_dsr(state: &mut usize, byte: u8) -> bool {
+    const DSR: &[u8] = b"\x1b[6n";
+    if byte == DSR[*state] {
+        *state += 1;
+        if *state == DSR.len() {
+            *state = 0;
+            return true;
+        }
+    } else {
+        *state = usize::from(byte == DSR[0]);
+    }
+    false
+}


### PR DESCRIPTION
## What changed
- show compact `walk`, `check`, and `scan` progress in interactive terminals
- keep redirected and machine-readable output unchanged
- parallelize file prechecks and batch worker results
- avoid single-backend merge allocations and release per-hit details after aggregation
- bound concurrent analysis of large text files
- add a real PTY regression test, including the final `N/N` state

## Root cause
`pentect scan .` scans broadly by default. In this repository that means about 667,000 files, but the command emitted nothing until the final report and performed all metadata checks on one thread.

## Validation
- `cargo test -p pentect-cli scan::`
- `cargo test -p pentect-cli --test scan_progress`
- `cargo clippy -p pentect-cli --all-targets --all-features -- -D warnings`
- same 25,289 findings on the 22k-file comparison corpus
- 22k-file runtime: 67.1s -> 58.6s
- 667k-file probe reaches parallel detection in about 5s instead of remaining in serial precheck after 16s