### PR TITLE
Honor gitignore in scans by default

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -134,7 +134,7 @@ fn usage() {
          pentect doctor\n\
          pentect extensions list|inspect|test [NAME]\n\
          pentect eval [--json]\n\
-         pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--gitignore] [PATH...]\n\
+         pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--no-gitignore] [PATH...]\n\
          pentect view <HANDLE>\n\
          pentect statusline\n\
          pentect resolve [PATH...]\n\
@@ -170,7 +170,7 @@ fn help_text() -> &'static str {
         "  pentect doctor [--json]\n",
         "  pentect extensions list|inspect|test [NAME|PATH] [--json]\n",
         "  pentect eval [--json]\n\n",
-        "  pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--gitignore] [PATH...]\n\n",
+        "  pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--no-gitignore] [PATH...]\n\n",
         "  pentect view '<HANDLE>'\n\n",
         "  pentect statusline\n\n",
         "  pentect log [--json]\n\n",
@@ -182,7 +182,7 @@ fn help_text() -> &'static str {
         "statusline: masked count\n",
         "log: live events\n",
         "resolve: write handles\n",
-        "scan: CredSweeper + core; binary skip(default)|text(lossy); narrow with --exclude, --gitignore, .pentectignore\n",
+        "scan: secrets; gitignore on; --no-gitignore broadens\n",
         "groups: ~vcs ~deps ~build ~cache ~pentect ~heavy ~all; ! restores\n",
         "doctor: readiness\n",
         "extensions: list, inspect, test\n",

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -3691,7 +3691,10 @@ mod tests {
         assert!(help.contains("doctor: readiness"), "{help}");
         assert!(help.contains("extensions: list, inspect, test"), "{help}");
         assert!(help.contains("eval: precision, recall"), "{help}");
-        assert!(help.contains("scan: CredSweeper + core"), "{help}");
+        assert!(
+            help.contains("scan: secrets; gitignore on; --no-gitignore broadens"),
+            "{help}"
+        );
         assert!(help.contains("statusline: masked count"), "{help}");
         assert!(!help.contains("pentect purge"), "{help}");
         assert!(!help.contains("authenticated browser/API/MCP"), "{help}");

--- a/crates/pentect-cli/src/scan.rs
+++ b/crates/pentect-cli/src/scan.rs
@@ -74,7 +74,7 @@ fn run_scan_with_engine(
     let files = match collect_scan_roots(
         &opts.paths,
         &opts.excludes,
-        opts.gitignore,
+        opts.use_gitignore,
         &mut report.skipped,
         &mut report.skipped_count,
         retain_skipped,
@@ -132,7 +132,7 @@ mod tests {
         assert_eq!(opts.paths, vec![PathBuf::from(".")]);
         assert!(!opts.json);
         assert!(!opts.no_fail);
-        assert!(!opts.gitignore);
+        assert!(opts.use_gitignore);
         assert_eq!(opts.binary, BinaryMode::Skip);
     }
 
@@ -143,7 +143,7 @@ mod tests {
             "scan".into(),
             "--json".into(),
             "--no-fail".into(),
-            "--gitignore".into(),
+            "--no-gitignore".into(),
             "--binary".into(),
             "text".into(),
             "app.env".into(),
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(opts.paths, vec![PathBuf::from("app.env")]);
         assert!(opts.json);
         assert!(opts.no_fail);
-        assert!(opts.gitignore);
+        assert!(!opts.use_gitignore);
         assert_eq!(opts.binary, BinaryMode::Text);
         assert!(opts.excludes.is_empty());
     }
@@ -167,6 +167,13 @@ mod tests {
         ];
         let err = ScanOpts::parse(&args).unwrap_err();
         assert!(err.contains("binary must be skip or text"), "{err}");
+    }
+
+    #[test]
+    fn scan_parse_rejects_removed_gitignore_flag() {
+        let args = vec!["pentect".into(), "scan".into(), "--gitignore".into()];
+        let err = ScanOpts::parse(&args).unwrap_err();
+        assert!(err.contains("unknown option"), "{err}");
     }
 
     #[test]
@@ -572,7 +579,7 @@ label = "ACME_CASE"
     }
 
     #[test]
-    fn scan_ignores_gitignore_by_default() {
+    fn scan_honors_gitignore_by_default() {
         let root = temp_scan_root("pentect-scan-gitignore");
         std::fs::write(root.join(".gitignore"), "ignored.env\n").unwrap();
         std::fs::write(
@@ -597,13 +604,13 @@ label = "ACME_CASE"
         assert!(report
             .files
             .iter()
-            .any(|file| file.path.file_name().unwrap() == "ignored.env"));
+            .all(|file| file.path.file_name().unwrap() != "ignored.env"));
 
         let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
-    fn scan_gitignore_flag_removes_files_from_walk() {
+    fn scan_no_gitignore_includes_ignored_files() {
         let root = temp_scan_root("pentect-scan-gitignore-flag");
         std::fs::write(root.join(".gitignore"), "ignored.env\n").unwrap();
         std::fs::write(
@@ -620,7 +627,7 @@ label = "ACME_CASE"
         let args = vec![
             "pentect".into(),
             "scan".into(),
-            "--gitignore".into(),
+            "--no-gitignore".into(),
             root.to_string_lossy().to_string(),
         ];
         let opts = ScanOpts::parse(&args).unwrap();
@@ -629,13 +636,58 @@ label = "ACME_CASE"
         assert!(report
             .files
             .iter()
-            .all(|file| file.path.file_name().unwrap() != "ignored.env"));
+            .any(|file| file.path.file_name().unwrap() == "ignored.env"));
 
         let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
-    fn scan_includes_vcs_dirs_by_default() {
+    fn scan_explicit_file_bypasses_ignore_files() {
+        let root = temp_scan_root("pentect-scan-explicit-ignored-file");
+        std::fs::write(root.join(".gitignore"), "ignored.env\n").unwrap();
+        std::fs::write(root.join(".pentectignore"), "ignored.env\n").unwrap();
+        let ignored = root.join("ignored.env");
+        std::fs::write(
+            &ignored,
+            "RUNPOD_API_KEY=rpa_FAKEPENTECTSCAN1234567890abcdef\n",
+        )
+        .unwrap();
+
+        let args = vec![
+            "pentect".into(),
+            "scan".into(),
+            ignored.to_string_lossy().to_string(),
+        ];
+        let opts = ScanOpts::parse(&args).unwrap();
+        let report = run_scan_core_for_tests(&args, &opts).unwrap();
+
+        assert_eq!(1, report.files_scanned, "{}", report_json(&report));
+        assert!(report
+            .files
+            .iter()
+            .any(|file| file.path.file_name() == ignored.file_name()));
+
+        let excluded_args = vec![
+            "pentect".into(),
+            "scan".into(),
+            "--exclude".into(),
+            "ignored.env".into(),
+            ignored.to_string_lossy().to_string(),
+        ];
+        let excluded_opts = ScanOpts::parse(&excluded_args).unwrap();
+        let excluded_report = run_scan_core_for_tests(&excluded_args, &excluded_opts).unwrap();
+        assert_eq!(
+            0,
+            excluded_report.files_scanned,
+            "{}",
+            report_json(&excluded_report)
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_no_gitignore_includes_vcs_dirs() {
         let root = temp_scan_root("pentect-scan-vcs-default");
         std::fs::create_dir_all(root.join(".git")).unwrap();
         std::fs::write(
@@ -647,6 +699,7 @@ label = "ACME_CASE"
         let args = vec![
             "pentect".into(),
             "scan".into(),
+            "--no-gitignore".into(),
             root.to_string_lossy().to_string(),
         ];
         let opts = ScanOpts::parse(&args).unwrap();
@@ -732,7 +785,6 @@ label = "ACME_CASE"
         let args = vec![
             "pentect".into(),
             "scan".into(),
-            "--gitignore".into(),
             root.to_string_lossy().to_string(),
         ];
         let opts = ScanOpts::parse(&args).unwrap();

--- a/crates/pentect-cli/src/scan/options.rs
+++ b/crates/pentect-cli/src/scan/options.rs
@@ -5,7 +5,7 @@ pub(super) struct ScanOpts {
     pub(super) paths: Vec<PathBuf>,
     pub(super) json: bool,
     pub(super) no_fail: bool,
-    pub(super) gitignore: bool,
+    pub(super) use_gitignore: bool,
     pub(super) binary: BinaryMode,
     pub(super) excludes: Vec<String>,
 }
@@ -31,7 +31,7 @@ impl ScanOpts {
         let mut paths = Vec::new();
         let mut json = false;
         let mut no_fail = false;
-        let mut gitignore = false;
+        let mut use_gitignore = true;
         let mut binary = BinaryMode::Skip;
         let mut excludes = Vec::new();
         let mut i = 2usize;
@@ -45,8 +45,8 @@ impl ScanOpts {
                     no_fail = true;
                     i += 1;
                 }
-                "--gitignore" => {
-                    gitignore = true;
+                "--no-gitignore" => {
+                    use_gitignore = false;
                     i += 1;
                 }
                 "--binary" => {
@@ -79,7 +79,7 @@ impl ScanOpts {
             paths,
             json,
             no_fail,
-            gitignore,
+            use_gitignore,
             binary,
             excludes,
         })

--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -2,6 +2,7 @@ use super::progress::ScanProgress;
 use super::report::SkippedFile;
 use super::rules;
 use ignore::{DirEntry, ParallelVisitor, ParallelVisitorBuilder, WalkBuilder, WalkState};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::mpsc;
@@ -53,7 +54,13 @@ pub(super) fn collect_scan_roots(
 }
 
 fn explicit_file_is_excluded(path: &Path, excludes: &[String]) -> Result<bool, String> {
-    let Some(overrides) = rules::build_overrides(&scan_base(path), excludes)? else {
+    if excludes.is_empty() {
+        return Ok(false);
+    }
+    let base = git_context(path)
+        .map(|context| context.top)
+        .unwrap_or_else(|| scan_base(path));
+    let Some(overrides) = rules::build_overrides(&base, excludes)? else {
         return Ok(false);
     };
     Ok(overrides.matched(path, false).is_ignore())
@@ -318,7 +325,7 @@ fn filter_git_files(
     excludes: &[String],
     progress: &ScanProgress,
 ) -> Result<Vec<PathBuf>, String> {
-    if !has_pentectignore(&base, &git_files) {
+    if !has_pentectignore(&base, &walk_root, &git_files) {
         let Some(overrides) = rules::build_overrides(&base, excludes)? else {
             progress.advance_by(git_files.len());
             return Ok(git_files);
@@ -332,6 +339,7 @@ fn filter_git_files(
     }
     let mut builder = WalkBuilder::new(&walk_root);
     configure_walker(&mut builder, &base, excludes, true)?;
+    add_ancestor_pentectignores(&mut builder, &base, &walk_root)?;
     let mut allowed = Vec::new();
     let mut skipped = Vec::new();
     let mut skipped_count = 0;
@@ -354,13 +362,45 @@ fn filter_git_files(
     Ok(filtered)
 }
 
-fn has_pentectignore(base: &Path, paths: &[PathBuf]) -> bool {
-    if base.join(".pentectignore").is_file() {
-        return true;
+fn has_pentectignore(base: &Path, walk_root: &Path, paths: &[PathBuf]) -> bool {
+    !ancestor_pentectignores(base, walk_root).is_empty()
+        || walk_root.join(".pentectignore").is_file()
+        || paths
+            .iter()
+            .any(|path| path.file_name().and_then(|name| name.to_str()) == Some(".pentectignore"))
+}
+
+fn add_ancestor_pentectignores(
+    builder: &mut WalkBuilder,
+    base: &Path,
+    walk_root: &Path,
+) -> Result<(), String> {
+    for path in ancestor_pentectignores(base, walk_root) {
+        if let Some(error) = builder.add_ignore(path) {
+            return Err(format!("could not load ancestor .pentectignore: {error}"));
+        }
     }
+    Ok(())
+}
+
+fn ancestor_pentectignores(base: &Path, walk_root: &Path) -> Vec<PathBuf> {
+    if !walk_root.starts_with(base) {
+        return Vec::new();
+    }
+    let mut paths = Vec::new();
+    let mut current = walk_root.parent();
+    while let Some(dir) = current.filter(|dir| dir.starts_with(base)) {
+        let path = dir.join(".pentectignore");
+        if path.is_file() {
+            paths.push(path);
+        }
+        if dir == base {
+            break;
+        }
+        current = dir.parent();
+    }
+    paths.reverse();
     paths
-        .iter()
-        .any(|path| path.file_name().and_then(|name| name.to_str()) == Some(".pentectignore"))
 }
 
 fn has_extension(path: &Path, extensions: &[&str]) -> bool {
@@ -376,34 +416,21 @@ fn has_extension(path: &Path, extensions: &[&str]) -> bool {
 }
 
 fn git_files_for_root(root: &Path) -> Option<(PathBuf, PathBuf, Vec<PathBuf>)> {
-    let root_abs = root.canonicalize().ok()?;
-    let git_cwd = if root_abs.is_file() {
-        root_abs.parent()?
-    } else {
-        root_abs.as_path()
-    };
-    let top = Command::new("git")
-        .arg("-C")
-        .arg(git_cwd)
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()
-        .filter(|output| output.status.success())?;
-    let top = PathBuf::from(String::from_utf8_lossy(&top.stdout).trim())
-        .canonicalize()
-        .ok()?;
-    let rel = root_abs.strip_prefix(&top).ok()?;
+    let context = git_context(root)?;
     let mut cmd = Command::new("git");
-    cmd.arg("-C").arg(&top).args([
-        "ls-files",
-        "--cached",
-        "--others",
-        "--exclude-standard",
-        "-z",
-        "--",
-    ]);
-    if !rel.as_os_str().is_empty() {
-        cmd.arg(git_pathspec(rel));
+    cmd.arg("-C")
+        .arg(&context.top)
+        .arg("--literal-pathspecs")
+        .args([
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+        ]);
+    if !context.relative.as_os_str().is_empty() {
+        cmd.arg(git_pathspec(&context.relative));
     }
     let output = cmd.output().ok()?;
     if !output.status.success() {
@@ -414,10 +441,64 @@ fn git_files_for_root(root: &Path) -> Option<(PathBuf, PathBuf, Vec<PathBuf>)> {
         if raw.is_empty() {
             continue;
         }
-        let rel = String::from_utf8_lossy(raw);
-        push_git_regular_file(&top, rel.as_ref(), &mut files);
+        let rel = git_path_from_bytes(raw)?;
+        push_git_regular_file(&context.top, &rel, &mut files);
     }
-    Some((top, root_abs, files))
+    Some((context.top, context.root, files))
+}
+
+struct GitContext {
+    top: PathBuf,
+    root: PathBuf,
+    relative: PathBuf,
+}
+
+fn git_context(root: &Path) -> Option<GitContext> {
+    let root = root.canonicalize().ok()?;
+    let git_cwd = if root.is_file() {
+        root.parent()?
+    } else {
+        root.as_path()
+    };
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(git_cwd)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())?;
+    let top = git_path_from_bytes(trim_line_end(&output.stdout))?
+        .canonicalize()
+        .ok()?;
+    let relative = root.strip_prefix(&top).ok()?.to_path_buf();
+    Some(GitContext {
+        top,
+        root,
+        relative,
+    })
+}
+
+fn trim_line_end(mut bytes: &[u8]) -> &[u8] {
+    while bytes
+        .last()
+        .is_some_and(|byte| matches!(byte, b'\r' | b'\n'))
+    {
+        bytes = &bytes[..bytes.len() - 1];
+    }
+    bytes
+}
+
+#[cfg(unix)]
+fn git_path_from_bytes(bytes: &[u8]) -> Option<PathBuf> {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    Some(PathBuf::from(OsStr::from_bytes(bytes)))
+}
+
+#[cfg(not(unix))]
+fn git_path_from_bytes(bytes: &[u8]) -> Option<PathBuf> {
+    String::from_utf8(bytes.to_vec()).ok().map(PathBuf::from)
 }
 
 struct WalkHeartbeat {
@@ -454,15 +535,21 @@ impl Drop for WalkHeartbeat {
     }
 }
 
-fn push_git_regular_file(top: &Path, rel: &str, files: &mut Vec<PathBuf>) {
+fn push_git_regular_file(top: &Path, rel: &Path, files: &mut Vec<PathBuf>) {
     let path = top.join(rel);
     if path.is_file() {
         files.push(path);
     }
 }
 
-fn git_pathspec(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+#[cfg(windows)]
+fn git_pathspec(path: &Path) -> OsString {
+    OsString::from(path.to_string_lossy().replace('\\', "/"))
+}
+
+#[cfg(not(windows))]
+fn git_pathspec(path: &Path) -> OsString {
+    path.as_os_str().to_os_string()
 }
 
 fn scan_base(root: &Path) -> PathBuf {
@@ -492,9 +579,11 @@ fn minimal_scan_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
     });
     let mut minimal = Vec::<PathBuf>::new();
     for root in roots {
-        if minimal
-            .iter()
-            .any(|parent| parent.is_dir() && root.starts_with(parent))
+        if minimal.contains(&root)
+            || (root.is_dir()
+                && minimal
+                    .iter()
+                    .any(|parent| parent.is_dir() && root.starts_with(parent)))
         {
             continue;
         }
@@ -528,6 +617,31 @@ mod tests {
         root
     }
 
+    fn init_git(root: &Path) {
+        let status = Command::new("git")
+            .arg("init")
+            .arg("--quiet")
+            .arg(root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    fn collect_test_roots(roots: &[PathBuf], excludes: &[String]) -> Vec<PathBuf> {
+        let mut skipped = Vec::new();
+        let mut skipped_count = 0;
+        collect_scan_roots(
+            roots,
+            excludes,
+            true,
+            &mut skipped,
+            &mut skipped_count,
+            false,
+            &ScanProgress::disabled(),
+        )
+        .unwrap()
+    }
+
     #[test]
     fn git_listed_directories_are_not_scanned_as_files() {
         let root = temp_root("pentect-git-listed-dir");
@@ -535,8 +649,8 @@ mod tests {
         std::fs::write(root.join("tracked.txt"), "ok").unwrap();
 
         let mut files = Vec::new();
-        push_git_regular_file(&root, "vendor-submodule", &mut files);
-        push_git_regular_file(&root, "tracked.txt", &mut files);
+        push_git_regular_file(&root, Path::new("vendor-submodule"), &mut files);
+        push_git_regular_file(&root, Path::new("tracked.txt"), &mut files);
 
         assert_eq!(vec![root.join("tracked.txt")], files);
         let _ = std::fs::remove_dir_all(root);
@@ -546,7 +660,68 @@ mod tests {
     fn untracked_root_pentectignore_is_detected_for_git_filtering() {
         let root = temp_root("pentect-untracked-ignore");
         std::fs::write(root.join(".pentectignore"), "ignored.env\n").unwrap();
-        assert!(has_pentectignore(&root, &[]));
+        assert!(has_pentectignore(&root, &root, &[]));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn explicit_file_is_kept_beside_parent_root() {
+        let root = temp_root("pentect-explicit-file-root");
+        init_git(&root);
+        let ignored = root.join("ignored.env");
+        std::fs::write(root.join(".gitignore"), "ignored.env\n").unwrap();
+        std::fs::write(&ignored, "secret\n").unwrap();
+
+        let files = collect_test_roots(&[root.clone(), ignored.clone()], &[]);
+        assert!(files.contains(&ignored.canonicalize().unwrap()));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn explicit_file_exclude_is_relative_to_git_root() {
+        let root = temp_root("pentect-explicit-file-exclude");
+        init_git(&root);
+        let sub = root.join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let ignored = sub.join("ignored.env");
+        std::fs::write(&ignored, "secret\n").unwrap();
+
+        let files = collect_test_roots(&[ignored], &["sub/ignored.env".to_string()]);
+        assert!(files.is_empty(), "{files:?}");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn git_subtree_honors_ancestor_pentectignore() {
+        let root = temp_root("pentect-git-subtree-ignore");
+        init_git(&root);
+        let subtree = root.join("sub").join("child");
+        std::fs::create_dir_all(&subtree).unwrap();
+        std::fs::write(root.join("sub").join(".pentectignore"), "ignored.env\n").unwrap();
+        let ignored = subtree.join("ignored.env");
+        std::fs::write(&ignored, "secret\n").unwrap();
+
+        let files = collect_test_roots(&[subtree], &[]);
+        assert!(!files.contains(&ignored), "{files:?}");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_listing_preserves_non_utf8_paths() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = temp_root("pentect-git-non-utf8");
+        init_git(&root);
+        let path = root.join(OsString::from_vec(b"secret-\xff.env".to_vec()));
+        std::fs::write(&path, "secret\n").unwrap();
+
+        let (_, _, files) = git_files_for_root(&root).unwrap();
+        assert!(files.contains(&path), "{files:?}");
+
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -576,7 +751,7 @@ mod tests {
         std::fs::write(&file, "fn main() {}\n").unwrap();
 
         assert_eq!(
-            vec![normalize_root(&root)],
+            vec![normalize_root(&root), normalize_root(&file)],
             minimal_scan_roots(&[nested, file, root.clone(), root.clone()])
         );
 

--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -22,6 +22,13 @@ pub(super) fn collect_scan_roots(
     let _heartbeat = WalkHeartbeat::start(progress);
     let mut files = Vec::new();
     for root in minimal_scan_roots(roots) {
+        if root.is_file() {
+            if !explicit_file_is_excluded(&root, excludes)? {
+                files.push(root);
+                progress.advance_by(1);
+            }
+            continue;
+        }
         if use_gitignore {
             if let Some((base, walk_root, git_files)) = git_files_for_root(&root) {
                 let filtered = filter_git_files(base, walk_root, git_files, excludes, progress)?;
@@ -43,6 +50,13 @@ pub(super) fn collect_scan_roots(
     files.sort_unstable();
     files.dedup();
     Ok(files)
+}
+
+fn explicit_file_is_excluded(path: &Path, excludes: &[String]) -> Result<bool, String> {
+    let Some(overrides) = rules::build_overrides(&scan_base(path), excludes)? else {
+        return Ok(false);
+    };
+    Ok(overrides.matched(path, false).is_ignore())
 }
 
 pub(super) fn ignored_file_reason(path: &Path) -> Option<&'static str> {

--- a/crates/pentect-cli/src/scan/walk.rs
+++ b/crates/pentect-cli/src/scan/walk.rs
@@ -1,7 +1,9 @@
 use super::progress::ScanProgress;
 use super::report::SkippedFile;
 use super::rules;
-use ignore::{DirEntry, ParallelVisitor, ParallelVisitorBuilder, WalkBuilder, WalkState};
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use ignore::{DirEntry, Match, ParallelVisitor, ParallelVisitorBuilder, WalkBuilder, WalkState};
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -57,9 +59,7 @@ fn explicit_file_is_excluded(path: &Path, excludes: &[String]) -> Result<bool, S
     if excludes.is_empty() {
         return Ok(false);
     }
-    let base = git_context(path)
-        .map(|context| context.top)
-        .unwrap_or_else(|| scan_base(path));
+    let base = filesystem_git_root(path).unwrap_or_else(|| scan_base(path));
     let Some(overrides) = rules::build_overrides(&base, excludes)? else {
         return Ok(false);
     };
@@ -325,36 +325,30 @@ fn filter_git_files(
     excludes: &[String],
     progress: &ScanProgress,
 ) -> Result<Vec<PathBuf>, String> {
-    if !has_pentectignore(&base, &walk_root, &git_files) {
-        let Some(overrides) = rules::build_overrides(&base, excludes)? else {
-            progress.advance_by(git_files.len());
-            return Ok(git_files);
-        };
-        let filtered = git_files
-            .into_iter()
-            .filter(|path| !overrides.matched(path, false).is_ignore())
-            .collect::<Vec<_>>();
-        progress.advance_by(filtered.len());
-        return Ok(filtered);
-    }
-    let mut builder = WalkBuilder::new(&walk_root);
-    configure_walker(&mut builder, &base, excludes, true)?;
-    add_ancestor_pentectignores(&mut builder, &base, &walk_root)?;
-    let mut allowed = Vec::new();
-    let mut skipped = Vec::new();
-    let mut skipped_count = 0;
-    collect_with_walker(
-        builder,
-        &mut allowed,
-        &mut skipped,
-        &mut skipped_count,
-        false,
-        &ScanProgress::disabled(),
-    )?;
-    allowed.sort_unstable();
+    debug_assert!(walk_root.starts_with(&base));
+    let custom_ignores = load_custom_ignores(&base, &git_files)?;
+    let overrides = rules::build_overrides(&base, excludes)?;
     let mut filtered = Vec::with_capacity(git_files.len());
     for path in git_files {
-        if allowed.binary_search(&path).is_ok() {
+        let custom_ignored = custom_ignores.iter().fold(false, |ignored, matcher| {
+            if !path.starts_with(&matcher.root) {
+                return ignored;
+            }
+            match matcher.matcher.matched_path_or_any_parents(&path, false) {
+                Match::Ignore(_) => true,
+                Match::Whitelist(_) => false,
+                Match::None => ignored,
+            }
+        });
+        let allowed = match overrides
+            .as_ref()
+            .map(|overrides| overrides.matched(&path, false))
+        {
+            Some(Match::Ignore(_)) => false,
+            Some(Match::Whitelist(_)) => true,
+            Some(Match::None) | None => !custom_ignored,
+        };
+        if allowed {
             filtered.push(path);
         }
     }
@@ -362,45 +356,48 @@ fn filter_git_files(
     Ok(filtered)
 }
 
-fn has_pentectignore(base: &Path, walk_root: &Path, paths: &[PathBuf]) -> bool {
-    !ancestor_pentectignores(base, walk_root).is_empty()
-        || walk_root.join(".pentectignore").is_file()
-        || paths
-            .iter()
-            .any(|path| path.file_name().and_then(|name| name.to_str()) == Some(".pentectignore"))
+struct CustomIgnore {
+    root: PathBuf,
+    matcher: Gitignore,
 }
 
-fn add_ancestor_pentectignores(
-    builder: &mut WalkBuilder,
-    base: &Path,
-    walk_root: &Path,
-) -> Result<(), String> {
-    for path in ancestor_pentectignores(base, walk_root) {
-        if let Some(error) = builder.add_ignore(path) {
-            return Err(format!("could not load ancestor .pentectignore: {error}"));
-        }
-    }
-    Ok(())
-}
-
-fn ancestor_pentectignores(base: &Path, walk_root: &Path) -> Vec<PathBuf> {
-    if !walk_root.starts_with(base) {
-        return Vec::new();
-    }
+fn load_custom_ignores(base: &Path, files: &[PathBuf]) -> Result<Vec<CustomIgnore>, String> {
+    let mut visited = HashSet::new();
     let mut paths = Vec::new();
-    let mut current = walk_root.parent();
-    while let Some(dir) = current.filter(|dir| dir.starts_with(base)) {
-        let path = dir.join(".pentectignore");
-        if path.is_file() {
-            paths.push(path);
+    for file in files {
+        let mut current = file.parent();
+        while let Some(dir) = current.filter(|dir| dir.starts_with(base)) {
+            if !visited.insert(dir.to_path_buf()) {
+                break;
+            }
+            let path = dir.join(".pentectignore");
+            if path.is_file() {
+                paths.push(path);
+            }
+            if dir == base {
+                break;
+            }
+            current = dir.parent();
         }
-        if dir == base {
-            break;
-        }
-        current = dir.parent();
     }
-    paths.reverse();
+    paths.sort_unstable_by_key(|path| path.components().count());
     paths
+        .into_iter()
+        .map(|path| {
+            let root = path
+                .parent()
+                .ok_or_else(|| format!("invalid .pentectignore path: {}", path.display()))?
+                .to_path_buf();
+            let mut builder = GitignoreBuilder::new(&root);
+            if let Some(error) = builder.add(&path) {
+                return Err(format!("could not load '{}': {error}", path.display()));
+            }
+            let matcher = builder
+                .build()
+                .map_err(|error| format!("could not load '{}': {error}", path.display()))?;
+            Ok(CustomIgnore { root, matcher })
+        })
+        .collect()
 }
 
 fn has_extension(path: &Path, extensions: &[&str]) -> bool {
@@ -460,22 +457,32 @@ fn git_context(root: &Path) -> Option<GitContext> {
     } else {
         root.as_path()
     };
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(git_cwd)
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()
-        .filter(|output| output.status.success())?;
-    let top = git_path_from_bytes(trim_line_end(&output.stdout))?
-        .canonicalize()
-        .ok()?;
+    let top = filesystem_git_root(&root).or_else(|| {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(git_cwd)
+            .args(["rev-parse", "--show-toplevel"])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())?;
+        git_path_from_bytes(trim_line_end(&output.stdout))?
+            .canonicalize()
+            .ok()
+    })?;
     let relative = root.strip_prefix(&top).ok()?.to_path_buf();
     Some(GitContext {
         top,
         root,
         relative,
     })
+}
+
+fn filesystem_git_root(path: &Path) -> Option<PathBuf> {
+    let start = if path.is_file() { path.parent()? } else { path };
+    start
+        .ancestors()
+        .find(|ancestor| ancestor.join(".git").try_exists().ok() == Some(true))
+        .map(Path::to_path_buf)
 }
 
 fn trim_line_end(mut bytes: &[u8]) -> &[u8] {
@@ -657,10 +664,15 @@ mod tests {
     }
 
     #[test]
-    fn untracked_root_pentectignore_is_detected_for_git_filtering() {
-        let root = temp_root("pentect-untracked-ignore");
-        std::fs::write(root.join(".pentectignore"), "ignored.env\n").unwrap();
-        assert!(has_pentectignore(&root, &root, &[]));
+    fn gitignored_pentectignore_is_detected_for_git_filtering() {
+        let root = temp_root("pentect-gitignored-ignore");
+        init_git(&root);
+        std::fs::create_dir(root.join("sub")).unwrap();
+        std::fs::write(root.join(".gitignore"), "**/.pentectignore\n").unwrap();
+        std::fs::write(root.join("sub").join(".pentectignore"), "ignored.env\n").unwrap();
+        let candidate = root.join("sub").join("ignored.env");
+        std::fs::write(&candidate, "secret\n").unwrap();
+        assert_eq!(1, load_custom_ignores(&root, &[candidate]).unwrap().len());
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -699,12 +711,53 @@ mod tests {
         init_git(&root);
         let subtree = root.join("sub").join("child");
         std::fs::create_dir_all(&subtree).unwrap();
-        std::fs::write(root.join("sub").join(".pentectignore"), "ignored.env\n").unwrap();
+        std::fs::write(
+            root.join("sub").join(".pentectignore"),
+            "child/ignored.env\n",
+        )
+        .unwrap();
         let ignored = subtree.join("ignored.env");
         std::fs::write(&ignored, "secret\n").unwrap();
 
         let files = collect_test_roots(&[subtree], &[]);
         assert!(!files.contains(&ignored), "{files:?}");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn git_scan_honors_gitignored_pentectignore() {
+        let root = temp_root("pentect-hidden-custom-ignore");
+        init_git(&root);
+        let sub = root.join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(root.join(".gitignore"), "**/.pentectignore\n").unwrap();
+        std::fs::write(sub.join(".pentectignore"), "ignored.env\n").unwrap();
+        let ignored = sub.join("ignored.env");
+        std::fs::write(&ignored, "secret\n").unwrap();
+
+        let files = collect_test_roots(std::slice::from_ref(&root), &[]);
+        assert!(!files.contains(&ignored), "{files:?}");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn deeper_pentectignore_can_restore_a_parent_rule() {
+        let root = temp_root("pentect-nested-custom-ignore");
+        init_git(&root);
+        let sub = root.join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(root.join(".pentectignore"), "*.env\n").unwrap();
+        std::fs::write(sub.join(".pentectignore"), "!keep.env\n").unwrap();
+        let keep = sub.join("keep.env");
+        let drop = sub.join("drop.env");
+        std::fs::write(&keep, "keep\n").unwrap();
+        std::fs::write(&drop, "drop\n").unwrap();
+
+        let files = collect_test_roots(std::slice::from_ref(&root), &[]);
+        assert!(files.contains(&keep.canonicalize().unwrap()), "{files:?}");
+        assert!(!files.contains(&drop.canonicalize().unwrap()), "{files:?}");
 
         let _ = std::fs::remove_dir_all(root);
     }


### PR DESCRIPTION
## Summary
- honor gitignore rules in scan by default
- replace --gitignore with --no-gitignore for broad scans
- scan explicitly named ignored files unless --exclude removes them
- update concise help and regression tests

## Verification
- 43 scan tests pass
- clippy -p pentect-cli --all-targets -- -D warnings
- release pentect scan . --json --no-fail: 137 files in 3.009s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gitignore rules are now honored by default during scans.
  * Added `--no-gitignore` to include files normally excluded by gitignore rules.

* **Bug Fixes**
  * Scanning an explicitly provided file now handles ignore rules correctly.
  * Improved scan handling for ignored files and version-control directories when gitignore filtering is disabled.

* **Documentation**
  * Updated `pentect scan` usage and help text to reflect the new option and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->