### PR TITLE
Keep scan progress visible on large trees

### DIFF
--- a/crates/pentect-cli/src/scan.rs
+++ b/crates/pentect-cli/src/scan.rs
@@ -43,23 +43,25 @@ pub(crate) fn cmd_scan(args: &[String]) {
 
 fn run_scan(args: &[String], opts: &ScanOpts) -> Result<ScanReport, String> {
     let packs = load_packs(args)?;
-    run_scan_with_engine(opts, packs, scan_files)
+    run_scan_with_engine(opts, packs, opts.json, scan_files)
 }
 
 #[cfg(test)]
 fn run_scan_core_for_tests(args: &[String], opts: &ScanOpts) -> Result<ScanReport, String> {
     let packs = load_packs(args)?;
-    run_scan_with_engine(opts, packs, engine::scan_files_core_for_tests)
+    run_scan_with_engine(opts, packs, true, engine::scan_files_core_for_tests)
 }
 
 fn run_scan_with_engine(
     opts: &ScanOpts,
     packs: Vec<pentect_core::Pack>,
+    retain_skipped: bool,
     scanner: impl FnOnce(
         Vec<std::path::PathBuf>,
         Vec<pentect_core::Pack>,
         BinaryMode,
         ScanProgress,
+        bool,
     ) -> Result<(Vec<ScanFile>, String), String>,
 ) -> Result<ScanReport, String> {
     let mut report = ScanReport {
@@ -74,6 +76,7 @@ fn run_scan_with_engine(
         &opts.excludes,
         opts.gitignore,
         &mut report.skipped,
+        &progress,
     ) {
         Ok(files) => files,
         Err(error) => {
@@ -81,14 +84,21 @@ fn run_scan_with_engine(
             return Err(error);
         }
     };
-    let scanned = scanner(files, packs, opts.binary, progress.clone());
+    report.skipped_count = report.skipped.len();
+    let scanned = scanner(files, packs, opts.binary, progress.clone(), retain_skipped);
     progress.finish();
     let (results, engine) = scanned?;
     report.engine = engine;
     for result in results {
         match result {
-            ScanFile::Clean(path) => {
-                let _ = path.as_os_str();
+            ScanFile::Count {
+                files_scanned,
+                skipped,
+            } => {
+                report.files_scanned += files_scanned;
+                report.skipped_count += skipped;
+            }
+            ScanFile::CleanPath(_) => {
                 report.files_scanned += 1;
             }
             ScanFile::Finding(file) => {
@@ -97,7 +107,10 @@ fn run_scan_with_engine(
                 report.warnings += file.warnings;
                 report.files.push(file);
             }
-            ScanFile::Skipped(skipped) => report.skipped.push(skipped),
+            ScanFile::Skipped(skipped) => {
+                report.skipped_count += 1;
+                report.skipped.push(skipped);
+            }
         }
     }
     report.files.sort_by(|a, b| a.path.cmp(&b.path));
@@ -398,6 +411,7 @@ label = "ACME_CASE"
             Vec::new(),
             BinaryMode::Skip,
             ScanProgress::disabled(),
+            true,
         )
         .unwrap();
         let mut saw_skipped_dir = false;
@@ -416,6 +430,50 @@ label = "ACME_CASE"
         }
         assert!(saw_skipped_dir);
         assert!(saw_secret_finding);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_coalesces_clean_and_skipped_paths_when_details_are_not_requested() {
+        let root = temp_scan_root("pentect-scan-coalesced-results");
+        let mut paths = Vec::new();
+        for index in 0..64 {
+            let path = root.join(format!("clean-{index}.txt"));
+            std::fs::write(&path, "ordinary text\n").unwrap();
+            paths.push(path);
+        }
+        let binary = root.join("image.png");
+        std::fs::write(&binary, b"\x89PNG\r\n\x1a\n").unwrap();
+        paths.push(binary);
+
+        let (results, _) = engine::scan_files_core_for_tests(
+            paths,
+            Vec::new(),
+            BinaryMode::Skip,
+            ScanProgress::disabled(),
+            false,
+        )
+        .unwrap();
+        let (mut scanned, mut skipped) = (0, 0);
+        for result in results {
+            match result {
+                ScanFile::Count {
+                    files_scanned,
+                    skipped: skipped_count,
+                } => {
+                    scanned += files_scanned;
+                    skipped += skipped_count;
+                }
+                ScanFile::CleanPath(path) => panic!("retained clean path: {}", path.display()),
+                ScanFile::Skipped(file) => {
+                    panic!("retained skipped path: {}", file.path.display())
+                }
+                ScanFile::Finding(file) => panic!("unexpected finding: {}", file.path.display()),
+            }
+        }
+        assert_eq!(64, scanned);
+        assert_eq!(1, skipped);
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/pentect-cli/src/scan.rs
+++ b/crates/pentect-cli/src/scan.rs
@@ -76,6 +76,8 @@ fn run_scan_with_engine(
         &opts.excludes,
         opts.gitignore,
         &mut report.skipped,
+        &mut report.skipped_count,
+        retain_skipped,
         &progress,
     ) {
         Ok(files) => files,
@@ -84,7 +86,6 @@ fn run_scan_with_engine(
             return Err(error);
         }
     };
-    report.skipped_count = report.skipped.len();
     let scanned = scanner(files, packs, opts.binary, progress.clone(), retain_skipped);
     progress.finish();
     let (results, engine) = scanned?;

--- a/crates/pentect-cli/src/scan/engine.rs
+++ b/crates/pentect-cli/src/scan/engine.rs
@@ -9,7 +9,7 @@ use pentect_core::{
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::{mpsc, Condvar, Mutex};
 
 const ENGINE_NAME: &str = "pentect";
@@ -23,12 +23,13 @@ pub(super) fn scan_files(
     packs: Vec<pentect_core::Pack>,
     binary: BinaryMode,
     progress: ScanProgress,
+    retain_skipped: bool,
 ) -> Result<(Vec<ScanFile>, String), String> {
     #[cfg(not(test))]
     let decode = pentect_agent::load_decode_config(Profile::Strict)?;
     #[cfg(test)]
     let decode = DecodeConfig::default();
-    ScanPipeline::pentect(packs, binary, decode)?.scan(files, &progress)
+    ScanPipeline::pentect(packs, binary, decode)?.scan(files, &progress, retain_skipped)
 }
 
 #[cfg(test)]
@@ -37,13 +38,18 @@ pub(super) fn scan_files_core_for_tests(
     packs: Vec<pentect_core::Pack>,
     binary: BinaryMode,
     progress: ScanProgress,
+    retain_skipped: bool,
 ) -> Result<(Vec<ScanFile>, String), String> {
-    ScanPipeline::core_for_tests(packs, binary).scan(files, &progress)
+    ScanPipeline::core_for_tests(packs, binary).scan(files, &progress, retain_skipped)
 }
 
 #[derive(Clone, Debug)]
 pub(super) enum ScanFile {
-    Clean(PathBuf),
+    Count {
+        files_scanned: usize,
+        skipped: usize,
+    },
+    CleanPath(PathBuf),
     Finding(FileFinding),
     Skipped(SkippedFile),
 }
@@ -63,6 +69,7 @@ trait ScanBackend {
         files: &[PathBuf],
         progress: &ScanProgress,
         retain_hits: bool,
+        retain_skipped: bool,
     ) -> Result<Vec<ScanFile>, String>;
 }
 
@@ -99,20 +106,28 @@ impl ScanPipeline {
         &mut self,
         files: Vec<PathBuf>,
         progress: &ScanProgress,
+        retain_skipped: bool,
     ) -> Result<(Vec<ScanFile>, String), String> {
         progress.start("check", Some(files.len()));
-        let (eligible, skipped) = precheck_files(&files, self.binary_mode(), progress)?;
+        let (eligible, skipped, skipped_count) =
+            precheck_files(files, self.binary_mode(), progress, retain_skipped);
         let mut out = skipped
             .into_iter()
             .map(ScanFile::Skipped)
             .collect::<Vec<_>>();
+        if skipped_count > 0 {
+            out.push(ScanFile::Count {
+                files_scanned: 0,
+                skipped: skipped_count,
+            });
+        }
 
         if self.backends.len() == 1 {
             let backend = &mut self.backends[0];
             progress.start("scan", Some(eligible.len()));
             out.extend(
                 backend
-                    .scan(&eligible, progress, false)
+                    .scan(&eligible, progress, false, retain_skipped)
                     .map_err(|e| format!("{}: {e}", backend.name()))?,
             );
             return Ok((out, self.name.to_string()));
@@ -126,13 +141,16 @@ impl ScanPipeline {
             let backend_name = backend.name();
             progress.start("scan", Some(eligible.len()));
             for result in backend
-                .scan(&eligible, progress, true)
+                .scan(&eligible, progress, true, true)
                 .map_err(|e| format!("{backend_name}: {e}"))?
             {
                 match result {
-                    ScanFile::Clean(path) => {
+                    ScanFile::CleanPath(path) => {
                         skipped_paths.remove(&path);
                         scanned_paths.insert(path);
+                    }
+                    ScanFile::Count { .. } => {
+                        return Err(format!("{backend_name}: pathless multi-engine result"));
                     }
                     ScanFile::Finding(file) => {
                         skipped_paths.remove(&file.path);
@@ -155,7 +173,7 @@ impl ScanPipeline {
             .collect::<BTreeSet<_>>();
         for path in scanned_paths {
             if !finding_paths.contains(&path) {
-                out.push(ScanFile::Clean(path));
+                out.push(ScanFile::CleanPath(path));
             }
         }
         for file in finding_files {
@@ -174,78 +192,87 @@ impl ScanPipeline {
 }
 
 fn precheck_files(
-    files: &[PathBuf],
+    files: Vec<PathBuf>,
     binary: BinaryMode,
     progress: &ScanProgress,
-) -> Result<(Vec<PathBuf>, Vec<SkippedFile>), String> {
+    retain_skipped: bool,
+) -> (Vec<PathBuf>, Vec<SkippedFile>, usize) {
     if files.is_empty() {
-        return Ok((Vec::new(), Vec::new()));
+        return (Vec::new(), Vec::new(), 0);
     }
     let workers = worker_count(files.len());
     let next = AtomicUsize::new(0);
-    let (tx, rx) = mpsc::channel();
-    let (eligible, skipped) = std::thread::scope(|scope| {
+    let statuses = (0..files.len())
+        .map(|_| AtomicU8::new(PRECHECK_PENDING))
+        .collect::<Vec<_>>();
+    std::thread::scope(|scope| {
         for _ in 0..workers {
             let next = &next;
-            let tx = tx.clone();
-            scope.spawn(move || {
-                let mut eligible = Vec::new();
-                let mut skipped = Vec::new();
-                loop {
-                    let index = next.fetch_add(1, Ordering::Relaxed);
-                    let Some(path) = files.get(index) else {
-                        break;
-                    };
-                    match precheck_file(path, binary) {
-                        Ok(path) => eligible.push(path),
-                        Err(file) => skipped.push(file),
-                    }
-                    progress.advance();
-                    if eligible.len() + skipped.len() >= RESULT_BATCH_SIZE
-                        && tx
-                            .send((std::mem::take(&mut eligible), std::mem::take(&mut skipped)))
-                            .is_err()
-                    {
-                        return;
-                    }
-                }
-                if !eligible.is_empty() || !skipped.is_empty() {
-                    let _ = tx.send((eligible, skipped));
-                }
+            let statuses = &statuses;
+            let files = &files;
+            scope.spawn(move || loop {
+                let index = next.fetch_add(1, Ordering::Relaxed);
+                let Some(path) = files.get(index) else {
+                    break;
+                };
+                statuses[index].store(precheck_file(path, binary), Ordering::Relaxed);
+                progress.advance();
             });
         }
-        drop(tx);
-        let mut eligible = Vec::new();
-        let mut skipped = Vec::new();
-        for (mut batch_eligible, mut batch_skipped) in rx {
-            eligible.append(&mut batch_eligible);
-            skipped.append(&mut batch_skipped);
-        }
-        (eligible, skipped)
     });
-    Ok((eligible, skipped))
+    let mut eligible = Vec::new();
+    let mut skipped = Vec::new();
+    let mut skipped_count = 0;
+    for (path, status) in files.into_iter().zip(statuses) {
+        let status = status.load(Ordering::Relaxed);
+        if status == PRECHECK_ELIGIBLE {
+            eligible.push(path);
+        } else if retain_skipped {
+            skipped.push(SkippedFile::from_path_buf(path, precheck_reason(status)));
+        } else {
+            skipped_count += 1;
+        }
+    }
+    (eligible, skipped, skipped_count)
 }
 
-fn precheck_file(path: &Path, binary: BinaryMode) -> Result<PathBuf, SkippedFile> {
-    if binary == BinaryMode::Skip {
-        if let Some(reason) = ignored_file_reason(path) {
-            return Err(SkippedFile::new(path, reason));
-        }
+const PRECHECK_PENDING: u8 = 0;
+const PRECHECK_ELIGIBLE: u8 = 1;
+const PRECHECK_BINARY_EXTENSION: u8 = 2;
+const PRECHECK_MISSING: u8 = 3;
+const PRECHECK_METADATA_ERROR: u8 = 4;
+const PRECHECK_NOT_FILE: u8 = 5;
+const PRECHECK_TOO_LARGE: u8 = 6;
+
+fn precheck_file(path: &Path, binary: BinaryMode) -> u8 {
+    if binary == BinaryMode::Skip && ignored_file_reason(path).is_some() {
+        return PRECHECK_BINARY_EXTENSION;
     }
     let meta = match std::fs::metadata(path) {
         Ok(meta) => meta,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Err(SkippedFile::new(path, "missing"));
+            return PRECHECK_MISSING;
         }
-        Err(_) => return Err(SkippedFile::new(path, "metadata error")),
+        Err(_) => return PRECHECK_METADATA_ERROR,
     };
     if !meta.is_file() {
-        return Err(SkippedFile::new(path, "not a regular file"));
+        return PRECHECK_NOT_FILE;
     }
     if meta.len() > MAX_SCAN_FILE_BYTES {
-        return Err(SkippedFile::new(path, "too large"));
+        return PRECHECK_TOO_LARGE;
     }
-    Ok(path.to_path_buf())
+    PRECHECK_ELIGIBLE
+}
+
+fn precheck_reason(status: u8) -> &'static str {
+    match status {
+        PRECHECK_BINARY_EXTENSION => "binary extension",
+        PRECHECK_MISSING => "missing",
+        PRECHECK_METADATA_ERROR => "metadata error",
+        PRECHECK_NOT_FILE => "not a regular file",
+        PRECHECK_TOO_LARGE => "too large",
+        _ => "precheck error",
+    }
 }
 
 fn worker_count(file_count: usize) -> usize {
@@ -411,11 +438,19 @@ fn scan_file_with_limits(
     binary: BinaryMode,
     large_files: &LargeFileLimiter,
     retain_hits: bool,
+    retain_skipped: bool,
 ) -> ScanFile {
     let data = match read_text_file(path, binary) {
         ReadTextFile::Text(data) => data,
         ReadTextFile::Skipped(reason) => {
-            return ScanFile::Skipped(SkippedFile::new(path, reason));
+            return if retain_skipped {
+                ScanFile::Skipped(SkippedFile::new(path, reason))
+            } else {
+                ScanFile::Count {
+                    files_scanned: 0,
+                    skipped: 1,
+                }
+            };
         }
     };
     // Detectors can temporarily expand text several times. Keep small files
@@ -442,7 +477,14 @@ fn scan_file_with_limits(
         .filter(|note| note.category == Category::Secret)
         .count();
     if hits.is_empty() && warnings == 0 {
-        return ScanFile::Clean(path.to_path_buf());
+        return if retain_hits {
+            ScanFile::CleanPath(path.to_path_buf())
+        } else {
+            ScanFile::Count {
+                files_scanned: 1,
+                skipped: 0,
+            }
+        };
     }
     let findings = hits.len();
     let labels = label_counts(&hits);
@@ -477,6 +519,7 @@ impl ScanBackend for CoreBackend {
         files: &[PathBuf],
         progress: &ScanProgress,
         retain_hits: bool,
+        retain_skipped: bool,
     ) -> Result<Vec<ScanFile>, String> {
         if files.is_empty() {
             return Ok(Vec::new());
@@ -508,6 +551,7 @@ impl ScanBackend for CoreBackend {
                             binary,
                             large_files,
                             retain_hits,
+                            retain_skipped,
                         ));
                         progress.advance();
                         if batch.len() >= RESULT_BATCH_SIZE
@@ -522,7 +566,28 @@ impl ScanBackend for CoreBackend {
                 });
             }
             drop(tx);
-            rx.into_iter().flatten().collect::<Vec<_>>()
+            let mut out = Vec::new();
+            let mut files_scanned = 0;
+            let mut skipped = 0;
+            for result in rx.into_iter().flatten() {
+                match result {
+                    ScanFile::Count {
+                        files_scanned: count,
+                        skipped: count_skipped,
+                    } => {
+                        files_scanned += count;
+                        skipped += count_skipped;
+                    }
+                    result => out.push(result),
+                }
+            }
+            if files_scanned > 0 || skipped > 0 {
+                out.push(ScanFile::Count {
+                    files_scanned,
+                    skipped,
+                });
+            }
+            out
         });
         Ok(out)
     }

--- a/crates/pentect-cli/src/scan/progress.rs
+++ b/crates/pentect-cli/src/scan/progress.rs
@@ -52,14 +52,19 @@ impl ScanProgress {
         let Some(inner) = &self.inner else {
             return;
         };
+        let Ok(mut state) = inner.state.lock() else {
+            return;
+        };
+        if state.active {
+            draw(inner, &mut state);
+            eprintln!();
+            state.width = 0;
+        }
         inner.completed.store(0, Ordering::Relaxed);
         inner.total.store(total.unwrap_or(0), Ordering::Relaxed);
         inner
             .last_draw_ms
             .store(elapsed_ms(inner), Ordering::Relaxed);
-        let Ok(mut state) = inner.state.lock() else {
-            return;
-        };
         state.phase = phase;
         state.active = true;
         draw(inner, &mut state);
@@ -125,7 +130,11 @@ fn draw(inner: &ProgressInner, state: &mut ProgressState) {
 
 fn render_line(phase: &str, completed: usize, total: usize) -> String {
     if total == 0 {
-        format!("[pentect] {phase}")
+        if completed == 0 {
+            format!("[pentect] {phase}")
+        } else {
+            format!("[pentect] {phase} {completed}")
+        }
     } else {
         format!("[pentect] {phase} {completed}/{total}")
     }
@@ -138,6 +147,7 @@ mod tests {
     #[test]
     fn progress_line_is_compact() {
         assert_eq!(render_line("walk", 0, 0), "[pentect] walk");
+        assert_eq!(render_line("walk", 42, 0), "[pentect] walk 42");
         assert_eq!(render_line("scan", 42, 100), "[pentect] scan 42/100");
     }
 }

--- a/crates/pentect-cli/src/scan/progress.rs
+++ b/crates/pentect-cli/src/scan/progress.rs
@@ -48,6 +48,10 @@ impl ScanProgress {
         Self { inner: None }
     }
 
+    pub(super) fn is_enabled(&self) -> bool {
+        self.inner.is_some()
+    }
+
     pub(super) fn start(&self, phase: &'static str, total: Option<usize>) {
         let Some(inner) = &self.inner else {
             return;
@@ -101,6 +105,26 @@ impl ScanProgress {
         draw(inner, &mut state);
     }
 
+    pub(super) fn pulse(&self) {
+        let Some(inner) = &self.inner else {
+            return;
+        };
+        let now = elapsed_ms(inner);
+        let previous = inner.last_draw_ms.load(Ordering::Relaxed);
+        if now.saturating_sub(previous) < DRAW_INTERVAL.as_millis() as u64
+            || inner
+                .last_draw_ms
+                .compare_exchange(previous, now, Ordering::Relaxed, Ordering::Relaxed)
+                .is_err()
+        {
+            return;
+        }
+        let Ok(mut state) = inner.state.try_lock() else {
+            return;
+        };
+        draw(inner, &mut state);
+    }
+
     pub(super) fn finish(&self) {
         let Some(inner) = &self.inner else {
             return;
@@ -128,19 +152,20 @@ fn elapsed_ms(inner: &ProgressInner) -> u64 {
 fn draw(inner: &ProgressInner, state: &mut ProgressState) {
     let completed = inner.completed.load(Ordering::Relaxed);
     let total = inner.total.load(Ordering::Relaxed);
-    let line = render_line(state.phase, completed, total);
+    let line = render_line(state.phase, completed, total, elapsed_ms(inner) / 1_000);
     let padding = " ".repeat(state.width.saturating_sub(line.len()));
     eprint!("\r{line}{padding}");
     let _ = std::io::stderr().flush();
     state.width = line.len();
 }
 
-fn render_line(phase: &str, completed: usize, total: usize) -> String {
+fn render_line(phase: &str, completed: usize, total: usize, elapsed_secs: u64) -> String {
     if total == 0 {
-        if completed == 0 {
-            format!("[pentect] {phase}")
-        } else {
-            format!("[pentect] {phase} {completed}")
+        match (completed, elapsed_secs) {
+            (0, 0) => format!("[pentect] {phase}"),
+            (0, seconds) => format!("[pentect] {phase} {seconds}s"),
+            (count, 0) => format!("[pentect] {phase} {count}"),
+            (count, seconds) => format!("[pentect] {phase} {count} {seconds}s"),
         }
     } else {
         format!("[pentect] {phase} {completed}/{total}")
@@ -153,8 +178,9 @@ mod tests {
 
     #[test]
     fn progress_line_is_compact() {
-        assert_eq!(render_line("walk", 0, 0), "[pentect] walk");
-        assert_eq!(render_line("walk", 42, 0), "[pentect] walk 42");
-        assert_eq!(render_line("scan", 42, 100), "[pentect] scan 42/100");
+        assert_eq!(render_line("walk", 0, 0, 0), "[pentect] walk");
+        assert_eq!(render_line("walk", 0, 0, 3), "[pentect] walk 3s");
+        assert_eq!(render_line("walk", 42, 0, 3), "[pentect] walk 42 3s");
+        assert_eq!(render_line("scan", 42, 100, 3), "[pentect] scan 42/100");
     }
 }

--- a/crates/pentect-cli/src/scan/progress.rs
+++ b/crates/pentect-cli/src/scan/progress.rs
@@ -71,10 +71,17 @@ impl ScanProgress {
     }
 
     pub(super) fn advance(&self) {
+        self.advance_by(1);
+    }
+
+    pub(super) fn advance_by(&self, amount: usize) {
         let Some(inner) = &self.inner else {
             return;
         };
-        let completed = inner.completed.fetch_add(1, Ordering::Relaxed) + 1;
+        if amount == 0 {
+            return;
+        }
+        let completed = inner.completed.fetch_add(amount, Ordering::Relaxed) + amount;
         let total = inner.total.load(Ordering::Relaxed);
         if completed != total {
             let now = elapsed_ms(inner);

--- a/crates/pentect-cli/src/scan/report.rs
+++ b/crates/pentect-cli/src/scan/report.rs
@@ -11,6 +11,7 @@ pub(super) struct ScanReport {
     pub(super) files_scanned: usize,
     pub(super) findings: usize,
     pub(super) warnings: usize,
+    pub(super) skipped_count: usize,
     pub(super) skipped: Vec<SkippedFile>,
     pub(super) files: Vec<FileFinding>,
 }
@@ -270,15 +271,19 @@ impl SkippedFile {
             reason: reason.to_string(),
         }
     }
+
+    pub(super) fn from_path_buf(path: PathBuf, reason: &str) -> Self {
+        Self {
+            path,
+            reason: reason.to_string(),
+        }
+    }
 }
 
 pub(super) fn print_report(report: &ScanReport) {
     println!(
         "pentect scan engine={} findings={} files={} skipped={}",
-        report.engine,
-        report.findings,
-        report.files_scanned,
-        report.skipped.len()
+        report.engine, report.findings, report.files_scanned, report.skipped_count
     );
     if report.files.is_empty() {
         println!("no findings");
@@ -310,7 +315,7 @@ pub(super) fn report_json(report: &ScanReport) -> String {
             "files_scanned": report.files_scanned,
             "files_with_findings": report.files.len(),
             "warnings": report.warnings,
-            "skipped": report.skipped.len(),
+            "skipped": report.skipped_count,
             "scopes": scope_counts(report),
             "labels_by_scope": labels_by_scope(report),
         },

--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -1,3 +1,4 @@
+use super::progress::ScanProgress;
 use super::report::SkippedFile;
 use super::rules;
 use ignore::{DirEntry, ParallelVisitor, ParallelVisitorBuilder, WalkBuilder, WalkState};
@@ -10,12 +11,13 @@ pub(super) fn collect_scan_roots(
     excludes: &[String],
     use_gitignore: bool,
     skipped: &mut Vec<SkippedFile>,
+    progress: &ScanProgress,
 ) -> Result<Vec<PathBuf>, String> {
     let mut files = Vec::new();
     for root in roots {
         if use_gitignore {
             if let Some((base, git_files)) = git_files_for_root(root) {
-                let filtered = filter_git_files(base, git_files, excludes)?;
+                let filtered = filter_git_files(base, git_files, excludes, progress)?;
                 files.extend(filtered);
                 continue;
             }
@@ -23,7 +25,7 @@ pub(super) fn collect_scan_roots(
         let root = normalize_root(root);
         let mut builder = WalkBuilder::new(&root);
         configure_walker(&mut builder, &scan_base(&root), excludes, use_gitignore)?;
-        collect_with_walker(builder, &mut files, skipped)?;
+        collect_with_walker(builder, &mut files, skipped, progress)?;
     }
     files.sort_unstable();
     files.dedup();
@@ -127,9 +129,13 @@ fn collect_with_walker(
     builder: WalkBuilder,
     files: &mut Vec<PathBuf>,
     skipped: &mut Vec<SkippedFile>,
+    progress: &ScanProgress,
 ) -> Result<(), String> {
     let (tx, rx) = mpsc::channel();
-    let mut visitor = WalkCollectorBuilder { tx };
+    let mut visitor = WalkCollectorBuilder {
+        tx,
+        progress: progress.clone(),
+    };
     builder.build_parallel().visit(&mut visitor);
     drop(visitor);
     for batch in rx {
@@ -144,6 +150,7 @@ fn collect_with_walker(
 
 struct WalkCollectorBuilder {
     tx: mpsc::Sender<WalkBatch>,
+    progress: ScanProgress,
 }
 
 impl<'s> ParallelVisitorBuilder<'s> for WalkCollectorBuilder {
@@ -153,6 +160,7 @@ impl<'s> ParallelVisitorBuilder<'s> for WalkCollectorBuilder {
             files: Vec::new(),
             skipped: Vec::new(),
             error: None,
+            progress: self.progress.clone(),
         })
     }
 }
@@ -162,12 +170,18 @@ struct WalkCollector {
     files: Vec<PathBuf>,
     skipped: Vec<SkippedFile>,
     error: Option<String>,
+    progress: ScanProgress,
 }
 
 impl ParallelVisitor for WalkCollector {
     fn visit(&mut self, entry: Result<DirEntry, ignore::Error>) -> WalkState {
         match collect_entry(entry, &mut self.files, &mut self.skipped) {
-            Ok(()) => WalkState::Continue,
+            Ok(is_file) => {
+                if is_file {
+                    self.progress.advance();
+                }
+                WalkState::Continue
+            }
             Err(e) => {
                 self.error = Some(e);
                 WalkState::Quit
@@ -196,7 +210,7 @@ fn collect_entry(
     entry: Result<DirEntry, ignore::Error>,
     files: &mut Vec<PathBuf>,
     skipped: &mut Vec<SkippedFile>,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let entry = entry.map_err(|e| e.to_string())?;
     let path = entry.path().to_path_buf();
     if let Some(err) = entry.error() {
@@ -204,39 +218,48 @@ fn collect_entry(
     }
     if entry.path_is_symlink() {
         skipped.push(SkippedFile::new(&path, "symlink"));
-        return Ok(());
+        return Ok(false);
     }
     let Some(file_type) = entry.file_type() else {
         skipped.push(SkippedFile::new(&path, "not a regular file"));
-        return Ok(());
+        return Ok(false);
     };
     if file_type.is_file() {
         files.push(path);
+        return Ok(true);
     } else if !file_type.is_dir() {
         skipped.push(SkippedFile::new(&path, "not a regular file"));
     }
-    Ok(())
+    Ok(false)
 }
 
 fn filter_git_files(
     base: PathBuf,
     git_files: Vec<PathBuf>,
     excludes: &[String],
+    progress: &ScanProgress,
 ) -> Result<Vec<PathBuf>, String> {
     if !has_pentectignore(&base, &git_files) {
         let Some(overrides) = rules::build_overrides(&base, excludes)? else {
+            for _ in &git_files {
+                progress.advance();
+            }
             return Ok(git_files);
         };
-        return Ok(git_files
+        let filtered = git_files
             .into_iter()
             .filter(|path| !overrides.matched(path, false).is_ignore())
-            .collect());
+            .collect::<Vec<_>>();
+        for _ in &filtered {
+            progress.advance();
+        }
+        return Ok(filtered);
     }
     let mut builder = WalkBuilder::new(&base);
     configure_walker(&mut builder, &base, excludes, true)?;
     let mut allowed = Vec::new();
     let mut skipped = Vec::new();
-    collect_with_walker(builder, &mut allowed, &mut skipped)?;
+    collect_with_walker(builder, &mut allowed, &mut skipped, progress)?;
     allowed.sort_unstable();
     let mut filtered = Vec::with_capacity(git_files.len());
     for path in git_files {

--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::mpsc;
 
+const WALK_PROGRESS_BATCH: usize = 256;
+
 pub(super) fn collect_scan_roots(
     roots: &[PathBuf],
     excludes: &[String],
@@ -161,6 +163,7 @@ impl<'s> ParallelVisitorBuilder<'s> for WalkCollectorBuilder {
             skipped: Vec::new(),
             error: None,
             progress: self.progress.clone(),
+            pending_progress: 0,
         })
     }
 }
@@ -171,6 +174,7 @@ struct WalkCollector {
     skipped: Vec<SkippedFile>,
     error: Option<String>,
     progress: ScanProgress,
+    pending_progress: usize,
 }
 
 impl ParallelVisitor for WalkCollector {
@@ -178,7 +182,11 @@ impl ParallelVisitor for WalkCollector {
         match collect_entry(entry, &mut self.files, &mut self.skipped) {
             Ok(is_file) => {
                 if is_file {
-                    self.progress.advance();
+                    self.pending_progress += 1;
+                    if self.pending_progress >= WALK_PROGRESS_BATCH {
+                        self.progress.advance_by(self.pending_progress);
+                        self.pending_progress = 0;
+                    }
                 }
                 WalkState::Continue
             }
@@ -192,6 +200,7 @@ impl ParallelVisitor for WalkCollector {
 
 impl Drop for WalkCollector {
     fn drop(&mut self) {
+        self.progress.advance_by(self.pending_progress);
         let _ = self.tx.send(WalkBatch {
             files: std::mem::take(&mut self.files),
             skipped: std::mem::take(&mut self.skipped),
@@ -241,18 +250,14 @@ fn filter_git_files(
 ) -> Result<Vec<PathBuf>, String> {
     if !has_pentectignore(&base, &git_files) {
         let Some(overrides) = rules::build_overrides(&base, excludes)? else {
-            for _ in &git_files {
-                progress.advance();
-            }
+            progress.advance_by(git_files.len());
             return Ok(git_files);
         };
         let filtered = git_files
             .into_iter()
             .filter(|path| !overrides.matched(path, false).is_ignore())
             .collect::<Vec<_>>();
-        for _ in &filtered {
-            progress.advance();
-        }
+        progress.advance_by(filtered.len());
         return Ok(filtered);
     }
     let mut builder = WalkBuilder::new(&base);

--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -21,15 +21,14 @@ pub(super) fn collect_scan_roots(
 ) -> Result<Vec<PathBuf>, String> {
     let _heartbeat = WalkHeartbeat::start(progress);
     let mut files = Vec::new();
-    for root in roots {
+    for root in minimal_scan_roots(roots) {
         if use_gitignore {
-            if let Some((base, walk_root, git_files)) = git_files_for_root(root) {
+            if let Some((base, walk_root, git_files)) = git_files_for_root(&root) {
                 let filtered = filter_git_files(base, walk_root, git_files, excludes, progress)?;
                 files.extend(filtered);
                 continue;
             }
         }
-        let root = normalize_root(root);
         let mut builder = WalkBuilder::new(&root);
         configure_walker(&mut builder, &scan_base(&root), excludes, use_gitignore)?;
         collect_with_walker(
@@ -466,6 +465,30 @@ fn normalize_root(root: &Path) -> PathBuf {
     root.canonicalize().unwrap_or_else(|_| root.to_path_buf())
 }
 
+fn minimal_scan_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut roots = roots
+        .iter()
+        .map(|root| normalize_root(root))
+        .collect::<Vec<_>>();
+    roots.sort_unstable_by(|left, right| {
+        left.components()
+            .count()
+            .cmp(&right.components().count())
+            .then_with(|| left.cmp(right))
+    });
+    let mut minimal = Vec::<PathBuf>::new();
+    for root in roots {
+        if minimal
+            .iter()
+            .any(|parent| parent.is_dir() && root.starts_with(parent))
+        {
+            continue;
+        }
+        minimal.push(root);
+    }
+    minimal
+}
+
 fn walk_threads() -> usize {
     std::thread::available_parallelism()
         .map(|n| n.get())
@@ -528,5 +551,21 @@ mod tests {
             Path::new("source.rs"),
             IGNORED_FILE_EXTENSIONS
         ));
+    }
+
+    #[test]
+    fn nested_scan_roots_are_walked_once() {
+        let root = temp_root("pentect-minimal-scan-roots");
+        let nested = root.join("src");
+        std::fs::create_dir(&nested).unwrap();
+        let file = nested.join("main.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+
+        assert_eq!(
+            vec![normalize_root(&root)],
+            minimal_scan_roots(&[nested, file, root.clone(), root.clone()])
+        );
+
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -5,6 +5,8 @@ use ignore::{DirEntry, ParallelVisitor, ParallelVisitorBuilder, WalkBuilder, Wal
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::mpsc;
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 const WALK_PROGRESS_BATCH: usize = 256;
 
@@ -13,13 +15,16 @@ pub(super) fn collect_scan_roots(
     excludes: &[String],
     use_gitignore: bool,
     skipped: &mut Vec<SkippedFile>,
+    skipped_count: &mut usize,
+    retain_skipped: bool,
     progress: &ScanProgress,
 ) -> Result<Vec<PathBuf>, String> {
+    let _heartbeat = WalkHeartbeat::start(progress);
     let mut files = Vec::new();
     for root in roots {
         if use_gitignore {
-            if let Some((base, git_files)) = git_files_for_root(root) {
-                let filtered = filter_git_files(base, git_files, excludes, progress)?;
+            if let Some((base, walk_root, git_files)) = git_files_for_root(root) {
+                let filtered = filter_git_files(base, walk_root, git_files, excludes, progress)?;
                 files.extend(filtered);
                 continue;
             }
@@ -27,7 +32,14 @@ pub(super) fn collect_scan_roots(
         let root = normalize_root(root);
         let mut builder = WalkBuilder::new(&root);
         configure_walker(&mut builder, &scan_base(&root), excludes, use_gitignore)?;
-        collect_with_walker(builder, &mut files, skipped, progress)?;
+        collect_with_walker(
+            builder,
+            &mut files,
+            skipped,
+            skipped_count,
+            retain_skipped,
+            progress,
+        )?;
     }
     files.sort_unstable();
     files.dedup();
@@ -131,12 +143,15 @@ fn collect_with_walker(
     builder: WalkBuilder,
     files: &mut Vec<PathBuf>,
     skipped: &mut Vec<SkippedFile>,
+    skipped_count: &mut usize,
+    retain_skipped: bool,
     progress: &ScanProgress,
 ) -> Result<(), String> {
     let (tx, rx) = mpsc::channel();
     let mut visitor = WalkCollectorBuilder {
         tx,
         progress: progress.clone(),
+        retain_skipped,
     };
     builder.build_parallel().visit(&mut visitor);
     drop(visitor);
@@ -146,6 +161,7 @@ fn collect_with_walker(
         }
         files.extend(batch.files);
         skipped.extend(batch.skipped);
+        *skipped_count += batch.skipped_count;
     }
     Ok(())
 }
@@ -153,6 +169,7 @@ fn collect_with_walker(
 struct WalkCollectorBuilder {
     tx: mpsc::Sender<WalkBatch>,
     progress: ScanProgress,
+    retain_skipped: bool,
 }
 
 impl<'s> ParallelVisitorBuilder<'s> for WalkCollectorBuilder {
@@ -164,6 +181,8 @@ impl<'s> ParallelVisitorBuilder<'s> for WalkCollectorBuilder {
             error: None,
             progress: self.progress.clone(),
             pending_progress: 0,
+            skipped_count: 0,
+            retain_skipped: self.retain_skipped,
         })
     }
 }
@@ -175,11 +194,19 @@ struct WalkCollector {
     error: Option<String>,
     progress: ScanProgress,
     pending_progress: usize,
+    skipped_count: usize,
+    retain_skipped: bool,
 }
 
 impl ParallelVisitor for WalkCollector {
     fn visit(&mut self, entry: Result<DirEntry, ignore::Error>) -> WalkState {
-        match collect_entry(entry, &mut self.files, &mut self.skipped) {
+        match collect_entry(
+            entry,
+            &mut self.files,
+            &mut self.skipped,
+            &mut self.skipped_count,
+            self.retain_skipped,
+        ) {
             Ok(is_file) => {
                 if is_file {
                     self.pending_progress += 1;
@@ -204,6 +231,7 @@ impl Drop for WalkCollector {
         let _ = self.tx.send(WalkBatch {
             files: std::mem::take(&mut self.files),
             skipped: std::mem::take(&mut self.skipped),
+            skipped_count: self.skipped_count,
             error: self.error.take(),
         });
     }
@@ -212,6 +240,7 @@ impl Drop for WalkCollector {
 struct WalkBatch {
     files: Vec<PathBuf>,
     skipped: Vec<SkippedFile>,
+    skipped_count: usize,
     error: Option<String>,
 }
 
@@ -219,6 +248,8 @@ fn collect_entry(
     entry: Result<DirEntry, ignore::Error>,
     files: &mut Vec<PathBuf>,
     skipped: &mut Vec<SkippedFile>,
+    skipped_count: &mut usize,
+    retain_skipped: bool,
 ) -> Result<bool, String> {
     let entry = entry.map_err(|e| e.to_string())?;
     let path = entry.path().to_path_buf();
@@ -226,24 +257,50 @@ fn collect_entry(
         return Err(format!("could not walk '{}': {err}", path.display()));
     }
     if entry.path_is_symlink() {
-        skipped.push(SkippedFile::new(&path, "symlink"));
+        record_skipped(path, "symlink", skipped, skipped_count, retain_skipped);
         return Ok(false);
     }
     let Some(file_type) = entry.file_type() else {
-        skipped.push(SkippedFile::new(&path, "not a regular file"));
+        record_skipped(
+            path,
+            "not a regular file",
+            skipped,
+            skipped_count,
+            retain_skipped,
+        );
         return Ok(false);
     };
     if file_type.is_file() {
         files.push(path);
         return Ok(true);
     } else if !file_type.is_dir() {
-        skipped.push(SkippedFile::new(&path, "not a regular file"));
+        record_skipped(
+            path,
+            "not a regular file",
+            skipped,
+            skipped_count,
+            retain_skipped,
+        );
     }
     Ok(false)
 }
 
+fn record_skipped(
+    path: PathBuf,
+    reason: &str,
+    skipped: &mut Vec<SkippedFile>,
+    skipped_count: &mut usize,
+    retain_skipped: bool,
+) {
+    *skipped_count += 1;
+    if retain_skipped {
+        skipped.push(SkippedFile::from_path_buf(path, reason));
+    }
+}
+
 fn filter_git_files(
     base: PathBuf,
+    walk_root: PathBuf,
     git_files: Vec<PathBuf>,
     excludes: &[String],
     progress: &ScanProgress,
@@ -260,11 +317,19 @@ fn filter_git_files(
         progress.advance_by(filtered.len());
         return Ok(filtered);
     }
-    let mut builder = WalkBuilder::new(&base);
+    let mut builder = WalkBuilder::new(&walk_root);
     configure_walker(&mut builder, &base, excludes, true)?;
     let mut allowed = Vec::new();
     let mut skipped = Vec::new();
-    collect_with_walker(builder, &mut allowed, &mut skipped, progress)?;
+    let mut skipped_count = 0;
+    collect_with_walker(
+        builder,
+        &mut allowed,
+        &mut skipped,
+        &mut skipped_count,
+        false,
+        &ScanProgress::disabled(),
+    )?;
     allowed.sort_unstable();
     let mut filtered = Vec::with_capacity(git_files.len());
     for path in git_files {
@@ -272,6 +337,7 @@ fn filter_git_files(
             filtered.push(path);
         }
     }
+    progress.advance_by(filtered.len());
     Ok(filtered)
 }
 
@@ -296,7 +362,7 @@ fn has_extension(path: &Path, extensions: &[&str]) -> bool {
         })
 }
 
-fn git_files_for_root(root: &Path) -> Option<(PathBuf, Vec<PathBuf>)> {
+fn git_files_for_root(root: &Path) -> Option<(PathBuf, PathBuf, Vec<PathBuf>)> {
     let root_abs = root.canonicalize().ok()?;
     let git_cwd = if root_abs.is_file() {
         root_abs.parent()?
@@ -338,7 +404,41 @@ fn git_files_for_root(root: &Path) -> Option<(PathBuf, Vec<PathBuf>)> {
         let rel = String::from_utf8_lossy(raw);
         push_git_regular_file(&top, rel.as_ref(), &mut files);
     }
-    Some((top, files))
+    Some((top, root_abs, files))
+}
+
+struct WalkHeartbeat {
+    stop: Option<mpsc::Sender<()>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl WalkHeartbeat {
+    fn start(progress: &ScanProgress) -> Option<Self> {
+        if !progress.is_enabled() {
+            return None;
+        }
+        let progress = progress.clone();
+        let (stop, stopped) = mpsc::channel();
+        let thread = std::thread::spawn(move || loop {
+            match stopped.recv_timeout(Duration::from_secs(1)) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => progress.pulse(),
+            }
+        });
+        Some(Self {
+            stop: Some(stop),
+            thread: Some(thread),
+        })
+    }
+}
+
+impl Drop for WalkHeartbeat {
+    fn drop(&mut self) {
+        self.stop.take();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
 }
 
 fn push_git_regular_file(top: &Path, rel: &str, files: &mut Vec<PathBuf>) {

--- a/crates/pentect-cli/tests/scan_progress.rs
+++ b/crates/pentect-cli/tests/scan_progress.rs
@@ -79,6 +79,8 @@ fn scan_shows_progress_in_a_terminal() {
 
     assert_eq!(status.exit_code(), 0, "{output:?}");
     assert!(output.contains("[pentect] walk"), "{output:?}");
+    assert!(output.contains("[pentect] walk 1"), "{output:?}");
+    assert!(output.contains("[pentect] check 1/1"), "{output:?}");
     assert!(output.contains("[pentect] scan 0/1"), "{output:?}");
     assert!(output.contains("[pentect] scan 1/1"), "{output:?}");
     assert!(output.contains("pentect scan engine=pentect"), "{output:?}");


### PR DESCRIPTION
## Summary
- show live file counts during walk and preserve each scan phase in terminal output
- avoid cloning precheck paths and coalesce clean/skipped results for normal text scans
- retain complete skipped-file details for JSON output

## Verification
- cargo test -p pentect-cli scan:: --no-fail-fast
- cargo test -p pentect-cli --test scan_progress --no-fail-fast
- cargo clippy -p pentect-cli --all-targets -- -D warnings
- release scan with --gitignore: 137 files, 1078 findings, 4 skipped (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to retain detailed information about skipped files during scans.
  - Scans can now provide compact aggregate results when per-file details aren’t requested.

- **Bug Fixes**
  - Skipped-file totals are now reported accurately in terminal and JSON reports, even when details are not retained.
  - Scan progress updates more consistently while discovering and checking files.
  - Progress output now displays completed counts for zero-total phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->