### PR TITLE
Fix terminal mouse reporting cleanup

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1026,6 +1026,7 @@ fn run_interactive_command_pty(
         (cols, rows),
         &output_error,
     );
+    terminal_guard.quiesce_input_reporting();
     if status.is_err() {
         let _ = child.kill();
     }

--- a/crates/pentect-cli/src/terminal.rs
+++ b/crates/pentect-cli/src/terminal.rs
@@ -43,6 +43,11 @@ impl TuiSessionGuard {
         self.restore(ResetLine::Keep);
     }
 
+    pub(crate) fn quiesce_input_reporting(&self) {
+        sanitize_platform_console_mode();
+        reset_ansi_input_reporting();
+    }
+
     fn restore(&mut self, reset_line: ResetLine) {
         if self.restored {
             return;
@@ -76,6 +81,23 @@ impl Drop for IgnoreCtrlCGuard {
     }
 }
 
+const ANSI_INPUT_REPORTING_RESET: &str = concat!(
+    "\x1b[?9l",    // disable xterm mouse reporting
+    "\x1b[?1000l", // disable X10 mouse
+    "\x1b[?1001l", // disable highlight mouse
+    "\x1b[?1002l", // disable button-event mouse
+    "\x1b[?1003l", // disable any-event mouse
+    "\x1b[?1004l", // disable focus events
+    "\x1b[?1005l", // disable UTF-8 mouse mode
+    "\x1b[?1006l", // disable SGR mouse mode
+    "\x1b[?1007l", // disable alternate scroll mode
+    "\x1b[?1015l", // disable urxvt mouse mode
+    "\x1b[?1016l", // disable SGR pixel mouse mode
+    "\x1b[?2004l", // disable bracketed paste
+    "\x1b[?2005l", // disable bracketed paste quote mode
+    "\x1b[?2006l", // disable bracketed paste literal newline mode
+);
+
 const ANSI_TUI_RESET: &str = concat!(
     "\x1b[0m",     // reset SGR attributes
     "\x1b(B",      // restore ASCII character set
@@ -86,20 +108,7 @@ const ANSI_TUI_RESET: &str = concat!(
     "\x1b[?1l",    // leave application cursor-key mode
     "\x1b[?5l",    // disable reverse video
     "\x1b[?6l",    // disable origin mode
-    "\x1b[?9l",    // disable xterm mouse reporting
     "\x1b[?69l",   // disable left/right margin mode
-    "\x1b[?1000l", // disable X10 mouse
-    "\x1b[?1001l", // disable highlight mouse
-    "\x1b[?1002l", // disable button-event mouse
-    "\x1b[?1003l", // disable any-event mouse
-    "\x1b[?1004l", // disable focus events
-    "\x1b[?1005l", // disable UTF-8 mouse mode
-    "\x1b[?1006l", // disable SGR mouse mode
-    "\x1b[?1007l", // disable alternate scroll mode
-    "\x1b[?1015l", // disable urxvt mouse mode
-    "\x1b[?2004l", // disable bracketed paste
-    "\x1b[?2005l", // disable bracketed paste quote mode
-    "\x1b[?2006l", // disable bracketed paste literal newline mode
     "\x1b[?2026l", // disable synchronized output
     "\x1b[r",      // reset top/bottom scroll margins
 );
@@ -427,10 +436,21 @@ fn restore_ansi_state(reset_line: ResetLine, keyboard_restore: &KeyboardModeRest
         ResetColor
     );
     let _ = out.write_all(&keyboard_restore.after_screen_leave);
+    let _ = out.write_all(ANSI_INPUT_REPORTING_RESET.as_bytes());
     let _ = out.write_all(ANSI_TUI_RESET.as_bytes());
     if reset_line == ResetLine::FreshPrompt {
         let _ = out.write_all(ANSI_FRESH_PROMPT_LINE.as_bytes());
     }
+    let _ = out.flush();
+}
+
+fn reset_ansi_input_reporting() {
+    let mut out = std::io::stdout();
+    if !out.is_terminal() {
+        return;
+    }
+    enable_ansi_for_reset();
+    let _ = out.write_all(ANSI_INPUT_REPORTING_RESET.as_bytes());
     let _ = out.flush();
 }
 
@@ -662,7 +682,6 @@ mod tests {
     #[test]
     fn ansi_tui_reset_covers_common_leftover_private_modes() {
         for mode in [
-            "\x1b[?25h",
             "\x1b[?1000l",
             "\x1b[?1001l",
             "\x1b[?1002l",
@@ -672,11 +691,17 @@ mod tests {
             "\x1b[?1006l",
             "\x1b[?1007l",
             "\x1b[?1015l",
+            "\x1b[?1016l",
             "\x1b[?2004l",
             "\x1b[?2005l",
             "\x1b[?2006l",
-            "\x1b[?2026l",
             "\x1b[?9l",
+        ] {
+            assert!(ANSI_INPUT_REPORTING_RESET.contains(mode), "{mode:?}");
+        }
+        for mode in [
+            "\x1b[?25h",
+            "\x1b[?2026l",
             "\x1b[?5l",
             "\x1b[?6l",
             "\x1b[?69l",

--- a/crates/pentect-cli/tests/pty_dimensions.rs
+++ b/crates/pentect-cli/tests/pty_dimensions.rs
@@ -171,6 +171,122 @@ fn agent_pty_does_not_forward_nested_win32_input_mode() {
 }
 
 #[test]
+fn agent_pty_does_not_leak_mouse_reports_to_parent_shell() {
+    let _serial = PTY_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let root = test_root();
+    std::fs::create_dir_all(&root).unwrap();
+    let parent_script = root.join("parent.ps1");
+    let release_file = root.join("release-child");
+    std::fs::write(
+        &parent_script,
+        concat!(
+            "$child = '$esc=[char]27;[Console]::Out.Write($esc+''[?1003h''+$esc+''[?1006h''+$esc+''[?1016h'');",
+            "Write-Output ''READY'';while(-not (Test-Path -LiteralPath $env:PENTECT_TEST_RELEASE)){Start-Sleep -Milliseconds 5}'\n",
+            "& $env:PENTECT_BIN opencode --tool powershell.exe -- -NoLogo -NoProfile -NonInteractive -Command $child\n",
+            "Write-Output 'PARENT_READY'\n",
+            "$line = [Console]::ReadLine()\n",
+            "Write-Output ('PARENT_INPUT:' + $line + ':END')\n",
+        ),
+    )
+    .unwrap();
+
+    let pty = native_pty_system();
+    let pair = pty.openpty(pty_size(INITIAL_SIZE)).unwrap();
+    let mut command = CommandBuilder::new("powershell.exe");
+    command.args(["-NoLogo", "-NoProfile", "-File"]);
+    command.arg(&parent_script);
+    command.cwd(&root);
+    command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_TEST_RELEASE", &release_file);
+    for name in [
+        "PENTECT_MEMORY_STORE_ADDR",
+        "PENTECT_MEMORY_STORE_TOKEN",
+        "PENTECT_PROCESS_HOST_READ_TOKEN",
+        "PENTECT_PROCESS_HOST_WRITE_TOKEN",
+        "PENTECT_AGENT_LAUNCHED",
+    ] {
+        command.env_remove(name);
+    }
+
+    let mut child = pair.slave.spawn_command(command).unwrap();
+    drop(pair.slave);
+    let reader = pair.master.try_clone_reader().unwrap();
+    let writer = Arc::new(Mutex::new(pair.master.take_writer().unwrap()));
+    let terminal_size = Arc::new(AtomicU32::new(pack_size(INITIAL_SIZE)));
+    let (tx, rx) = mpsc::channel();
+    let reader_thread = {
+        let writer = writer.clone();
+        std::thread::spawn(move || forward_output(reader, writer, terminal_size, tx))
+    };
+
+    let mut output = String::new();
+    wait_for_text(&rx, &mut output, "READY");
+    let enabled = output
+        .find("\x1b[?1016h")
+        .expect("pixel mouse mode was not enabled");
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let injected = Arc::new(AtomicU32::new(0));
+    let input_thread = {
+        let writer = writer.clone();
+        let stop = stop.clone();
+        let injected = injected.clone();
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::Acquire) {
+                if let Ok(mut input) = writer.lock() {
+                    if input
+                        .write_all(b"\x1b[<35;48;15M")
+                        .and_then(|_| input.flush())
+                        .is_ok()
+                    {
+                        injected.fetch_add(1, Ordering::Release);
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        })
+    };
+    let injection_deadline = Instant::now() + Duration::from_secs(2);
+    while injected.load(Ordering::Acquire) < 10 && Instant::now() < injection_deadline {
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    assert!(injected.load(Ordering::Acquire) >= 10);
+    std::fs::write(&release_file, b"ready").unwrap();
+    wait_for_text(&rx, &mut output, "\x1b[?1016l");
+    let disabled = output[enabled + "\x1b[?1016h".len()..]
+        .find("\x1b[?1016l")
+        .map(|offset| enabled + "\x1b[?1016h".len() + offset)
+        .expect("pixel mouse mode was not disabled");
+    assert!(disabled > enabled);
+    stop.store(true, Ordering::Release);
+    input_thread.join().unwrap();
+    wait_for_text(&rx, &mut output, "PARENT_READY");
+    {
+        let mut input = writer.lock().unwrap();
+        input.write_all(b"SAFE\r").unwrap();
+        input.flush().unwrap();
+    }
+    wait_for_text(&rx, &mut output, ":END");
+
+    let status = wait_for_child(child.as_mut());
+    assert_eq!(status.exit_code(), 0, "{output:?}");
+    let start = output
+        .rfind("PARENT_INPUT:")
+        .map(|offset| offset + "PARENT_INPUT:".len())
+        .expect("parent input marker was not written");
+    let end = output[start..]
+        .find(":END")
+        .map(|offset| start + offset)
+        .expect("parent input marker was incomplete");
+    assert_eq!(&output[start..end], "SAFE", "{output:?}");
+    drop(pair.master);
+    join_reader(reader_thread);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn agent_pty_stops_background_processes_on_exit() {
     let _serial = PTY_TEST_LOCK
         .lock()

--- a/crates/pentect-cli/tests/pty_dimensions.rs
+++ b/crates/pentect-cli/tests/pty_dimensions.rs
@@ -3,7 +3,7 @@
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -227,9 +227,9 @@ fn agent_pty_does_not_leak_mouse_reports_to_parent_shell() {
     let enabled = output
         .find("\x1b[?1016h")
         .expect("pixel mouse mode was not enabled");
-    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop = Arc::new(AtomicBool::new(false));
     let injected = Arc::new(AtomicU32::new(0));
-    let input_thread = {
+    let mut input_thread = InputThreadGuard::new(stop.clone(), {
         let writer = writer.clone();
         let stop = stop.clone();
         let injected = injected.clone();
@@ -247,7 +247,7 @@ fn agent_pty_does_not_leak_mouse_reports_to_parent_shell() {
                 std::thread::sleep(Duration::from_millis(1));
             }
         })
-    };
+    });
     let injection_deadline = Instant::now() + Duration::from_secs(2);
     while injected.load(Ordering::Acquire) < 10 && Instant::now() < injection_deadline {
         std::thread::sleep(Duration::from_millis(1));
@@ -260,8 +260,7 @@ fn agent_pty_does_not_leak_mouse_reports_to_parent_shell() {
         .map(|offset| enabled + "\x1b[?1016h".len() + offset)
         .expect("pixel mouse mode was not disabled");
     assert!(disabled > enabled);
-    stop.store(true, Ordering::Release);
-    input_thread.join().unwrap();
+    input_thread.stop_and_join().unwrap();
     wait_for_text(&rx, &mut output, "PARENT_READY");
     {
         let mut input = writer.lock().unwrap();
@@ -493,6 +492,34 @@ fn join_reader(thread: std::thread::JoinHandle<()>) {
     }
     assert!(thread.is_finished(), "PTY reader did not reach EOF");
     thread.join().unwrap();
+}
+
+struct InputThreadGuard {
+    stop: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl InputThreadGuard {
+    fn new(stop: Arc<AtomicBool>, thread: std::thread::JoinHandle<()>) -> Self {
+        Self {
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    fn stop_and_join(&mut self) -> std::thread::Result<()> {
+        self.stop.store(true, Ordering::Release);
+        match self.thread.take() {
+            Some(thread) => thread.join(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for InputThreadGuard {
+    fn drop(&mut self) {
+        let _ = self.stop_and_join();
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- disable SGR pixel mouse reporting when an interactive child exits
- quiesce terminal input reporting before process teardown and restore it again after output drains
- verify Windows ConPTY handoff does not leak mouse reports into the parent PowerShell prompt

## Tests
- cargo test -p pentect-cli --no-default-features --bin pentect
- cargo test -p pentect-cli --no-default-features --test pty_dimensions
- cargo clippy -p pentect-cli --no-default-features --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal cleanup after interactive sessions to prevent mouse and other input-reporting modes from leaking into the parent shell.
  * Ensured terminal input is safely quiesced before returning control to the user.
* **Tests**
  * Added Windows coverage verifying that terminal mouse reporting is disabled correctly and subsequent input reaches the parent shell as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->