### PR TITLE
Harden agent sessions and terminal cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,146 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    if: github.repository == 'EdamAme-x/pentect'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Verify tag, version, and commit
+        shell: pwsh
+        run: |
+          git fetch origin main --no-tags
+          $metadata = cargo metadata --no-deps --format-version 1 | ConvertFrom-Json
+          $versions = @(
+            $metadata.packages |
+              Where-Object { $_.name -in @('pentect-cli', 'pentect-pii-ner') } |
+              Select-Object -ExpandProperty version -Unique
+          )
+          if ($versions.Count -ne 1) {
+            throw "pentect-cli and pentect-pii-ner versions must match"
+          }
+          $version = $versions[0]
+          if ($env:GITHUB_REF_NAME -ne "v$version") {
+            throw "tag $env:GITHUB_REF_NAME must match pentect-cli version v$version"
+          }
+          $main = git rev-parse origin/main
+          if ($env:GITHUB_SHA -ne $main) {
+            throw "release tag must point at origin/main ($main)"
+          }
+      - name: Validate POSIX installer
+        run: sh -n tools/install.sh
+      - name: Validate PowerShell installer
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path 'tools/install.ps1'),
+            [ref]$tokens,
+            [ref]$errors
+          )
+          if ($errors.Count -ne 0) {
+            throw ($errors | Out-String)
+          }
+
+  build:
+    needs: verify
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            asset: pentect-windows-x86_64.exe
+            binary: target/release/pentect.exe
+            helper_asset: pentect-pii-ner-windows-x86_64.exe
+            helper_binary: target/release/pentect-pii-ner.exe
+          - os: ubuntu-latest
+            asset: pentect-linux-x86_64
+            binary: target/release/pentect
+            helper_asset: pentect-pii-ner-linux-x86_64
+            helper_binary: target/release/pentect-pii-ner
+          - os: macos-15-intel
+            asset: pentect-macos-x86_64
+            binary: target/release/pentect
+            helper_asset: pentect-pii-ner-macos-x86_64
+            helper_binary: target/release/pentect-pii-ner
+          - os: macos-15
+            asset: pentect-macos-aarch64
+            binary: target/release/pentect
+            helper_asset: pentect-pii-ner-macos-aarch64
+            helper_binary: target/release/pentect-pii-ner
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build release binary
+        run: cargo build --release --locked -p pentect-cli -p pentect-pii-ner
+      - name: Package binary and checksum
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force dist | Out-Null
+          $asset = '${{ matrix.asset }}'
+          $destination = Join-Path dist $asset
+          Copy-Item '${{ matrix.binary }}' $destination
+          $hash = (Get-FileHash -Algorithm SHA256 $destination).Hash.ToLowerInvariant()
+          "$hash  $asset" | Set-Content -NoNewline -Encoding utf8 "$destination.sha256"
+          $helperAsset = '${{ matrix.helper_asset }}'
+          $helperDestination = Join-Path dist $helperAsset
+          Copy-Item '${{ matrix.helper_binary }}' $helperDestination
+          $helperHash = (Get-FileHash -Algorithm SHA256 $helperDestination).Hash.ToLowerInvariant()
+          "$helperHash  $helperAsset" | Set-Content -NoNewline -Encoding utf8 "$helperDestination.sha256"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" dist/* --clobber --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$GITHUB_REF_NAME" dist/* \
+              --verify-tag \
+              --generate-notes \
+              --title "Pentect $GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY"
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,7 @@ dependencies = [
  "pentect-runtime",
  "portable-pty",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +960,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "esaxx-rs"
@@ -1337,6 +1358,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2020,6 +2050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,6 +2452,7 @@ dependencies = [
  "portable-pty",
  "reqwest",
  "rten",
+ "rustyline",
  "rxing",
  "serde",
  "serde_json",
@@ -2773,6 +2813,16 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -3257,6 +3307,27 @@ dependencies = [
  "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rustyline"
+version = "18.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "clipboard-win",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.31.3",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4265,6 +4336,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ aho-corasick = "1"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+semver = "1"
 sha2 = "0.10"
 serde_yaml = "0.9"
 fancy-regex = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ rten = { version = "0.24.0", default-features = false, features = ["rten_format"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 anstream = "0.6"
 crossterm = "0.28"
+rustyline = "18.0.1"
 portable-pty = "0.9.0"
 ed25519-dalek = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -1,0 +1,70 @@
+# Extensions
+
+An extension can be selected by name, local path, GitHub URL, or the compact
+GitHub form:
+
+```text
+github:@EdamAme-x/pentect/extensions/jp-pii
+```
+
+The compact form resolves the path from the repository's `main` branch.
+
+## Metadata and setup
+
+Optional metadata lives in `extension.toml`:
+
+```toml
+schema = "pentect.extension.v1"
+name = "example"
+description = "Example extension"
+
+[[postscript]]
+name = "install helper"
+command = ["cargo", "install", "example-helper", "--locked"]
+platforms = ["windows", "macos", "linux"]
+permissions = ["network", "filesystem", "process"]
+timeout_ms = 120000
+```
+
+Postscripts never run while loading an extension. They only run through
+`pentect extensions setup NAME`. Pentect prints every command and its declared
+permissions first, then requires an interactive `y`/`yes` confirmation. CI can
+provide the same explicit approval with `--yes`. The process receives only a
+small allowlist of operating-system environment variables plus its isolated
+Pentect extension paths; credentials from the parent process are not inherited.
+
+Release-hosted helper binaries use a declarative artifact entry instead of a
+postscript:
+
+```toml
+[[artifact]]
+name = "example-helper"
+repository = "owner/repository"
+destination = "bin/example-helper"
+
+[artifact.assets]
+windows-x86_64 = "example-helper-windows-x86_64.exe"
+linux-x86_64 = "example-helper-linux-x86_64"
+macos-x86_64 = "example-helper-macos-x86_64"
+macos-aarch64 = "example-helper-macos-aarch64"
+```
+
+`pentect extensions setup NAME` installs the platform asset from the latest
+stable GitHub Release after verifying its sibling `.sha256` asset.
+`pentect extensions update NAME` repeats the verified lookup and replaces the
+binary only when its hash changed.
+
+## Configuration
+
+Adapters receive the path to their config file in `PENTECT_EXTENSION_CONFIG`.
+Arbitrary TOML values can be managed without printing their values:
+
+```text
+pentect extensions config example threshold=0.8
+pentect extensions config example model.name=small
+pentect extensions config example
+pentect extensions config example --unset model.name
+```
+
+The no-value form prints the config path and key names only. Configuration is
+stored under `.pentect/extensions-data/<extension>/config.toml`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,46 @@
+# Releasing Pentect
+
+Pentect releases are driven by a `v<version>` tag on `main`. The version must
+match both `pentect-cli` and `pentect-pii-ner` in their Cargo manifests.
+
+Pushing the tag runs `.github/workflows/release.yml`, which builds and uploads:
+
+- `pentect` for Windows x64, Linux x64, macOS Intel, and macOS Apple Silicon;
+- `pentect-pii-ner` for the same platforms;
+- one `.sha256` file beside every binary.
+
+The workflow rejects a tag that does not match the Cargo version or does not
+point at `origin/main`. It creates the GitHub Release after every platform build
+succeeds. Re-running the workflow replaces the assets on the same release.
+
+Users update the main executable with:
+
+```text
+pentect update
+```
+
+`pentect update --check` only reports availability. Downloads are accepted only
+when the release asset size and its sibling SHA-256 file match. On Windows, a
+detached copy of the verified new executable performs the replacement after the
+running updater exits.
+
+First-time installation automatically selects the OS and CPU architecture:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.sh | sh
+```
+
+```powershell
+irm https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.ps1 | iex
+```
+
+Set `PENTECT_INSTALL_DIR` to override the default destination. The installers
+download the matching latest-release binary and its `.sha256` file before
+installing anything.
+
+Release-backed extension binaries are installed or refreshed with:
+
+```text
+pentect extensions setup pii-ner
+pentect extensions update pii-ner
+```

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -25,6 +25,7 @@ ignore = { workspace = true }
 pdf-extract = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+semver = { workspace = true }
 sha2 = { workspace = true }
 memchr = { workspace = true }
 zerocopy = { workspace = true }

--- a/crates/pentect-cli/src/agent_integrations.rs
+++ b/crates/pentect-cli/src/agent_integrations.rs
@@ -48,8 +48,15 @@ function createPentectBridge() {
       const waiter = pending.get(response.id);
       if (!waiter) continue;
       pending.delete(response.id);
-      if (response.ok) waiter.resolve(response.value);
-      else waiter.reject(new Error("Pentect rejected the operation"));
+      if (response.ok) {
+        waiter.resolve(response.value);
+      } else {
+        const error = new Error(response.error?.message || "Operation unavailable");
+        error.code = response.error?.code;
+        error.phase = response.error?.phase;
+        error.executed = response.error?.executed === true;
+        waiter.reject(error);
+      }
     }
   });
   child.on("error", fail);
@@ -78,7 +85,7 @@ function createPentectBridge() {
 "#;
 
 const OPENCODE_PLUGIN_BODY: &str = r#"
-const SAFE_TEXT = "[Pentect: content unavailable]";
+const SAFE_TEXT = "[Content unavailable]";
 
 export const PentectPlugin = async () => {
   const bridge = createPentectBridge();
@@ -99,7 +106,7 @@ export const PentectPlugin = async () => {
         }
         replaceArray(output.parts, withSafeImages);
       } catch {
-        throw new Error("Pentect could not protect this message");
+        throw new Error("Message unavailable");
       }
     },
     "tool.execute.before": async (input, output) => {
@@ -107,12 +114,12 @@ export const PentectPlugin = async () => {
         const next = await bridge.request("before", { tool: input.tool, value: output.args });
         replaceObject(output.args, next);
       } catch {
-        throw new Error("Pentect could not protect this tool call");
+        throw new Error("Tool unavailable");
       }
     },
     "tool.execute.after": async (input, output) => {
       const original = structuredClone(output);
-      replaceObject(output, { title: "Pentect", output: SAFE_TEXT, metadata: {} });
+      replaceObject(output, { title: original.title || "Tool", output: SAFE_TEXT, metadata: {} });
       try {
         const next = await bridge.request("after", {
           tool: input.tool,
@@ -120,8 +127,10 @@ export const PentectPlugin = async () => {
           value: original,
         });
         replaceObject(output, next);
-      } catch {
-        // Keep the safe replacement already installed above.
+      } catch (error) {
+        if (error?.executed) {
+          output.output = "Tool completed, but its output was unavailable. Check side effects before retrying.";
+        }
       }
     },
     dispose: async () => bridge.close(),

--- a/crates/pentect-cli/src/agent_integrations.rs
+++ b/crates/pentect-cli/src/agent_integrations.rs
@@ -127,10 +127,8 @@ export const PentectPlugin = async () => {
           value: original,
         });
         replaceObject(output, next);
-      } catch (error) {
-        if (error?.executed) {
-          output.output = "Tool completed, but its output was unavailable. Check side effects before retrying.";
-        }
+      } catch {
+        output.output = "Tool completed, but its output was unavailable. Check side effects before retrying.";
       }
     },
     dispose: async () => bridge.close(),
@@ -218,6 +216,10 @@ mod tests {
         assert!(opencode.contains("chat.message"));
         assert!(opencode.contains("tool.execute.before"));
         assert!(opencode.contains("tool.execute.after"));
+        assert!(opencode.contains(
+            "Tool completed, but its output was unavailable. Check side effects before retrying."
+        ));
+        assert!(!OPENCODE_PLUGIN_BODY.contains("error?.executed"));
     }
 
     #[test]

--- a/crates/pentect-cli/src/app_server_proxy.rs
+++ b/crates/pentect-cli/src/app_server_proxy.rs
@@ -673,7 +673,7 @@ where
     if clean_command_display {
         suppress_partial_json_deltas(&mut value);
     }
-    mask_app_server_display_strings(&mut value, None, clean_command_display, mask)?;
+    mask_app_server_display_strings(&mut value, None, false, clean_command_display, mask)?;
     if clean_command_display {
         prefer_command_action_display(&mut value);
     }
@@ -718,6 +718,7 @@ fn redact_app_server_images(value: &mut Value) -> Result<(), String> {
 fn mask_app_server_display_strings<F>(
     value: &mut Value,
     key: Option<&str>,
+    inside_payload: bool,
     clean_command_display: bool,
     mask: &mut F,
 ) -> Result<(), String>
@@ -736,7 +737,10 @@ where
                 }
             }
             if !looks_like_image_payload_string(text)
-                && !key.is_some_and(|key| safe_protocol_path(key, text))
+                && !key.is_some_and(|key| {
+                    (!inside_payload && app_server_protocol_metadata_key(key))
+                        || safe_protocol_path(key, text)
+                })
             {
                 let masked = mask(text)?;
                 if masked != *text {
@@ -746,17 +750,47 @@ where
         }
         Value::Array(values) => {
             for value in values {
-                mask_app_server_display_strings(value, key, clean_command_display, mask)?;
+                mask_app_server_display_strings(
+                    value,
+                    key,
+                    inside_payload,
+                    clean_command_display,
+                    mask,
+                )?;
             }
         }
         Value::Object(object) => {
             for (key, value) in object {
-                mask_app_server_display_strings(value, Some(key), clean_command_display, mask)?;
+                mask_app_server_display_strings(
+                    value,
+                    Some(key),
+                    inside_payload || app_server_payload_key(key),
+                    clean_command_display,
+                    mask,
+                )?;
             }
         }
         _ => {}
     }
     Ok(())
+}
+
+fn app_server_payload_key(key: &str) -> bool {
+    matches!(
+        key,
+        "content"
+            | "data"
+            | "details"
+            | "input"
+            | "output"
+            | "result"
+            | "structuredContent"
+            | "structured_content"
+            | "toolInput"
+            | "toolOutput"
+            | "tool_input"
+            | "tool_output"
+    )
 }
 
 fn prefer_command_action_display(value: &mut Value) {
@@ -1007,7 +1041,7 @@ fn clear_partial_json_payload(value: &mut Value, key: Option<&str>) -> bool {
             }
             changed
         }
-        Value::String(text) if !key.is_some_and(partial_json_metadata_key) => {
+        Value::String(text) if !key.is_some_and(app_server_protocol_metadata_key) => {
             text.zeroize();
             text.clear();
             true
@@ -1016,7 +1050,7 @@ fn clear_partial_json_payload(value: &mut Value, key: Option<&str>) -> bool {
     }
 }
 
-fn partial_json_metadata_key(key: &str) -> bool {
+fn app_server_protocol_metadata_key(key: &str) -> bool {
     matches!(
         key,
         "type"
@@ -1084,14 +1118,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn server_frame_masks_nested_strings() {
+    fn server_frame_masks_content_without_changing_protocol_ids() {
         let raw = serde_json::json!({
             "method": "item/completed",
             "session_id": "sk-abcdefghijklmnopqrstuvwx",
+            "threadId": "sk-zyxwvutsrqponmlkjihgfedc",
             "params": {
                 "item": {
                     "content": [
-                        {"text": "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx"}
+                        {
+                            "text": "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx",
+                            "structuredContent": {
+                                "id": "sk-abcdefghijklmnopqrstuvwx"
+                            }
+                        }
                     ],
                     "output": {"value": "sk-abcdefghijklmnopqrstuvwx"}
                 }
@@ -1104,10 +1144,15 @@ mod tests {
         .unwrap();
         assert!(masked.contains("<<OPENAI_API_KEY_x>>"), "{masked}");
         let value: Value = serde_json::from_str(&masked).unwrap();
-        assert_eq!(value["session_id"], "<<OPENAI_API_KEY_x>>");
+        assert_eq!(value["session_id"], "sk-abcdefghijklmnopqrstuvwx");
+        assert_eq!(value["threadId"], "sk-zyxwvutsrqponmlkjihgfedc");
         assert_eq!(
             value["params"]["item"]["content"][0]["text"],
             "OPENAI_API_KEY=<<OPENAI_API_KEY_x>>"
+        );
+        assert_eq!(
+            value["params"]["item"]["content"][0]["structuredContent"]["id"],
+            "<<OPENAI_API_KEY_x>>"
         );
         assert_eq!(
             value["params"]["item"]["output"]["value"],
@@ -1360,7 +1405,7 @@ mod tests {
     }
 
     #[test]
-    fn server_frame_scans_metadata_keys_that_do_not_contain_real_paths() {
+    fn server_frame_preserves_protocol_ids_but_scans_non_path_payloads() {
         let raw = serde_json::json!({
             "id": "sk-abcdefghijklmnopqrstuvwx",
             "path": "Authorization: Bearer sk-abcdefghijklmnopqrstuvwx"
@@ -1370,8 +1415,9 @@ mod tests {
             Ok(text.replace("sk-abcdefghijklmnopqrstuvwx", "<<OPENAI_API_KEY_x>>"))
         })
         .unwrap();
-        assert!(!masked.contains("sk-abcdefghijklmnopqrstuvwx"), "{masked}");
-        assert_eq!(masked.matches("<<OPENAI_API_KEY_x>>").count(), 2);
+        let value: Value = serde_json::from_str(&masked).unwrap();
+        assert_eq!(value["id"], "sk-abcdefghijklmnopqrstuvwx");
+        assert_eq!(value["path"], "Authorization: Bearer <<OPENAI_API_KEY_x>>");
     }
 
     #[test]

--- a/crates/pentect-cli/src/exec_proxy.rs
+++ b/crates/pentect-cli/src/exec_proxy.rs
@@ -144,13 +144,8 @@ async fn handle_client(fut: upgrade::UpgradeFut, codex: PathBuf) -> Result<(), S
         .arg("stdio")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .env_remove("PENTECT_MEMORY_STORE_ADDR")
-        .env_remove("PENTECT_MEMORY_STORE_TOKEN")
-        .env_remove("PENTECT_PROCESS_HOST_READ_TOKEN")
-        .env_remove("PENTECT_PROCESS_HOST_WRITE_TOKEN")
-        .env_remove("PENTECT_PROCESS_HOST_ROOT")
-        .env_remove("PENTECT_AGENT_LAUNCHED");
+        .stderr(std::process::Stdio::piped());
+    remove_pentect_control_env(&mut backend);
     let mut backend = backend
         .spawn()
         .map_err(|e| format!("could not start codex exec-server stdio: {e}"))?;
@@ -330,12 +325,21 @@ where
 }
 
 fn strip_private_env(env: &mut serde_json::Map<String, Value>) {
-    env.remove("PENTECT_MEMORY_STORE_ADDR");
-    env.remove("PENTECT_MEMORY_STORE_TOKEN");
-    env.remove("PENTECT_PROCESS_HOST_READ_TOKEN");
-    env.remove("PENTECT_PROCESS_HOST_WRITE_TOKEN");
-    env.remove("PENTECT_PROCESS_HOST_ROOT");
-    env.remove("PENTECT_AGENT_LAUNCHED");
+    env.retain(|name, _| !pentect_agent::is_pentect_control_env_name(name));
+}
+
+fn remove_pentect_control_env(command: &mut Command) {
+    for name in pentect_agent::pentect_control_env_names() {
+        command.env_remove(name);
+    }
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_str()
+            .is_some_and(pentect_agent::is_pentect_control_env_name)
+        {
+            command.env_remove(name);
+        }
+    }
 }
 
 fn json_array_strings(values: &[Value]) -> Vec<String> {
@@ -672,9 +676,10 @@ mod tests {
                 "argv": ["powershell", "-Command", "echo <<SECRET_x>>"],
                 "cwd": "file:///tmp",
                 "env": {
-                    "PENTECT_MEMORY_STORE_TOKEN": "token",
+                    "pentect_memory_store_token": "token",
                     "PENTECT_PROCESS_HOST_READ_TOKEN": "read-token",
                     "PENTECT_PROCESS_HOST_WRITE_TOKEN": "write-token",
+                    "Pentect_CodeX_App_Server_Proxy": "1",
                     "SAFE": "<<SECRET_x>>"
                 },
                 "tty": false,
@@ -707,7 +712,9 @@ mod tests {
         assert!(rewritten.contains("\"SAFE\":\"raw\""), "{rewritten}");
         assert!(rewritten.contains("\"RUNPOD_API_KEY\":\"runpod-raw\""));
         assert!(
-            !rewritten.contains("PENTECT_MEMORY_STORE_TOKEN"),
+            !rewritten
+                .to_ascii_lowercase()
+                .contains("pentect_memory_store_token"),
             "{rewritten}"
         );
         assert!(
@@ -716,6 +723,12 @@ mod tests {
         );
         assert!(
             !rewritten.contains("PENTECT_PROCESS_HOST_WRITE_TOKEN"),
+            "{rewritten}"
+        );
+        assert!(
+            !rewritten
+                .to_ascii_lowercase()
+                .contains("pentect_codex_app_server_proxy"),
             "{rewritten}"
         );
     }

--- a/crates/pentect-cli/src/extensions.rs
+++ b/crates/pentect-cli/src/extensions.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, SystemTime};
 
 pub(crate) const CONFIGS_ENV: &str = "PENTECT_EXTENSION_CONFIGS";
 pub(crate) const ADAPTERS_ENV: &str = "PENTECT_EXTENSION_ADAPTERS";
+pub(crate) const EXTENSION_MANIFEST_FILE: &str = "extension.toml";
 
 const PENTECT_DIR: &str = ".pentect";
 const EXTENSIONS_DIR: &str = "extensions";
@@ -25,6 +26,13 @@ const REMOTE_EXTENSION_CACHE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 pub(crate) struct ActiveExtensions {
     config_paths: Vec<PathBuf>,
     adapter_paths: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ExtensionSource {
+    pub(crate) name: String,
+    pub(crate) root: PathBuf,
+    pub(crate) manifest_path: Option<PathBuf>,
 }
 
 impl ActiveExtensions {
@@ -265,7 +273,7 @@ fn extension_paths_for_specs(
     let mut configs = Vec::new();
     let mut adapters = Vec::new();
     for spec in specs {
-        if is_url_spec(spec) {
+        if is_remote_spec(spec) {
             let found = extension_paths_for_url(spec)?;
             configs.extend(found.config_paths);
             adapters.extend(found.adapter_paths);
@@ -430,6 +438,120 @@ fn official_extensions_root() -> PathBuf {
     PathBuf::from(OFFICIAL_EXTENSIONS_DIR)
 }
 
+pub(crate) fn extension_source(spec: &str) -> Result<ExtensionSource> {
+    validate_extension_spec(spec)?;
+    if is_remote_spec(spec) {
+        let normalized = normalize_github_extension_url(spec)?;
+        let (base, manifest_url) = if normalized.ends_with("/extension.toml") {
+            let base = normalized
+                .strip_suffix("/extension.toml")
+                .unwrap_or(&normalized)
+                .to_string();
+            (base, normalized)
+        } else if normalized.ends_with(".toml") {
+            bail!("extension metadata must be an extension.toml file: {spec}");
+        } else {
+            let base = normalized.trim_end_matches('/').to_string();
+            let manifest = format!("{base}/{EXTENSION_MANIFEST_FILE}");
+            (base, manifest)
+        };
+        let manifest_path = fetch_remote_extension_file(&manifest_url)?;
+        let name = remote_extension_name(&base)?;
+        let root = manifest_path
+            .as_deref()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| {
+                remote_cache_file(&format!("{base}/config.toml"))
+                    .parent()
+                    .unwrap_or_else(|| Path::new("."))
+                    .to_path_buf()
+            });
+        return Ok(ExtensionSource {
+            name,
+            root,
+            manifest_path,
+        });
+    }
+    if is_path_spec(spec) {
+        let path = Path::new(spec);
+        let root = if path.is_dir() {
+            path.to_path_buf()
+        } else if path.file_name().and_then(|name| name.to_str()) == Some(EXTENSION_MANIFEST_FILE) {
+            path.parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf()
+        } else if path.is_file() {
+            path.parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf()
+        } else {
+            bail!("extension path does not exist: {}", path.display());
+        };
+        let root = root
+            .canonicalize()
+            .with_context(|| format!("could not resolve '{}'", root.display()))?;
+        let manifest = root.join(EXTENSION_MANIFEST_FILE);
+        let name = root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .unwrap_or("extension")
+            .to_string();
+        return Ok(ExtensionSource {
+            name,
+            root,
+            manifest_path: manifest.is_file().then_some(manifest),
+        });
+    }
+
+    validate_extension_name(spec)?;
+    for root in [
+        extensions_root().join(spec),
+        official_extensions_root().join(spec),
+    ] {
+        if root.is_dir() {
+            let root = root
+                .canonicalize()
+                .with_context(|| format!("could not resolve '{}'", root.display()))?;
+            let manifest = root.join(EXTENSION_MANIFEST_FILE);
+            return Ok(ExtensionSource {
+                name: spec.to_string(),
+                root,
+                manifest_path: manifest.is_file().then_some(manifest),
+            });
+        }
+    }
+    let base = format!("{DEFAULT_REMOTE_EXTENSIONS_BASE}/{spec}");
+    let manifest_path = fetch_remote_extension_file(&format!("{base}/{EXTENSION_MANIFEST_FILE}"))?;
+    let root = manifest_path
+        .as_deref()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| {
+            remote_cache_file(&format!("{base}/config.toml"))
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf()
+        });
+    Ok(ExtensionSource {
+        name: spec.to_string(),
+        root,
+        manifest_path,
+    })
+}
+
+fn remote_extension_name(base: &str) -> Result<String> {
+    let name = base
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| anyhow!("remote extension path has no name: {base}"))?;
+    validate_extension_name(name)?;
+    Ok(name.to_string())
+}
+
 fn looks_like_adapter_file(path: &Path) -> bool {
     path.file_name().and_then(|name| name.to_str()) == Some("adapter.toml")
         || path
@@ -440,7 +562,7 @@ fn looks_like_adapter_file(path: &Path) -> bool {
 }
 
 fn validate_extension_spec(spec: &str) -> Result<()> {
-    if is_url_spec(spec) {
+    if is_remote_spec(spec) {
         normalize_github_extension_url(spec).map(|_| ())?;
         return Ok(());
     }
@@ -481,8 +603,9 @@ fn is_path_spec(spec: &str) -> bool {
         || spec.starts_with('.')
 }
 
-fn is_url_spec(spec: &str) -> bool {
-    spec.starts_with("https://github.com/")
+fn is_remote_spec(spec: &str) -> bool {
+    spec.starts_with("github:")
+        || spec.starts_with("https://github.com/")
         || spec.starts_with("https://raw.githubusercontent.com/")
 }
 
@@ -567,6 +690,22 @@ fn remote_cache_file(url: &str) -> PathBuf {
 }
 
 fn normalize_github_extension_url(url: &str) -> Result<String> {
+    if let Some(rest) = url.strip_prefix("github:") {
+        let rest = rest.strip_prefix('@').unwrap_or(rest).trim_matches('/');
+        let parts = rest.split('/').collect::<Vec<_>>();
+        if parts.len() < 3 || parts.iter().any(|part| part.is_empty()) {
+            bail!("GitHub extension shorthand must be github:@OWNER/REPO/PATH: {url}");
+        }
+        let owner = parts[0];
+        let repo = parts[1];
+        let path = parts[2..].join("/");
+        if !valid_github_segment(owner) || !valid_github_segment(repo) {
+            bail!("invalid GitHub owner or repository in extension shorthand: {url}");
+        }
+        return Ok(format!(
+            "https://raw.githubusercontent.com/{owner}/{repo}/main/{path}"
+        ));
+    }
     if let Some(rest) = url.strip_prefix("https://raw.githubusercontent.com/") {
         if rest.split('/').count() < 4 {
             bail!("GitHub raw extension URL is incomplete: {url}");
@@ -592,6 +731,14 @@ fn normalize_github_extension_url(url: &str) -> Result<String> {
         )),
         _ => bail!("GitHub extension URL must use /blob/ or /tree/: {url}"),
     }
+}
+
+fn valid_github_segment(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 100
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
 }
 
 fn looks_like_adapter_url(url: &str) -> bool {
@@ -649,6 +796,10 @@ mod tests {
         assert!(parse_extension_value("../x.toml").is_err());
         assert!(parse_extension_value("../x").is_err());
         assert!(parse_extension_value("").is_err());
+        assert_eq!(
+            parse_extension_value("github:@EdamAme-x/pentect/extensions/jp-pii").unwrap(),
+            ["github:@EdamAme-x/pentect/extensions/jp-pii"]
+        );
     }
 
     #[test]
@@ -739,6 +890,11 @@ mod tests {
         assert!(
             normalize_github_extension_url("https://raw.githubusercontent.com/owner/repo").is_err()
         );
+        assert_eq!(
+            normalize_github_extension_url("github:@EdamAme-x/pentect/extensions/jp-pii").unwrap(),
+            "https://raw.githubusercontent.com/EdamAme-x/pentect/main/extensions/jp-pii"
+        );
+        assert!(normalize_github_extension_url("github:@owner/repo").is_err());
     }
 
     #[test]

--- a/crates/pentect-cli/src/extensions_cmd.rs
+++ b/crates/pentect-cli/src/extensions_cmd.rs
@@ -1,8 +1,9 @@
-use crate::extensions;
+use crate::{extensions, update};
 use pentect_core::load_pack;
 use serde::Deserialize;
 use serde_json::json;
-use std::io::{Read, Write};
+use std::collections::BTreeMap;
+use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, ExitStatus, Stdio};
 use std::thread::JoinHandle;
@@ -27,6 +28,9 @@ pub(crate) fn cmd_extensions(args: &[String]) {
         Action::List => list_extensions(opts.json),
         Action::Inspect { spec } => inspect_extension(&spec, opts.json),
         Action::Test { spec } => test_extension(&spec, opts.json),
+        Action::Config { spec, change } => config_extension(&spec, change, opts.json),
+        Action::Setup { spec, approved } => setup_extension(&spec, approved, opts.json),
+        Action::Update { spec } => update_extension(&spec, opts.json),
     };
     if let Err(e) = result {
         crate::die(e);
@@ -44,39 +48,113 @@ enum Action {
     List,
     Inspect { spec: String },
     Test { spec: String },
+    Config { spec: String, change: ConfigChange },
+    Setup { spec: String, approved: bool },
+    Update { spec: String },
+}
+
+#[derive(Debug)]
+enum ConfigChange {
+    Show,
+    Set(String),
+    Unset(String),
 }
 
 impl ExtensionCmd {
     fn parse(args: &[String]) -> Result<Self, String> {
         let Some(action) = args.get(2).map(String::as_str) else {
-            return Err("extensions list|inspect|test".to_string());
+            return Err("extensions list|inspect|test|config|setup|update".to_string());
         };
         let mut json = false;
+        let mut approved = false;
+        let mut unset = None;
         let mut values = Vec::new();
-        for arg in &args[3..] {
-            match arg.as_str() {
+        let mut i = 3usize;
+        while i < args.len() {
+            match args[i].as_str() {
                 "--json" => json = true,
+                "--yes" => approved = true,
+                "--unset" => {
+                    let Some(key) = args.get(i + 1) else {
+                        return Err("--unset requires a key".to_string());
+                    };
+                    unset = Some(key.clone());
+                    i += 1;
+                }
                 flag if flag.starts_with("--") => return Err(format!("unknown option: {flag}")),
                 value => values.push(value.to_string()),
             }
+            i += 1;
         }
         let action = match action {
             "list" => {
+                reject_action_flags(approved, unset.as_deref())?;
                 if !values.is_empty() {
                     return Err("extensions list".to_string());
                 }
                 Action::List
             }
-            "inspect" => Action::Inspect {
-                spec: one_value("extensions inspect", values)?,
-            },
-            "test" => Action::Test {
-                spec: one_value("extensions test", values)?,
-            },
+            "inspect" => {
+                reject_action_flags(approved, unset.as_deref())?;
+                Action::Inspect {
+                    spec: one_value("extensions inspect", values)?,
+                }
+            }
+            "test" => {
+                reject_action_flags(approved, unset.as_deref())?;
+                Action::Test {
+                    spec: one_value("extensions test", values)?,
+                }
+            }
+            "config" => {
+                if approved {
+                    return Err("--yes is only valid for extensions setup".to_string());
+                }
+                let spec = values
+                    .first()
+                    .cloned()
+                    .ok_or_else(|| "extensions config NAME|PATH [KEY=VALUE]".to_string())?;
+                let change = match (values.get(1), values.get(2), unset) {
+                    (None, None, None) => ConfigChange::Show,
+                    (Some(value), None, None) => ConfigChange::Set(value.clone()),
+                    (None, None, Some(key)) => ConfigChange::Unset(key),
+                    _ => {
+                        return Err(
+                            "extensions config NAME|PATH [KEY=VALUE | --unset KEY]".to_string()
+                        )
+                    }
+                };
+                Action::Config { spec, change }
+            }
+            "setup" => {
+                if unset.is_some() {
+                    return Err("--unset is only valid for extensions config".to_string());
+                }
+                Action::Setup {
+                    spec: one_value("extensions setup", values)?,
+                    approved,
+                }
+            }
+            "update" => {
+                reject_action_flags(approved, unset.as_deref())?;
+                Action::Update {
+                    spec: one_value("extensions update", values)?,
+                }
+            }
             other => return Err(format!("unknown extensions command: {other}")),
         };
         Ok(Self { action, json })
     }
+}
+
+fn reject_action_flags(approved: bool, unset: Option<&str>) -> Result<(), String> {
+    if approved {
+        return Err("--yes is only valid for extensions setup".to_string());
+    }
+    if unset.is_some() {
+        return Err("--unset is only valid for extensions config".to_string());
+    }
+    Ok(())
 }
 
 fn one_value(command: &str, values: Vec<String>) -> Result<String, String> {
@@ -123,9 +201,32 @@ fn list_extensions(json_output: bool) -> Result<(), String> {
 
 fn inspect_extension(spec: &str, json_output: bool) -> Result<(), String> {
     let active = active_for_one(spec)?;
+    let source = extensions::extension_source(spec).map_err(|e| e.to_string())?;
+    let manifest = load_extension_manifest(&source)?;
     if json_output {
-        println!("{}", active_json(&active));
+        println!(
+            "{}",
+            json!({
+                "name": extension_name(&source, manifest.as_ref()),
+                "description": manifest.as_ref().and_then(|manifest| manifest.description.as_deref()),
+                "manifest": source.manifest_path.as_deref().map(display_path),
+                "configs": active.config_paths().iter().map(|path| display_path(path)).collect::<Vec<_>>(),
+                "adapters": active.adapter_paths().iter().map(|path| display_path(path)).collect::<Vec<_>>(),
+                "postscripts": manifest.as_ref().map(|manifest| manifest.postscript.len()).unwrap_or(0),
+                "artifacts": manifest.as_ref().map(|manifest| manifest.artifact.len()).unwrap_or(0),
+            })
+        );
         return Ok(());
+    }
+    println!("name: {}", extension_name(&source, manifest.as_ref()));
+    if let Some(description) = manifest
+        .as_ref()
+        .and_then(|manifest| manifest.description.as_deref())
+    {
+        println!("description: {description}");
+    }
+    if let Some(path) = source.manifest_path.as_deref() {
+        println!("manifest: {}", display_path(path));
     }
     println!("configs: {}", active.config_paths().len());
     for path in active.config_paths() {
@@ -135,6 +236,20 @@ fn inspect_extension(spec: &str, json_output: bool) -> Result<(), String> {
     for path in active.adapter_paths() {
         println!("adapter: {}", display_path(path));
     }
+    println!(
+        "postscripts: {}",
+        manifest
+            .as_ref()
+            .map(|manifest| manifest.postscript.len())
+            .unwrap_or(0)
+    );
+    println!(
+        "artifacts: {}",
+        manifest
+            .as_ref()
+            .map(|manifest| manifest.artifact.len())
+            .unwrap_or(0)
+    );
     Ok(())
 }
 
@@ -172,17 +287,565 @@ fn test_extension(spec: &str, json_output: bool) -> Result<(), String> {
     Ok(())
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct ExtensionManifest {
+    schema: Option<String>,
+    name: Option<String>,
+    description: Option<String>,
+    #[serde(default)]
+    postscript: Vec<Postscript>,
+    #[serde(default)]
+    artifact: Vec<ReleaseArtifact>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseArtifact {
+    name: String,
+    repository: String,
+    destination: Option<String>,
+    assets: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Postscript {
+    name: Option<String>,
+    command: Vec<String>,
+    #[serde(default)]
+    platforms: Vec<String>,
+    #[serde(default)]
+    permissions: Vec<String>,
+    timeout_ms: Option<u64>,
+}
+
+fn load_extension_manifest(
+    source: &extensions::ExtensionSource,
+) -> Result<Option<ExtensionManifest>, String> {
+    let Some(path) = &source.manifest_path else {
+        return Ok(None);
+    };
+    let src = std::fs::read_to_string(path).map_err(|e| {
+        format!(
+            "could not read extension manifest '{}': {e}",
+            display_path(path)
+        )
+    })?;
+    let manifest: ExtensionManifest = toml::from_str(&src)
+        .map_err(|e| format!("invalid extension manifest '{}': {e}", display_path(path)))?;
+    if manifest
+        .schema
+        .as_deref()
+        .is_some_and(|schema| schema != "pentect.extension.v1")
+    {
+        return Err(format!(
+            "unsupported extension schema in '{}': {}",
+            display_path(path),
+            manifest.schema.as_deref().unwrap_or_default()
+        ));
+    }
+    Ok(Some(manifest))
+}
+
+fn extension_name(
+    source: &extensions::ExtensionSource,
+    manifest: Option<&ExtensionManifest>,
+) -> String {
+    manifest
+        .and_then(|manifest| manifest.name.as_deref())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or(&source.name)
+        .to_string()
+}
+
+fn config_extension(spec: &str, change: ConfigChange, json_output: bool) -> Result<(), String> {
+    let source = extensions::extension_source(spec).map_err(|e| e.to_string())?;
+    let manifest = load_extension_manifest(&source)?;
+    let name = extension_name(&source, manifest.as_ref());
+    let dirs = extension_runtime_dirs(&extension_id(&name))?;
+    let path = dirs.config_file;
+    let mut table = read_extension_config(&path)?;
+    let action = match change {
+        ConfigChange::Show => "show",
+        ConfigChange::Set(assignment) => {
+            let (key, raw_value) = assignment.split_once('=').ok_or_else(|| {
+                "config assignment must be KEY=VALUE; quote strings as needed".to_string()
+            })?;
+            let key = key.trim();
+            if key.is_empty() || raw_value.trim().is_empty() {
+                return Err("config assignment must be KEY=VALUE".to_string());
+            }
+            let update = parse_config_assignment(key, raw_value.trim())?;
+            merge_toml_tables(&mut table, update);
+            write_extension_config(&path, &table)?;
+            "set"
+        }
+        ConfigChange::Unset(key) => {
+            if !remove_toml_key(&mut table, &key)? {
+                return Err(format!("config key was not set: {key}"));
+            }
+            write_extension_config(&path, &table)?;
+            "unset"
+        }
+    };
+    let keys = toml_leaf_keys(&table);
+    if json_output {
+        println!(
+            "{}",
+            json!({
+                "name": name,
+                "action": action,
+                "path": display_path(&path),
+                "keys": keys,
+            })
+        );
+    } else {
+        println!("config: {}", display_path(&path));
+        println!(
+            "keys: {}",
+            if keys.is_empty() {
+                "none".to_string()
+            } else {
+                keys.join(", ")
+            }
+        );
+    }
+    Ok(())
+}
+
+fn read_extension_config(path: &Path) -> Result<toml::Table, String> {
+    if !path.exists() {
+        return Ok(toml::Table::new());
+    }
+    let src = std::fs::read_to_string(path).map_err(|e| {
+        format!(
+            "could not read extension config '{}': {e}",
+            display_path(path)
+        )
+    })?;
+    toml::from_str(&src)
+        .map_err(|e| format!("invalid extension config '{}': {e}", display_path(path)))
+}
+
+fn parse_config_assignment(key: &str, value: &str) -> Result<toml::Table, String> {
+    validate_config_key(key)?;
+    let src = format!("{key} = {value}");
+    toml::from_str(&src)
+        .or_else(|_| {
+            let quoted = toml::Value::String(value.to_string()).to_string();
+            toml::from_str(&format!("{key} = {quoted}"))
+        })
+        .map_err(|e| format!("invalid config assignment '{key}': {e}"))
+}
+
+fn validate_config_key(key: &str) -> Result<(), String> {
+    if key.split('.').any(|part| {
+        part.is_empty()
+            || !part
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+    }) {
+        return Err(format!("invalid config key: {key}"));
+    }
+    Ok(())
+}
+
+fn merge_toml_tables(target: &mut toml::Table, update: toml::Table) {
+    for (key, value) in update {
+        match (target.get_mut(&key), value) {
+            (Some(toml::Value::Table(target)), toml::Value::Table(update)) => {
+                merge_toml_tables(target, update)
+            }
+            (_, value) => {
+                target.insert(key, value);
+            }
+        }
+    }
+}
+
+fn remove_toml_key(table: &mut toml::Table, key: &str) -> Result<bool, String> {
+    validate_config_key(key)?;
+    let parts = key.split('.').collect::<Vec<_>>();
+    remove_toml_key_parts(table, &parts)
+}
+
+fn remove_toml_key_parts(table: &mut toml::Table, parts: &[&str]) -> Result<bool, String> {
+    if parts.len() == 1 {
+        return Ok(table.remove(parts[0]).is_some());
+    }
+    let Some(value) = table.get_mut(parts[0]) else {
+        return Ok(false);
+    };
+    let Some(child) = value.as_table_mut() else {
+        return Err(format!("config key is not a table: {}", parts[0]));
+    };
+    let removed = remove_toml_key_parts(child, &parts[1..])?;
+    if child.is_empty() {
+        table.remove(parts[0]);
+    }
+    Ok(removed)
+}
+
+fn write_extension_config(path: &Path, table: &toml::Table) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "invalid extension config path".to_string())?;
+    std::fs::create_dir_all(parent).map_err(|e| {
+        format!(
+            "could not create extension config dir '{}': {e}",
+            display_path(parent)
+        )
+    })?;
+    let src = toml::to_string_pretty(table).map_err(|e| format!("could not encode config: {e}"))?;
+    std::fs::write(path, src).map_err(|e| {
+        format!(
+            "could not write extension config '{}': {e}",
+            display_path(path)
+        )
+    })
+}
+
+fn toml_leaf_keys(table: &toml::Table) -> Vec<String> {
+    fn visit(table: &toml::Table, prefix: &str, out: &mut Vec<String>) {
+        for (key, value) in table {
+            let full = if prefix.is_empty() {
+                key.clone()
+            } else {
+                format!("{prefix}.{key}")
+            };
+            if let Some(child) = value.as_table() {
+                visit(child, &full, out);
+            } else {
+                out.push(full);
+            }
+        }
+    }
+    let mut keys = Vec::new();
+    visit(table, "", &mut keys);
+    keys.sort();
+    keys
+}
+
+fn setup_extension(spec: &str, approved: bool, json_output: bool) -> Result<(), String> {
+    if json_output {
+        return Err("extensions setup does not support --json".to_string());
+    }
+    let source = extensions::extension_source(spec).map_err(|e| e.to_string())?;
+    let manifest = load_extension_manifest(&source)?
+        .ok_or_else(|| format!("extension '{}' has no extension.toml", source.name))?;
+    let name = extension_name(&source, Some(&manifest));
+    let steps = manifest
+        .postscript
+        .iter()
+        .filter(|step| postscript_matches_platform(step))
+        .collect::<Vec<_>>();
+    if steps.is_empty() && manifest.artifact.is_empty() {
+        println!("setup: nothing to do for {}", current_platform());
+        return Ok(());
+    }
+    println!("extension: {name}");
+    if let Some(description) = manifest.description.as_deref() {
+        println!("description: {description}");
+    }
+    println!(
+        "source: {}",
+        source
+            .manifest_path
+            .as_deref()
+            .map(display_path)
+            .unwrap_or_else(|| "extension.toml".to_string())
+    );
+    for artifact in &manifest.artifact {
+        let asset = artifact_asset(artifact)?;
+        println!("artifact: {}", artifact.name);
+        println!("  release: github:{}", artifact.repository);
+        println!("  asset: {asset}");
+        println!(
+            "  destination: {}",
+            artifact_destination(&name, artifact)?.display()
+        );
+    }
+    for (index, step) in steps.iter().enumerate() {
+        validate_postscript(step)?;
+        println!(
+            "postscript {}: {}",
+            index + 1,
+            step.name.as_deref().unwrap_or("setup")
+        );
+        println!("  command: {}", display_command(&step.command));
+        println!("  permissions: {}", step.permissions.join(", "));
+    }
+    if !approved && !confirm_setup()? {
+        return Err("extension setup was not approved".to_string());
+    }
+    for artifact in &manifest.artifact {
+        install_release_artifact(&name, artifact)?;
+    }
+    for step in steps {
+        run_postscript(&name, &source.root, step)?;
+    }
+    println!("setup: complete");
+    Ok(())
+}
+
+fn update_extension(spec: &str, json_output: bool) -> Result<(), String> {
+    if json_output {
+        return Err("extensions update does not support --json".to_string());
+    }
+    let source = extensions::extension_source(spec).map_err(|e| e.to_string())?;
+    let manifest = load_extension_manifest(&source)?
+        .ok_or_else(|| format!("extension '{}' has no extension.toml", source.name))?;
+    let name = extension_name(&source, Some(&manifest));
+    if manifest.artifact.is_empty() {
+        println!("update: no release artifacts for {name}");
+        return Ok(());
+    }
+    for artifact in &manifest.artifact {
+        install_release_artifact(&name, artifact)?;
+    }
+    println!("update: complete");
+    Ok(())
+}
+
+fn artifact_platform_key() -> Result<String, String> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("windows", "x86_64") => Ok("windows-x86_64".to_string()),
+        ("linux", "x86_64") => Ok("linux-x86_64".to_string()),
+        ("macos", "x86_64") => Ok("macos-x86_64".to_string()),
+        ("macos", "aarch64") => Ok("macos-aarch64".to_string()),
+        (os, arch) => Err(format!(
+            "extension artifacts are not published for {os}/{arch}"
+        )),
+    }
+}
+
+fn artifact_asset(artifact: &ReleaseArtifact) -> Result<&str, String> {
+    let platform = artifact_platform_key()?;
+    artifact
+        .assets
+        .get(&platform)
+        .map(String::as_str)
+        .ok_or_else(|| {
+            format!(
+                "extension artifact '{}' has no asset for {platform}",
+                artifact.name
+            )
+        })
+}
+
+fn artifact_destination(name: &str, artifact: &ReleaseArtifact) -> Result<PathBuf, String> {
+    let default = format!("bin/{}", artifact.name);
+    let raw = artifact.destination.as_deref().unwrap_or(&default);
+    let mut relative = PathBuf::from(raw);
+    if relative.as_os_str().is_empty()
+        || relative.is_absolute()
+        || relative.components().any(|component| {
+            !matches!(
+                component,
+                std::path::Component::Normal(_) | std::path::Component::CurDir
+            )
+        })
+    {
+        return Err(format!(
+            "extension artifact '{}' has unsafe destination: {raw}",
+            artifact.name
+        ));
+    }
+    if cfg!(windows) && relative.extension().is_none() {
+        relative.set_extension("exe");
+    }
+    let dirs = extension_runtime_dirs(&extension_id(name))?;
+    Ok(dirs.data_dir.join(relative))
+}
+
+fn install_release_artifact(name: &str, artifact: &ReleaseArtifact) -> Result<(), String> {
+    let asset = artifact_asset(artifact)?;
+    let destination = artifact_destination(name, artifact)?;
+    let download = update::download_latest_release_asset(&artifact.repository, asset)?;
+    if destination.is_file() && sha256_path(&destination)? == download.sha256 {
+        println!(
+            "artifact {}: up to date ({})",
+            artifact.name, download.version
+        );
+        return Ok(());
+    }
+    let parent = destination
+        .parent()
+        .ok_or_else(|| "extension artifact destination has no parent".to_string())?;
+    std::fs::create_dir_all(parent).map_err(|e| {
+        format!(
+            "could not create extension artifact directory '{}': {e}",
+            parent.display()
+        )
+    })?;
+    let staged = destination.with_extension(format!(
+        "{}download-{}",
+        destination
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| format!("{ext}."))
+            .unwrap_or_default(),
+        std::process::id()
+    ));
+    std::fs::write(&staged, &download.bytes)
+        .map_err(|e| format!("could not stage extension artifact: {e}"))?;
+    mark_artifact_executable(&staged)?;
+    if sha256_path(&staged)? != download.sha256 {
+        let _ = std::fs::remove_file(&staged);
+        return Err("staged extension artifact checksum mismatch".to_string());
+    }
+    replace_artifact(&staged, &destination)?;
+    println!("artifact {}: installed {}", artifact.name, download.version);
+    Ok(())
+}
+
+fn sha256_path(path: &Path) -> Result<String, String> {
+    use sha2::{Digest, Sha256};
+    let bytes = std::fs::read(path).map_err(|e| {
+        format!(
+            "could not verify extension artifact '{}': {e}",
+            path.display()
+        )
+    })?;
+    Ok(data_encoding::HEXLOWER.encode(&Sha256::digest(bytes)))
+}
+
+fn replace_artifact(staged: &Path, destination: &Path) -> Result<(), String> {
+    if !destination.exists() {
+        return std::fs::rename(staged, destination)
+            .map_err(|e| format!("could not install extension artifact: {e}"));
+    }
+    let backup = destination.with_extension(format!(
+        "{}previous",
+        destination
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| format!("{ext}."))
+            .unwrap_or_default()
+    ));
+    if backup.exists() {
+        std::fs::remove_file(&backup)
+            .map_err(|e| format!("could not remove old extension artifact backup: {e}"))?;
+    }
+    std::fs::rename(destination, &backup).map_err(|e| {
+        format!(
+            "could not replace running extension artifact '{}': {e}",
+            destination.display()
+        )
+    })?;
+    if let Err(error) = std::fs::rename(staged, destination) {
+        let _ = std::fs::rename(&backup, destination);
+        return Err(format!("could not install extension artifact: {error}"));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn mark_artifact_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+        .map_err(|e| format!("could not mark extension artifact executable: {e}"))
+}
+
+#[cfg(windows)]
+fn mark_artifact_executable(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+fn current_platform() -> &'static str {
+    if cfg!(windows) {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else {
+        "linux"
+    }
+}
+
+fn postscript_matches_platform(step: &Postscript) -> bool {
+    step.platforms.is_empty()
+        || step
+            .platforms
+            .iter()
+            .any(|platform| platform.eq_ignore_ascii_case(current_platform()))
+}
+
+fn validate_postscript(step: &Postscript) -> Result<(), String> {
+    if step.command.is_empty() || step.command.iter().any(|part| part.is_empty()) {
+        return Err("postscript command must be a non-empty string array".to_string());
+    }
+    if step.permissions.is_empty() {
+        return Err("postscript must declare at least one permission".to_string());
+    }
+    const PERMISSIONS: &[&str] = &["filesystem", "network", "process", "environment"];
+    for permission in &step.permissions {
+        if !PERMISSIONS.contains(&permission.as_str()) {
+            return Err(format!("unknown postscript permission: {permission}"));
+        }
+    }
+    Ok(())
+}
+
+fn confirm_setup() -> Result<bool, String> {
+    if !std::io::stdin().is_terminal() {
+        return Err("extension setup requires interactive approval or --yes".to_string());
+    }
+    eprint!("Apply this extension setup? [y/N] ");
+    std::io::stderr().flush().map_err(|e| e.to_string())?;
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .map_err(|e| e.to_string())?;
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn display_command(command: &[String]) -> String {
+    command
+        .iter()
+        .map(|part| {
+            if part
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || "-._/:\\".contains(ch))
+            {
+                part.clone()
+            } else {
+                format!("{:?}", part)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn run_postscript(name: &str, cwd: &Path, step: &Postscript) -> Result<(), String> {
+    let program = adapter_program(&step.command[0], cwd, &extension_id(name));
+    if find_command(&program).is_none() {
+        return Err(format!("postscript command not found: {}", step.command[0]));
+    }
+    let mut command = adapter_command(&program, &extension_id(name))?;
+    command
+        .args(&step.command[1..])
+        .current_dir(cwd)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("could not start postscript: {e}"))?;
+    let status = wait_for_adapter_child(
+        &mut child,
+        step.name.as_deref().unwrap_or("postscript"),
+        Duration::from_millis(step.timeout_ms.unwrap_or(120_000)),
+    )?;
+    if !status.success() {
+        return Err(format!("postscript failed: {status}"));
+    }
+    Ok(())
+}
+
 fn active_for_one(spec: &str) -> Result<extensions::ActiveExtensions, String> {
     let specs = extensions::parse_extension_value(spec).map_err(|e| e.to_string())?;
     extensions::active_from_explicit_specs(specs, true).map_err(|e| e.to_string())
-}
-
-fn active_json(active: &extensions::ActiveExtensions) -> String {
-    json!({
-        "configs": active.config_paths().iter().map(|path| display_path(path)).collect::<Vec<_>>(),
-        "adapters": active.adapter_paths().iter().map(|path| display_path(path)).collect::<Vec<_>>(),
-    })
-    .to_string()
 }
 
 fn test_pack(path: &Path) -> Check {
@@ -247,15 +910,15 @@ impl AdapterFile {
             .map(Path::to_path_buf)
             .unwrap_or_else(|| PathBuf::from("."));
         let command = adapter_command_from_manifest(manifest.command)?;
-        let program = adapter_program(&command[0], &cwd);
-        if find_command(&program).is_none() {
-            return Err("command not found".to_string());
-        }
         let name = manifest
             .name
             .filter(|name| !name.trim().is_empty())
             .unwrap_or_else(|| adapter_default_name(path));
         let id = extension_id(&name);
+        let program = adapter_program(&command[0], &cwd, &id);
+        if find_command(&program).is_none() {
+            return Err("command not found; run `pentect extensions setup`".to_string());
+        }
         Ok(Self {
             name,
             id,
@@ -278,7 +941,7 @@ impl AdapterFile {
         if request.len() > self.max_input_bytes {
             return Err(format!("{}: input limit", self.name));
         }
-        let program = adapter_program(&self.command[0], &self.cwd);
+        let program = adapter_program(&self.command[0], &self.cwd, &self.id);
         let mut command = adapter_command(&program, &self.id)?;
         command
             .args(&self.command[1..])
@@ -626,7 +1289,7 @@ impl Check {
     }
 }
 
-fn adapter_program(program: &str, cwd: &Path) -> PathBuf {
+fn adapter_program(program: &str, cwd: &Path, id: &str) -> PathBuf {
     let path = Path::new(program);
     if path.is_absolute() {
         return path.to_path_buf();
@@ -634,7 +1297,23 @@ fn adapter_program(program: &str, cwd: &Path) -> PathBuf {
     if looks_like_path_command(program) {
         return cwd.join(path);
     }
-    adapter_sidecar_program(program).unwrap_or_else(|| path.to_path_buf())
+    installed_extension_program(program, id)
+        .or_else(|| adapter_sidecar_program(program))
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+fn installed_extension_program(program: &str, id: &str) -> Option<PathBuf> {
+    let bin = PathBuf::from(PENTECT_DIR)
+        .join(EXTENSIONS_DATA_DIR)
+        .join(extension_id(id))
+        .join("bin");
+    for name in command_names(program) {
+        let candidate = bin.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 fn looks_like_path_command(program: &str) -> bool {
@@ -723,6 +1402,136 @@ mod tests {
     fn inspect_requires_one_spec() {
         let args = vec!["pentect".into(), "extensions".into(), "inspect".into()];
         assert!(ExtensionCmd::parse(&args).is_err());
+    }
+
+    #[test]
+    fn parses_config_and_approved_setup() {
+        let args = vec![
+            "pentect".into(),
+            "extensions".into(),
+            "config".into(),
+            "pii-ner".into(),
+            "model.threshold=0.8".into(),
+        ];
+        assert!(matches!(
+            ExtensionCmd::parse(&args).unwrap().action,
+            Action::Config {
+                change: ConfigChange::Set(_),
+                ..
+            }
+        ));
+
+        let args = vec![
+            "pentect".into(),
+            "extensions".into(),
+            "setup".into(),
+            "pii-ner".into(),
+            "--yes".into(),
+        ];
+        assert!(matches!(
+            ExtensionCmd::parse(&args).unwrap().action,
+            Action::Setup { approved: true, .. }
+        ));
+
+        let args = vec![
+            "pentect".into(),
+            "extensions".into(),
+            "update".into(),
+            "pii-ner".into(),
+        ];
+        assert!(matches!(
+            ExtensionCmd::parse(&args).unwrap().action,
+            Action::Update { .. }
+        ));
+    }
+
+    #[test]
+    fn config_values_are_nested_and_key_listing_omits_values() {
+        let mut table = toml::Table::new();
+        merge_toml_tables(
+            &mut table,
+            parse_config_assignment("model.threshold", "0.8").unwrap(),
+        );
+        merge_toml_tables(
+            &mut table,
+            parse_config_assignment("model.name", "small").unwrap(),
+        );
+        assert_eq!(toml_leaf_keys(&table), ["model.name", "model.threshold"]);
+        assert_eq!(
+            table["model"]["name"].as_str(),
+            Some("small"),
+            "bare values fall back to TOML strings"
+        );
+        assert!(remove_toml_key(&mut table, "model.name").unwrap());
+        assert_eq!(toml_leaf_keys(&table), ["model.threshold"]);
+    }
+
+    #[test]
+    fn postscript_requires_declared_known_permissions() {
+        let missing = Postscript {
+            name: None,
+            command: vec!["tool".into()],
+            platforms: Vec::new(),
+            permissions: Vec::new(),
+            timeout_ms: None,
+        };
+        assert!(validate_postscript(&missing).is_err());
+
+        let valid = Postscript {
+            permissions: vec!["network".into(), "filesystem".into()],
+            ..missing
+        };
+        assert!(validate_postscript(&valid).is_ok());
+    }
+
+    #[test]
+    fn postscript_does_not_run_before_approval() {
+        let root =
+            std::env::temp_dir().join(format!("pentect-extension-approval-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let marker = root.join("approved.txt");
+        #[cfg(windows)]
+        let command = r#"["cmd", "/C", "echo approved>approved.txt"]"#;
+        #[cfg(not(windows))]
+        let command = r#"["sh", "-c", "printf approved > approved.txt"]"#;
+        std::fs::write(
+            root.join("extension.toml"),
+            format!(
+                r#"
+schema = "pentect.extension.v1"
+name = "approval-test"
+
+[[postscript]]
+command = {command}
+permissions = ["filesystem", "process"]
+"#
+            ),
+        )
+        .unwrap();
+
+        let spec = root.to_string_lossy();
+        assert!(setup_extension(&spec, false, false).is_err());
+        assert!(!marker.exists());
+        setup_extension(&spec, true, false).unwrap();
+        assert_eq!(std::fs::read_to_string(&marker).unwrap().trim(), "approved");
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn release_artifacts_select_platform_and_reject_unsafe_destinations() {
+        let platform = artifact_platform_key().unwrap();
+        let mut assets = BTreeMap::new();
+        assets.insert(platform, "helper.bin".to_string());
+        let artifact = ReleaseArtifact {
+            name: "helper".to_string(),
+            repository: "owner/repo".to_string(),
+            destination: Some("../outside".to_string()),
+            assets,
+        };
+        assert_eq!(artifact_asset(&artifact).unwrap(), "helper.bin");
+        assert!(artifact_destination("test", &artifact).is_err());
     }
 
     #[test]

--- a/crates/pentect-cli/src/headless.rs
+++ b/crates/pentect-cli/src/headless.rs
@@ -399,11 +399,6 @@ pub(crate) fn run_noninteractive_command(
     protect_stdin: bool,
 ) -> Result<ExitStatus, String> {
     let protected_stdin = protect_stdin;
-    let buffered_stdin = if protected_stdin && input_mode == InputMode::Buffered {
-        Some(read_masked_buffered_stdin()?)
-    } else {
-        None
-    };
     let streaming_masker = if protected_stdin && input_mode == InputMode::JsonLines {
         Some(pentect_agent::ActiveToolOutputMasker::new()?)
     } else {
@@ -436,10 +431,13 @@ pub(crate) fn run_noninteractive_command(
             .stdin
             .take()
             .ok_or_else(|| format!("could not open '{}' stdin", display.display()))?;
-        if let Some(buffered) = buffered_stdin {
+        if input_mode == InputMode::Buffered {
             let cancelled = Arc::clone(&cancelled);
             stdin_thread = Some(thread::spawn(move || {
-                let result = write_buffered_stdin(stdin, buffered);
+                // Start the agent before waiting for inherited stdin. A positional
+                // prompt can finish while an unrelated automation pipe stays open.
+                let result = read_masked_buffered_stdin()
+                    .and_then(|buffered| write_buffered_stdin(stdin, buffered));
                 if result.is_err() {
                     cancelled.store(true, Ordering::Release);
                 }
@@ -568,7 +566,11 @@ pub(crate) fn run_noninteractive_command(
     join_output(stdout_thread, "stdout")?;
     join_output(stderr_thread, "stderr")?;
     if let Some(stdin_thread) = stdin_thread {
-        join_input(stdin_thread)?;
+        // An agent with a complete positional prompt need not consume inherited
+        // stdin. Do not keep Pentect alive solely for an unrelated open pipe.
+        if stdin_thread.is_finished() {
+            join_input(stdin_thread)?;
+        }
     }
     if let Some(error) = streaming_input_error {
         return Err(error);
@@ -898,22 +900,55 @@ fn mask_json_value<F>(
 where
     F: FnMut(&str) -> Result<Option<String>, String>,
 {
+    mask_json_value_scoped(value, scan_string, JsonProtocolScope::Root, mask)
+}
+
+#[derive(Clone, Copy)]
+enum JsonProtocolScope {
+    Root,
+    Message,
+    MessageContent,
+    Other,
+}
+
+fn mask_json_value_scoped<F>(
+    value: &mut serde_json::Value,
+    scan_string: bool,
+    scope: JsonProtocolScope,
+    mask: &mut F,
+) -> Result<bool, String>
+where
+    F: FnMut(&str) -> Result<Option<String>, String>,
+{
     match value {
         serde_json::Value::Object(object) => {
+            let object_type = object
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
             let mut changed = false;
             for (key, value) in object {
-                let scan_child = !value.as_str().is_some_and(looks_like_image_payload_string)
+                let scan_child = scan_string
+                    && !value.as_str().is_some_and(looks_like_image_payload_string)
                     && !value
                         .as_str()
-                        .is_some_and(|text| safe_protocol_path(key, text));
-                changed |= mask_json_value(value, scan_child, mask)?;
+                        .is_some_and(|text| safe_protocol_path(key, text))
+                    && !value.as_str().is_some_and(|text| {
+                        safe_agent_protocol_metadata(scope, object_type.as_deref(), key, text)
+                    });
+                let child_scope = match (scope, key.as_str()) {
+                    (JsonProtocolScope::Root, "message") => JsonProtocolScope::Message,
+                    (JsonProtocolScope::Message, "content") => JsonProtocolScope::MessageContent,
+                    _ => JsonProtocolScope::Other,
+                };
+                changed |= mask_json_value_scoped(value, scan_child, child_scope, mask)?;
             }
             Ok(changed)
         }
         serde_json::Value::Array(values) => {
             let mut changed = false;
             for value in values {
-                changed |= mask_json_value(value, scan_string, mask)?;
+                changed |= mask_json_value_scoped(value, scan_string, scope, mask)?;
             }
             Ok(changed)
         }
@@ -930,6 +965,79 @@ where
         }
         _ => Ok(false),
     }
+}
+
+fn safe_agent_protocol_metadata(
+    scope: JsonProtocolScope,
+    object_type: Option<&str>,
+    key: &str,
+    text: &str,
+) -> bool {
+    match scope {
+        JsonProtocolScope::Root => {
+            matches!(
+                key,
+                "uuid"
+                    | "session_id"
+                    | "sessionId"
+                    | "request_id"
+                    | "requestId"
+                    | "response_id"
+                    | "responseId"
+                    | "parent_tool_use_id"
+                    | "parentToolUseId"
+                    | "hook_id"
+                    | "hookId"
+                    | "prompt_id"
+                    | "promptId"
+                    | "parent_uuid"
+                    | "parentUuid"
+                    | "leaf_uuid"
+                    | "leafUuid"
+            ) && known_agent_protocol_id(text)
+        }
+        JsonProtocolScope::Message => {
+            key == "id" && text.starts_with("msg_") && protocol_tail(text)
+        }
+        JsonProtocolScope::MessageContent => {
+            (key == "id" && text.starts_with("toolu_") && protocol_tail(text))
+                || (matches!(key, "tool_use_id" | "toolUseId")
+                    && text.starts_with("toolu_")
+                    && protocol_tail(text))
+                || (key == "signature" && object_type == Some("thinking"))
+        }
+        JsonProtocolScope::Other => false,
+    }
+}
+
+fn known_agent_protocol_id(text: &str) -> bool {
+    uuid_shape(text)
+        || [
+            "req_", "resp_", "msg_", "toolu_", "call_", "item_", "thread_", "turn_",
+        ]
+        .iter()
+        .any(|prefix| text.starts_with(prefix) && protocol_tail(text))
+}
+
+fn protocol_tail(text: &str) -> bool {
+    let Some((_, tail)) = text.split_once('_') else {
+        return false;
+    };
+    tail.len() >= 8
+        && tail
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+fn uuid_shape(text: &str) -> bool {
+    text.len() == 36
+        && text.bytes().enumerate().all(|(index, byte)| {
+            if matches!(index, 8 | 13 | 18 | 23) {
+                byte == b'-'
+            } else {
+                byte.is_ascii_hexdigit()
+            }
+        })
 }
 
 fn safe_protocol_path(key: &str, text: &str) -> bool {
@@ -1454,12 +1562,14 @@ fn claude_reads_prompt_from_stdin(
     {
         return false;
     }
+    if let Some(prompt) = claude_prompt_index(args) {
+        return args[prompt] == "-" || !stdin_is_terminal;
+    }
     !stdin_is_terminal
-        || (claude_prompt_index(args).is_none()
-            && (args
-                .iter()
-                .any(|arg| matches!(arg.as_str(), "-p" | "--print"))
-                || !stdout_is_terminal))
+        || args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "-p" | "--print"))
+        || !stdout_is_terminal
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -1934,6 +2044,49 @@ mod tests {
     }
 
     #[test]
+    fn structured_output_keeps_only_contextual_agent_protocol_metadata() {
+        let signature = "Es0HCokBCA8YAipAWCkIbWnhWvXGSzbzfDUe9zlTS3NWm5lxvwRIrEHE9xdyn94F";
+        let mut value = serde_json::json!({
+            "type": "assistant",
+            "uuid": "a18f48ad-fefb-47be-a6ac-4448de1b0485",
+            "request_id": "req_011CdA1L1mNyKdPJUnGC2P8S",
+            "message": {
+                "id": "msg_011CdA1L4pvzK9sHJpEdvmd8",
+                "content": [
+                    {"type": "thinking", "signature": signature},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01JqZnVvjYnsgRq4noGzy8xG",
+                        "input": {"id": "secret-value", "signature": "secret-value"}
+                    },
+                    {"type": "tool_result", "tool_use_id": "toolu_01JqZnVvjYnsgRq4noGzy8xG"}
+                ]
+            }
+        });
+        let changed =
+            mask_json_value(&mut value, true, &mut |_| Ok(Some("SCANNED".to_string()))).unwrap();
+        assert!(changed);
+        assert_eq!(value["uuid"], "a18f48ad-fefb-47be-a6ac-4448de1b0485");
+        assert_eq!(value["request_id"], "req_011CdA1L1mNyKdPJUnGC2P8S");
+        assert_eq!(value["message"]["id"], "msg_011CdA1L4pvzK9sHJpEdvmd8");
+        assert_eq!(value["message"]["content"][0]["signature"], signature);
+        assert_eq!(
+            value["message"]["content"][1]["id"],
+            "toolu_01JqZnVvjYnsgRq4noGzy8xG"
+        );
+        assert_eq!(
+            value["message"]["content"][2]["tool_use_id"],
+            "toolu_01JqZnVvjYnsgRq4noGzy8xG"
+        );
+        assert_eq!(value["message"]["content"][1]["input"]["id"], "SCANNED");
+        assert_eq!(
+            value["message"]["content"][1]["input"]["signature"],
+            "SCANNED"
+        );
+        zeroize_json_strings(&mut value);
+    }
+
+    #[test]
     fn structured_output_suppresses_partial_deltas() {
         let mut value = serde_json::json!({
             "method": "item/agentMessage/delta",
@@ -2021,6 +2174,12 @@ mod tests {
             AgentKind::Claude,
             &["-p".into(), "hello".into()],
             true,
+            true
+        ));
+        assert!(protect_stdin(
+            AgentKind::Claude,
+            &["-p".into(), "-".into()],
+            false,
             true
         ));
         assert!(protect_stdin(

--- a/crates/pentect-cli/src/headless.rs
+++ b/crates/pentect-cli/src/headless.rs
@@ -974,59 +974,39 @@ fn safe_agent_protocol_metadata(
     text: &str,
 ) -> bool {
     match scope {
-        JsonProtocolScope::Root => {
-            matches!(
-                key,
-                "uuid"
-                    | "session_id"
-                    | "sessionId"
-                    | "request_id"
-                    | "requestId"
-                    | "response_id"
-                    | "responseId"
-                    | "parent_tool_use_id"
-                    | "parentToolUseId"
-                    | "hook_id"
-                    | "hookId"
-                    | "prompt_id"
-                    | "promptId"
-                    | "parent_uuid"
-                    | "parentUuid"
-                    | "leaf_uuid"
-                    | "leafUuid"
-            ) && known_agent_protocol_id(text)
-        }
-        JsonProtocolScope::Message => {
-            key == "id" && text.starts_with("msg_") && protocol_tail(text)
-        }
+        JsonProtocolScope::Root => match key {
+            "uuid" | "session_id" | "sessionId" | "hook_id" | "hookId" | "prompt_id"
+            | "promptId" | "parent_uuid" | "parentUuid" | "leaf_uuid" | "leafUuid" => {
+                uuid_shape(text)
+            }
+            "request_id" | "requestId" => protocol_id(text, "req_"),
+            "response_id" | "responseId" => protocol_id(text, "resp_"),
+            "parent_tool_use_id" | "parentToolUseId" => protocol_id(text, "toolu_"),
+            _ => false,
+        },
+        JsonProtocolScope::Message => key == "id" && protocol_id(text, "msg_"),
         JsonProtocolScope::MessageContent => {
-            (key == "id" && text.starts_with("toolu_") && protocol_tail(text))
-                || (matches!(key, "tool_use_id" | "toolUseId")
-                    && text.starts_with("toolu_")
-                    && protocol_tail(text))
-                || (key == "signature" && object_type == Some("thinking"))
+            (key == "id" && protocol_id(text, "toolu_"))
+                || (matches!(key, "tool_use_id" | "toolUseId") && protocol_id(text, "toolu_"))
+                || (key == "signature"
+                    && object_type == Some("thinking")
+                    && thinking_signature(text))
         }
         JsonProtocolScope::Other => false,
     }
 }
 
-fn known_agent_protocol_id(text: &str) -> bool {
-    uuid_shape(text)
-        || [
-            "req_", "resp_", "msg_", "toolu_", "call_", "item_", "thread_", "turn_",
-        ]
-        .iter()
-        .any(|prefix| text.starts_with(prefix) && protocol_tail(text))
-}
-
-fn protocol_tail(text: &str) -> bool {
-    let Some((_, tail)) = text.split_once('_') else {
+fn protocol_id(text: &str, prefix: &str) -> bool {
+    let Some(tail) = text.strip_prefix(prefix) else {
         return false;
     };
-    tail.len() >= 8
-        && tail
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    (20..=64).contains(&tail.len()) && tail.bytes().all(|byte| byte.is_ascii_alphanumeric())
+}
+
+fn thinking_signature(text: &str) -> bool {
+    (64..=16 * 1024).contains(&text.len())
+        && text.len().is_multiple_of(4)
+        && data_encoding::BASE64.decode(text.as_bytes()).is_ok()
 }
 
 fn uuid_shape(text: &str) -> bool {
@@ -2083,6 +2063,31 @@ mod tests {
             value["message"]["content"][1]["input"]["signature"],
             "SCANNED"
         );
+        zeroize_json_strings(&mut value);
+    }
+
+    #[test]
+    fn structured_output_scans_malformed_protocol_metadata() {
+        let mut value = serde_json::json!({
+            "type": "assistant",
+            "uuid": "secret-value",
+            "request_id": "req_secret_value_with_underscores",
+            "message": {
+                "id": "msg_too-short",
+                "content": [
+                    {"type": "thinking", "signature": "secret-value"},
+                    {"type": "tool_use", "id": "toolu_secret_value_with_underscores"}
+                ]
+            }
+        });
+        let changed =
+            mask_json_value(&mut value, true, &mut |_| Ok(Some("SCANNED".to_string()))).unwrap();
+        assert!(changed);
+        assert_eq!(value["uuid"], "SCANNED");
+        assert_eq!(value["request_id"], "SCANNED");
+        assert_eq!(value["message"]["id"], "SCANNED");
+        assert_eq!(value["message"]["content"][0]["signature"], "SCANNED");
+        assert_eq!(value["message"]["content"][1]["id"], "SCANNED");
         zeroize_json_strings(&mut value);
     }
 

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -4232,8 +4232,8 @@ mod tests {
         assert!(rendered.contains("user asks"), "{rendered}");
         assert!(rendered.contains("not a failed operation"), "{rendered}");
         assert!(rendered.contains("do not retry"), "{rendered}");
-        assert!(rendered.contains("$env:PENTECT_NAME_hash"), "{rendered}");
-        assert!(rendered.contains("$PENTECT_NAME_hash"), "{rendered}");
+        assert!(rendered.contains("$env:PENTECT_KEY_hash"), "{rendered}");
+        assert!(rendered.contains("$PENTECT_KEY_hash"), "{rendered}");
         assert!(
             rendered.contains("User-authorized secret work"),
             "{rendered}"
@@ -4341,8 +4341,24 @@ mod tests {
         );
         assert!(rendered.contains("not a failed operation"), "{rendered}");
         assert!(rendered.contains("do not retry"), "{rendered}");
-        assert!(rendered.contains("$env:PENTECT_NAME_hash"), "{rendered}");
-        assert!(rendered.contains("$PENTECT_NAME_hash"), "{rendered}");
+        assert!(rendered.contains("$env:PENTECT_KEY_hash"), "{rendered}");
+        assert!(rendered.contains("$PENTECT_KEY_hash"), "{rendered}");
+        assert!(rendered.contains("use it immediately"), "{rendered}");
+        assert!(rendered.contains("Do not reread or reparse"), "{rendered}");
+        assert!(
+            rendered.contains("unavailable or inaccessible"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("Do not parse the dotenv file"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("SetEnvironmentVariable"), "{rendered}");
+        assert!(rendered.contains("separate processes"), "{rendered}");
+        assert!(
+            rendered.contains("reference the provided binding directly"),
+            "{rendered}"
+        );
         assert!(
             rendered.contains("User-authorized secret work"),
             "{rendered}"
@@ -4373,9 +4389,9 @@ mod tests {
     #[test]
     fn agent_contract_uses_configured_environment_prefix() {
         let rendered = pentect_agent::agent_contract_instructions("SAFE_");
-        assert!(rendered.contains("$env:SAFE_NAME_hash"), "{rendered}");
-        assert!(rendered.contains("$SAFE_NAME_hash"), "{rendered}");
-        assert!(!rendered.contains("PENTECT_NAME_hash"), "{rendered}");
+        assert!(rendered.contains("$env:SAFE_KEY_hash"), "{rendered}");
+        assert!(rendered.contains("$SAFE_KEY_hash"), "{rendered}");
+        assert!(!rendered.contains("PENTECT_KEY_hash"), "{rendered}");
     }
 
     #[test]

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -104,7 +104,8 @@ fn dispatch(args: Vec<String>, inherited_env_is_trusted: bool) -> Option<i32> {
         Some("eval") => eval::cmd_eval(&args),
         Some("scan") => scan::cmd_scan(&args),
         Some(
-            "exec" | "shell" | "resolve" | "log" | "hook" | "bridge" | "memory-store" | "purge",
+            "exec" | "shell" | "resolve" | "log" | "hook" | "bridge" | "memory-store" | "purge"
+            | "__agent-script" | "__agent-stream",
         ) => return Some(cmd_agent_from(1, &args, inherited_env_is_trusted)),
         Some("agent") => return Some(cmd_agent_from(2, &args, inherited_env_is_trusted)),
         Some("codex") => return Some(cmd_agent_tool(AgentTool::Codex, &args)),
@@ -808,7 +809,7 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
             ),
         ])
     });
-    apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()));
+    apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()))?;
     apply_memory_store_env(&mut cmd, Some(&memory_store));
     apply_status_line_env(&mut cmd, status_line_enabled);
     if let Some(exec_proxy) = &exec_proxy {
@@ -886,7 +887,7 @@ fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::Exit
     let mut cmd = Command::new(&opts.command);
     clear_pentect_control_env(&mut cmd);
     apply_extension_env(&mut cmd, &active_extensions)?;
-    apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()));
+    apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()))?;
     apply_memory_store_env(&mut cmd, Some(&memory_store));
     apply_status_line_env(&mut cmd, status_line_enabled);
     cmd.args(&args);
@@ -922,7 +923,7 @@ fn run_bridge_agent(
     let mut cmd = Command::new(&opts.command);
     clear_pentect_control_env(&mut cmd);
     apply_extension_env(&mut cmd, &active_extensions)?;
-    apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()));
+    apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()))?;
     apply_memory_store_env(&mut cmd, Some(&memory_store));
     apply_status_line_env(&mut cmd, status_line_enabled);
     cmd.env("PENTECT_AGENT_CONTRACT", contract);
@@ -1065,10 +1066,29 @@ fn current_pty_size() -> (u16, u16) {
     )
 }
 
+#[cfg(not(windows))]
 fn observed_terminal_size() -> Option<(u16, u16)> {
     crossterm::terminal::size()
         .ok()
         .filter(|(cols, rows)| *cols >= 2 && *rows >= 2)
+}
+
+#[cfg(windows)]
+fn observed_terminal_size() -> Option<(u16, u16)> {
+    use windows_sys::Win32::System::Console::{
+        GetConsoleScreenBufferInfo, GetStdHandle, CONSOLE_SCREEN_BUFFER_INFO, STD_OUTPUT_HANDLE,
+    };
+
+    let handle = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+    let mut info = unsafe { std::mem::zeroed::<CONSOLE_SCREEN_BUFFER_INFO>() };
+    if unsafe { GetConsoleScreenBufferInfo(handle, &mut info) } == 0 {
+        return None;
+    }
+    let cols = i32::from(info.srWindow.Right) - i32::from(info.srWindow.Left) + 1;
+    let rows = i32::from(info.srWindow.Bottom) - i32::from(info.srWindow.Top) + 1;
+    let cols = u16::try_from(cols).ok()?;
+    let rows = u16::try_from(rows).ok()?;
+    (cols >= 2 && rows >= 2).then_some((cols, rows))
 }
 
 fn select_pty_size(
@@ -1302,11 +1322,50 @@ fn cancel_pty_output_read(_output_thread: &thread::JoinHandle<Result<(), String>
 fn finish_pty_child(child: &mut dyn PtyChild) {
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
     while std::time::Instant::now() < deadline {
-        match child.try_wait() {
+        match poll_pty_child(child) {
             Ok(Some(_)) | Err(_) => return,
             Ok(None) => thread::sleep(Duration::from_millis(10)),
         }
     }
+}
+
+#[cfg(windows)]
+fn poll_pty_child(child: &mut dyn PtyChild) -> Result<Option<portable_pty::ExitStatus>, String> {
+    use windows_sys::Win32::{
+        Foundation::{WAIT_FAILED, WAIT_OBJECT_0},
+        System::Threading::{GetExitCodeProcess, WaitForSingleObject},
+    };
+
+    let Some(handle) = child.as_raw_handle() else {
+        return child
+            .try_wait()
+            .map_err(|e| format!("could not poll agent: {e}"));
+    };
+    let wait = unsafe { WaitForSingleObject(handle.cast(), 0) };
+    if wait == WAIT_OBJECT_0 {
+        let mut code = 0u32;
+        if unsafe { GetExitCodeProcess(handle.cast(), &mut code) } == 0 {
+            return Err(format!(
+                "could not read agent exit status: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        return Ok(Some(portable_pty::ExitStatus::with_exit_code(code)));
+    }
+    if wait == WAIT_FAILED {
+        return Err(format!(
+            "could not poll agent process: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(None)
+}
+
+#[cfg(not(windows))]
+fn poll_pty_child(child: &mut dyn PtyChild) -> Result<Option<portable_pty::ExitStatus>, String> {
+    child
+        .try_wait()
+        .map_err(|e| format!("could not poll agent: {e}"))
 }
 
 #[cfg(unix)]
@@ -1541,74 +1600,123 @@ fn pump_prompt_guarded_pty_input(
 ) -> Result<portable_pty::ExitStatus, String> {
     let _raw = RawModeGuard::enable()?;
     let mut protector = PromptInputProtector::default();
-    let mut child_stdin = Some(child_stdin);
+    let mut child_input = PtyInputWriter::start(child_stdin);
+    let mut child_input_open = true;
     let input = PtyInputReader::start();
     loop {
         if let Some(error) = current_output_error(output_error) {
             return Err(error);
         }
+        if let Some(error) = child_input.take_error() {
+            return Err(error);
+        }
         sync_pty_size(master, &mut pty_size);
-        if let Some(status) = child
-            .try_wait()
-            .map_err(|e| format!("could not poll agent: {e}"))?
-        {
+        if let Some(status) = poll_pty_child(child)? {
+            drop(input);
+            drop(child_input);
             return Ok(status);
         }
-        if child_stdin.is_none() {
+        if !child_input_open {
             thread::sleep(PROMPT_INPUT_POLL);
             continue;
         }
         match input.receiver.recv_timeout(PROMPT_INPUT_POLL) {
             Ok(PtyInputEvent::Eof) => {
                 let tail = protector.flush()?;
-                if let Some(writer) = child_stdin.as_mut() {
-                    if !tail.is_empty() {
-                        writer
-                            .write_all(&tail)
-                            .map_err(|e| format!("could not write agent input: {e}"))?;
-                    }
-                }
-                child_stdin.take();
+                child_input.send(tail)?;
+                child_input.close();
+                child_input_open = false;
             }
             Ok(PtyInputEvent::Data(bytes)) => {
                 let rewritten = protector.rewrite_bytes(&bytes)?;
-                if let Some(writer) = child_stdin.as_mut() {
-                    if !rewritten.is_empty() {
-                        writer
-                            .write_all(&rewritten)
-                            .map_err(|e| format!("could not write agent input: {e}"))?;
-                        writer
-                            .flush()
-                            .map_err(|e| format!("could not flush agent input: {e}"))?;
-                    }
-                }
+                child_input.send(rewritten)?;
             }
             Ok(PtyInputEvent::Error(error)) => return Err(error),
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 let idle = protector.flush_idle()?;
-                if let Some(writer) = child_stdin.as_mut() {
-                    if !idle.is_empty() {
-                        writer
-                            .write_all(&idle)
-                            .map_err(|e| format!("could not write agent input: {e}"))?;
-                        writer
-                            .flush()
-                            .map_err(|e| format!("could not flush agent input: {e}"))?;
-                    }
-                }
+                child_input.send(idle)?;
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 let tail = protector.flush()?;
-                if let Some(writer) = child_stdin.as_mut() {
-                    if !tail.is_empty() {
-                        writer
-                            .write_all(&tail)
-                            .map_err(|e| format!("could not write agent input: {e}"))?;
-                    }
-                }
-                child_stdin.take();
+                child_input.send(tail)?;
+                child_input.close();
+                child_input_open = false;
             }
         }
+    }
+}
+
+struct PtyInputWriter {
+    sender: Option<mpsc::SyncSender<Vec<u8>>>,
+    error: Arc<Mutex<Option<String>>>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl PtyInputWriter {
+    fn start(mut writer: Box<dyn Write + Send>) -> Self {
+        let (sender, receiver) = mpsc::sync_channel::<Vec<u8>>(64);
+        let error = Arc::new(Mutex::new(None));
+        let worker_error = Arc::clone(&error);
+        let thread = thread::spawn(move || {
+            while let Ok(mut bytes) = receiver.recv() {
+                let result = writer.write_all(&bytes).and_then(|_| writer.flush());
+                bytes.zeroize();
+                if let Err(error) = result {
+                    record_output_error(
+                        &worker_error,
+                        &format!("could not write agent input: {error}"),
+                    );
+                    break;
+                }
+            }
+        });
+        Self {
+            sender: Some(sender),
+            error,
+            thread: Some(thread),
+        }
+    }
+
+    fn send(&self, mut bytes: Vec<u8>) -> Result<(), String> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let Some(sender) = self.sender.as_ref() else {
+            bytes.zeroize();
+            return Err("agent input is closed".to_string());
+        };
+        match sender.try_send(bytes) {
+            Ok(()) => Ok(()),
+            Err(mpsc::TrySendError::Full(mut bytes)) => {
+                bytes.zeroize();
+                Err("agent input is not being consumed".to_string())
+            }
+            Err(mpsc::TrySendError::Disconnected(mut bytes)) => {
+                bytes.zeroize();
+                Err(self
+                    .take_error()
+                    .unwrap_or_else(|| "agent input is closed".to_string()))
+            }
+        }
+    }
+
+    fn close(&mut self) {
+        self.sender.take();
+    }
+
+    fn take_error(&self) -> Option<String> {
+        let mut error = match self.error.lock() {
+            Ok(error) => error,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        error.take()
+    }
+}
+
+impl Drop for PtyInputWriter {
+    fn drop(&mut self) {
+        self.close();
+        self.thread.take();
     }
 }
 
@@ -1673,25 +1781,7 @@ impl PtyInputReader {
 impl Drop for PtyInputReader {
     fn drop(&mut self) {
         self.stop.store(true, Ordering::Release);
-        let Some(thread) = self.thread.take() else {
-            return;
-        };
-        #[cfg(windows)]
-        {
-            use std::os::windows::io::AsRawHandle;
-            unsafe {
-                let _ = windows_sys::Win32::System::IO::CancelSynchronousIo(
-                    thread.as_raw_handle().cast(),
-                );
-            }
-        }
-        let deadline = std::time::Instant::now() + Duration::from_secs(1);
-        while !thread.is_finished() && std::time::Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        if thread.is_finished() {
-            let _ = thread.join();
-        }
+        self.thread.take();
     }
 }
 
@@ -2359,13 +2449,35 @@ fn configure_persistent_child(command: &mut Command) {
     command.process_group(0);
 }
 
-fn apply_pentect_env(cmd: &mut Command, pentect: &Path, launch_proof: Option<&str>) {
-    cmd.env(PENTECT_BIN_ENV, pentect);
+fn apply_pentect_env(
+    cmd: &mut Command,
+    pentect: &Path,
+    launch_proof: Option<&str>,
+) -> Result<(), String> {
+    let absolute = if pentect.is_absolute() {
+        pentect.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| format!("could not read current dir: {error}"))?
+            .join(pentect)
+    };
+    let directory = absolute
+        .parent()
+        .ok_or_else(|| format!("Pentect path has no parent: '{}'", pentect.display()))?;
+    let mut path_entries = vec![directory.to_path_buf()];
+    if let Some(path) = std::env::var_os("PATH") {
+        path_entries.extend(std::env::split_paths(&path).filter(|entry| entry != directory));
+    }
+    let path = std::env::join_paths(path_entries)
+        .map_err(|error| format!("could not prepare Pentect PATH: {error}"))?;
+    cmd.env("PATH", path);
+    cmd.env(PENTECT_BIN_ENV, &absolute);
     if let Some(launch_proof) = launch_proof.filter(|value| !value.is_empty()) {
         cmd.env(PENTECT_AGENT_LAUNCHED_ENV, launch_proof);
     } else {
         cmd.env_remove(PENTECT_AGENT_LAUNCHED_ENV);
     }
+    Ok(())
 }
 
 fn clear_pentect_control_env(command: &mut Command) {
@@ -3789,10 +3901,10 @@ mod tests {
 
     #[test]
     fn launched_agent_tools_export_pentect_path_for_hooks() {
-        let pentect = Path::new(r"C:\repo\target\debug\pentect.exe");
+        let pentect = absolute_pentect_fixture_path();
         let launch_proof = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
         let mut cmd = Command::new("codex");
-        apply_pentect_env(&mut cmd, pentect, Some(launch_proof));
+        apply_pentect_env(&mut cmd, &pentect, Some(launch_proof)).unwrap();
         let actual = cmd
             .get_envs()
             .find(|(key, _)| *key == std::ffi::OsStr::new(PENTECT_BIN_ENV))
@@ -3805,6 +3917,15 @@ mod tests {
             .and_then(|(_, value)| value)
             .unwrap();
         assert_eq!(launched, std::ffi::OsStr::new(launch_proof));
+        let path = cmd
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new("PATH"))
+            .and_then(|(_, value)| value)
+            .unwrap();
+        assert_eq!(
+            std::env::split_paths(path).next().as_deref(),
+            pentect.parent()
+        );
     }
 
     #[test]
@@ -4028,6 +4149,7 @@ mod tests {
         assert!(!rendered.contains("cat .env"), "{rendered}");
         assert!(rendered.contains("Masked handles"), "{rendered}");
         assert!(rendered.contains("$env:PENTECT_NAME_hash"), "{rendered}");
+        assert!(rendered.contains("not the assignment key"), "{rendered}");
         assert!(!rendered.contains("$env:NAME"), "{rendered}");
         assert!(rendered.contains("user-authorized secrets"), "{rendered}");
         assert!(
@@ -4043,6 +4165,7 @@ mod tests {
             "{rendered}"
         );
         assert!(rendered.contains("tool text output"), "{rendered}");
+        assert!(rendered.contains("display-time redaction"), "{rendered}");
         assert!(rendered.contains("user-requested storage"), "{rendered}");
         assert!(rendered.contains("exact requested"), "{rendered}");
         assert!(rendered.contains("local file"), "{rendered}");

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -66,9 +66,13 @@ fn run(args: Vec<String>) -> Option<i32> {
         return dispatch(args, inherited_env_is_trusted);
     }
     let pentect = default_pentect_path();
-    let process_host = MemoryStoreGuard::start(&pentect, false)
-        .unwrap_or_else(|error| die_with_issue(error))
-        .unwrap_or_else(|| die_with_issue("could not start process host candidate"));
+    let process_host = if is_shell_command(&args) && !inherited_env_is_trusted {
+        MemoryStoreGuard::start_in_process()
+    } else {
+        MemoryStoreGuard::start(&pentect, false)
+    }
+    .unwrap_or_else(|error| die_with_issue(error))
+    .unwrap_or_else(|| die_with_issue("could not start process host candidate"));
     let _process_host_env = memory_store_parent_env_guard(&pentect, &process_host);
     let exit_code = dispatch(args, inherited_env_is_trusted);
     drop(_process_host_env);
@@ -139,6 +143,16 @@ fn supports_process_host(args: &[String]) -> bool {
         ),
         (Some("exec" | "shell" | "log" | "bridge"), _)
             | (Some("agent"), Some("exec" | "shell" | "log" | "bridge"))
+    )
+}
+
+fn is_shell_command(args: &[String]) -> bool {
+    matches!(
+        (
+            args.get(1).map(String::as_str),
+            args.get(2).map(String::as_str),
+        ),
+        (Some("shell"), _) | (Some("agent"), Some("shell"))
     )
 }
 
@@ -2305,6 +2319,7 @@ fn partial_suffix_prefix_len(bytes: &[u8], prefix: &[u8]) -> usize {
 struct MemoryStoreGuard {
     child: Option<Child>,
     lease: Option<pentect_agent::MemoryStoreLease>,
+    _in_process: Option<pentect_agent::InProcessMemoryStore>,
     addr: String,
     token: String,
     process_host_candidate: Option<PathBuf>,
@@ -2338,6 +2353,7 @@ impl MemoryStoreGuard {
                     return Ok(Some(Self {
                         child: None,
                         lease: None,
+                        _in_process: None,
                         addr,
                         token,
                         process_host_candidate: None,
@@ -2440,6 +2456,34 @@ impl MemoryStoreGuard {
         Ok(Some(Self {
             child: Some(child),
             lease,
+            _in_process: None,
+            addr,
+            token,
+            process_host_candidate: Some(process_host_candidate),
+        }))
+    }
+
+    fn start_in_process() -> Result<Option<Self>, String> {
+        let server = pentect_agent::start_in_process_memory_store().map_err(|e| e.to_string())?;
+        let addr = server.addr().to_string();
+        let token = server.token().to_string();
+        let process_host_root = process_host_root()?;
+        let process_host_candidate = pentect_agent::register_process_host_candidate(
+            &process_host_root,
+            &addr,
+            &token,
+            server.process_host_read_token(),
+            server.process_host_write_token(),
+            std::process::id(),
+            false,
+        )?;
+        let Some(process_host_candidate) = process_host_candidate else {
+            return Ok(None);
+        };
+        Ok(Some(Self {
+            child: None,
+            lease: None,
+            _in_process: Some(server),
             addr,
             token,
             process_host_candidate: Some(process_host_candidate),
@@ -4177,48 +4221,44 @@ mod tests {
         let rendered = args.join("\n");
         assert!(!args.contains(&"--dangerously-bypass-hook-trust".to_string()));
         assert!(rendered.contains("developer_instructions="), "{rendered}");
-        assert!(rendered.contains("Pentect agent contract"), "{rendered}");
-        assert!(rendered.contains("Use normal shell commands"), "{rendered}");
+        assert!(rendered.contains("Session rules"), "{rendered}");
+        assert!(rendered.contains("Work normally"), "{rendered}");
         assert!(rendered.contains("--enable\nunified_exec"), "{rendered}");
-        assert!(rendered.contains("protected runner"), "{rendered}");
-        assert!(rendered.contains("tool results"), "{rendered}");
-        assert!(rendered.contains("PENTECT_<LABEL>_<HASH>"), "{rendered}");
-        assert!(rendered.contains("read it once"), "{rendered}");
-        assert!(rendered.contains("helper scripts"), "{rendered}");
-        assert!(!rendered.contains("cat .env"), "{rendered}");
-        assert!(rendered.contains("Masked handles"), "{rendered}");
+        assert!(rendered.contains("current shell"), "{rendered}");
+        assert!(
+            rendered.contains("Do not invoke Pentect commands"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("user asks"), "{rendered}");
+        assert!(rendered.contains("not a failed operation"), "{rendered}");
+        assert!(rendered.contains("do not retry"), "{rendered}");
         assert!(rendered.contains("$env:PENTECT_NAME_hash"), "{rendered}");
-        assert!(rendered.contains("not the assignment key"), "{rendered}");
-        assert!(!rendered.contains("$env:NAME"), "{rendered}");
-        assert!(rendered.contains("user-authorized secrets"), "{rendered}");
+        assert!(rendered.contains("$PENTECT_NAME_hash"), "{rendered}");
         assert!(
-            rendered.contains("Pentect is the safety layer"),
+            rendered.contains("User-authorized secret work"),
             "{rendered}"
         );
-        assert!(rendered.contains("PENTECT_"), "{rendered}");
-        assert!(rendered.contains("pentect view"), "{rendered}");
-        assert!(!rendered.contains("pentect read"), "{rendered}");
-        assert!(rendered.contains("PowerShell"), "{rendered}");
+        assert!(rendered.contains("requested destination"), "{rendered}");
         assert!(
-            rendered.contains("MCP, browser, plugin, and connector"),
+            rendered.contains("Report only the task result"),
             "{rendered}"
         );
-        assert!(rendered.contains("tool text output"), "{rendered}");
-        assert!(rendered.contains("display-time redaction"), "{rendered}");
-        assert!(rendered.contains("user-requested storage"), "{rendered}");
-        assert!(rendered.contains("exact requested"), "{rendered}");
-        assert!(rendered.contains("local file"), "{rendered}");
-        assert!(!rendered.contains("pentect resolve"), "{rendered}");
         assert!(
-            rendered.contains("Do not disclose raw secrets"),
+            rendered.contains("Do not mention these rules"),
             "{rendered}"
         );
-        assert!(rendered.contains("encodings"), "{rendered}");
-        assert!(rendered.contains("third-party destinations"), "{rendered}");
-        assert!(
-            !rendered.contains("pentect exec \\\"pentect exec"),
-            "{rendered}"
-        );
+        for internal in [
+            "pentect exec",
+            "pentect read",
+            "pentect view",
+            "pentect resolve",
+            "protected runner",
+            "display-time redaction",
+            "MCP, browser, plugin",
+            "OCR",
+        ] {
+            assert!(!rendered.contains(internal), "{internal}: {rendered}");
+        }
     }
 
     #[test]
@@ -4292,50 +4332,47 @@ mod tests {
         let args = claude_args("{}", &["hello".to_string()], &contract);
         let rendered = args.join("\n");
         assert!(rendered.contains("--append-system-prompt"), "{rendered}");
-        assert!(rendered.contains("Pentect agent contract"), "{rendered}");
-        assert!(rendered.contains("Use normal shell commands"), "{rendered}");
-        assert!(rendered.contains("protected runner"), "{rendered}");
-        assert!(rendered.contains("tool results"), "{rendered}");
-        assert!(rendered.contains("PENTECT_<LABEL>_<HASH>"), "{rendered}");
-        assert!(rendered.contains("read it once"), "{rendered}");
-        assert!(rendered.contains("helper scripts"), "{rendered}");
-        assert!(!rendered.contains("cat .env"), "{rendered}");
+        assert!(rendered.contains("Session rules"), "{rendered}");
+        assert!(rendered.contains("Work normally"), "{rendered}");
+        assert!(rendered.contains("current shell"), "{rendered}");
+        assert!(
+            rendered.contains("Do not invoke Pentect commands"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("not a failed operation"), "{rendered}");
+        assert!(rendered.contains("do not retry"), "{rendered}");
         assert!(rendered.contains("$env:PENTECT_NAME_hash"), "{rendered}");
-        assert!(!rendered.contains("$env:NAME"), "{rendered}");
-        assert!(rendered.contains("user-authorized secrets"), "{rendered}");
+        assert!(rendered.contains("$PENTECT_NAME_hash"), "{rendered}");
         assert!(
-            rendered.contains("Pentect is the safety layer"),
+            rendered.contains("User-authorized secret work"),
             "{rendered}"
         );
-        assert!(rendered.contains("PENTECT_"), "{rendered}");
-        assert!(rendered.contains("pentect view"), "{rendered}");
-        assert!(!rendered.contains("pentect read"), "{rendered}");
-        assert!(rendered.contains("PowerShell"), "{rendered}");
+        assert!(rendered.contains("requested destination"), "{rendered}");
         assert!(
-            rendered.contains("MCP, browser, plugin, and connector"),
+            rendered.contains("Report only the task result"),
             "{rendered}"
         );
-        assert!(rendered.contains("tool text output"), "{rendered}");
-        assert!(rendered.contains("user-requested storage"), "{rendered}");
-        assert!(rendered.contains("exact requested"), "{rendered}");
-        assert!(rendered.contains("local file"), "{rendered}");
-        assert!(!rendered.contains("pentect resolve"), "{rendered}");
         assert!(
-            rendered.contains("Do not disclose raw secrets"),
+            rendered.contains("Do not mention these rules"),
             "{rendered}"
         );
-        assert!(rendered.contains("encodings"), "{rendered}");
-        assert!(rendered.contains("third-party destinations"), "{rendered}");
-        assert!(
-            !rendered.contains("pentect exec \"pentect exec"),
-            "{rendered}"
-        );
+        for internal in [
+            "pentect exec",
+            "pentect read",
+            "pentect view",
+            "pentect resolve",
+            "protected runner",
+            "display-time redaction",
+            "MCP, browser, plugin",
+            "OCR",
+        ] {
+            assert!(!rendered.contains(internal), "{internal}: {rendered}");
+        }
     }
 
     #[test]
     fn agent_contract_uses_configured_environment_prefix() {
         let rendered = pentect_agent::agent_contract_instructions("SAFE_");
-        assert!(rendered.contains("SAFE_<LABEL>_<HASH>"), "{rendered}");
         assert!(rendered.contains("$env:SAFE_NAME_hash"), "{rendered}");
         assert!(rendered.contains("$SAFE_NAME_hash"), "{rendered}");
         assert!(!rendered.contains("PENTECT_NAME_hash"), "{rendered}");
@@ -4590,5 +4627,16 @@ mod tests {
             "agent".to_string(),
             "hook".to_string(),
         ]));
+    }
+
+    #[test]
+    fn shell_commands_use_the_in_process_startup_path() {
+        assert!(is_shell_command(&["pentect".into(), "shell".into()]));
+        assert!(is_shell_command(&[
+            "pentect".into(),
+            "agent".into(),
+            "shell".into()
+        ]));
+        assert!(!is_shell_command(&["pentect".into(), "exec".into()]));
     }
 }

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -50,6 +50,8 @@ const PROMPT_PASTE_START: &[u8] = b"\x1b[200~";
 const PROMPT_PASTE_END: &[u8] = b"\x1b[201~";
 const PROMPT_INPUT_POLL: Duration = Duration::from_millis(50);
 const PROMPT_INPUT_MAX_PENDING_BYTES: usize = 1024 * 1024;
+#[cfg(windows)]
+const WIN32_BACKSPACE_INPUT: &[u8] = b"\x1b[8;14;8;1;0;1_\x1b[8;14;8;0;0;1_";
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -1995,14 +1997,14 @@ where
             let emit_len = state.decode_pending.len().saturating_sub(keep);
             if emit_len > 0 {
                 let mut raw: Vec<u8> = state.decode_pending.drain(..emit_len).collect();
-                out.extend(rewrite_prompt_input_bytes_with(normal, &raw, mask)?);
+                out.extend(rewrite_windows_vt_input_bytes_with(normal, &raw, mask)?);
                 raw.zeroize();
             }
             break;
         };
         if start > 0 {
             let mut raw: Vec<u8> = state.decode_pending.drain(..start).collect();
-            out.extend(rewrite_prompt_input_bytes_with(normal, &raw, mask)?);
+            out.extend(rewrite_windows_vt_input_bytes_with(normal, &raw, mask)?);
             raw.zeroize();
             continue;
         }
@@ -2089,6 +2091,43 @@ where
 }
 
 #[cfg(windows)]
+fn rewrite_windows_vt_input_bytes_with<F>(
+    normal: &mut PromptInputState,
+    bytes: &[u8],
+    mask: &mut F,
+) -> Result<Vec<u8>, String>
+where
+    F: FnMut(&str) -> Result<Option<String>, String>,
+{
+    if normal.in_bracketed_paste {
+        return rewrite_prompt_input_bytes_with(normal, bytes, mask);
+    }
+
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut start = 0;
+    for (index, byte) in bytes.iter().enumerate() {
+        if !matches!(byte, 0x08 | 0x7f) {
+            continue;
+        }
+        out.extend(rewrite_prompt_input_bytes_with(
+            normal,
+            &bytes[start..index],
+            mask,
+        )?);
+        // Terminals without ?9001 support use BS/DEL. Normalize both to the
+        // Win32 key record required by the nested Windows ConPTY.
+        out.extend_from_slice(WIN32_BACKSPACE_INPUT);
+        start = index + 1;
+    }
+    out.extend(rewrite_prompt_input_bytes_with(
+        normal,
+        &bytes[start..],
+        mask,
+    )?);
+    Ok(out)
+}
+
+#[cfg(windows)]
 fn flush_win32_paste_prefix(state: &mut Win32PromptInputState, out: &mut Vec<u8>) {
     out.append(&mut state.paste_prefix_raw);
     state.paste_prefix_text.zeroize();
@@ -2149,7 +2188,7 @@ where
     flush_win32_paste_prefix(state, &mut out);
     if !state.decode_pending.is_empty() {
         let mut raw = std::mem::take(&mut state.decode_pending);
-        out.extend(rewrite_prompt_input_bytes_with(normal, &raw, mask)?);
+        out.extend(rewrite_windows_vt_input_bytes_with(normal, &raw, mask)?);
         raw.zeroize();
     }
     out.extend(flush_prompt_input_with(normal, mask)?);
@@ -4461,6 +4500,22 @@ mod tests {
             rewrite_win32_prompt_input_bytes_with(&mut normal, &mut win32, encoded, &mut mask)
                 .unwrap();
         assert_eq!(out, encoded);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn prompt_input_normalizes_vt_backspace_for_nested_conpty() {
+        for encoded in [b"abc\x08".as_slice(), b"abc\x7f".as_slice()] {
+            let mut normal = PromptInputState::default();
+            let mut win32 = Win32PromptInputState::default();
+            let mut mask = |_: &str| Ok(None);
+            let out =
+                rewrite_win32_prompt_input_bytes_with(&mut normal, &mut win32, encoded, &mut mask)
+                    .unwrap();
+            let mut expected = b"abc".to_vec();
+            expected.extend_from_slice(WIN32_BACKSPACE_INPUT);
+            assert_eq!(out, expected);
+        }
     }
 
     #[cfg(windows)]

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -11,6 +11,7 @@ mod headless;
 mod input;
 mod scan;
 mod terminal;
+mod update;
 
 use input::{decode_utf8_text, ImageOcrInput, InputAdapter, TextInput};
 use pentect_core::{
@@ -100,6 +101,9 @@ fn dispatch(args: Vec<String>, inherited_env_is_trusted: bool) -> Option<i32> {
     match args.get(1).map(String::as_str) {
         None => usage(),
         Some("help" | "--help" | "-h") => cmd_help(),
+        Some("version" | "--version" | "-V") => update::cmd_version(),
+        Some("update") => update::cmd_update(&args),
+        Some("__apply-update") => return Some(update::cmd_apply_update(&args)),
         Some("mask") => cmd_mask(&args),
         Some("read") => cmd_read(&args),
         Some("view") => cmd_view(&args),
@@ -164,7 +168,8 @@ fn usage() {
          pentect shell\n\
          pentect up\n\
          pentect doctor\n\
-         pentect extensions list|inspect|test [NAME]\n\
+         pentect update [--check]\n\
+         pentect extensions list|inspect|test|config|setup|update [NAME]\n\
          pentect eval [--json]\n\
          pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--no-gitignore] [PATH...]\n\
          pentect view <HANDLE>\n\
@@ -200,7 +205,11 @@ fn help_text() -> &'static str {
         "  pentect shell\n\n",
         "  pentect up\n\n",
         "  pentect doctor [--json]\n",
+        "  pentect update [--check | --force]\n",
         "  pentect extensions list|inspect|test [NAME|PATH] [--json]\n",
+        "  pentect extensions config NAME|PATH [KEY=VALUE | --unset KEY]\n",
+        "  pentect extensions setup NAME|PATH [--yes]\n",
+        "  pentect extensions update NAME|PATH\n",
         "  pentect eval [--json]\n\n",
         "  pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--no-gitignore] [PATH...]\n\n",
         "  pentect view '<HANDLE>'\n\n",
@@ -217,7 +226,8 @@ fn help_text() -> &'static str {
         "scan: secrets; gitignore on; --no-gitignore broadens\n",
         "groups: ~vcs ~deps ~build ~cache ~pentect ~heavy ~all; ! restores\n",
         "doctor: readiness\n",
-        "extensions: list, inspect, test\n",
+        "update: verified GitHub Release binary\n",
+        "extensions: list, inspect, test, config, setup, update\n",
         "eval: precision, recall\n",
     )
 }

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -40,9 +40,6 @@ const PENTECT_BIN_ENV: &str = "PENTECT_BIN";
 const PENTECT_AGENT_LAUNCHED_ENV: &str = "PENTECT_AGENT_LAUNCHED";
 const PENTECT_MEMORY_STORE_ADDR_ENV: &str = "PENTECT_MEMORY_STORE_ADDR";
 const PENTECT_MEMORY_STORE_TOKEN_ENV: &str = "PENTECT_MEMORY_STORE_TOKEN";
-const PENTECT_PROCESS_HOST_ROOT_ENV: &str = "PENTECT_PROCESS_HOST_ROOT";
-const PENTECT_PROCESS_HOST_READ_TOKEN_ENV: &str = "PENTECT_PROCESS_HOST_READ_TOKEN";
-const PENTECT_PROCESS_HOST_WRITE_TOKEN_ENV: &str = "PENTECT_PROCESS_HOST_WRITE_TOKEN";
 const PENTECT_STATUS_LINE_ENV: &str = "PENTECT_STATUS_LINE";
 const PENTECT_DIR: &str = ".pentect";
 const PENTECT_CONFIG_FILE: &str = "config.toml";
@@ -56,26 +53,44 @@ const PROMPT_INPUT_MAX_PENDING_BYTES: usize = 1024 * 1024;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    if is_memory_store_server(&args) || !supports_process_host(&args) {
-        dispatch(args);
-        return;
+    if let Some(code) = catch_cli_exit(|| run(args)) {
+        std::process::exit(code);
     }
-    let pentect = std::env::var_os(PENTECT_BIN_ENV)
-        .map(PathBuf::from)
-        .unwrap_or_else(default_pentect_path);
-    let process_host_root = process_host_root().unwrap_or_else(|error| die_with_issue(error));
-    let _process_host_root_env = EnvVarGuard::set_optional([(
-        PENTECT_PROCESS_HOST_ROOT_ENV,
-        Some(process_host_root.clone().into_os_string()),
-    )]);
+}
+
+fn run(args: Vec<String>) -> Option<i32> {
+    let inherited_env_is_trusted = pentect_agent::active_memory_store_ready();
+    if is_memory_store_server(&args) || !supports_process_host(&args) {
+        return dispatch(args, inherited_env_is_trusted);
+    }
+    let pentect = default_pentect_path();
     let process_host = MemoryStoreGuard::start(&pentect, false)
         .unwrap_or_else(|error| die_with_issue(error))
         .unwrap_or_else(|| die_with_issue("could not start process host candidate"));
     let _process_host_env = memory_store_parent_env_guard(&pentect, &process_host);
-    dispatch(args);
+    let exit_code = dispatch(args, inherited_env_is_trusted);
+    drop(_process_host_env);
+    drop(process_host);
+    exit_code
 }
 
-fn dispatch(args: Vec<String>) {
+fn catch_cli_exit(operation: impl FnOnce() -> Option<i32>) -> Option<i32> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(operation)) {
+        Ok(code) => code,
+        Err(payload) => match payload.downcast::<CliExit>() {
+            Ok(exit) => {
+                eprintln!("[pentect] {}", exit.message);
+                if exit.report_issue {
+                    eprintln!("[pentect] report: {}", issue_report_url());
+                }
+                Some(2)
+            }
+            Err(payload) => std::panic::resume_unwind(payload),
+        },
+    }
+}
+
+fn dispatch(args: Vec<String>, inherited_env_is_trusted: bool) -> Option<i32> {
     match args.get(1).map(String::as_str) {
         None => usage(),
         Some("help" | "--help" | "-h") => cmd_help(),
@@ -90,13 +105,14 @@ fn dispatch(args: Vec<String>) {
         Some("scan") => scan::cmd_scan(&args),
         Some(
             "exec" | "shell" | "resolve" | "log" | "hook" | "bridge" | "memory-store" | "purge",
-        ) => cmd_agent_from(1, &args),
-        Some("agent") => cmd_agent_from(2, &args),
-        Some("codex") => cmd_agent_tool(AgentTool::Codex, &args),
-        Some("claude") => cmd_agent_tool(AgentTool::Claude, &args),
-        Some("opencode") => cmd_agent_tool(AgentTool::OpenCode, &args),
+        ) => return Some(cmd_agent_from(1, &args, inherited_env_is_trusted)),
+        Some("agent") => return Some(cmd_agent_from(2, &args, inherited_env_is_trusted)),
+        Some("codex") => return Some(cmd_agent_tool(AgentTool::Codex, &args)),
+        Some("claude") => return Some(cmd_agent_tool(AgentTool::Claude, &args)),
+        Some("opencode") => return Some(cmd_agent_tool(AgentTool::OpenCode, &args)),
         _ => usage(),
     }
+    None
 }
 
 fn is_memory_store_server(args: &[String]) -> bool {
@@ -118,8 +134,7 @@ fn supports_process_host(args: &[String]) -> bool {
             args.get(1).map(String::as_str),
             args.get(2).map(String::as_str),
         ),
-        (Some("codex" | "claude" | "opencode"), _)
-            | (Some("exec" | "shell" | "log" | "bridge"), _)
+        (Some("exec" | "shell" | "log" | "bridge"), _)
             | (Some("agent"), Some("exec" | "shell" | "log" | "bridge"))
     )
 }
@@ -190,35 +205,30 @@ fn help_text() -> &'static str {
     )
 }
 
+#[derive(Debug)]
+struct CliExit {
+    message: String,
+    report_issue: bool,
+}
+
 fn die(msg: impl std::fmt::Display) -> ! {
-    eprintln!("[pentect] {msg}");
-    std::process::exit(2);
+    std::panic::resume_unwind(Box::new(CliExit {
+        message: msg.to_string(),
+        report_issue: false,
+    }))
 }
 
 fn die_with_issue(msg: impl std::fmt::Display) -> ! {
-    eprintln!("[pentect] {msg}");
-    eprintln!("[pentect] report: {}", issue_report_url());
-    std::process::exit(2);
+    std::panic::resume_unwind(Box::new(CliExit {
+        message: msg.to_string(),
+        report_issue: true,
+    }))
 }
 
 fn issue_report_url() -> String {
-    let body = concat!(
-        "## What happened\n\n",
-        "<what did you run?>\n\n",
-        "## Error\n\n",
-        "```text\n",
-        "<paste Pentect error output here>\n",
-        "```\n\n",
-        "## Environment\n\n",
-        "- OS:\n",
-        "- Pentect version or commit:\n",
-        "- Terminal:\n\n",
-        "Do not paste raw secrets, API keys, tokens, cookies, or private files.\n",
-    );
     format!(
-        "{ISSUE_NEW_URL}?title={}&body={}",
-        url_query_encode("Pentect error"),
-        url_query_encode(body)
+        "{ISSUE_NEW_URL}?title={}",
+        url_query_encode("Pentect error")
     )
 }
 
@@ -234,7 +244,7 @@ fn url_query_encode(value: &str) -> String {
     out
 }
 
-fn cmd_agent_from(start: usize, args: &[String]) {
+fn cmd_agent_from(start: usize, args: &[String], inherited_env_is_trusted: bool) -> i32 {
     let (forward_args, explicit_extensions) = match extensions::strip_from_args(&args[start..]) {
         Ok(parsed) => parsed,
         Err(e) => die(&e),
@@ -243,18 +253,28 @@ fn cmd_agent_from(start: usize, args: &[String]) {
         Ok(active) => active,
         Err(e) => die(&e),
     };
-    if let Some(value) = match active_extensions.config_env_value() {
+    let config_env = match active_extensions.config_env_value() {
         Ok(value) => value,
         Err(e) => die(&e),
-    } {
-        std::env::set_var(extensions::CONFIGS_ENV, value);
     }
-    if let Some(value) = match active_extensions.adapter_env_value() {
+    .or_else(|| {
+        inherited_env_is_trusted
+            .then(|| std::env::var_os(extensions::CONFIGS_ENV))
+            .flatten()
+    });
+    let adapter_env = match active_extensions.adapter_env_value() {
         Ok(value) => value,
         Err(e) => die(&e),
-    } {
-        std::env::set_var(extensions::ADAPTERS_ENV, value);
     }
+    .or_else(|| {
+        inherited_env_is_trusted
+            .then(|| std::env::var_os(extensions::ADAPTERS_ENV))
+            .flatten()
+    });
+    let extension_env = EnvVarGuard::set_optional([
+        (extensions::CONFIGS_ENV, config_env),
+        (extensions::ADAPTERS_ENV, adapter_env),
+    ]);
     let mut agent_args = Vec::with_capacity(forward_args.len() + 1);
     agent_args.push(
         args.first()
@@ -266,9 +286,7 @@ fn cmd_agent_from(start: usize, args: &[String]) {
         .get(1)
         .is_some_and(|arg| matches!(arg.as_str(), "shell" | "log"))
     {
-        let pentect = std::env::var_os(PENTECT_BIN_ENV)
-            .map(PathBuf::from)
-            .unwrap_or_else(default_pentect_path);
+        let pentect = default_pentect_path();
         Some(start_memory_store(&pentect).unwrap_or_else(|e| die_with_issue(e)))
     } else {
         None
@@ -284,18 +302,6 @@ fn cmd_agent_from(start: usize, args: &[String]) {
                 Some(OsString::from(store.token.as_str())),
             ),
             (
-                PENTECT_PROCESS_HOST_READ_TOKEN_ENV,
-                Some(OsString::from(store.process_host_read_token.as_str())),
-            ),
-            (
-                PENTECT_PROCESS_HOST_WRITE_TOKEN_ENV,
-                Some(OsString::from(store.process_host_write_token.as_str())),
-            ),
-            (
-                PENTECT_PROCESS_HOST_ROOT_ENV,
-                Some(store.process_host_root.clone().into_os_string()),
-            ),
-            (
                 PENTECT_AGENT_LAUNCHED_ENV,
                 Some(OsString::from(store.token.as_str())),
             ),
@@ -304,10 +310,11 @@ fn cmd_agent_from(start: usize, args: &[String]) {
     let code = pentect_agent::run_from(agent_args);
     drop(_shell_store_env);
     drop(shell_store);
-    std::process::exit(code);
+    drop(extension_env);
+    code
 }
 
-fn cmd_agent_tool(tool: AgentTool, args: &[String]) {
+fn cmd_agent_tool(tool: AgentTool, args: &[String]) -> i32 {
     let opts = match AgentToolOpts::parse(tool, args) {
         Ok(o) => o,
         Err(e) => die(&e),
@@ -325,8 +332,7 @@ fn cmd_agent_tool(tool: AgentTool, args: &[String]) {
         AgentTool::OpenCode => run_bridge_agent(&opts, &pentect),
     }
     .unwrap_or_else(|e| die_with_issue(&e));
-    let code = status.code().unwrap_or(1);
-    std::process::exit(code);
+    status.code().unwrap_or(1)
 }
 
 fn start_memory_store(pentect: &Path) -> Result<MemoryStoreGuard, String> {
@@ -342,9 +348,7 @@ fn cmd_up(args: &[String]) {
     if pentect_agent::persistent_process_host_running(&root) {
         return;
     }
-    let pentect = std::env::var_os(PENTECT_BIN_ENV)
-        .map(PathBuf::from)
-        .unwrap_or_else(default_pentect_path);
+    let pentect = default_pentect_path();
     if let Some(host) =
         MemoryStoreGuard::start(&pentect, true).unwrap_or_else(|error| die_with_issue(error))
     {
@@ -652,14 +656,6 @@ impl AgentTool {
         }
     }
 
-    fn env_var(self) -> &'static str {
-        match self {
-            AgentTool::Codex => "PENTECT_CODEX",
-            AgentTool::Claude => "PENTECT_CLAUDE",
-            AgentTool::OpenCode => "PENTECT_OPENCODE",
-        }
-    }
-
     fn default_command(self) -> &'static str {
         self.name()
     }
@@ -688,9 +684,7 @@ impl AgentToolOpts {
     fn parse(tool: AgentTool, args: &[String]) -> Result<Self, String> {
         let mut session = None;
         let mut pentect = None;
-        let mut command = std::env::var_os(tool.env_var())
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from(tool.default_command()));
+        let mut command = PathBuf::from(tool.default_command());
         let mut extensions = Vec::new();
         let mut dry_run = false;
         let mut codex_app_server_proxy_disabled = false;
@@ -750,7 +744,7 @@ impl AgentToolOpts {
         }
         Ok(Self {
             session,
-            pentect: pentect.or_else(|| std::env::var_os(PENTECT_BIN_ENV).map(PathBuf::from)),
+            pentect,
             command,
             extensions,
             dry_run,
@@ -795,6 +789,7 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
         return Ok(success_status());
     }
     let mut cmd = Command::new(&opts.command);
+    clear_pentect_control_env(&mut cmd);
     apply_extension_env(&mut cmd, &active_extensions)?;
     let exec_proxy = if codex_unified_exec_proxy_enabled(&tool_args) {
         Some(exec_proxy::ExecProxyGuard::start(&opts.command)?)
@@ -889,6 +884,7 @@ fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::Exit
         return Ok(success_status());
     }
     let mut cmd = Command::new(&opts.command);
+    clear_pentect_control_env(&mut cmd);
     apply_extension_env(&mut cmd, &active_extensions)?;
     apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()));
     apply_memory_store_env(&mut cmd, Some(&memory_store));
@@ -924,6 +920,7 @@ fn run_bridge_agent(
         &active_extensions,
     )?;
     let mut cmd = Command::new(&opts.command);
+    clear_pentect_control_env(&mut cmd);
     apply_extension_env(&mut cmd, &active_extensions)?;
     apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()));
     apply_memory_store_env(&mut cmd, Some(&memory_store));
@@ -1016,8 +1013,16 @@ fn run_interactive_command_pty(
     let mode_tracker = terminal_guard.mode_tracker();
     let output_error = Arc::new(Mutex::new(None));
     let output_error_writer = output_error.clone();
-    let output_thread =
-        thread::spawn(move || proxy_pty_output(reader, mode_tracker, output_error_writer));
+    let output_control = Arc::new(PtyOutputControl::new());
+    let output_control_writer = Arc::clone(&output_control);
+    let output_thread = thread::spawn(move || {
+        proxy_pty_output(
+            reader,
+            mode_tracker,
+            output_error_writer,
+            output_control_writer,
+        )
+    });
     let ctrl_c_guard = terminal::IgnoreCtrlCGuard::new();
     let status = pump_prompt_guarded_pty_input(
         child.as_mut(),
@@ -1034,7 +1039,7 @@ fn run_interactive_command_pty(
     finish_pty_child(child.as_mut());
     drop(ctrl_c_guard);
     drop(pair.master);
-    match join_pty_output(output_thread) {
+    match join_pty_output(output_thread, &output_control) {
         Ok(()) => {}
         Err(e) => {
             terminal_guard.restore_after_tui();
@@ -1093,6 +1098,12 @@ fn command_builder_from_process_command(cmd: &Command) -> Result<CommandBuilder,
         None => std::env::current_dir().map_err(|e| format!("could not read current dir: {e}"))?,
     };
     command.cwd(cwd.as_os_str());
+    // portable-pty rebuilds the Windows base environment from the registry,
+    // which drops process-local PATH entries installed by tools such as fnm.
+    command.env_clear();
+    for (name, value) in std::env::vars_os() {
+        command.env(name, value);
+    }
     for (name, value) in cmd.get_envs() {
         match value {
             Some(value) => command.env(name, value),
@@ -1106,8 +1117,9 @@ fn proxy_pty_output(
     mut reader: Box<dyn Read + Send>,
     mode_tracker: terminal::TerminalModeTracker,
     output_error: Arc<Mutex<Option<String>>>,
+    output_control: Arc<PtyOutputControl>,
 ) -> Result<(), String> {
-    let mut buf = [0u8; 8192];
+    let mut buf = [0u8; 64 * 1024];
     let mut remasker = match pentect_agent::ActiveTerminalOutputRemasker::new() {
         Ok(remasker) => remasker,
         Err(error) => {
@@ -1123,7 +1135,8 @@ fn proxy_pty_output(
             Err(error) => {
                 let error = format!("could not read pty output: {error}");
                 record_output_error(&output_error, &error);
-                return Err(error);
+                first_error = Some(error);
+                break;
             }
         };
         if n == 0 {
@@ -1143,26 +1156,36 @@ fn proxy_pty_output(
             }
         };
         buf[..n].zeroize();
-        mode_tracker.observe(&remasked);
-        if let Err(error) = write_pty_output(&remasked) {
-            record_output_error(&output_error, &error);
-            first_error = Some(error);
+        match write_pty_output(&remasked, &output_control) {
+            Ok(true) => mode_tracker.observe(&remasked),
+            Ok(false) => {}
+            Err(error) => {
+                record_output_error(&output_error, &error);
+                first_error = Some(error);
+            }
         }
     }
     if let Some(error) = first_error {
+        let tail = remasker.finish_after_error();
+        let _ = write_pty_output(&tail, &output_control);
         return Err(error);
     }
     let tail = match remasker.finish() {
         Ok(tail) => tail,
         Err(error) => {
             record_output_error(&output_error, &error);
+            let tail = remasker.finish_after_error();
+            let _ = write_pty_output(&tail, &output_control);
             return Err(error);
         }
     };
-    mode_tracker.observe(&tail);
-    if let Err(error) = write_pty_output(&tail) {
-        record_output_error(&output_error, &error);
-        return Err(error);
+    match write_pty_output(&tail, &output_control) {
+        Ok(true) => mode_tracker.observe(&tail),
+        Ok(false) => {}
+        Err(error) => {
+            record_output_error(&output_error, &error);
+            return Err(error);
+        }
     }
     Ok(())
 }
@@ -1187,24 +1210,74 @@ fn record_output_error(output_error: &Arc<Mutex<Option<String>>>, error: &str) {
     }
 }
 
-fn write_pty_output(bytes: &[u8]) -> Result<(), String> {
+struct PtyOutputControl {
+    enabled: AtomicBool,
+    write_gate: Mutex<()>,
+}
+
+impl PtyOutputControl {
+    fn new() -> Self {
+        Self {
+            enabled: AtomicBool::new(true),
+            write_gate: Mutex::new(()),
+        }
+    }
+
+    fn disable(&self) {
+        let _gate = match self.write_gate.lock() {
+            Ok(gate) => gate,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if self.enabled.load(Ordering::Acquire) {
+            let mut out = std::io::stdout().lock();
+            let _ = out.write_all(b"\x1b\\");
+            let _ = out.flush();
+        }
+        self.enabled.store(false, Ordering::Release);
+    }
+}
+
+fn write_pty_output(bytes: &[u8], control: &PtyOutputControl) -> Result<bool, String> {
     if bytes.is_empty() {
-        return Ok(());
+        return Ok(true);
+    }
+    let _gate = match control.write_gate.lock() {
+        Ok(gate) => gate,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if !control.enabled.load(Ordering::Acquire) {
+        return Ok(false);
     }
     let mut out = std::io::stdout().lock();
     out.write_all(bytes)
         .map_err(|e| format!("could not write pty output: {e}"))?;
     out.flush()
         .map_err(|e| format!("could not flush pty output: {e}"))?;
-    Ok(())
+    Ok(true)
 }
 
-fn join_pty_output(output_thread: thread::JoinHandle<Result<(), String>>) -> Result<(), String> {
+fn join_pty_output(
+    output_thread: thread::JoinHandle<Result<(), String>>,
+    control: &PtyOutputControl,
+) -> Result<(), String> {
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
     while !output_thread.is_finished() && std::time::Instant::now() < deadline {
         thread::sleep(Duration::from_millis(10));
     }
+    let timed_out = !output_thread.is_finished();
+    if timed_out {
+        control.disable();
+        let cancel_deadline = std::time::Instant::now() + Duration::from_secs(3);
+        while !output_thread.is_finished() && std::time::Instant::now() < cancel_deadline {
+            cancel_pty_output_read(&output_thread);
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
     if !output_thread.is_finished() {
+        return Err("pty output did not close".to_string());
+    }
+    if timed_out {
+        let _ = output_thread.join();
         return Err("pty output did not close".to_string());
     }
     match output_thread.join() {
@@ -1212,6 +1285,19 @@ fn join_pty_output(output_thread: thread::JoinHandle<Result<(), String>>) -> Res
         Err(_) => Err("pty output thread panicked".to_string()),
     }
 }
+
+#[cfg(windows)]
+fn cancel_pty_output_read(output_thread: &thread::JoinHandle<Result<(), String>>) {
+    use std::os::windows::io::AsRawHandle;
+    unsafe {
+        let _ = windows_sys::Win32::System::IO::CancelSynchronousIo(
+            output_thread.as_raw_handle().cast(),
+        );
+    }
+}
+
+#[cfg(not(windows))]
+fn cancel_pty_output_read(_output_thread: &thread::JoinHandle<Result<(), String>>) {}
 
 fn finish_pty_child(child: &mut dyn PtyChild) {
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
@@ -2092,53 +2178,46 @@ struct MemoryStoreGuard {
     lease: Option<pentect_agent::MemoryStoreLease>,
     addr: String,
     token: String,
-    process_host_read_token: String,
-    process_host_write_token: String,
-    process_host_root: PathBuf,
     process_host_candidate: Option<PathBuf>,
 }
 
 impl MemoryStoreGuard {
     fn start(pentect: &Path, persistent: bool) -> Result<Option<Self>, String> {
         if !persistent {
-            if let (
-                Some(addr),
-                Some(token),
-                Some(process_host_read_token),
-                Some(process_host_write_token),
-                Some(process_host_root),
-            ) = (
+            if let (Some(addr), Some(token), Some(launch_proof)) = (
                 std::env::var_os(PENTECT_MEMORY_STORE_ADDR_ENV),
                 std::env::var_os(PENTECT_MEMORY_STORE_TOKEN_ENV),
-                std::env::var_os(PENTECT_PROCESS_HOST_READ_TOKEN_ENV),
-                std::env::var_os(PENTECT_PROCESS_HOST_WRITE_TOKEN_ENV),
-                std::env::var_os(PENTECT_PROCESS_HOST_ROOT_ENV),
+                std::env::var_os(PENTECT_AGENT_LAUNCHED_ENV),
             ) {
                 let addr = addr.to_string_lossy().to_string();
                 let token = token.to_string_lossy().to_string();
-                let process_host_read_token = process_host_read_token.to_string_lossy().to_string();
-                let process_host_write_token =
-                    process_host_write_token.to_string_lossy().to_string();
+                let launch_proof = launch_proof.to_string_lossy();
+                let process_host_root = process_host_root()?;
                 if !addr.is_empty()
-                    && !token.is_empty()
-                    && !process_host_read_token.is_empty()
-                    && !process_host_write_token.is_empty()
-                    && !process_host_root.is_empty()
+                    && valid_runtime_token(&token)
+                    && launch_proof == token
+                    && addr
+                        .parse::<std::net::SocketAddr>()
+                        .is_ok_and(|addr| addr.ip().is_loopback())
+                    && pentect_agent::delegated_process_host_contains(
+                        &process_host_root,
+                        &addr,
+                        &token,
+                    )
+                    && pentect_agent::memory_store_ready(&addr, &token)
                 {
                     return Ok(Some(Self {
                         child: None,
                         lease: None,
                         addr,
                         token,
-                        process_host_read_token,
-                        process_host_write_token,
-                        process_host_root: PathBuf::from(process_host_root),
                         process_host_candidate: None,
                     }));
                 }
             }
         }
         let mut command = Command::new(pentect);
+        clear_pentect_control_env(&mut command);
         command
             .arg("agent")
             .arg("memory-store")
@@ -2184,7 +2263,7 @@ impl MemoryStoreGuard {
                 return Err("Pentect memory store did not start within 5 seconds".to_string());
             }
         };
-        let (addr, token, process_host_read_token, process_host_write_token) =
+        let (addr, token, mut process_host_read_token, mut process_host_write_token) =
             match parse_memory_store_startup(&line) {
                 Ok(parsed) => parsed,
                 Err(e) => {
@@ -2209,6 +2288,7 @@ impl MemoryStoreGuard {
         let process_host_candidate = match pentect_agent::register_process_host_candidate(
             &process_host_root,
             &addr,
+            &token,
             &process_host_read_token,
             &process_host_write_token,
             child.id(),
@@ -2226,14 +2306,13 @@ impl MemoryStoreGuard {
                 return Err(e);
             }
         };
+        process_host_read_token.zeroize();
+        process_host_write_token.zeroize();
         Ok(Some(Self {
             child: Some(child),
             lease,
             addr,
             token,
-            process_host_read_token,
-            process_host_write_token,
-            process_host_root,
             process_host_candidate: Some(process_host_candidate),
         }))
     }
@@ -2243,6 +2322,10 @@ impl MemoryStoreGuard {
         self.child.take();
         self.process_host_candidate.take();
     }
+}
+
+fn valid_runtime_token(token: &str) -> bool {
+    token.len() == 64 && token.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 impl Drop for MemoryStoreGuard {
@@ -2255,8 +2338,6 @@ impl Drop for MemoryStoreGuard {
             let _ = child.wait();
         }
         self.token.zeroize();
-        self.process_host_read_token.zeroize();
-        self.process_host_write_token.zeroize();
     }
 }
 
@@ -2269,44 +2350,7 @@ fn configure_persistent_child(command: &mut Command) {
 }
 
 fn process_host_root() -> Result<PathBuf, String> {
-    if let Some(root) = std::env::var_os(PENTECT_PROCESS_HOST_ROOT_ENV).filter(|v| !v.is_empty()) {
-        return Ok(PathBuf::from(root));
-    }
-    #[cfg(windows)]
-    {
-        std::env::var_os("LOCALAPPDATA")
-            .or_else(|| {
-                std::env::var_os("USERPROFILE").map(|home| {
-                    PathBuf::from(home)
-                        .join("AppData")
-                        .join("Local")
-                        .into_os_string()
-                })
-            })
-            .map(PathBuf::from)
-            .map(|root| root.join("pentect"))
-            .ok_or_else(|| "could not locate local application data".to_string())
-    }
-    #[cfg(target_os = "macos")]
-    {
-        std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .map(|home| home.join("Library").join("Caches").join("pentect"))
-            .ok_or_else(|| "could not locate the user cache directory".to_string())
-    }
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        if let Some(root) = std::env::var_os("XDG_RUNTIME_DIR").filter(|v| !v.is_empty()) {
-            return Ok(PathBuf::from(root).join("pentect"));
-        }
-        if let Some(root) = std::env::var_os("XDG_CACHE_HOME").filter(|v| !v.is_empty()) {
-            return Ok(PathBuf::from(root).join("pentect"));
-        }
-        std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .map(|home| home.join(".cache").join("pentect"))
-            .ok_or_else(|| "could not locate the user cache directory".to_string())
-    }
+    pentect_agent::process_host_root()
 }
 
 #[cfg(unix)]
@@ -2324,24 +2368,26 @@ fn apply_pentect_env(cmd: &mut Command, pentect: &Path, launch_proof: Option<&st
     }
 }
 
+fn clear_pentect_control_env(command: &mut Command) {
+    for name in pentect_agent::pentect_control_env_names() {
+        command.env_remove(name);
+    }
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_str()
+            .is_some_and(pentect_agent::is_pentect_control_env_name)
+        {
+            command.env_remove(name);
+        }
+    }
+}
+
 fn apply_memory_store_env(cmd: &mut Command, memory_store: Option<&MemoryStoreGuard>) {
     let Some(memory_store) = memory_store else {
         return;
     };
     cmd.env(PENTECT_MEMORY_STORE_ADDR_ENV, &memory_store.addr);
     cmd.env(PENTECT_MEMORY_STORE_TOKEN_ENV, &memory_store.token);
-    cmd.env(
-        PENTECT_PROCESS_HOST_READ_TOKEN_ENV,
-        &memory_store.process_host_read_token,
-    );
-    cmd.env(
-        PENTECT_PROCESS_HOST_WRITE_TOKEN_ENV,
-        &memory_store.process_host_write_token,
-    );
-    cmd.env(
-        PENTECT_PROCESS_HOST_ROOT_ENV,
-        &memory_store.process_host_root,
-    );
 }
 
 fn apply_status_line_env(cmd: &mut Command, enabled: bool) {
@@ -2357,22 +2403,6 @@ fn memory_store_parent_env_guard(pentect: &Path, memory_store: &MemoryStoreGuard
         (
             PENTECT_MEMORY_STORE_TOKEN_ENV,
             Some(OsString::from(memory_store.token.as_str())),
-        ),
-        (
-            PENTECT_PROCESS_HOST_READ_TOKEN_ENV,
-            Some(OsString::from(
-                memory_store.process_host_read_token.as_str(),
-            )),
-        ),
-        (
-            PENTECT_PROCESS_HOST_WRITE_TOKEN_ENV,
-            Some(OsString::from(
-                memory_store.process_host_write_token.as_str(),
-            )),
-        ),
-        (
-            PENTECT_PROCESS_HOST_ROOT_ENV,
-            Some(memory_store.process_host_root.clone().into_os_string()),
         ),
         (PENTECT_BIN_ENV, Some(pentect.as_os_str().to_os_string())),
         (
@@ -2402,22 +2432,6 @@ fn agent_parent_env_guard(
         (
             PENTECT_MEMORY_STORE_TOKEN_ENV,
             Some(OsString::from(memory_store.token.as_str())),
-        ),
-        (
-            PENTECT_PROCESS_HOST_READ_TOKEN_ENV,
-            Some(OsString::from(
-                memory_store.process_host_read_token.as_str(),
-            )),
-        ),
-        (
-            PENTECT_PROCESS_HOST_WRITE_TOKEN_ENV,
-            Some(OsString::from(
-                memory_store.process_host_write_token.as_str(),
-            )),
-        ),
-        (
-            PENTECT_PROCESS_HOST_ROOT_ENV,
-            Some(memory_store.process_host_root.clone().into_os_string()),
         ),
         (PENTECT_BIN_ENV, Some(pentect.as_os_str().to_os_string())),
         (
@@ -3671,8 +3685,19 @@ mod tests {
 
     #[test]
     fn opencode_has_distinct_command_and_path_flag() {
-        assert_eq!(AgentTool::OpenCode.env_var(), "PENTECT_OPENCODE");
+        assert_eq!(AgentTool::OpenCode.default_command(), "opencode");
         assert_eq!(AgentTool::OpenCode.path_flag(), "--opencode");
+    }
+
+    #[test]
+    fn runtime_tokens_require_full_random_hex() {
+        assert!(valid_runtime_token(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
+        assert!(!valid_runtime_token("user-selected"));
+        assert!(!valid_runtime_token(
+            "z123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
     }
 
     #[test]
@@ -3702,13 +3727,12 @@ mod tests {
     }
 
     #[test]
-    fn issue_report_url_prefills_safe_template() {
+    fn issue_report_url_is_compact() {
         let url = issue_report_url();
         assert!(url.starts_with("https://github.com/EdamAme-x/pentect/issues/new?"));
         assert!(url.contains("title=Pentect%20error"), "{url}");
-        assert!(url.contains("body="), "{url}");
-        assert!(url.contains("Do%20not%20paste%20raw%20secrets"), "{url}");
-        assert!(!url.contains("<paste Pentect error output here>"), "{url}");
+        assert!(!url.contains("body="), "{url}");
+        assert!(url.len() < 100, "{url}");
     }
 
     #[test]
@@ -4356,9 +4380,7 @@ mod tests {
 
     #[test]
     fn only_session_commands_support_process_host_handoff() {
-        for command in [
-            "exec", "shell", "log", "bridge", "codex", "claude", "opencode",
-        ] {
+        for command in ["exec", "shell", "log", "bridge"] {
             let args = vec!["pentect".to_string(), command.to_string()];
             assert!(supports_process_host(&args), "{command}");
         }
@@ -4373,6 +4395,9 @@ mod tests {
             "scan",
             "resolve",
             "up",
+            "codex",
+            "claude",
+            "opencode",
         ] {
             let args = vec!["pentect".to_string(), command.to_string()];
             assert!(!supports_process_host(&args), "{command}");

--- a/crates/pentect-cli/src/terminal.rs
+++ b/crates/pentect-cli/src/terminal.rs
@@ -96,6 +96,7 @@ const ANSI_INPUT_REPORTING_RESET: &str = concat!(
     "\x1b[?2004l", // disable bracketed paste
     "\x1b[?2005l", // disable bracketed paste quote mode
     "\x1b[?2006l", // disable bracketed paste literal newline mode
+    "\x1b[?9001l", // disable Windows Terminal Win32 input mode
 );
 
 const ANSI_TUI_RESET: &str = concat!(
@@ -695,6 +696,7 @@ mod tests {
             "\x1b[?2004l",
             "\x1b[?2005l",
             "\x1b[?2006l",
+            "\x1b[?9001l",
             "\x1b[?9l",
         ] {
             assert!(ANSI_INPUT_REPORTING_RESET.contains(mode), "{mode:?}");

--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -1,0 +1,486 @@
+use semver::Version;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const RELEASE_API: &str = "https://api.github.com/repos/EdamAme-x/pentect/releases/latest";
+const USER_AGENT: &str = "pentect-updater";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_BINARY_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_CHECKSUM_BYTES: u64 = 4 * 1024;
+
+pub(crate) struct DownloadedReleaseAsset {
+    pub(crate) version: Version,
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Release {
+    tag_name: String,
+    draft: bool,
+    prerelease: bool,
+    assets: Vec<ReleaseAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseAsset {
+    name: String,
+    browser_download_url: String,
+    size: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct UpdateOptions {
+    check: bool,
+    force: bool,
+}
+
+pub(crate) fn cmd_version() {
+    println!("pentect {}", env!("CARGO_PKG_VERSION"));
+}
+
+pub(crate) fn cmd_update(args: &[String]) {
+    let options = match parse_update_options(args) {
+        Ok(options) => options,
+        Err(error) => crate::die(error),
+    };
+    if let Err(error) = update(options) {
+        crate::die(error);
+    }
+}
+
+fn parse_update_options(args: &[String]) -> Result<UpdateOptions, String> {
+    let mut options = UpdateOptions::default();
+    for arg in &args[2..] {
+        match arg.as_str() {
+            "--check" => options.check = true,
+            "--force" => options.force = true,
+            flag if flag.starts_with('-') => return Err(format!("unknown update option: {flag}")),
+            value => return Err(format!("unexpected update argument: {value}")),
+        }
+    }
+    if options.check && options.force {
+        return Err("update accepts either --check or --force".to_string());
+    }
+    Ok(options)
+}
+
+fn update(options: UpdateOptions) -> Result<(), String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|e| format!("could not create update client: {e}"))?;
+    let release: Release = get_response(&client, RELEASE_API, MAX_CHECKSUM_BYTES * 16)?;
+    if release.draft || release.prerelease {
+        return Err("latest GitHub release is not a stable release".to_string());
+    }
+    let latest = release_version(&release.tag_name)?;
+    let current = Version::parse(env!("CARGO_PKG_VERSION"))
+        .map_err(|e| format!("invalid installed version: {e}"))?;
+    if !options.force && latest <= current {
+        println!("up to date: {current}");
+        return Ok(());
+    }
+    println!("update available: {current} -> {latest}");
+    if options.check {
+        return Ok(());
+    }
+
+    let binary_name = release_asset_name()?;
+    let checksum_name = format!("{binary_name}.sha256");
+    let binary = find_asset(&release, &binary_name)?;
+    let checksum = find_asset(&release, &checksum_name)?;
+    if binary.size == 0 || binary.size > MAX_BINARY_BYTES {
+        return Err(format!(
+            "release binary has invalid size: {} bytes",
+            binary.size
+        ));
+    }
+    if checksum.size == 0 || checksum.size > MAX_CHECKSUM_BYTES {
+        return Err(format!(
+            "release checksum has invalid size: {} bytes",
+            checksum.size
+        ));
+    }
+    let expected = download_text(&client, checksum, MAX_CHECKSUM_BYTES)?;
+    let expected = parse_sha256(&expected)?;
+    let bytes = download_bytes(&client, binary, MAX_BINARY_BYTES)?;
+    if bytes.len() as u64 != binary.size {
+        return Err(format!(
+            "release binary size mismatch: expected {}, received {}",
+            binary.size,
+            bytes.len()
+        ));
+    }
+    let actual = sha256_hex(&bytes);
+    if actual != expected {
+        return Err(format!(
+            "release checksum mismatch: expected {expected}, received {actual}"
+        ));
+    }
+    install_update(&bytes, &latest, &expected)
+}
+
+pub(crate) fn download_latest_release_asset(
+    repository: &str,
+    asset_name: &str,
+) -> Result<DownloadedReleaseAsset, String> {
+    validate_repository(repository)?;
+    if asset_name.is_empty()
+        || asset_name.contains('/')
+        || asset_name.contains('\\')
+        || asset_name.len() > 200
+    {
+        return Err(format!("invalid release asset name: {asset_name}"));
+    }
+    let client = reqwest::blocking::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|e| format!("could not create release client: {e}"))?;
+    let api = format!("https://api.github.com/repos/{repository}/releases/latest");
+    let release: Release = get_response(&client, &api, MAX_CHECKSUM_BYTES * 16)?;
+    if release.draft || release.prerelease {
+        return Err("latest GitHub release is not a stable release".to_string());
+    }
+    let version = release_version(&release.tag_name)?;
+    let binary = find_asset(&release, asset_name)?;
+    let checksum = find_asset(&release, &format!("{asset_name}.sha256"))?;
+    if binary.size == 0 || binary.size > MAX_BINARY_BYTES {
+        return Err(format!(
+            "release asset has invalid size: {} bytes",
+            binary.size
+        ));
+    }
+    let expected = parse_sha256(&download_text(&client, checksum, MAX_CHECKSUM_BYTES)?)?;
+    let bytes = download_bytes(&client, binary, MAX_BINARY_BYTES)?;
+    if bytes.len() as u64 != binary.size {
+        return Err(format!(
+            "release asset size mismatch: expected {}, received {}",
+            binary.size,
+            bytes.len()
+        ));
+    }
+    let actual = sha256_hex(&bytes);
+    if actual != expected {
+        return Err(format!(
+            "release checksum mismatch: expected {expected}, received {actual}"
+        ));
+    }
+    Ok(DownloadedReleaseAsset {
+        version,
+        bytes,
+        sha256: expected,
+    })
+}
+
+fn validate_repository(repository: &str) -> Result<(), String> {
+    let parts = repository.split('/').collect::<Vec<_>>();
+    if parts.len() != 2
+        || parts.iter().any(|part| {
+            part.is_empty()
+                || part.len() > 100
+                || !part
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+        })
+    {
+        return Err(format!("invalid GitHub repository: {repository}"));
+    }
+    Ok(())
+}
+
+fn get_response<T: for<'de> Deserialize<'de>>(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    max_bytes: u64,
+) -> Result<T, String> {
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|e| format!("could not fetch GitHub release: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "could not fetch GitHub release: HTTP {}",
+            response.status()
+        ));
+    }
+    if response
+        .content_length()
+        .is_some_and(|size| size > max_bytes)
+    {
+        return Err("GitHub release response is too large".to_string());
+    }
+    let bytes = response
+        .bytes()
+        .map_err(|e| format!("could not read GitHub release: {e}"))?;
+    if bytes.len() as u64 > max_bytes {
+        return Err("GitHub release response is too large".to_string());
+    }
+    serde_json::from_slice(&bytes).map_err(|e| format!("invalid GitHub release response: {e}"))
+}
+
+fn release_version(tag: &str) -> Result<Version, String> {
+    let raw = tag.strip_prefix('v').unwrap_or(tag);
+    Version::parse(raw).map_err(|e| format!("invalid GitHub release tag '{tag}': {e}"))
+}
+
+fn release_asset_name() -> Result<String, String> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+    match (os, arch) {
+        ("windows", "x86_64") => Ok("pentect-windows-x86_64.exe".to_string()),
+        ("linux", "x86_64") => Ok("pentect-linux-x86_64".to_string()),
+        ("macos", "x86_64") => Ok("pentect-macos-x86_64".to_string()),
+        ("macos", "aarch64") => Ok("pentect-macos-aarch64".to_string()),
+        _ => Err(format!("updates are not published for {os}/{arch}")),
+    }
+}
+
+fn find_asset<'a>(release: &'a Release, name: &str) -> Result<&'a ReleaseAsset, String> {
+    release
+        .assets
+        .iter()
+        .find(|asset| asset.name == name)
+        .ok_or_else(|| format!("GitHub release is missing asset '{name}'"))
+}
+
+fn download_text(
+    client: &reqwest::blocking::Client,
+    asset: &ReleaseAsset,
+    max_bytes: u64,
+) -> Result<String, String> {
+    let bytes = download_bytes(client, asset, max_bytes)?;
+    String::from_utf8(bytes).map_err(|e| format!("release checksum is not UTF-8: {e}"))
+}
+
+fn download_bytes(
+    client: &reqwest::blocking::Client,
+    asset: &ReleaseAsset,
+    max_bytes: u64,
+) -> Result<Vec<u8>, String> {
+    let response = client
+        .get(&asset.browser_download_url)
+        .send()
+        .map_err(|e| format!("could not download '{}': {e}", asset.name))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "could not download '{}': HTTP {}",
+            asset.name,
+            response.status()
+        ));
+    }
+    if response
+        .content_length()
+        .is_some_and(|size| size > max_bytes)
+    {
+        return Err(format!("release asset '{}' is too large", asset.name));
+    }
+    let bytes = response
+        .bytes()
+        .map_err(|e| format!("could not read '{}': {e}", asset.name))?;
+    if bytes.len() as u64 > max_bytes {
+        return Err(format!("release asset '{}' is too large", asset.name));
+    }
+    Ok(bytes.to_vec())
+}
+
+fn parse_sha256(value: &str) -> Result<String, String> {
+    let hash = value
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| "release checksum is empty".to_string())?
+        .to_ascii_lowercase();
+    if hash.len() != 64 || !hash.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return Err("release checksum is not a SHA-256 digest".to_string());
+    }
+    Ok(hash)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    data_encoding::HEXLOWER.encode(&digest)
+}
+
+fn install_update(bytes: &[u8], latest: &Version, expected: &str) -> Result<(), String> {
+    let current = std::env::current_exe()
+        .map_err(|e| format!("could not locate the installed executable: {e}"))?;
+    let parent = current
+        .parent()
+        .ok_or_else(|| "installed executable has no parent directory".to_string())?;
+    let suffix = if cfg!(windows) { ".exe" } else { "" };
+    let staged = parent.join(format!(
+        "pentect.update-{}-{latest}{suffix}",
+        std::process::id()
+    ));
+    std::fs::write(&staged, bytes)
+        .map_err(|e| format!("could not stage update '{}': {e}", staged.display()))?;
+    if sha256_file(&staged)? != expected {
+        let _ = std::fs::remove_file(&staged);
+        return Err("staged update checksum mismatch".to_string());
+    }
+    copy_executable_permissions(&current, &staged)?;
+    let backup = backup_path(&current)?;
+    std::fs::copy(&current, &backup)
+        .map_err(|e| format!("could not back up '{}': {e}", current.display()))?;
+
+    #[cfg(windows)]
+    {
+        spawn_windows_update_helper(&staged, &current, &backup, expected)?;
+        println!("update staged: {latest}");
+        println!("the executable will be replaced when this process exits");
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        if let Err(error) = std::fs::rename(&current, &backup) {
+            let _ = std::fs::remove_file(&staged);
+            return Err(format!("could not move current executable: {error}"));
+        }
+        if let Err(error) = std::fs::rename(&staged, &current) {
+            let _ = std::fs::rename(&backup, &current);
+            return Err(format!("could not install update: {error}"));
+        }
+        println!("updated to {latest}");
+        Ok(())
+    }
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let bytes =
+        std::fs::read(path).map_err(|e| format!("could not verify '{}': {e}", path.display()))?;
+    Ok(sha256_hex(&bytes))
+}
+
+fn backup_path(current: &Path) -> Result<PathBuf, String> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("system clock error: {e}"))?
+        .as_secs();
+    let name = current
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "installed executable name is not UTF-8".to_string())?;
+    Ok(current.with_file_name(format!("{name}.previous-{timestamp}")))
+}
+
+#[cfg(unix)]
+fn copy_executable_permissions(current: &Path, staged: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = std::fs::metadata(current)
+        .map(|metadata| metadata.permissions().mode())
+        .unwrap_or(0o755);
+    std::fs::set_permissions(staged, std::fs::Permissions::from_mode(mode | 0o111))
+        .map_err(|e| format!("could not mark update executable: {e}"))
+}
+
+#[cfg(windows)]
+fn copy_executable_permissions(_current: &Path, _staged: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn spawn_windows_update_helper(
+    staged: &Path,
+    destination: &Path,
+    backup: &Path,
+    expected: &str,
+) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    const DETACHED_PROCESS: u32 = 0x0000_0008;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    Command::new(staged)
+        .arg("__apply-update")
+        .arg(std::process::id().to_string())
+        .arg(destination)
+        .arg(backup)
+        .arg(expected)
+        .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("could not start update helper: {e}"))
+}
+
+pub(crate) fn cmd_apply_update(args: &[String]) -> i32 {
+    match apply_update(args) {
+        Ok(()) => 0,
+        Err(_) => 1,
+    }
+}
+
+fn apply_update(args: &[String]) -> Result<(), String> {
+    let [_, command, parent_pid, destination, backup, expected] = args else {
+        return Err("invalid update helper arguments".to_string());
+    };
+    if command != "__apply-update" {
+        return Err("invalid update helper command".to_string());
+    }
+    let _: u32 = parent_pid
+        .parse()
+        .map_err(|_| "invalid update helper parent".to_string())?;
+    let source = std::env::current_exe().map_err(|e| e.to_string())?;
+    if sha256_file(&source)? != expected.to_ascii_lowercase() {
+        return Err("update helper checksum mismatch".to_string());
+    }
+    let destination = Path::new(destination);
+    let backup = Path::new(backup);
+    for _ in 0..600 {
+        match std::fs::copy(&source, destination) {
+            Ok(_) if sha256_file(destination)? == expected.to_ascii_lowercase() => return Ok(()),
+            Ok(_) => {
+                let _ = std::fs::copy(backup, destination);
+                return Err("installed update checksum mismatch".to_string());
+            }
+            Err(_) => std::thread::sleep(Duration::from_millis(500)),
+        }
+    }
+    Err("timed out waiting to replace the executable".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_update_flags() {
+        let args = vec!["pentect".into(), "update".into(), "--check".into()];
+        assert!(parse_update_options(&args).unwrap().check);
+        let args = vec![
+            "pentect".into(),
+            "update".into(),
+            "--check".into(),
+            "--force".into(),
+        ];
+        assert!(parse_update_options(&args).is_err());
+    }
+
+    #[test]
+    fn parses_release_versions_and_checksums() {
+        assert_eq!(release_version("v1.2.3").unwrap(), Version::new(1, 2, 3));
+        assert!(release_version("latest").is_err());
+        let hash = "a".repeat(64);
+        assert_eq!(
+            parse_sha256(&format!("{hash}  pentect.exe\n")).unwrap(),
+            hash
+        );
+        assert!(parse_sha256("abc").is_err());
+    }
+
+    #[test]
+    fn selects_a_platform_asset() {
+        let name = release_asset_name().unwrap();
+        assert!(name.starts_with("pentect-"));
+        assert!(!name.ends_with(".zip"));
+    }
+
+    #[test]
+    fn validates_release_coordinates() {
+        assert!(validate_repository("EdamAme-x/pentect").is_ok());
+        assert!(validate_repository("owner/repo/extra").is_err());
+        assert!(validate_repository("owner/../repo").is_err());
+    }
+}

--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -2,6 +2,7 @@ use semver::Version;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
+#[cfg(windows)]
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 

--- a/crates/pentect-cli/tests/process_host.rs
+++ b/crates/pentect-cli/tests/process_host.rs
@@ -100,9 +100,9 @@ fn codex_dry_run_uses_project_environment_prefix() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(rendered.contains("$env:SAFE_NAME_hash"), "{rendered}");
-    assert!(rendered.contains("$SAFE_NAME_hash"), "{rendered}");
-    assert!(!rendered.contains("PENTECT_NAME_hash"), "{rendered}");
+    assert!(rendered.contains("$env:SAFE_KEY_hash"), "{rendered}");
+    assert!(rendered.contains("$SAFE_KEY_hash"), "{rendered}");
+    assert!(!rendered.contains("PENTECT_KEY_hash"), "{rendered}");
 }
 
 #[test]

--- a/crates/pentect-cli/tests/process_host.rs
+++ b/crates/pentect-cli/tests/process_host.rs
@@ -100,8 +100,8 @@ fn codex_dry_run_uses_project_environment_prefix() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(rendered.contains("SAFE_<LABEL>_<HASH>"), "{rendered}");
     assert!(rendered.contains("$env:SAFE_NAME_hash"), "{rendered}");
+    assert!(rendered.contains("$SAFE_NAME_hash"), "{rendered}");
     assert!(!rendered.contains("PENTECT_NAME_hash"), "{rendered}");
 }
 

--- a/crates/pentect-cli/tests/process_host.rs
+++ b/crates/pentect-cli/tests/process_host.rs
@@ -25,8 +25,7 @@ fn up_returns_keeps_one_host_and_is_idempotent() {
     };
 
     run_up(&root);
-    let host_file = root
-        .join("host")
+    let host_file = host_root(&root)
         .join("runtime")
         .join("delegated-process-host.json");
     wait_until(Duration::from_secs(10), || host_file.is_file());
@@ -58,8 +57,7 @@ fn concurrent_up_keeps_one_persistent_host() {
     wait_for_up(first);
     wait_for_up(second);
 
-    let host_file = root
-        .join("host")
+    let host_file = host_root(&root)
         .join("runtime")
         .join("delegated-process-host.json");
     wait_until(Duration::from_secs(10), || host_file.is_file());
@@ -119,8 +117,7 @@ fn log_hosts_while_running_but_help_does_not() {
 
     let mut log = spawn_command(&root, &["log", "--json"]);
     cleanup.command_pids.push(log.id());
-    let host_file = root
-        .join("host")
+    let host_file = host_root(&root)
         .join("runtime")
         .join("delegated-process-host.json");
     wait_until(Duration::from_secs(10), || host_file.is_file());
@@ -138,7 +135,7 @@ fn log_hosts_while_running_but_help_does_not() {
     let mut help = spawn_command(&help_root, &["help"]);
     let status = help.wait().unwrap();
     assert!(status.success(), "pentect help failed: {status}");
-    assert!(!help_root.join("host").join("runtime").exists());
+    assert!(!host_root(&help_root).join("runtime").exists());
 }
 
 fn run_up(root: &Path) {
@@ -160,7 +157,8 @@ fn spawn_command(root: &Path, args: &[&str]) -> std::process::Child {
     for name in PRIVATE_ENV {
         command.env_remove(name);
     }
-    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    configure_runtime_root(&mut command, root);
     command.spawn().unwrap()
 }
 
@@ -192,7 +190,7 @@ fn assert_host_alive(host: &Value) {
 }
 
 fn candidate_count(root: &Path) -> usize {
-    std::fs::read_dir(root.join("host").join("runtime"))
+    std::fs::read_dir(host_root(root).join("runtime"))
         .unwrap()
         .filter_map(Result::ok)
         .filter(|entry| {
@@ -202,6 +200,36 @@ fn candidate_count(root: &Path) -> usize {
             })
         })
         .count()
+}
+
+#[cfg(windows)]
+fn configure_runtime_root(command: &mut Command, root: &Path) {
+    command.env("LOCALAPPDATA", root);
+}
+
+#[cfg(windows)]
+fn host_root(root: &Path) -> PathBuf {
+    root.join("pentect")
+}
+
+#[cfg(target_os = "macos")]
+fn configure_runtime_root(command: &mut Command, root: &Path) {
+    command.env("HOME", root);
+}
+
+#[cfg(target_os = "macos")]
+fn host_root(root: &Path) -> PathBuf {
+    root.join("Library").join("Caches").join("pentect")
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn configure_runtime_root(command: &mut Command, root: &Path) {
+    command.env("XDG_RUNTIME_DIR", root);
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn host_root(root: &Path) -> PathBuf {
+    root.join("pentect")
 }
 
 fn read_json(path: &Path) -> Value {

--- a/crates/pentect-cli/tests/process_host_lifecycle.rs
+++ b/crates/pentect-cli/tests/process_host_lifecycle.rs
@@ -1,0 +1,161 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn one_shot_process_host_is_removed_after_command_exit() {
+    run_and_assert_clean(exec_args(), "exec", false);
+}
+
+#[test]
+fn agent_process_host_is_removed_after_command_exit() {
+    run_and_assert_clean(agent_args(), "agent", false);
+}
+
+#[test]
+fn agent_replaces_stale_inherited_memory_store() {
+    run_and_assert_clean(agent_args(), "stale-agent", true);
+}
+
+#[test]
+fn process_host_is_removed_after_argument_error() {
+    run_and_assert_clean(vec!["exec", "--extensions"], "argument-error", false);
+}
+
+#[cfg(windows)]
+#[test]
+fn process_host_initialization_error_is_reported_without_a_panic() {
+    let root = test_root("init-error");
+    std::fs::create_dir_all(&root).unwrap();
+    let blocker = root.join("not-a-directory");
+    std::fs::write(&blocker, b"x").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_pentect"))
+        .args(exec_args())
+        .env("LOCALAPPDATA", &blocker)
+        .env_remove("PENTECT_PROCESS_HOST_ROOT")
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(2), "{stderr}");
+    assert!(stderr.contains("[pentect]"), "{stderr}");
+    assert!(!stderr.contains("panicked"), "{stderr}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+fn run_and_assert_clean(args: Vec<&'static str>, suffix: &str, stale_store: bool) {
+    let root = test_root(suffix);
+    std::fs::create_dir_all(&root).unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+    command.args(args);
+    command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env(
+        "PENTECT_EXTENSION_CONFIGS",
+        root.join("untrusted-extension.toml"),
+    );
+    let process_host_root = configure_runtime_root(&mut command, &root);
+    if stale_store {
+        command.env("PENTECT_MEMORY_STORE_ADDR", "127.0.0.1:9");
+        command.env("PENTECT_MEMORY_STORE_TOKEN", "stale-token");
+        command.env("PENTECT_PROCESS_HOST_READ_TOKEN", "stale-read-token");
+        command.env("PENTECT_PROCESS_HOST_WRITE_TOKEN", "stale-write-token");
+        command.env("PENTECT_AGENT_LAUNCHED", "stale-token");
+    } else {
+        for name in [
+            "PENTECT_MEMORY_STORE_ADDR",
+            "PENTECT_MEMORY_STORE_TOKEN",
+            "PENTECT_PROCESS_HOST_READ_TOKEN",
+            "PENTECT_PROCESS_HOST_WRITE_TOKEN",
+            "PENTECT_AGENT_LAUNCHED",
+        ] {
+            command.env_remove(name);
+        }
+    }
+
+    let output = command.output().unwrap();
+    if suffix != "argument-error" {
+        assert!(
+            output.status.success(),
+            "stdout={:?} stderr={:?}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    } else {
+        assert_eq!(output.status.code(), Some(2));
+    }
+    let runtime = process_host_root.join("runtime");
+    assert!(
+        !runtime.exists() || std::fs::read_dir(&runtime).unwrap().next().is_none(),
+        "process host metadata remained in {}",
+        runtime.display()
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(windows)]
+fn configure_runtime_root(command: &mut Command, root: &std::path::Path) -> PathBuf {
+    command.env("LOCALAPPDATA", root);
+    root.join("pentect")
+}
+
+#[cfg(target_os = "macos")]
+fn configure_runtime_root(command: &mut Command, root: &std::path::Path) -> PathBuf {
+    command.env("HOME", root);
+    root.join("Library").join("Caches").join("pentect")
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn configure_runtime_root(command: &mut Command, root: &std::path::Path) -> PathBuf {
+    command.env("XDG_RUNTIME_DIR", root);
+    root.join("pentect")
+}
+
+#[cfg(windows)]
+fn agent_args() -> Vec<&'static str> {
+    vec![
+        "opencode",
+        "--tool",
+        "powershell.exe",
+        "--",
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Write-Output OK",
+    ]
+}
+
+#[cfg(not(windows))]
+fn agent_args() -> Vec<&'static str> {
+    vec!["opencode", "--tool", "sh", "--", "-c", "printf OK"]
+}
+
+#[cfg(windows)]
+fn exec_args() -> Vec<&'static str> {
+    vec![
+        "exec",
+        "--",
+        "powershell.exe",
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Write-Output OK",
+    ]
+}
+
+#[cfg(not(windows))]
+fn exec_args() -> Vec<&'static str> {
+    vec!["exec", "--", "sh", "-c", "printf OK"]
+}
+
+fn test_root(suffix: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "pentect-process-host-lifecycle-{}-{suffix}-{stamp}",
+        std::process::id(),
+    ))
+}

--- a/crates/pentect-cli/tests/pty_dimensions.rs
+++ b/crates/pentect-cli/tests/pty_dimensions.rs
@@ -66,7 +66,8 @@ fn agent_pty_preserves_backspace_as_one_key_event() {
     ));
     command.cwd(&root);
     command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
-    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("LOCALAPPDATA", root.join("runtime-base"));
     for name in [
         "PENTECT_MEMORY_STORE_ADDR",
         "PENTECT_MEMORY_STORE_TOKEN",
@@ -130,7 +131,8 @@ fn agent_pty_does_not_forward_nested_win32_input_mode() {
     ]);
     command.cwd(&root);
     command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
-    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("LOCALAPPDATA", root.join("runtime-base"));
     for name in [
         "PENTECT_MEMORY_STORE_ADDR",
         "PENTECT_MEMORY_STORE_TOKEN",
@@ -171,6 +173,123 @@ fn agent_pty_does_not_forward_nested_win32_input_mode() {
 }
 
 #[test]
+fn agent_pty_preserves_parent_process_path() {
+    let _serial = PTY_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let root = test_root();
+    std::fs::create_dir_all(&root).unwrap();
+    let marker = root.join("pentect-process-path-marker");
+    let inherited_path = std::env::var_os("PATH").unwrap_or_default();
+    let child_path = format!("{};{}", marker.display(), inherited_path.to_string_lossy());
+
+    let pty = native_pty_system();
+    let pair = pty.openpty(pty_size(INITIAL_SIZE)).unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_pentect"));
+    command.args([
+        "opencode",
+        "--tool",
+        "powershell.exe",
+        "--",
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Write-Output ('PATH_MARKER:' + ($env:PATH -like '*pentect-process-path-marker*'))",
+    ]);
+    command.cwd(&root);
+    command.env("PATH", child_path);
+    command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("LOCALAPPDATA", root.join("runtime-base"));
+    for name in [
+        "PENTECT_MEMORY_STORE_ADDR",
+        "PENTECT_MEMORY_STORE_TOKEN",
+        "PENTECT_PROCESS_HOST_READ_TOKEN",
+        "PENTECT_PROCESS_HOST_WRITE_TOKEN",
+        "PENTECT_AGENT_LAUNCHED",
+    ] {
+        command.env_remove(name);
+    }
+
+    let mut child = pair.slave.spawn_command(command).unwrap();
+    drop(pair.slave);
+    let reader = pair.master.try_clone_reader().unwrap();
+    let writer = Arc::new(Mutex::new(pair.master.take_writer().unwrap()));
+    let terminal_size = Arc::new(AtomicU32::new(pack_size(INITIAL_SIZE)));
+    let (tx, rx) = mpsc::channel();
+    let reader_thread = {
+        let writer = writer.clone();
+        std::thread::spawn(move || forward_output(reader, writer, terminal_size, tx))
+    };
+
+    let mut output = String::new();
+    wait_for_text(&rx, &mut output, "PATH_MARKER:True");
+    let status = wait_for_child(child.as_mut());
+    assert_eq!(status.exit_code(), 0, "{output:?}");
+    drop(pair.master);
+    join_reader(reader_thread);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn agent_pty_streams_large_terminal_control_strings() {
+    let _serial = PTY_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let root = test_root();
+    std::fs::create_dir_all(&root).unwrap();
+
+    let pty = native_pty_system();
+    let pair = pty.openpty(pty_size(INITIAL_SIZE)).unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_pentect"));
+    command.args([
+        "opencode",
+        "--tool",
+        "powershell.exe",
+        "--",
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "$esc=[char]27;[Console]::Out.Write($esc+']1337;File='+('a'*(2*1024*1024))+$esc+'\\');Write-Output 'READY'",
+    ]);
+    command.cwd(&root);
+    command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("LOCALAPPDATA", root.join("runtime-base"));
+    for name in [
+        "PENTECT_MEMORY_STORE_ADDR",
+        "PENTECT_MEMORY_STORE_TOKEN",
+        "PENTECT_PROCESS_HOST_READ_TOKEN",
+        "PENTECT_PROCESS_HOST_WRITE_TOKEN",
+        "PENTECT_AGENT_LAUNCHED",
+    ] {
+        command.env_remove(name);
+    }
+
+    let mut child = pair.slave.spawn_command(command).unwrap();
+    drop(pair.slave);
+    let reader = pair.master.try_clone_reader().unwrap();
+    let writer = Arc::new(Mutex::new(pair.master.take_writer().unwrap()));
+    let terminal_size = Arc::new(AtomicU32::new(pack_size(INITIAL_SIZE)));
+    let (tx, rx) = mpsc::channel();
+    let reader_thread = {
+        let writer = writer.clone();
+        std::thread::spawn(move || forward_output(reader, writer, terminal_size, tx))
+    };
+
+    let status = wait_for_child(child.as_mut());
+    assert_eq!(status.exit_code(), 0);
+    drop(pair.master);
+    join_reader(reader_thread);
+    let output = rx.try_iter().collect::<String>();
+    assert!(output.contains("READY"));
+    assert!(output.len() > 2 * 1024 * 1024, "{}", output.len());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn agent_pty_does_not_leak_mouse_reports_to_parent_shell() {
     let _serial = PTY_TEST_LOCK
         .lock()
@@ -199,7 +318,8 @@ fn agent_pty_does_not_leak_mouse_reports_to_parent_shell() {
     command.arg(&parent_script);
     command.cwd(&root);
     command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
-    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("LOCALAPPDATA", root.join("runtime-base"));
     command.env("PENTECT_TEST_RELEASE", &release_file);
     for name in [
         "PENTECT_MEMORY_STORE_ADDR",
@@ -309,7 +429,8 @@ fn agent_pty_stops_background_processes_on_exit() {
     ]);
     command.cwd(&root);
     command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
-    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("LOCALAPPDATA", root.join("runtime-base"));
     for name in [
         "PENTECT_MEMORY_STORE_ADDR",
         "PENTECT_MEMORY_STORE_TOKEN",
@@ -354,7 +475,8 @@ fn assert_pty_dimensions(command_prefix: &[&str]) {
     command.arg(size_probe_script());
     command.cwd(&root);
     command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
-    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("LOCALAPPDATA", root.join("runtime-base"));
     for name in [
         "PENTECT_MEMORY_STORE_ADDR",
         "PENTECT_MEMORY_STORE_TOKEN",

--- a/crates/pentect-cli/tests/pty_dimensions.rs
+++ b/crates/pentect-cli/tests/pty_dimensions.rs
@@ -188,7 +188,7 @@ fn agent_pty_preserves_backspace_as_one_key_event() {
 }
 
 #[test]
-fn agent_pty_does_not_forward_nested_win32_input_mode() {
+fn parent_conpty_consumes_forwarded_nested_win32_input_mode() {
     let _serial = PTY_TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -243,6 +243,9 @@ fn agent_pty_does_not_forward_nested_win32_input_mode() {
     let end = find_bytes(&output[start..], b"AFTER")
         .map(|offset| start + offset + b"AFTER".len())
         .expect("child output was truncated");
+    // The runtime unit test verifies that Pentect forwards these controls.
+    // The parent ConPTY consumes them to select its input encoding, so they
+    // must not appear as printable output at this outer boundary.
     assert!(!output[start..end]
         .windows(b"\x1b[?9001h".len())
         .any(|window| window == b"\x1b[?9001h"));

--- a/crates/pentect-cli/tests/pty_dimensions.rs
+++ b/crates/pentect-cli/tests/pty_dimensions.rs
@@ -62,7 +62,6 @@ fn default_shell_keeps_split_input_aligned_and_does_not_enable_nested_terminal_m
     };
 
     let mut output = String::new();
-    wait_for_text(&rx, &mut output, "protected PowerShell");
     wait_for_text(&rx, &mut output, "PS ");
     {
         let mut input = writer.lock().unwrap();
@@ -86,6 +85,10 @@ fn default_shell_keeps_split_input_aligned_and_does_not_enable_nested_terminal_m
         .find("PS ")
         .map(|start| &output[start..])
         .unwrap_or(&output);
+    assert!(
+        !shell_output.contains("\x1b[1G"),
+        "simple append input must not redraw from an absolute column: {shell_output:?}"
+    );
     for forbidden in [
         "\x1b[?9001h",
         "\x1b[?1000h",

--- a/crates/pentect-cli/tests/pty_dimensions.rs
+++ b/crates/pentect-cli/tests/pty_dimensions.rs
@@ -25,7 +25,7 @@ fn shell_pty_inherits_and_tracks_parent_dimensions() {
 }
 
 #[test]
-fn default_shell_keeps_split_input_aligned_and_does_not_enable_nested_terminal_modes() {
+fn default_shell_accepts_backspace_enter_and_masks_command_output() {
     let _serial = PTY_TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -63,47 +63,31 @@ fn default_shell_keeps_split_input_aligned_and_does_not_enable_nested_terminal_m
 
     let mut output = String::new();
     wait_for_text(&rx, &mut output, "PS ");
+    let raw_secret = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
     {
         let mut input = writer.lock().unwrap();
-        input.write_all(b"ca").unwrap();
+        input.write_all(b"Write-Outpuz").unwrap();
+        input
+            .write_all(b"\x1b[8;14;8;1;0;1_\x1b[8;14;8;0;0;1_")
+            .unwrap();
+        input.write_all(b"t ").unwrap();
+        input.write_all(raw_secret.as_bytes()).unwrap();
+        input.write_all(b"\r").unwrap();
         input.flush().unwrap();
     }
-    std::thread::sleep(Duration::from_millis(75));
-    {
-        let mut input = writer.lock().unwrap();
-        input.write_all(b"t .env").unwrap();
-        input.flush().unwrap();
-    }
-    wait_for_text(&rx, &mut output, "cat .env");
+    wait_for_text(&rx, &mut output, "<<SECRET_");
     child.kill().unwrap();
     let _ = wait_for_child(child.as_mut());
     drop(pair.master);
     join_reader(reader_thread);
     output.extend(rx.try_iter());
-    assert!(output.contains("cat .env"), "{output:?}");
-    let shell_output = output
-        .find("PS ")
-        .map(|start| &output[start..])
-        .unwrap_or(&output);
+    assert!(output.contains("<<SECRET_"), "{output:?}");
+    assert!(!output.contains(raw_secret), "{output:?}");
+    assert!(!output.contains("rpa_"), "{output:?}");
     assert!(
-        !shell_output.contains("\x1b[1G"),
-        "simple append input must not redraw from an absolute column: {shell_output:?}"
+        !output.contains("[555;"),
+        "mouse input leaked into the shell: {output:?}"
     );
-    for forbidden in [
-        "\x1b[?9001h",
-        "\x1b[?1000h",
-        "\x1b[?1002h",
-        "\x1b[?1003h",
-        "\x1b[?1006h",
-        "\x1b[?1015h",
-        "\x1b[?1016h",
-        "\x1b[?1049h",
-    ] {
-        assert!(
-            !shell_output.contains(forbidden),
-            "{forbidden:?} in {shell_output:?}"
-        );
-    }
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/crates/pentect-cli/tests/pty_dimensions.rs
+++ b/crates/pentect-cli/tests/pty_dimensions.rs
@@ -25,6 +25,86 @@ fn shell_pty_inherits_and_tracks_parent_dimensions() {
 }
 
 #[test]
+fn default_shell_keeps_split_input_aligned_and_does_not_enable_nested_terminal_modes() {
+    let _serial = PTY_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let root = test_root();
+    std::fs::create_dir_all(&root).unwrap();
+
+    let pty = native_pty_system();
+    let pair = pty.openpty(pty_size(INITIAL_SIZE)).unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_pentect"));
+    command.arg("shell");
+    command.cwd(&root);
+    command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("LOCALAPPDATA", root.join("runtime-base"));
+    for name in [
+        "PENTECT_MEMORY_STORE_ADDR",
+        "PENTECT_MEMORY_STORE_TOKEN",
+        "PENTECT_PROCESS_HOST_READ_TOKEN",
+        "PENTECT_PROCESS_HOST_WRITE_TOKEN",
+        "PENTECT_AGENT_LAUNCHED",
+    ] {
+        command.env_remove(name);
+    }
+
+    let mut child = pair.slave.spawn_command(command).unwrap();
+    drop(pair.slave);
+    let reader = pair.master.try_clone_reader().unwrap();
+    let writer = Arc::new(Mutex::new(pair.master.take_writer().unwrap()));
+    let terminal_size = Arc::new(AtomicU32::new(pack_size(INITIAL_SIZE)));
+    let (tx, rx) = mpsc::channel();
+    let reader_thread = {
+        let writer = writer.clone();
+        std::thread::spawn(move || forward_output(reader, writer, terminal_size, tx))
+    };
+
+    let mut output = String::new();
+    wait_for_text(&rx, &mut output, "protected PowerShell");
+    wait_for_text(&rx, &mut output, "PS ");
+    {
+        let mut input = writer.lock().unwrap();
+        input.write_all(b"ca").unwrap();
+        input.flush().unwrap();
+    }
+    std::thread::sleep(Duration::from_millis(75));
+    {
+        let mut input = writer.lock().unwrap();
+        input.write_all(b"t .env").unwrap();
+        input.flush().unwrap();
+    }
+    wait_for_text(&rx, &mut output, "cat .env");
+    child.kill().unwrap();
+    let _ = wait_for_child(child.as_mut());
+    drop(pair.master);
+    join_reader(reader_thread);
+    output.extend(rx.try_iter());
+    assert!(output.contains("cat .env"), "{output:?}");
+    let shell_output = output
+        .find("PS ")
+        .map(|start| &output[start..])
+        .unwrap_or(&output);
+    for forbidden in [
+        "\x1b[?9001h",
+        "\x1b[?1000h",
+        "\x1b[?1002h",
+        "\x1b[?1003h",
+        "\x1b[?1006h",
+        "\x1b[?1015h",
+        "\x1b[?1016h",
+        "\x1b[?1049h",
+    ] {
+        assert!(
+            !shell_output.contains(forbidden),
+            "{forbidden:?} in {shell_output:?}"
+        );
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn agent_pty_inherits_and_tracks_parent_dimensions() {
     assert_pty_dimensions(&[
         "opencode",
@@ -505,7 +585,7 @@ fn assert_pty_dimensions(command_prefix: &[&str]) {
     pair.master.resize(pty_size(RESIZED_SIZE)).unwrap();
     wait_for_text(&rx, &mut output, "SIZE:101x31");
 
-    let status = wait_for_child(child.as_mut());
+    let status = wait_for_child_with_output(child.as_mut(), &rx, &mut output);
     assert_eq!(status.exit_code(), 0, "{output:?}");
     drop(pair.master);
     join_reader(reader_thread);
@@ -614,6 +694,25 @@ fn join_reader(thread: std::thread::JoinHandle<()>) {
     }
     assert!(thread.is_finished(), "PTY reader did not reach EOF");
     thread.join().unwrap();
+}
+
+fn wait_for_child_with_output(
+    child: &mut dyn portable_pty::Child,
+    rx: &mpsc::Receiver<String>,
+    output: &mut String,
+) -> portable_pty::ExitStatus {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        output.extend(rx.try_iter());
+        if let Some(status) = child.try_wait().unwrap() {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            panic!("PTY child did not exit within 15 seconds: {output:?}");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
 }
 
 struct InputThreadGuard {

--- a/crates/pentect-cli/tests/pty_unix.rs
+++ b/crates/pentect-cli/tests/pty_unix.rs
@@ -31,7 +31,8 @@ fn agent_pty_inherits_and_tracks_parent_dimensions() {
     ]);
     command.cwd(&root);
     command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
-    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("XDG_RUNTIME_DIR", root.join("runtime-base"));
     for name in [
         "PENTECT_MEMORY_STORE_ADDR",
         "PENTECT_MEMORY_STORE_TOKEN",
@@ -96,7 +97,8 @@ fn agent_pty_releases_a_standalone_escape_key() {
     ]);
     command.cwd(&root);
     command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
-    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("XDG_RUNTIME_DIR", root.join("runtime-base"));
     for name in [
         "PENTECT_MEMORY_STORE_ADDR",
         "PENTECT_MEMORY_STORE_TOKEN",
@@ -164,7 +166,8 @@ fn agent_pty_stops_background_process_groups_on_exit() {
     ]);
     command.cwd(&root);
     command.env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
-    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("host"));
+    command.env("PENTECT_PROCESS_HOST_ROOT", root.join("untrusted-override"));
+    command.env("XDG_RUNTIME_DIR", root.join("runtime-base"));
     for name in [
         "PENTECT_MEMORY_STORE_ADDR",
         "PENTECT_MEMORY_STORE_TOKEN",

--- a/crates/pentect-core/src/detect/benign.rs
+++ b/crates/pentect-core/src/detect/benign.rs
@@ -568,15 +568,12 @@ pub(crate) fn is_crypto_test_vector_identifier_value(value: &str) -> bool {
 /// True for byte-pattern fixtures such as `000102...` or repeated-byte blocks.
 ///
 /// Rationale: published crypto fixtures and RFC examples often use visual byte
-/// sequences, repeated sentinels, or canonical nibble patterns to make expected
+/// sequences, repeated sentinels, or regular byte progressions to make expected
 /// values auditable. Generated secrets can contain these locally, but not as
 /// the whole value split into obvious runs. This is used only to suppress raw
 /// entropy/keyed guesses; specific private-key and vendor validators still run.
 pub(crate) fn is_synthetic_hex_test_vector_value(value: &str) -> bool {
     let value = value.trim();
-    if is_canonical_hex_fixture_literal(value) {
-        return true;
-    }
     let Some(bytes) = decode_hex_literal(value) else {
         return false;
     };
@@ -605,7 +602,11 @@ fn is_crypto_test_vector_identifier_part(value: &str) -> bool {
 }
 
 fn decode_hex_literal(value: &str) -> Option<Vec<u8>> {
-    let bytes = value.as_bytes();
+    let bytes = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value)
+        .as_bytes();
     if bytes.len() < 16
         || bytes.len() > 1024
         || !bytes.len().is_multiple_of(2)
@@ -632,7 +633,7 @@ fn is_segmented_hex_fixture_bytes(bytes: &[u8]) -> bool {
             segments += 1;
             continue;
         }
-        let stepped = byte_step_run_len(&bytes[pos..], 1).max(byte_step_run_len(&bytes[pos..], -1));
+        let stepped = byte_progression_run_len(&bytes[pos..]);
         if stepped >= 8 {
             pos += stepped;
             segments += 1;
@@ -650,9 +651,16 @@ fn same_byte_run_len(bytes: &[u8]) -> usize {
     bytes.iter().take_while(|byte| *byte == first).count()
 }
 
-fn byte_step_run_len(bytes: &[u8], step: i16) -> usize {
-    if bytes.is_empty() {
+fn byte_progression_run_len(bytes: &[u8]) -> usize {
+    let Some(first) = bytes.first() else {
         return 0;
+    };
+    let Some(second) = bytes.get(1) else {
+        return 1;
+    };
+    let step = i16::from(*second) - i16::from(*first);
+    if step == 0 {
+        return 1;
     }
     let mut len = 1;
     for pair in bytes.windows(2) {
@@ -662,19 +670,6 @@ fn byte_step_run_len(bytes: &[u8], step: i16) -> usize {
         len += 1;
     }
     len
-}
-
-fn is_canonical_hex_fixture_literal(value: &str) -> bool {
-    let lower = value.to_ascii_lowercase();
-    contains_any(
-        &lower,
-        &[
-            "0123456789abcdef",
-            "fedcba9876543210",
-            "00112233445566778899aabbccddeeff",
-            "ffeeddccbbaa99887766554433221100",
-        ],
-    )
 }
 
 fn hex_nibble(byte: u8) -> Option<u8> {
@@ -1239,6 +1234,9 @@ mod tests {
         ));
         assert!(!is_synthetic_hex_test_vector_value(
             "A3F19C80E4B27D51F09A6C33D8E74215"
+        ));
+        assert!(!is_synthetic_hex_test_vector_value(
+            "ACME_SECRET_TOKEN_0123456789abcdef"
         ));
         assert!(!is_synthetic_hex_test_vector_value("tenant-7-trial"));
     }

--- a/crates/pentect-core/src/detect/entropy.rs
+++ b/crates/pentect-core/src/detect/entropy.rs
@@ -109,6 +109,7 @@ impl EntropyDetector {
             || is_encoded_public_metadata_value(run)
             || is_crypto_test_vector_identifier_value(run)
             || is_synthetic_hex_test_vector_value(run)
+            || is_masked_environment_reference(text, start, end, run)
             || is_api_route_fragment(run)
             || is_release_artifact_identifier(run)
             || is_jwk_public_parameter_context(text, start, &view.region.ctx)
@@ -125,6 +126,46 @@ impl EntropyDetector {
             source: DetectorId::Entropy,
         });
     }
+}
+
+fn is_masked_environment_reference(text: &str, start: usize, end: usize, value: &str) -> bool {
+    // A handle-shaped suffix alone is not enough: real secrets can have that
+    // shape. Exclude it only when shell syntax proves the token is an
+    // environment-variable reference. This also supports configured prefixes.
+    if !has_masked_reference_shape(value) {
+        return false;
+    }
+    let before = &text[..start];
+    let after = &text[end..];
+    before.ends_with('$')
+        || (before.ends_with("${") && after.starts_with('}'))
+        || ascii_ends_with_ignore_case(before, "$env:")
+        || (ascii_ends_with_ignore_case(before, "${env:") && after.starts_with('}'))
+        || (before.ends_with('%') && after.starts_with('%'))
+}
+
+fn has_masked_reference_shape(value: &str) -> bool {
+    let Some((head, hash)) = value.rsplit_once('_') else {
+        return false;
+    };
+    if !head.contains('_') {
+        return false;
+    }
+    let label_start = head
+        .char_indices()
+        .rfind(|(_, ch)| ch.is_ascii_lowercase())
+        .map_or(0, |(index, ch)| index + ch.len_utf8());
+    let label = head[label_start..].trim_start_matches('_');
+    if label.is_empty() {
+        return false;
+    }
+    crate::placeholder::parse_placeholder(&format!("{label}_{hash}")).is_ok()
+}
+
+fn ascii_ends_with_ignore_case(value: &str, suffix: &str) -> bool {
+    value
+        .get(value.len().saturating_sub(suffix.len())..)
+        .is_some_and(|tail| tail.eq_ignore_ascii_case(suffix))
 }
 
 struct Assignment {
@@ -1266,6 +1307,45 @@ mod tests {
             let v = NormalizedView::build(&reg, raw);
             assert!(EntropyDetector::default().detect(&v).is_empty(), "{raw}");
         }
+    }
+
+    #[test]
+    fn masked_environment_references_are_not_entropy_candidates() {
+        for raw in [
+            "$PENTECT_RUNPOD_API_KEY_80fba8fb9b3928a8",
+            "${safe_RUNPOD_API_KEY_80fba8fb9b3928a8}",
+            "$env:mySafeRUNPOD_API_KEY_80fba8fb9b3928a8",
+            "${env:RUNPOD_API_KEY_80fba8fb9b3928a8}",
+            "%RUNPOD_API_KEY_80fba8fb9b3928a8%",
+        ] {
+            let reg = region(raw);
+            let view = NormalizedView::build(&reg, raw);
+            assert!(EntropyDetector::default().detect(&view).is_empty(), "{raw}");
+        }
+    }
+
+    #[test]
+    fn handle_shaped_secret_names_remain_entropy_candidates() {
+        let raw = "ACME_SECRET_TOKEN_0123456789abcdef";
+        assert!(
+            entropy_candidate(raw, raw, 0, raw.len()),
+            "handle-shaped secret was rejected before entropy scoring"
+        );
+        assert!(
+            !is_masked_environment_reference(raw, 0, raw.len(), raw),
+            "a bare value must not be treated as an environment reference"
+        );
+        assert!(!is_encoded_public_metadata_value(raw));
+        assert!(!is_crypto_test_vector_identifier_value(raw));
+        assert!(!is_synthetic_hex_test_vector_value(raw));
+        assert!(!is_api_route_fragment(raw));
+        assert!(!is_release_artifact_identifier(raw));
+        let reg = region(raw);
+        let view = NormalizedView::build(&reg, raw);
+        assert!(
+            !EntropyDetector::default().detect(&view).is_empty(),
+            "{raw}"
+        );
     }
 
     #[test]

--- a/crates/pentect-core/src/detect/entropy.rs
+++ b/crates/pentect-core/src/detect/entropy.rs
@@ -137,11 +137,55 @@ fn is_masked_environment_reference(text: &str, start: usize, end: usize, value: 
     }
     let before = &text[..start];
     let after = &text[end..];
-    before.ends_with('$')
-        || (before.ends_with("${") && after.starts_with('}'))
-        || ascii_ends_with_ignore_case(before, "$env:")
-        || (ascii_ends_with_ignore_case(before, "${env:") && after.starts_with('}'))
-        || (before.ends_with('%') && after.starts_with('%'))
+    if inside_single_quoted_shell_text(before) {
+        return false;
+    }
+    dollar_suffix_is_active(before, "$")
+        || (dollar_suffix_is_active(before, "${") && after.starts_with('}'))
+        || dollar_suffix_is_active_ignore_case(before, "$env:")
+        || (dollar_suffix_is_active_ignore_case(before, "${env:") && after.starts_with('}'))
+}
+
+fn dollar_suffix_is_active(value: &str, suffix: &str) -> bool {
+    value
+        .strip_suffix(suffix)
+        .is_some_and(|prefix| trailing_backslash_count(prefix).is_multiple_of(2))
+}
+
+fn dollar_suffix_is_active_ignore_case(value: &str, suffix: &str) -> bool {
+    value
+        .get(value.len().saturating_sub(suffix.len())..)
+        .filter(|tail| tail.eq_ignore_ascii_case(suffix))
+        .and_then(|_| value.get(..value.len().saturating_sub(suffix.len())))
+        .is_some_and(|prefix| trailing_backslash_count(prefix).is_multiple_of(2))
+}
+
+fn trailing_backslash_count(value: &str) -> usize {
+    value
+        .bytes()
+        .rev()
+        .take_while(|byte| *byte == b'\\')
+        .count()
+}
+
+fn inside_single_quoted_shell_text(value: &str) -> bool {
+    let mut single = false;
+    let mut double = false;
+    let mut escaped = false;
+    for ch in value.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' && !single {
+            escaped = true;
+        } else if ch == '\'' && !double {
+            single = !single;
+        } else if ch == '"' && !single {
+            double = !double;
+        }
+    }
+    single
 }
 
 fn has_masked_reference_shape(value: &str) -> bool {
@@ -160,12 +204,6 @@ fn has_masked_reference_shape(value: &str) -> bool {
         return false;
     }
     crate::placeholder::parse_placeholder(&format!("{label}_{hash}")).is_ok()
-}
-
-fn ascii_ends_with_ignore_case(value: &str, suffix: &str) -> bool {
-    value
-        .get(value.len().saturating_sub(suffix.len())..)
-        .is_some_and(|tail| tail.eq_ignore_ascii_case(suffix))
 }
 
 struct Assignment {
@@ -1316,11 +1354,26 @@ mod tests {
             "${safe_RUNPOD_API_KEY_80fba8fb9b3928a8}",
             "$env:mySafeRUNPOD_API_KEY_80fba8fb9b3928a8",
             "${env:RUNPOD_API_KEY_80fba8fb9b3928a8}",
-            "%RUNPOD_API_KEY_80fba8fb9b3928a8%",
         ] {
             let reg = region(raw);
             let view = NormalizedView::build(&reg, raw);
             assert!(EntropyDetector::default().detect(&view).is_empty(), "{raw}");
+        }
+    }
+
+    #[test]
+    fn non_expanding_environment_like_text_remains_an_entropy_candidate() {
+        for raw in [
+            "'$PENTECT_RUNPOD_API_KEY_80fba8fb9b3928a8'",
+            r"\$PENTECT_RUNPOD_API_KEY_80fba8fb9b3928a8",
+            "%RUNPOD_API_KEY_80fba8fb9b3928a8%",
+        ] {
+            let reg = region(raw);
+            let view = NormalizedView::build(&reg, raw);
+            assert!(
+                !EntropyDetector::default().detect(&view).is_empty(),
+                "{raw}"
+            );
         }
     }
 

--- a/crates/pentect-core/src/detect/entropy.rs
+++ b/crates/pentect-core/src/detect/entropy.rs
@@ -157,7 +157,10 @@ fn dollar_suffix_is_active_ignore_case(value: &str, suffix: &str) -> bool {
         .get(value.len().saturating_sub(suffix.len())..)
         .filter(|tail| tail.eq_ignore_ascii_case(suffix))
         .and_then(|_| value.get(..value.len().saturating_sub(suffix.len())))
-        .is_some_and(|prefix| trailing_backslash_count(prefix).is_multiple_of(2))
+        .is_some_and(|prefix| {
+            trailing_backslash_count(prefix).is_multiple_of(2)
+                && trailing_backtick_count(prefix).is_multiple_of(2)
+        })
 }
 
 fn trailing_backslash_count(value: &str) -> usize {
@@ -166,6 +169,10 @@ fn trailing_backslash_count(value: &str) -> usize {
         .rev()
         .take_while(|byte| *byte == b'\\')
         .count()
+}
+
+fn trailing_backtick_count(value: &str) -> usize {
+    value.bytes().rev().take_while(|byte| *byte == b'`').count()
 }
 
 fn inside_single_quoted_shell_text(value: &str) -> bool {
@@ -1372,6 +1379,18 @@ mod tests {
             let view = NormalizedView::build(&reg, raw);
             assert!(
                 !EntropyDetector::default().detect(&view).is_empty(),
+                "{raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn powershell_backtick_escaped_environment_references_are_not_suppressed() {
+        let value = "PENTECT_RUNPOD_API_KEY_80fba8fb9b3928a8";
+        for raw in [format!("`$env:{value}"), format!("`${{env:{value}}}")] {
+            let start = raw.find(value).unwrap();
+            assert!(
+                !is_masked_environment_reference(&raw, start, start + value.len(), value),
                 "{raw}"
             );
         }

--- a/crates/pentect-core/src/detect/rule.rs
+++ b/crates/pentect-core/src/detect/rule.rs
@@ -65,7 +65,7 @@ impl RuleDetector {
                 "OPENAI_API_KEY",
                 High,
             ),
-            (r"rpa_[A-Za-z0-9]{24,}", Secret, "RUNPOD_API_KEY", High),
+            (r"rpa_[A-Za-z0-9]{24,}", Secret, "SECRET", High),
             (r"hf_[A-Za-z0-9]{30,}", Secret, "HUGGINGFACE_TOKEN", High),
             (r"xox[baprs]-[A-Za-z0-9-]{10,}", Secret, "SLACK_TOKEN", High),
             (
@@ -492,7 +492,7 @@ fn builtin_prefilter(label: &str, pattern: &str) -> Vec<String> {
         "ANTHROPIC_API_KEY" => &["sk-ant-"],
         "OPENAI_API_KEY" if pattern.contains(r"[ \t]+") => &["sk ", "sk\t"],
         "OPENAI_API_KEY" => &["sk-"],
-        "RUNPOD_API_KEY" => &["rpa_"],
+        "SECRET" if pattern.starts_with("rpa_") => &["rpa_"],
         "HUGGINGFACE_TOKEN" => &["hf_"],
         "SLACK_TOKEN" => &["xox"],
         "SLACK_WEBHOOK" => &["hooks.slack.com/services/"],
@@ -596,7 +596,7 @@ mod tests {
             ),
             (
                 concat!("rpa", "_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"),
-                "RUNPOD_API_KEY",
+                "SECRET",
             ),
             (
                 concat!("sk-ant-api03-", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"),

--- a/crates/pentect-core/src/detect/structural.rs
+++ b/crates/pentect-core/src/detect/structural.rs
@@ -76,7 +76,6 @@ impl Detector for EnvValueDetector {
         if region.span.is_empty()
             || region.ctx.format != Kind::Env
             || is_rendered_placeholder(view.text())
-            || is_documentation_placeholder(view.text())
         {
             return vec![];
         }
@@ -1145,8 +1144,8 @@ mod tests {
         ));
         assert_eq!(sensitive_key_fires(Some("cookie-signature"), "1.2.2"), None);
         assert_eq!(sensitive_key_fires(Some("pbkdf2-password"), "^1.0.0"), None);
-        assert!(!env_fires(Some("HIPCHAT_API_KEY"), "your_hipchat_api_key"));
-        assert!(!env_fires(Some("GRAPHITE_USER"), "username"));
-        assert!(!env_fires(Some("LOG_FILE"), "/dev/null"));
+        assert!(env_fires(Some("HIPCHAT_API_KEY"), "your_hipchat_api_key"));
+        assert!(env_fires(Some("GRAPHITE_USER"), "username"));
+        assert!(env_fires(Some("LOG_FILE"), "/dev/null"));
     }
 }

--- a/crates/pentect-core/src/parse/mod.rs
+++ b/crates/pentect-core/src/parse/mod.rs
@@ -98,26 +98,33 @@ fn parse_env_line(raw: &str, start: usize, end: usize) -> Option<(String, ByteRa
     };
     let after_bom = &line[bom..];
     let lead = after_bom.len() - after_bom.trim_start().len();
-    let body = &after_bom[lead..];
+    let mut body_off = bom + lead;
+    let mut body = &line[body_off..];
     if body.is_empty() || body.starts_with('#') {
         return None;
     }
-    // Optional `export ` prefix.
-    let body_off = bom
-        + lead
-        + body
-            .strip_prefix("export ")
-            .map_or(0, |rest| body.len() - rest.len());
-    let after_export = &line[body_off..];
 
-    let eq = after_export.find('=')?;
-    let key = after_export[..eq].trim();
+    // Tolerate common dotenv/shell spellings without making arbitrary prose an
+    // assignment: `export KEY=...`, `set KEY=...`, and `$env:KEY=...`.
+    if let Some(rest) =
+        strip_env_command_prefix(body, "export").or_else(|| strip_env_command_prefix(body, "set"))
+    {
+        body_off += body.len() - rest.len();
+        body = rest;
+    }
+    if let Some(rest) = body.strip_prefix("$env:") {
+        body_off += body.len() - rest.len();
+        body = rest;
+    }
+
+    let (separator, separator_len) = env_separator(body)?;
+    let key = body[..separator].trim();
     if key.is_empty() || !key.chars().all(is_key_char) {
         return None;
     }
 
-    // Value starts after '=' and any spaces/tabs.
-    let val_rel = body_off + eq + 1;
+    // Value starts after the separator and any spaces/tabs.
+    let val_rel = body_off + separator + separator_len;
     let val_part = &line[val_rel..];
     let skip = val_part.len() - val_part.trim_start_matches([' ', '\t']).len();
     let vstart = val_rel + skip;
@@ -134,7 +141,10 @@ fn parse_env_line(raw: &str, start: usize, end: usize) -> Option<(String, ByteRa
             let close = after.find('\'').map_or(after.len(), |i| i);
             (vstart + 1, vstart + 1 + close)
         }
-        _ => (vstart, vstart + value.trim_end().len()),
+        _ => {
+            let comment = inline_env_comment_start(value).unwrap_or(value.len());
+            (vstart, vstart + value[..comment].trim_end().len())
+        }
     };
     if inner_end <= inner_start {
         return None;
@@ -143,6 +153,40 @@ fn parse_env_line(raw: &str, start: usize, end: usize) -> Option<(String, ByteRa
         key.to_string(),
         ByteRange::new(start + inner_start, start + inner_end),
     ))
+}
+
+fn strip_env_command_prefix<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    let rest = value.strip_prefix(prefix)?;
+    let trimmed = rest.trim_start_matches([' ', '\t']);
+    (trimmed.len() < rest.len()).then_some(trimmed)
+}
+
+fn env_separator(value: &str) -> Option<(usize, usize)> {
+    if let Some(eq) = value.find('=') {
+        return Some((eq, 1));
+    }
+    value.char_indices().find_map(|(index, ch)| {
+        if ch != ':' {
+            return None;
+        }
+        value[index + ch.len_utf8()..]
+            .chars()
+            .next()
+            .is_some_and(|next| next == ' ' || next == '\t')
+            .then_some((index, ch.len_utf8()))
+    })
+}
+
+fn inline_env_comment_start(value: &str) -> Option<usize> {
+    value.char_indices().find_map(|(index, ch)| {
+        (ch == '#'
+            && (index == 0
+                || value[..index]
+                    .chars()
+                    .next_back()
+                    .is_some_and(char::is_whitespace)))
+        .then_some(index)
+    })
 }
 
 fn is_key_char(c: char) -> bool {
@@ -197,6 +241,25 @@ mod tests {
         let r = EnvParser.parse(raw).unwrap();
         assert_eq!(r.len(), 1);
         assert_eq!(&raw[r[0].span.start..r[0].span.end], "abc"); // no quotes
+    }
+
+    #[test]
+    fn tolerates_spacing_prefixes_inline_comments_and_colons() {
+        let raw = concat!(
+            "  export\tAPI_KEY = abc=def # keep this comment\r\n",
+            "set LOWER.name='quoted # value' # trailing\n",
+            "$env:PS_TOKEN = xyz#part\n",
+            "ODD_KEY: colon value # trailing\n",
+        );
+        assert_eq!(
+            parsed(raw),
+            [
+                (Some("API_KEY".into()), "abc=def".into()),
+                (Some("LOWER.name".into()), "quoted # value".into()),
+                (Some("PS_TOKEN".into()), "xyz#part".into()),
+                (Some("ODD_KEY".into()), "colon value".into()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -446,7 +446,8 @@ impl Engine {
         }
 
         let merged = merge(to_mask, &ir.protected);
-        let swept = identity_sweep(&ir.raw, merged, &ir.protected, &ir.regions);
+        let mut swept = identity_sweep(&ir.raw, merged, &ir.protected, &ir.regions);
+        relabel_env_spans(&mut swept, &ir.regions);
         (swept, residual)
     }
 
@@ -483,7 +484,8 @@ impl Engine {
         }
 
         let merged = merge(to_mask, &ir.protected);
-        let swept = identity_sweep(&ir.raw, merged, &ir.protected, &ir.regions);
+        let mut swept = identity_sweep(&ir.raw, merged, &ir.protected, &ir.regions);
+        relabel_env_spans(&mut swept, &ir.regions);
         (swept, residual)
     }
 
@@ -538,6 +540,40 @@ impl Engine {
             fell_back,
         )
     }
+}
+
+fn relabel_env_spans(spans: &mut [Span], regions: &[Region]) {
+    for span in spans {
+        let Some(key) = regions.iter().find_map(|region| {
+            (region.ctx.format == Kind::Env && region.span.contains(&span.range))
+                .then_some(region.ctx.key.as_deref())
+                .flatten()
+        }) else {
+            continue;
+        };
+        span.label = env_placeholder_label(key);
+    }
+}
+
+fn env_placeholder_label(key: &str) -> String {
+    let mut label = key
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                ch.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if !label
+        .bytes()
+        .next()
+        .is_some_and(|first| first.is_ascii_uppercase())
+    {
+        label.insert_str(0, "ENV_");
+    }
+    label
 }
 
 fn masked_items(spans: Vec<Span>) -> Vec<MaskedItem> {
@@ -2317,8 +2353,44 @@ mod tests {
         );
         assert!(!r.masked.contains("114514810"), "{}", r.masked);
         assert!(!r.masked.contains("false"), "{}", r.masked);
-        assert!(r.masked.contains("TEST_SECRET=<<SECRET_"), "{}", r.masked);
-        assert!(r.masked.contains("FEATURE_FLAG=<<SECRET_"), "{}", r.masked);
+        assert!(
+            r.masked.contains("TEST_SECRET=<<TEST_SECRET_"),
+            "{}",
+            r.masked
+        );
+        assert!(
+            r.masked.contains("FEATURE_FLAG=<<FEATURE_FLAG_"),
+            "{}",
+            r.masked
+        );
+    }
+
+    #[test]
+    fn env_placeholders_use_each_parsed_key_as_the_label() {
+        let raw = "RUNPOD_API_KEY=rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\nKAGGLE_API_TOKEN=KGAT_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\nrelease.flag=enabled\n9PATCH=value\n";
+        let r = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Env,
+                data: raw.into(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert!(
+            r.masked.contains("RUNPOD_API_KEY=<<RUNPOD_API_KEY_"),
+            "{}",
+            r.masked
+        );
+        assert!(
+            r.masked.contains("KAGGLE_API_TOKEN=<<KAGGLE_API_TOKEN_"),
+            "{}",
+            r.masked
+        );
+        assert!(
+            r.masked.contains("release.flag=<<RELEASE_FLAG_"),
+            "{}",
+            r.masked
+        );
+        assert!(r.masked.contains("9PATCH=<<ENV_9PATCH_"), "{}", r.masked);
     }
 
     #[test]
@@ -2329,7 +2401,7 @@ mod tests {
         assert!(!r
             .masked
             .contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"));
-        assert!(r.masked.contains("<<RUNPOD_API_KEY_"), "{}", r.masked);
+        assert!(r.masked.contains("<<SECRET_"), "{}", r.masked);
     }
 
     #[test]

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -43,6 +43,7 @@ chacha20 = { workspace = true }
 toml = { workspace = true }
 anstream = { workspace = true }
 crossterm = { workspace = true }
+rustyline = { workspace = true }
 portable-pty = { workspace = true }
 zeroize = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/crates/pentect-runtime/src/delegated_process_host.rs
+++ b/crates/pentect-runtime/src/delegated_process_host.rs
@@ -1,14 +1,11 @@
 use crate::memory_store::MemoryStoreClient;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-
-pub(crate) const ENV_ROOT: &str = "PENTECT_PROCESS_HOST_ROOT";
-pub(crate) const ENV_READ_TOKEN: &str = "PENTECT_PROCESS_HOST_READ_TOKEN";
-pub(crate) const ENV_WRITE_TOKEN: &str = "PENTECT_PROCESS_HOST_WRITE_TOKEN";
 
 const RUNTIME_DIR: &str = "runtime";
 const HOST_FILE: &str = "delegated-process-host.json";
@@ -21,6 +18,7 @@ const ELECTION_RETRY: Duration = Duration::from_millis(10);
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct ProcessHostEndpoint {
     pub(crate) addr: String,
+    pub(crate) store_token_hash: String,
     pub(crate) read_token: String,
     pub(crate) write_token: String,
     pub(crate) pid: u32,
@@ -30,6 +28,7 @@ pub(crate) struct ProcessHostEndpoint {
 pub fn register_candidate(
     root: &Path,
     addr: &str,
+    store_token: &str,
     read_token: &str,
     write_token: &str,
     pid: u32,
@@ -46,6 +45,7 @@ pub fn register_candidate(
     };
     let endpoint = ProcessHostEndpoint {
         addr: addr.to_string(),
+        store_token_hash: store_token_hash(store_token),
         read_token: read_token.to_string(),
         write_token: write_token.to_string(),
         pid,
@@ -95,7 +95,7 @@ pub fn unregister_candidate(path: &Path) {
 }
 
 pub(crate) fn send_activity(event_json: &str, share: bool) -> Result<(), String> {
-    send_activity_at(&registry_root(), event_json, share)
+    send_activity_at(&process_host_root()?, event_json, share)
 }
 
 fn send_activity_at(root: &Path, event_json: &str, share: bool) -> Result<(), String> {
@@ -149,11 +149,13 @@ fn broadcast_activity_at(root: &Path, event_json: &str) -> Result<(), String> {
 }
 
 pub(crate) fn reader_endpoint() -> Result<ProcessHostEndpoint, String> {
-    ensure_host_at(&registry_root())
+    ensure_host_at(&process_host_root()?)
 }
 
 pub(crate) fn invalidate_host(endpoint: &ProcessHostEndpoint) {
-    invalidate_host_at(&registry_root(), Some(endpoint));
+    if let Ok(root) = process_host_root() {
+        invalidate_host_at(&root, Some(endpoint));
+    }
 }
 
 pub fn is_running(root: &Path) -> bool {
@@ -167,11 +169,87 @@ pub fn is_host(root: &Path, addr: &str) -> bool {
         .is_some_and(|endpoint| endpoint.addr == addr && endpoint_is_alive(&endpoint))
 }
 
-fn registry_root() -> PathBuf {
-    std::env::var_os(ENV_ROOT)
-        .filter(|value| !value.is_empty())
+/// Environment values are only transport for an already-registered host. Requiring
+/// the complete endpoint prevents one overwritten control variable from redirecting
+/// a child process to an arbitrary listener.
+pub fn matches_host(root: &Path, addr: &str, read_token: &str, write_token: &str) -> bool {
+    let matches = |endpoint: &ProcessHostEndpoint| {
+        endpoint.addr == addr
+            && endpoint.read_token == read_token
+            && endpoint.write_token == write_token
+            && endpoint_is_alive(endpoint)
+    };
+    current_host_at(root)
+        .ok()
+        .flatten()
+        .as_ref()
+        .is_some_and(&matches)
+        || candidates_at(root)
+            .is_ok_and(|candidates| candidates.iter().any(|(endpoint, _)| matches(endpoint)))
+}
+
+pub fn contains_host(root: &Path, addr: &str, store_token: &str) -> bool {
+    let expected_hash = store_token_hash(store_token);
+    let matches = |endpoint: &ProcessHostEndpoint| {
+        endpoint.addr == addr
+            && endpoint.store_token_hash == expected_hash
+            && endpoint_is_alive(endpoint)
+    };
+    current_host_at(root)
+        .ok()
+        .flatten()
+        .as_ref()
+        .is_some_and(&matches)
+        || candidates_at(root)
+            .is_ok_and(|candidates| candidates.iter().any(|(endpoint, _)| matches(endpoint)))
+}
+
+fn store_token_hash(token: &str) -> String {
+    data_encoding::HEXLOWER.encode(&Sha256::digest(token.as_bytes()))
+}
+
+/// Derive the host registry independently in every process. A bearer value in
+/// `PENTECT_PROCESS_HOST_ROOT` must not be able to redirect authentication.
+pub fn process_host_root() -> Result<PathBuf, String> {
+    platform_process_host_root()
+}
+
+#[cfg(windows)]
+fn platform_process_host_root() -> Result<PathBuf, String> {
+    std::env::var_os("LOCALAPPDATA")
+        .or_else(|| {
+            std::env::var_os("USERPROFILE").map(|home| {
+                PathBuf::from(home)
+                    .join("AppData")
+                    .join("Local")
+                    .into_os_string()
+            })
+        })
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."))
+        .map(|root| root.join("pentect"))
+        .ok_or_else(|| "could not locate local application data".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn platform_process_host_root() -> Result<PathBuf, String> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join("Library").join("Caches").join("pentect"))
+        .ok_or_else(|| "could not locate the user cache directory".to_string())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn platform_process_host_root() -> Result<PathBuf, String> {
+    if let Some(root) = std::env::var_os("XDG_RUNTIME_DIR").filter(|v| !v.is_empty()) {
+        return Ok(PathBuf::from(root).join("pentect"));
+    }
+    if let Some(root) = std::env::var_os("XDG_CACHE_HOME").filter(|v| !v.is_empty()) {
+        return Ok(PathBuf::from(root).join("pentect"));
+    }
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join(".cache").join("pentect"))
+        .ok_or_else(|| "could not locate the user cache directory".to_string())
 }
 
 fn ensure_host_at(root: &Path) -> Result<ProcessHostEndpoint, String> {
@@ -403,9 +481,17 @@ mod tests {
             "read-1".to_string(),
             "write-1".to_string(),
         );
-        let first = register_candidate(&root, &first_addr, "read-1", "write-1", 101, false)
-            .unwrap()
-            .unwrap();
+        let first = register_candidate(
+            &root,
+            &first_addr,
+            "memory-1",
+            "read-1",
+            "write-1",
+            101,
+            false,
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(ensure_host_at(&root).unwrap().addr, first_addr);
 
         let second_addr = spawn_test_memory_store_with_activity(
@@ -413,10 +499,21 @@ mod tests {
             "read-2".to_string(),
             "write-2".to_string(),
         );
-        let second = register_candidate(&root, &second_addr, "read-2", "write-2", 202, false)
-            .unwrap()
-            .unwrap();
+        let second = register_candidate(
+            &root,
+            &second_addr,
+            "memory-2",
+            "read-2",
+            "write-2",
+            202,
+            false,
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(ensure_host_at(&root).unwrap().addr, first_addr);
+        assert!(matches_host(&root, &second_addr, "read-2", "write-2"));
+        assert!(contains_host(&root, &second_addr, "memory-2"));
+        assert!(!contains_host(&root, &second_addr, "replaced-memory"));
 
         unregister_candidate(&first);
         assert_eq!(ensure_host_at(&root).unwrap().addr, second_addr);
@@ -433,7 +530,7 @@ mod tests {
             "read".to_string(),
             "write".to_string(),
         );
-        let candidate = register_candidate(&root, &addr, "read", "write", 303, false)
+        let candidate = register_candidate(&root, &addr, "memory", "read", "write", 303, false)
             .unwrap()
             .unwrap();
         let candidate_json = std::fs::read_to_string(&candidate).unwrap();
@@ -455,20 +552,34 @@ mod tests {
             "read-1".to_string(),
             "write-1".to_string(),
         );
-        let first = register_candidate(&root, &first_addr, "read-1", "write-1", 401, true)
-            .unwrap()
-            .unwrap();
+        let first = register_candidate(
+            &root,
+            &first_addr,
+            "memory-1",
+            "read-1",
+            "write-1",
+            401,
+            true,
+        )
+        .unwrap()
+        .unwrap();
         let second_addr = spawn_test_memory_store_with_activity(
             "memory-2".to_string(),
             "read-2".to_string(),
             "write-2".to_string(),
         );
 
-        assert!(
-            register_candidate(&root, &second_addr, "read-2", "write-2", 402, true)
-                .unwrap()
-                .is_none()
-        );
+        assert!(register_candidate(
+            &root,
+            &second_addr,
+            "memory-2",
+            "read-2",
+            "write-2",
+            402,
+            true,
+        )
+        .unwrap()
+        .is_none());
         assert!(persistent_candidate_is_running(&root));
 
         unregister_candidate(&first);
@@ -483,17 +594,33 @@ mod tests {
             "read-1".to_string(),
             "write-1".to_string(),
         );
-        let first = register_candidate(&root, &first_addr, "read-1", "write-1", 501, false)
-            .unwrap()
-            .unwrap();
+        let first = register_candidate(
+            &root,
+            &first_addr,
+            "memory-1",
+            "read-1",
+            "write-1",
+            501,
+            false,
+        )
+        .unwrap()
+        .unwrap();
         let second_addr = spawn_test_memory_store_with_activity(
             "memory-2".to_string(),
             "read-2".to_string(),
             "write-2".to_string(),
         );
-        let second = register_candidate(&root, &second_addr, "read-2", "write-2", 502, false)
-            .unwrap()
-            .unwrap();
+        let second = register_candidate(
+            &root,
+            &second_addr,
+            "memory-2",
+            "read-2",
+            "write-2",
+            502,
+            false,
+        )
+        .unwrap()
+        .unwrap();
         let first_reader = MemoryStoreClient::for_activity(first_addr, "read-1".to_string());
         let second_reader = MemoryStoreClient::for_activity(second_addr, "read-2".to_string());
 

--- a/crates/pentect-runtime/src/extension_adapter.rs
+++ b/crates/pentect-runtime/src/extension_adapter.rs
@@ -161,7 +161,7 @@ impl ModelAdapter {
 
     fn run(&self, request: &str) -> Result<String, String> {
         let cwd = self.path.parent().unwrap_or_else(|| Path::new("."));
-        let program = adapter_program(&self.command[0], cwd);
+        let program = adapter_program(&self.command[0], cwd, &self.id);
         let mut cmd = Command::new(program);
         apply_adapter_child_env(&mut cmd, &self.id)?;
         cmd.args(&self.command[1..])
@@ -346,7 +346,7 @@ fn adapter_default_name(path: &Path) -> String {
         .to_string()
 }
 
-fn adapter_program(program: &str, cwd: &Path) -> PathBuf {
+fn adapter_program(program: &str, cwd: &Path, id: &str) -> PathBuf {
     let path = Path::new(program);
     if path.is_absolute() {
         return path.to_path_buf();
@@ -354,7 +354,23 @@ fn adapter_program(program: &str, cwd: &Path) -> PathBuf {
     if looks_like_path_command(program) {
         return cwd.join(path);
     }
-    adapter_sidecar_program(program).unwrap_or_else(|| path.to_path_buf())
+    installed_extension_program(program, id)
+        .or_else(|| adapter_sidecar_program(program))
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+fn installed_extension_program(program: &str, id: &str) -> Option<PathBuf> {
+    let bin = PathBuf::from(PENTECT_DIR)
+        .join(EXTENSIONS_DATA_DIR)
+        .join(extension_id(id))
+        .join("bin");
+    for name in command_names(program) {
+        let candidate = bin.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 fn looks_like_path_command(program: &str) -> bool {
@@ -691,11 +707,11 @@ command = ["pentect-pii-ner"]
     fn relative_adapter_program_is_resolved_from_adapter_dir() {
         let cwd = Path::new("extensions/pii-ner");
         assert_eq!(
-            adapter_program("./bin/pentect-pii-ner", cwd),
+            adapter_program("./bin/pentect-pii-ner", cwd, "pii-ner"),
             cwd.join("./bin/pentect-pii-ner")
         );
         assert_eq!(
-            adapter_program("pentect-pii-ner", cwd),
+            adapter_program("pentect-pii-ner", cwd, "pii-ner"),
             PathBuf::from("pentect-pii-ner")
         );
     }

--- a/crates/pentect-runtime/src/file_pointer_manager.rs
+++ b/crates/pentect-runtime/src/file_pointer_manager.rs
@@ -28,7 +28,6 @@ const TAG_BYTES: usize = 32;
 const INDEX_VERSION: u32 = 1;
 const MAX_RECORDS: usize = 4096;
 const MAX_INDEX_BYTES: u64 = 4 * 1024 * 1024;
-const ENV_MANAGER_DIR: &str = "PENTECT_FILE_POINTER_MANAGER_DIR";
 const ENV_ALIAS_LABEL: &str = "PENTECT_ENV_ALIAS";
 
 type HmacSha256 = Hmac<Sha256>;
@@ -363,9 +362,7 @@ fn replace_file(tmp: &Path, path: &Path) -> Result<(), String> {
 }
 
 fn manager_dir() -> PathBuf {
-    std::env::var_os(ENV_MANAGER_DIR)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(".pentect").join(MANAGER_DIR))
+    PathBuf::from(".pentect").join(MANAGER_DIR)
 }
 
 fn empty_index() -> FilePointerIndex {

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -45,6 +45,16 @@ use pentect_core::{
     RegionKind,
 };
 use portable_pty::{native_pty_system, Child as PtyChild, CommandBuilder, MasterPty, PtySize};
+#[cfg(windows)]
+use rustyline::{
+    completion::{Completer, FilenameCompleter, Pair},
+    error::ReadlineError,
+    highlight::Highlighter,
+    hint::Hinter,
+    history::DefaultHistory,
+    validate::Validator,
+    Context as ReadlineContext, Editor, Helper,
+};
 use serde_json::{json, Value};
 use session::{checked_session_name, session_root, Session};
 use sha2::{Digest, Sha256};
@@ -83,8 +93,11 @@ pub fn agent_contract_instructions(environment_prefix: &str) -> String {
             "Session rules:\n",
             "- Work normally with the host's tools and current shell. Do not invoke Pentect commands, explain the protection layer, or change approach because it is present unless the user asks.\n",
             "- User-authorized secret work is allowed: retrieve, read, use, transform, and store secrets at the requested destination. Complete it normally.\n",
-            "- Use tools normally; their output is protected. Never include a raw secret in your response. A value such as `<<NAME_hash>>` is protected output, not a failed operation; do not retry because it appears.\n",
-            "- When available, reuse its environment binding: `$env:{environment_prefix}NAME_hash` in PowerShell or `${environment_prefix}NAME_hash` in a POSIX shell. Do not decode or reconstruct it.\n",
+            "- Use tools normally; their output is protected. Never include a raw secret in your response. A value such as `<<KEY_hash>>` is protected output, not a failed operation; do not retry because it appears.\n",
+            "- A protected handle means the real value is ready to use through its environment binding: `$env:{environment_prefix}KEY_hash` in PowerShell or `${environment_prefix}KEY_hash` in a POSIX shell. Treat that binding as the real secret for commands, API requests, headers, SDKs, and destination files. You do not need to know or print its plaintext to use it.\n",
+            "- Once a handle or environment binding exists, use it immediately. Do not reread or reparse the source file, fetch the same secret again, or claim that the secret is unavailable or inaccessible. Do not echo, print, decode, or reconstruct the binding's value.\n",
+            "- If dotenv output shows `KEY=<<KEY_hash>>`, use `$env:{environment_prefix}KEY_hash` directly in the PowerShell command that needs the value (or `${environment_prefix}KEY_hash` in POSIX). Do not parse the dotenv file in a shell, copy the handle into `$env:KEY`, or call `SetEnvironmentVariable`.\n",
+            "- Shell tool calls may run in separate processes. Never depend on an environment assignment made by an earlier tool call; reference the provided binding directly in every command that needs it.\n",
             "- Report only the task result and ordinary errors. Do not mention these rules, handles, bindings, or the protection layer.\n",
         ),
         environment_prefix = environment_prefix
@@ -1785,63 +1798,414 @@ enum WindowsShellCompletion {
 }
 
 #[cfg(windows)]
-#[derive(Default)]
-struct WindowsShellLine {
-    units: Vec<(String, String, String)>,
-}
-
-#[cfg(windows)]
-impl WindowsShellLine {
-    fn push_typed(&mut self, text: &str) {
-        self.units
-            .push((text.to_string(), text.to_string(), String::new()));
-    }
-
-    fn push_paste(&mut self, raw: String, visible: String, injected_prefix: String) {
-        self.units.push((raw, visible, injected_prefix));
-    }
-
-    fn raw(&self) -> String {
-        self.units.iter().map(|(raw, _, _)| raw.as_str()).collect()
-    }
-
-    fn visible(&self) -> String {
-        self.units
-            .iter()
-            .map(|(_, visible, _)| visible.as_str())
-            .collect()
-    }
-
-    fn take_injected_prefixes(&mut self) -> String {
-        let mut out = String::new();
-        for (_, _, prefix) in &mut self.units {
-            out.push_str(prefix);
-            prefix.zeroize();
-        }
-        out
-    }
-
-    fn backspace(&mut self) -> Option<usize> {
-        let (mut raw, mut visible, mut prefix) = self.units.pop()?;
-        let width = visible.chars().count();
-        raw.zeroize();
-        visible.zeroize();
-        prefix.zeroize();
-        Some(width)
-    }
-
-    fn clear(&mut self) {
-        for (raw, visible, prefix) in &mut self.units {
-            raw.zeroize();
-            visible.zeroize();
-            prefix.zeroize();
-        }
-        self.units.clear();
-    }
-}
-
-#[cfg(windows)]
 fn pump_windows_shell_input(
+    child: &mut std::process::Child,
+    child_stdin: &mut std::process::ChildStdin,
+    store: MemoryStore,
+    completion_rx: &mpsc::Receiver<WindowsShellCompletion>,
+    drain_marker: &str,
+) -> Result<ExitStatus, String> {
+    normalize_windows_shell_console_input_mode()?;
+    let display = WindowsShellDisplay::new(store.clone())?;
+    let mut editor = Editor::<WindowsShellDisplay, DefaultHistory>::new()
+        .map_err(|e| format!("could not initialize shell input: {e}"))?;
+    editor.set_helper(Some(display));
+    let history_path = windows_shell_history_path()?;
+    if let Some(parent) = history_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("could not create shell history directory: {e}"))?;
+    }
+    load_windows_powershell_history(&mut editor);
+    if history_path.exists() {
+        let _ = editor.load_history(&history_path);
+    }
+    let mut protector = ShellInputProtector::new(store)?;
+    let mut cwd = std::env::current_dir()
+        .map_err(|e| format!("could not read current directory: {e}"))?
+        .to_string_lossy()
+        .into_owned();
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| format!("could not poll PowerShell: {e}"))?
+        {
+            return Ok(status);
+        }
+        let prompt = format!("PS {}> ", compact_windows_shell_cwd(&cwd));
+        let mut raw = match editor.readline(&prompt) {
+            Ok(line) => line,
+            Err(ReadlineError::Interrupted) => continue,
+            Err(ReadlineError::Eof) => {
+                child
+                    .kill()
+                    .map_err(|e| format!("could not stop PowerShell: {e}"))?;
+                return child
+                    .wait()
+                    .map_err(|e| format!("could not wait for PowerShell: {e}"));
+            }
+            Err(e) => return Err(format!("could not read shell input: {e}")),
+        };
+        if let Some(agent_args) = windows_shell_interactive_agent_args(&raw) {
+            let mut history_probe = protector.prepare_paste(&raw)?;
+            if windows_shell_history_is_safe(&raw, history_probe.changed) {
+                remember_windows_shell_history(&mut editor, &history_path, &raw);
+            }
+            history_probe.child.zeroize();
+            history_probe.injected_prefix.zeroize();
+            let result = run_windows_shell_interactive_agent(&agent_args, &cwd);
+            raw.zeroize();
+            result?;
+            continue;
+        }
+        let mut protected = protector.prepare_paste(&raw)?;
+        if windows_shell_history_is_safe(&raw, protected.changed) {
+            remember_windows_shell_history(&mut editor, &history_path, &raw);
+        }
+        raw.zeroize();
+        let mut encoded = data_encoding::BASE64.encode(protected.child.as_bytes());
+        child_stdin
+            .write_all(encoded.as_bytes())
+            .and_then(|_| child_stdin.write_all(b"\n"))
+            .and_then(|_| child_stdin.flush())
+            .map_err(|e| format!("could not write PowerShell input: {e}"))?;
+        encoded.zeroize();
+        protected.child.zeroize();
+        protected.injected_prefix.zeroize();
+        match wait_for_windows_shell_completion_without_terminal_input(
+            child,
+            child_stdin,
+            completion_rx,
+            drain_marker,
+        )? {
+            Some(next_cwd) => {
+                cwd.zeroize();
+                cwd = next_cwd;
+            }
+            None => {
+                return child
+                    .wait()
+                    .map_err(|e| format!("could not wait for PowerShell: {e}"));
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+fn windows_shell_history_path() -> Result<PathBuf, String> {
+    Ok(process_host_root()?.join("shell-history.txt"))
+}
+
+#[cfg(windows)]
+fn windows_powershell_history_path() -> Option<PathBuf> {
+    std::env::var_os("APPDATA").map(|root| {
+        PathBuf::from(root)
+            .join("Microsoft")
+            .join("Windows")
+            .join("PowerShell")
+            .join("PSReadLine")
+            .join("ConsoleHost_history.txt")
+    })
+}
+
+#[cfg(windows)]
+fn load_windows_powershell_history(editor: &mut Editor<WindowsShellDisplay, DefaultHistory>) {
+    const IMPORT_LIMIT: usize = 100;
+    let Some(path) = windows_powershell_history_path() else {
+        return;
+    };
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let mut recent = contents
+        .lines()
+        .rev()
+        .take(IMPORT_LIMIT)
+        .collect::<Vec<_>>();
+    recent.reverse();
+    for command in recent {
+        if windows_shell_history_is_safe(command, false) {
+            let _ = editor.add_history_entry(command);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn remember_windows_shell_history(
+    editor: &mut Editor<WindowsShellDisplay, DefaultHistory>,
+    path: &Path,
+    command: &str,
+) {
+    if command.trim().is_empty() {
+        return;
+    }
+    if editor.add_history_entry(command).is_ok() {
+        let _ = editor.save_history(path);
+    }
+}
+
+#[cfg(windows)]
+fn windows_shell_history_is_safe(command: &str, protected: bool) -> bool {
+    !protected
+        && likely_shell_secret_range(command).is_none()
+        && !contains_unresolved_masked_handle(command)
+        && !command.to_ascii_lowercase().contains("pentect_")
+}
+
+#[cfg(all(windows, test))]
+fn is_windows_shell_interactive_agent_command(command: &str) -> bool {
+    windows_shell_interactive_agent_args(command).is_some()
+}
+
+#[cfg(windows)]
+fn windows_shell_interactive_agent_args(command: &str) -> Option<Vec<String>> {
+    let trimmed = command.trim();
+    if trimmed.is_empty() || trimmed.contains([';', '|', '&', '\r', '\n']) {
+        return None;
+    }
+    let (program, _, mut cursor) = next_shell_word(trimmed, 0)?;
+    if !matches!(
+        program.to_ascii_lowercase().as_str(),
+        "codex" | "claude" | "opencode"
+    ) {
+        return None;
+    }
+    let mut args = vec![program.to_ascii_lowercase()];
+    while let Some((arg, _, next)) = next_shell_word(trimmed, cursor) {
+        args.push(arg);
+        cursor = next;
+    }
+    Some(args)
+}
+
+#[cfg(windows)]
+fn run_windows_shell_interactive_agent(args: &[String], cwd: &str) -> Result<(), String> {
+    let executable =
+        std::env::current_exe().map_err(|e| format!("could not locate pentect executable: {e}"))?;
+    let mut command = Command::new(executable);
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    command
+        .status()
+        .map_err(|e| format!("could not start interactive agent: {e}"))?;
+    Ok(())
+}
+
+#[cfg(windows)]
+struct WindowsShellDisplay {
+    protector: Mutex<ShellInputProtector>,
+    completer: FilenameCompleter,
+}
+
+#[cfg(windows)]
+impl WindowsShellDisplay {
+    fn new(store: MemoryStore) -> Result<Self, String> {
+        Ok(Self {
+            protector: Mutex::new(ShellInputProtector::new(store)?),
+            completer: FilenameCompleter::new(),
+        })
+    }
+}
+
+#[cfg(windows)]
+impl Completer for WindowsShellDisplay {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        ctx: &ReadlineContext<'_>,
+    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
+        self.completer.complete(line, pos, ctx)
+    }
+}
+
+#[cfg(windows)]
+impl Hinter for WindowsShellDisplay {
+    type Hint = String;
+}
+
+#[cfg(windows)]
+impl Validator for WindowsShellDisplay {}
+
+#[cfg(windows)]
+impl Helper for WindowsShellDisplay {}
+
+#[cfg(windows)]
+impl Highlighter for WindowsShellDisplay {
+    fn highlight<'line>(&self, line: &'line str, _pos: usize) -> std::borrow::Cow<'line, str> {
+        let Ok(mut protector) = self.protector.lock() else {
+            return provisional_shell_secret_display(line)
+                .map(std::borrow::Cow::Owned)
+                .unwrap_or(std::borrow::Cow::Borrowed(line));
+        };
+        let Ok(mut protected) = protector.prepare_paste(line) else {
+            return provisional_shell_secret_display(line)
+                .map(std::borrow::Cow::Owned)
+                .unwrap_or(std::borrow::Cow::Borrowed(line));
+        };
+        if !protected.changed {
+            return provisional_shell_secret_display(line)
+                .map(std::borrow::Cow::Owned)
+                .unwrap_or(std::borrow::Cow::Borrowed(line));
+        }
+        let visible = canonical_shell_secret_display(line, &protected.visible)
+            .unwrap_or_else(|| protected.visible.clone());
+        let display = shell_display_with_same_width(line, &visible);
+        protected.child.zeroize();
+        protected.injected_prefix.zeroize();
+        std::borrow::Cow::Owned(display)
+    }
+
+    fn highlight_char(
+        &self,
+        _line: &str,
+        _pos: usize,
+        _kind: rustyline::highlight::CmdKind,
+    ) -> bool {
+        true
+    }
+}
+
+#[cfg(windows)]
+fn canonical_shell_secret_display(raw: &str, protected: &str) -> Option<String> {
+    let (start, end) = likely_shell_secret_range(raw)?;
+    let env_start = protected.find("$env:PENTECT_")?;
+    let env_end = protected[env_start..]
+        .bytes()
+        .position(|byte| !is_env_name_byte(byte) && byte != b'$' && byte != b':')
+        .map(|offset| env_start + offset)
+        .unwrap_or(protected.len());
+    let mut display = String::new();
+    display.push_str(&raw[..start]);
+    display.push_str(&protected[env_start..env_end]);
+    display.push_str(&raw[end..]);
+    Some(display)
+}
+
+#[cfg(windows)]
+fn provisional_shell_secret_display(raw: &str) -> Option<String> {
+    let (start, end) = likely_shell_secret_range(raw)?;
+    let mut display = raw.to_string();
+    display.replace_range(start..end, &"•".repeat(raw[start..end].chars().count()));
+    Some(display)
+}
+
+fn likely_shell_secret_range(text: &str) -> Option<(usize, usize)> {
+    const PREFIXES: &[&str] = &[
+        "rpa_",
+        "KGAT_",
+        "sk-",
+        "ghp_",
+        "github_pat_",
+        "xoxb-",
+        "AKIA",
+    ];
+    let start = PREFIXES
+        .iter()
+        .filter_map(|prefix| text.find(prefix))
+        .min()?;
+    let mut end = start;
+    for (offset, ch) in text[start..].char_indices() {
+        if offset > 0
+            && (ch.is_whitespace() || matches!(ch, '\'' | '"' | ';' | '|' | ')' | ']' | '}'))
+        {
+            break;
+        }
+        end = start + offset + ch.len_utf8();
+    }
+    Some((start, end))
+}
+
+#[cfg(windows)]
+fn shell_display_with_same_width(raw: &str, protected: &str) -> String {
+    let raw_chars = raw.chars().count();
+    let protected_chars = protected.chars().count();
+    if protected_chars <= raw_chars {
+        let mut display = protected.to_string();
+        display.extend(std::iter::repeat_n(' ', raw_chars - protected_chars));
+        return display;
+    }
+    if raw_chars == 0 {
+        return String::new();
+    }
+    let mut display = protected
+        .chars()
+        .take(raw_chars.saturating_sub(1))
+        .collect::<String>();
+    display.push('…');
+    display
+}
+
+#[cfg(windows)]
+fn normalize_windows_shell_console_input_mode() -> Result<(), String> {
+    use windows_sys::Win32::System::Console::{
+        GetConsoleMode, GetStdHandle, SetConsoleMode, STD_INPUT_HANDLE,
+    };
+
+    let handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+    let mut current = 0;
+    if unsafe { GetConsoleMode(handle, &mut current) } == 0 {
+        return Ok(());
+    }
+    let sane = windows_shell_sane_input_mode(current);
+    if sane != current && unsafe { SetConsoleMode(handle, sane) } == 0 {
+        return Err("could not restore the Windows console input mode".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn windows_shell_sane_input_mode(current: u32) -> u32 {
+    use windows_sys::Win32::System::Console::{
+        ENABLE_ECHO_INPUT, ENABLE_EXTENDED_FLAGS, ENABLE_LINE_INPUT, ENABLE_MOUSE_INPUT,
+        ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT,
+    };
+
+    (current & !(ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_MOUSE_INPUT))
+        | ENABLE_PROCESSED_INPUT
+        | ENABLE_LINE_INPUT
+        | ENABLE_ECHO_INPUT
+        | ENABLE_EXTENDED_FLAGS
+}
+
+#[cfg(windows)]
+fn wait_for_windows_shell_completion_without_terminal_input(
+    child: &mut std::process::Child,
+    child_stdin: &mut std::process::ChildStdin,
+    completion_rx: &mpsc::Receiver<WindowsShellCompletion>,
+    drain_marker: &str,
+) -> Result<Option<String>, String> {
+    loop {
+        match completion_rx.recv_timeout(Duration::from_millis(50)) {
+            Ok(WindowsShellCompletion::DrainInput) => {
+                child_stdin
+                    .write_all(drain_marker.as_bytes())
+                    .and_then(|_| child_stdin.write_all(b"\r\n"))
+                    .and_then(|_| child_stdin.flush())
+                    .map_err(|e| format!("could not drain PowerShell input: {e}"))?;
+            }
+            Ok(WindowsShellCompletion::Complete(cwd)) => return Ok(Some(cwd)),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if child
+                    .try_wait()
+                    .map_err(|e| format!("could not poll PowerShell: {e}"))?
+                    .is_some()
+                {
+                    return Ok(None);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => return Ok(None),
+        }
+    }
+}
+
+#[cfg(any())]
+fn pump_windows_shell_input_legacy(
     child: &mut std::process::Child,
     child_stdin: &mut std::process::ChildStdin,
     store: MemoryStore,
@@ -1987,8 +2351,8 @@ fn pump_windows_shell_input(
     }
 }
 
-#[cfg(windows)]
-fn wait_for_windows_shell_completion(
+#[cfg(any())]
+fn wait_for_windows_shell_completion_legacy(
     child: &mut std::process::Child,
     child_stdin: &mut std::process::ChildStdin,
     completion_rx: &mpsc::Receiver<WindowsShellCompletion>,
@@ -2028,13 +2392,13 @@ fn wait_for_windows_shell_completion(
     }
 }
 
-#[cfg(windows)]
+#[cfg(any())]
 #[derive(Default)]
 struct WindowsRunningInput {
     pending: String,
 }
 
-#[cfg(windows)]
+#[cfg(any())]
 impl WindowsRunningInput {
     fn clear(&mut self) {
         self.pending.zeroize();
@@ -2067,7 +2431,7 @@ impl WindowsRunningInput {
     }
 }
 
-#[cfg(windows)]
+#[cfg(any())]
 fn forward_windows_running_input(
     event: crossterm::event::Event,
     child_stdin: &mut dyn Write,
@@ -2106,7 +2470,7 @@ fn forward_windows_running_input(
     }
 }
 
-#[cfg(windows)]
+#[cfg(any())]
 fn print_windows_shell_prompt(cwd: &str) -> Result<(), String> {
     let display = compact_windows_shell_cwd(cwd);
     print!("PS {display}> ");
@@ -2137,15 +2501,15 @@ fn compact_windows_shell_cwd_with_home(cwd: &str, home: &str) -> String {
         .unwrap_or_else(|| cwd.to_string())
 }
 
-#[cfg(windows)]
+#[cfg(any())]
 fn single_line_shell_display(text: &str) -> String {
     text.replace("\r\n", " ↵ ").replace(['\r', '\n'], " ↵ ")
 }
 
-#[cfg(windows)]
+#[cfg(any())]
 struct BracketedPasteGuard;
 
-#[cfg(windows)]
+#[cfg(any())]
 impl BracketedPasteGuard {
     fn enable() -> Result<Self, String> {
         crossterm::execute!(std::io::stdout(), crossterm::event::EnableBracketedPaste)
@@ -2154,7 +2518,7 @@ impl BracketedPasteGuard {
     }
 }
 
-#[cfg(windows)]
+#[cfg(any())]
 impl Drop for BracketedPasteGuard {
     fn drop(&mut self) {
         let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableBracketedPaste);
@@ -2974,20 +3338,25 @@ impl ShellInputProtector {
 
     fn prepare_paste(&mut self, text: &str) -> Result<ProtectedPaste, String> {
         let masked = self.masker.mask_text(text, live_output_kind(text))?;
-        let (visible, bindings) = replace_masked_handles_with_env_refs(
+        let (mut visible, mut bindings) = replace_masked_handles_with_env_refs(
             &masked,
             &self.store,
             self.syntax,
             self.masker.environment_prefix(),
         )?;
-        if bindings.is_empty() {
-            return Ok(ProtectedPaste {
-                child: text.to_string(),
-                visible: text.to_string(),
-                changed: false,
-                injected_prefix: String::new(),
-            });
+        if bindings.len() == 1 {
+            if let Some((start, end)) = likely_shell_secret_range(text) {
+                bindings[0].value.zeroize();
+                bindings[0].value.push_str(&text[start..end]);
+                let env_ref = self.syntax.env_ref(&bindings[0].name);
+                visible.clear();
+                visible.push_str(&text[..start]);
+                visible.push_str(&env_ref);
+                visible.push_str(&text[end..]);
+            }
         }
+        let replaced_secret = !bindings.is_empty();
+        let command_text = if replaced_secret { &visible } else { text };
         let mut child = String::new();
         let mut injected_prefix = String::new();
         for mut binding in bindings {
@@ -2998,14 +3367,37 @@ impl ShellInputProtector {
             }
             binding.value.zeroize();
         }
-        child.push_str(&visible);
+        let referenced = referenced_env_names_in_text(command_text);
+        if !referenced.is_empty() {
+            for (name, mut value) in self.store.auto_env_bindings().map_err(|e| e.to_string())? {
+                if referenced.contains(&name.to_ascii_lowercase())
+                    && self.defined_env.insert(name.clone())
+                {
+                    let assignment = self.syntax.env_assignment(&name, &value);
+                    injected_prefix.push_str(&assignment);
+                    child.push_str(&assignment);
+                }
+                value.zeroize();
+            }
+        }
+        child.push_str(command_text);
         Ok(ProtectedPaste {
             child,
-            visible,
-            changed: true,
+            visible: command_text.to_string(),
+            changed: replaced_secret || !injected_prefix.is_empty(),
             injected_prefix,
         })
     }
+}
+
+fn referenced_env_names_in_text(text: &str) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    collect_powershell_env_refs(text, &mut names);
+    collect_powershell_env_provider_refs(text, &mut names);
+    collect_printenv_refs(text, &mut names);
+    collect_percent_env_refs(text, &mut names);
+    collect_bare_dollar_env_refs(text, &mut names);
+    names
 }
 
 #[derive(Clone, Copy)]
@@ -3032,7 +3424,9 @@ impl ShellSyntax {
 
     fn env_assignment(self, name: &str, value: &str) -> String {
         match self {
-            Self::PowerShell => format!("$env:{name}={}; ", powershell_word(value)),
+            Self::PowerShell => {
+                format!("$env:{name}={}; ", powershell_string_literal(value))
+            }
             Self::Posix => format!("export {name}={}; ", shell_quote_unix(value)),
         }
     }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -833,9 +833,16 @@ fn cmd_agent_stream(args: &[String]) -> i32 {
         Ok(masker) => masker,
         Err(error) => return die(&error),
     };
-    if let Err(error) = stream_masked_reader(&mut masker, std::io::stdin(), opts.target)
-        .and_then(|_| masker.flush())
-    {
+    let stream_result = match opts.end_marker.as_deref() {
+        Some(marker) => stream_masked_reader_until_marker(
+            &mut masker,
+            std::io::stdin(),
+            opts.target,
+            marker.as_bytes(),
+        ),
+        None => stream_masked_reader(&mut masker, std::io::stdin(), opts.target),
+    };
+    if let Err(error) = stream_result.and_then(|_| masker.flush()) {
         return die(&error);
     }
     0
@@ -1610,6 +1617,7 @@ fn run_masked_shell(store: MemoryStore, opts: &ShellOpts) -> Result<i32, String>
 #[cfg(windows)]
 const WINDOWS_SHELL_HOST_SCRIPT: &str = concat!(
     "$marker=$env:PENTECT_SHELL_COMMAND_MARKER;",
+    "$drain=$env:PENTECT_SHELL_DRAIN_MARKER;",
     "while (($line=[Console]::In.ReadLine()) -ne $null) {",
     "try {",
     "$text=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($line));",
@@ -1617,6 +1625,8 @@ const WINDOWS_SHELL_HOST_SCRIPT: &str = concat!(
     "} catch {",
     "$message=$_ | Out-String;[Console]::Out.WriteLine($message)",
     "};",
+    "[Console]::Out.WriteLine($marker+'DRAIN');[Console]::Out.Flush();",
+    "while (($pending=[Console]::In.ReadLine()) -ne $null -and $pending -ne $drain) {}",
     "$cwd=[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes((Get-Location).Path));",
     "[Console]::Out.WriteLine($marker+$cwd);[Console]::Out.Flush()",
     "}"
@@ -1629,6 +1639,7 @@ fn run_masked_windows_powershell(
     shim: &ShellShimDir,
 ) -> Result<i32, String> {
     let marker = windows_shell_marker()?;
+    let drain_marker = windows_shell_marker()?;
     let mut command = Command::new(windows_powershell_path());
     command
         .arg("-NoLogo")
@@ -1639,6 +1650,7 @@ fn run_masked_windows_powershell(
     apply_child_env_overlays(&mut command, &[], &opts.session);
     apply_active_memory_store_env(&mut command);
     command.env("PENTECT_SHELL_COMMAND_MARKER", &marker);
+    command.env("PENTECT_SHELL_DRAIN_MARKER", &drain_marker);
     shim.apply_to_command(&mut command);
     command
         .stdin(Stdio::piped())
@@ -1671,7 +1683,13 @@ fn run_masked_windows_powershell(
         stream_masked_reader(&mut masker, stderr, StreamTarget::Stderr)?;
         masker.flush()
     });
-    let status = pump_windows_shell_input(&mut child, &mut child_stdin, store, &completion_rx)?;
+    let status = pump_windows_shell_input(
+        &mut child,
+        &mut child_stdin,
+        store,
+        &completion_rx,
+        &drain_marker,
+    )?;
     drop(child_stdin);
     join_stream_thread(stdout_thread)?;
     join_stream_thread(stderr_thread)?;
@@ -1694,7 +1712,7 @@ fn stream_windows_shell_stdout(
     store: MemoryStore,
     stdout: std::process::ChildStdout,
     marker: &str,
-    completion_tx: mpsc::Sender<String>,
+    completion_tx: mpsc::Sender<WindowsShellCompletion>,
 ) -> Result<(), String> {
     let mut reader = BufReader::new(stdout);
     let mut masker = OutputMasker::new_deferred(store)?;
@@ -1719,12 +1737,24 @@ fn stream_windows_shell_stdout(
                 )?;
             }
             let encoded = line[start + marker.len()..].trim_end_matches(['\r', '\n']);
+            if encoded == "DRAIN" {
+                if completion_tx
+                    .send(WindowsShellCompletion::DrainInput)
+                    .is_err()
+                {
+                    break;
+                }
+                continue;
+            }
             let cwd = data_encoding::BASE64
                 .decode(encoded.as_bytes())
                 .ok()
                 .and_then(|bytes| String::from_utf8(bytes).ok())
                 .ok_or_else(|| "PowerShell returned an invalid working directory".to_string())?;
-            if completion_tx.send(cwd).is_err() {
+            if completion_tx
+                .send(WindowsShellCompletion::Complete(cwd))
+                .is_err()
+            {
                 break;
             }
             continue;
@@ -1733,6 +1763,12 @@ fn stream_windows_shell_stdout(
         flush_masked_chunk(&mut masker, StreamTarget::Stdout, &mut line, kind)?;
     }
     masker.flush()
+}
+
+#[cfg(windows)]
+enum WindowsShellCompletion {
+    DrainInput,
+    Complete(String),
 }
 
 #[cfg(windows)]
@@ -1929,7 +1965,8 @@ fn pump_windows_shell_input(
     child: &mut std::process::Child,
     child_stdin: &mut std::process::ChildStdin,
     store: MemoryStore,
-    completion_rx: &mpsc::Receiver<String>,
+    completion_rx: &mpsc::Receiver<WindowsShellCompletion>,
+    drain_marker: &str,
 ) -> Result<ExitStatus, String> {
     let _raw = RawModeGuard::enable()?;
     let _paste = BracketedPasteGuard::enable()?;
@@ -2012,8 +2049,12 @@ fn pump_windows_shell_input(
                         child_command.zeroize();
                         paste.child.zeroize();
                         paste.injected_prefix.zeroize();
-                        match wait_for_windows_shell_completion(child, child_stdin, completion_rx)?
-                        {
+                        match wait_for_windows_shell_completion(
+                            child,
+                            child_stdin,
+                            completion_rx,
+                            drain_marker,
+                        )? {
                             Some(next_cwd) => {
                                 cwd.zeroize();
                                 cwd = next_cwd;
@@ -2106,11 +2147,22 @@ fn pump_windows_shell_input(
 fn wait_for_windows_shell_completion(
     child: &mut std::process::Child,
     child_stdin: &mut std::process::ChildStdin,
-    completion_rx: &mpsc::Receiver<String>,
+    completion_rx: &mpsc::Receiver<WindowsShellCompletion>,
+    drain_marker: &str,
 ) -> Result<Option<String>, String> {
+    let mut input = WindowsRunningInput::default();
     loop {
         match completion_rx.try_recv() {
-            Ok(cwd) => return Ok(Some(cwd)),
+            Ok(WindowsShellCompletion::DrainInput) => {
+                input.clear();
+                child_stdin
+                    .write_all(b"\r\n")
+                    .and_then(|_| child_stdin.write_all(drain_marker.as_bytes()))
+                    .and_then(|_| child_stdin.write_all(b"\r\n"))
+                    .and_then(|_| child_stdin.flush())
+                    .map_err(|e| format!("could not drain PowerShell input: {e}"))?;
+            }
+            Ok(WindowsShellCompletion::Complete(cwd)) => return Ok(Some(cwd)),
             Err(mpsc::TryRecvError::Empty) => {
                 if child
                     .try_wait()
@@ -2127,8 +2179,47 @@ fn wait_for_windows_shell_completion(
         {
             let event = crossterm::event::read()
                 .map_err(|e| format!("could not read terminal input: {e}"))?;
-            forward_windows_running_input(event, child_stdin)?;
+            forward_windows_running_input(event, child_stdin, &mut input)?;
         }
+    }
+}
+
+#[cfg(windows)]
+#[derive(Default)]
+struct WindowsRunningInput {
+    pending: String,
+}
+
+#[cfg(windows)]
+impl WindowsRunningInput {
+    fn clear(&mut self) {
+        self.pending.zeroize();
+        self.pending.clear();
+    }
+
+    fn submit(&mut self, child_stdin: &mut dyn Write) -> Result<(), String> {
+        child_stdin
+            .write_all(self.pending.as_bytes())
+            .and_then(|_| child_stdin.write_all(b"\r\n"))
+            .and_then(|_| child_stdin.flush())
+            .map_err(|e| format!("could not write PowerShell input: {e}"))?;
+        self.clear();
+        Ok(())
+    }
+
+    fn paste(&mut self, text: &str, child_stdin: &mut dyn Write) -> Result<(), String> {
+        let mut chars = text.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if matches!(ch, '\r' | '\n') {
+                if ch == '\r' && chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                self.submit(child_stdin)?;
+            } else {
+                self.pending.push(ch);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -2136,62 +2227,39 @@ fn wait_for_windows_shell_completion(
 fn forward_windows_running_input(
     event: crossterm::event::Event,
     child_stdin: &mut dyn Write,
+    input: &mut WindowsRunningInput,
 ) -> Result<(), String> {
     use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 
-    let bytes = match event {
-        Event::Paste(text) => text.into_bytes(),
+    match event {
+        Event::Paste(text) => input.paste(&text, child_stdin),
         Event::Key(event) if matches!(event.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
             match event.code {
-                KeyCode::Char(ch) if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    let lower = ch.to_ascii_lowercase();
-                    if lower.is_ascii_alphabetic()
-                        || matches!(lower, '@' | '[' | '\\' | ']' | '^' | '_')
-                    {
-                        vec![(lower.to_ascii_uppercase() as u8) & 0x1f]
-                    } else {
-                        Vec::new()
-                    }
+                KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {
+                    input.clear();
+                    child_stdin
+                        .write_all(&[0x03])
+                        .and_then(|_| child_stdin.flush())
+                        .map_err(|e| format!("could not write PowerShell input: {e}"))
                 }
                 KeyCode::Char(ch) => {
-                    let mut encoded = [0u8; 4];
-                    let text = ch.encode_utf8(&mut encoded);
-                    if event.modifiers.contains(KeyModifiers::ALT) {
-                        let mut bytes = Vec::with_capacity(text.len() + 1);
-                        bytes.push(0x1b);
-                        bytes.extend_from_slice(text.as_bytes());
-                        bytes
-                    } else {
-                        text.as_bytes().to_vec()
-                    }
+                    input.pending.push(ch);
+                    Ok(())
                 }
-                KeyCode::Enter => b"\r\n".to_vec(),
-                KeyCode::Backspace => vec![0x08],
-                KeyCode::Tab => vec![0x09],
-                KeyCode::BackTab => b"\x1b[Z".to_vec(),
-                KeyCode::Esc => vec![0x1b],
-                KeyCode::Left => b"\x1b[D".to_vec(),
-                KeyCode::Right => b"\x1b[C".to_vec(),
-                KeyCode::Up => b"\x1b[A".to_vec(),
-                KeyCode::Down => b"\x1b[B".to_vec(),
-                KeyCode::Home => b"\x1b[H".to_vec(),
-                KeyCode::End => b"\x1b[F".to_vec(),
-                KeyCode::Delete => b"\x1b[3~".to_vec(),
-                KeyCode::Insert => b"\x1b[2~".to_vec(),
-                KeyCode::PageUp => b"\x1b[5~".to_vec(),
-                KeyCode::PageDown => b"\x1b[6~".to_vec(),
-                _ => Vec::new(),
+                KeyCode::Enter => input.submit(child_stdin),
+                KeyCode::Backspace => {
+                    input.pending.pop();
+                    Ok(())
+                }
+                KeyCode::Tab => {
+                    input.pending.push('\t');
+                    Ok(())
+                }
+                _ => Ok(()),
             }
         }
-        _ => Vec::new(),
-    };
-    if bytes.is_empty() {
-        return Ok(());
+        _ => Ok(()),
     }
-    child_stdin
-        .write_all(&bytes)
-        .and_then(|_| child_stdin.flush())
-        .map_err(|e| format!("could not write PowerShell input: {e}"))
 }
 
 #[cfg(windows)]
@@ -3472,7 +3540,27 @@ fn stream_masked_reader<R: Read>(
     reader: R,
     target: StreamTarget,
 ) -> Result<(), String> {
-    let mut reader = BufReader::new(reader);
+    stream_masked_bufread(masker, BufReader::new(reader), target, None)
+}
+
+fn stream_masked_reader_until_marker<R: Read>(
+    masker: &mut OutputMasker,
+    reader: R,
+    target: StreamTarget,
+    end_marker: &[u8],
+) -> Result<(), String> {
+    if end_marker.is_empty() {
+        return Err("agent stream end marker is invalid".to_string());
+    }
+    stream_masked_bufread(masker, BufReader::new(reader), target, Some(end_marker))
+}
+
+fn stream_masked_bufread<R: BufRead>(
+    masker: &mut OutputMasker,
+    mut reader: R,
+    target: StreamTarget,
+    end_marker: Option<&[u8]>,
+) -> Result<(), String> {
     let mut buf = Vec::new();
     let mut chunk = String::new();
     let mut chunk_kind: Option<Kind> = None;
@@ -3485,7 +3573,15 @@ fn stream_masked_reader<R: Read>(
         if n == 0 {
             break;
         }
-        let text = String::from_utf8_lossy(&buf);
+        let marker_position = end_marker.and_then(|marker| {
+            buf.windows(marker.len())
+                .position(|window| window == marker)
+        });
+        let visible = marker_position.map_or(buf.as_slice(), |position| &buf[..position]);
+        let text = String::from_utf8_lossy(visible);
+        if text.is_empty() && marker_position.is_some() {
+            break;
+        }
         let line_kind = live_output_kind(&text);
         if !chunk.is_empty() && chunk_kind.as_ref() != Some(&line_kind) {
             flush_masked_chunk(masker, target, &mut chunk, chunk_kind.take().unwrap())?;
@@ -3497,6 +3593,9 @@ fn stream_masked_reader<R: Read>(
         if chunk.len() >= LIVE_MASK_CHUNK_BYTES || chunk_lines >= LIVE_MASK_CHUNK_LINES {
             flush_masked_chunk(masker, target, &mut chunk, chunk_kind.take().unwrap())?;
             chunk_lines = 0;
+        }
+        if marker_position.is_some() {
+            break;
         }
     }
     if let Some(kind) = chunk_kind {
@@ -4043,6 +4142,7 @@ struct AgentScriptOpts {
 struct AgentStreamOpts {
     session: String,
     target: StreamTarget,
+    end_marker: Option<String>,
 }
 
 enum ResolveMode {
@@ -4080,6 +4180,7 @@ impl AgentStreamOpts {
     fn parse(args: &[String]) -> Result<Self, String> {
         let mut session = default_session_name()?;
         let mut target = StreamTarget::Stdout;
+        let mut end_marker = None;
         let mut i = 2;
         while i < args.len() {
             match args[i].as_str() {
@@ -4091,10 +4192,26 @@ impl AgentStreamOpts {
                     target = StreamTarget::Stderr;
                     i += 1;
                 }
+                "--end-marker" => {
+                    let marker = value(args, &mut i, "--end-marker")?;
+                    if marker.len() < 32
+                        || marker.len() > 128
+                        || !marker
+                            .bytes()
+                            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+                    {
+                        return Err("agent stream end marker is invalid".to_string());
+                    }
+                    end_marker = Some(marker);
+                }
                 flag => return Err(format!("unknown option: {flag}")),
             }
         }
-        Ok(Self { session, target })
+        Ok(Self {
+            session,
+            target,
+            end_marker,
+        })
     }
 }
 
@@ -5406,22 +5523,20 @@ fn same_shell_agent_wrapper(
         .filter(|value| value.bytes().all(|byte| byte.is_ascii_hexdigit()))
         .ok_or_else(|| "agent script id is invalid".to_string())?;
     let mut script_args = vec!["__agent-script".to_string(), id.to_string()];
-    let mut stream_args = vec!["__agent-stream".to_string()];
+    let end_marker = format!("__PENTECT_STREAM_END_{id}__");
+    let mut stream_args = vec![
+        "__agent-stream".to_string(),
+        "--end-marker".to_string(),
+        end_marker.clone(),
+    ];
     add_non_default_session(&mut script_args, session_name);
     add_non_default_session(&mut stream_args, session_name);
     match shell {
         ScriptShell::Bash => Ok(bash_same_shell_wrapper(
             suffix,
+            &end_marker,
             &target_shell_pentect_command(shell, &script_args),
             &target_shell_pentect_command(shell, &stream_args),
-            &target_shell_pentect_command(
-                shell,
-                &stream_args
-                    .iter()
-                    .cloned()
-                    .chain(std::iter::once("--stderr".to_string()))
-                    .collect::<Vec<_>>(),
-            ),
         )),
         ScriptShell::PowerShell => Ok(powershell_same_shell_wrapper(
             suffix,
@@ -5437,7 +5552,10 @@ fn target_shell_pentect_command(shell: ScriptShell, args: &[String]) -> String {
         ScriptShell::Bash => shell_quote_unix,
         ScriptShell::PowerShell | ScriptShell::Native => powershell_word,
     };
-    let mut command = String::from("pentect");
+    let mut command = match shell {
+        ScriptShell::Bash => String::from("\"${PENTECT_BIN}\""),
+        ScriptShell::PowerShell | ScriptShell::Native => String::from("& $env:PENTECT_BIN"),
+    };
     for arg in args {
         command.push(' ');
         command.push_str(&quote(arg));
@@ -5447,19 +5565,18 @@ fn target_shell_pentect_command(shell: ScriptShell, args: &[String]) -> String {
 
 fn bash_same_shell_wrapper(
     suffix: &str,
+    end_marker: &str,
     script_command: &str,
-    stdout_command: &str,
-    stderr_command: &str,
+    stream_command: &str,
 ) -> String {
-    let out_fd = format!("_pentect_out_fd_{suffix}");
-    let err_fd = format!("_pentect_err_fd_{suffix}");
-    let out_pid = format!("_pentect_out_pid_{suffix}");
-    let err_pid = format!("_pentect_err_pid_{suffix}");
+    let stream_fd = format!("_pentect_stream_fd_{suffix}");
+    let stream_pid = format!("_pentect_stream_pid_{suffix}");
     let status = format!("_pentect_status_{suffix}");
-    let out_status = format!("_pentect_out_status_{suffix}");
-    let err_status = format!("_pentect_err_status_{suffix}");
+    let stream_status = format!("_pentect_stream_status_{suffix}");
+    let script = format!("_pentect_script_{suffix}");
     format!(
-        "exec {{{out_fd}}}> >({stdout_command}); {out_pid}=$!; exec {{{err_fd}}}> >({stderr_command}); {err_pid}=$!; (eval \"$({script_command})\") 1>&${out_fd} 2>&${err_fd}; {status}=$?; exec {{{out_fd}}}>&-; exec {{{err_fd}}}>&-; wait \"${out_pid}\"; {out_status}=$?; wait \"${err_pid}\"; {err_status}=$?; if [ \"${status}\" -eq 0 ] && [ \"${out_status}\" -ne 0 ]; then {status}=${out_status}; fi; if [ \"${status}\" -eq 0 ] && [ \"${err_status}\" -ne 0 ]; then {status}=${err_status}; fi; (exit \"${status}\")"
+        "(exec {{{stream_fd}}}> >({stream_command}); {stream_pid}=$!; exec 1>/dev/null 2>/dev/null; {script}=\"$({script_command} 2>&${stream_fd})\"; {status}=$?; if [ \"${status}\" -eq 0 ]; then eval \"${script}\" 1>&${stream_fd} 2>&${stream_fd}; {status}=$?; fi; unset {script}; printf '%s\\n' {marker} >&${stream_fd}; exec {{{stream_fd}}}>&-; wait \"${stream_pid}\"; {stream_status}=$?; if [ \"${status}\" -eq 0 ] && [ \"${stream_status}\" -ne 0 ]; then {status}=${stream_status}; fi; exit \"${status}\")",
+        marker = shell_quote_unix(end_marker),
     )
 }
 

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -35,7 +35,8 @@ use masking::{
 use masking::{first_reusable_env_name, mask_live_output, mask_tool_output};
 pub use memory_store::{
     active_memory_store_ready, is_pentect_control_env_name, memory_store_ready,
-    open_memory_store_lease, pentect_control_env_names, MemoryStoreLease,
+    open_memory_store_lease, pentect_control_env_names, start_in_process_memory_store,
+    InProcessMemoryStore, MemoryStoreLease,
 };
 use memory_store::{MemoryStore, MemoryStoreClient, ENV_ADDR, ENV_TOKEN};
 pub use output_remask::ActiveTerminalOutputRemasker;
@@ -47,7 +48,7 @@ use portable_pty::{native_pty_system, Child as PtyChild, CommandBuilder, MasterP
 use serde_json::{json, Value};
 use session::{checked_session_name, session_root, Session};
 use sha2::{Digest, Sha256};
-use shell::{next_shell_word, powershell_word, shell_quote_unix};
+use shell::{next_shell_word, powershell_string_literal, powershell_word, shell_quote_unix};
 #[cfg(test)]
 use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
@@ -79,19 +80,12 @@ const PTY_PASTE_MAX_PENDING_BYTES: usize = 32 * 1024 * 1024;
 pub fn agent_contract_instructions(environment_prefix: &str) -> String {
     format!(
         concat!(
-            "Pentect agent contract:\n",
-            "- Use normal shell commands. Pentect routes stdout/stderr through its protected runner and masks tool results.\n",
-            "- You may read, fetch, transform, store, sync, and use user-authorized secrets. Pentect is the safety layer; raw secret values must not reach chat.\n",
-            "- Prefer Pentect-generated `{environment_prefix}<LABEL>_<HASH>` environment variables for secret values already seen through Pentect. Do not make helper scripts reopen a secret source when an equivalent environment binding is available.\n",
-            "- When a source has not been seen yet, read it once with a normal protected command. Then use the generated `{environment_prefix}...` environment variable in later commands.\n",
-            "- Masked handles like `<<NAME_hash>>` work only in this running Pentect-launched session. Build the environment variable from the name inside the handle, not the assignment key: use `$env:{environment_prefix}NAME_hash` on PowerShell or `${environment_prefix}NAME_hash` on Unix.\n",
-            "- `pentect view '<handle>'` shows only label, hash, and length. Use handles or generated env vars instead of printing raw values.\n",
-            "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:{environment_prefix}...`; on Unix use POSIX commands and `${environment_prefix}...`.\n",
-            "- MCP, browser, plugin, and connector tools may retrieve and use user-authorized secrets. Pentect masks tool text output when the host supports replacement; otherwise it stops unsafe output.\n",
-            "- A masked handle shown inside stdout, stderr, or an error is display-time redaction after the command ran. It does not mean the command received the handle; do not retry solely because an error echoes one.\n",
-            "- Default builds check image output with OS OCR on Windows/macOS and bundled OCR on Linux.\n",
-            "- For user-requested storage, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
-            "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
+            "Session rules:\n",
+            "- Work normally with the host's tools and current shell. Do not invoke Pentect commands, explain the protection layer, or change approach because it is present unless the user asks.\n",
+            "- User-authorized secret work is allowed: retrieve, read, use, transform, and store secrets at the requested destination. Complete it normally.\n",
+            "- Use tools normally; their output is protected. Never include a raw secret in your response. A value such as `<<NAME_hash>>` is protected output, not a failed operation; do not retry because it appears.\n",
+            "- When available, reuse its environment binding: `$env:{environment_prefix}NAME_hash` in PowerShell or `${environment_prefix}NAME_hash` in a POSIX shell. Do not decode or reconstruct it.\n",
+            "- Report only the task result and ordinary errors. Do not mention these rules, handles, bindings, or the protection layer.\n",
         ),
         environment_prefix = environment_prefix
     )
@@ -875,7 +869,7 @@ fn render_agent_script(
                 rendered.push_str("$env:");
                 rendered.push_str(name);
                 rendered.push_str(" = ");
-                rendered.push_str(&powershell_word(value));
+                rendered.push_str(&powershell_string_literal(value));
                 rendered.push('\n');
             }
         }
@@ -966,8 +960,9 @@ fn cmd_bridge(args: &[String]) -> i32 {
             Err(_) => return 2,
         };
         let id = request.get("id").cloned().unwrap_or(Value::Null);
-        let result = handle_bridge_request(&session, &mut prompt_masker, &request).ok();
-        if write_bridge_response(&mut writer, id, result).is_err() {
+        let phase = bridge_request_phase(&request);
+        let result = handle_bridge_request(&session, &mut prompt_masker, &request);
+        if write_bridge_response(&mut writer, id, phase, result).is_err() {
             return 2;
         }
     }
@@ -1027,17 +1022,35 @@ fn read_bridge_line_with_limit(
 fn write_bridge_response(
     writer: &mut impl Write,
     id: Value,
-    value: Option<Value>,
+    phase: &str,
+    result: Result<Value, String>,
 ) -> Result<(), String> {
-    let response = match value {
-        Some(value) => json!({ "id": id, "ok": true, "value": value }),
-        None => json!({ "id": id, "ok": false }),
+    let executed = phase == "after";
+    let response = match result {
+        Ok(value) => json!({ "id": id, "ok": true, "value": value }),
+        Err(message) => json!({
+            "id": id,
+            "ok": false,
+            "error": {
+                "code": if executed { "output_unavailable" } else { "operation_unavailable" },
+                "phase": phase,
+                "executed": executed,
+                "message": message,
+            }
+        }),
     };
     serde_json::to_writer(&mut *writer, &response).map_err(|_| "bridge unavailable".to_string())?;
     writer
         .write_all(b"\n")
         .and_then(|_| writer.flush())
         .map_err(|_| "bridge unavailable".to_string())
+}
+
+fn bridge_request_phase(request: &Value) -> &str {
+    match request.get("op").and_then(Value::as_str) {
+        Some(phase @ ("session" | "prompt" | "media" | "before" | "after")) => phase,
+        _ => "request",
+    }
 }
 
 fn handle_bridge_request(
@@ -1070,7 +1083,7 @@ fn handle_bridge_request(
                 .ok_or_else(|| "invalid bridge request".to_string())?;
             match claude_image_tool_output(session, value)? {
                 Some(ToolTextOutput::Updated(updated)) => Ok(updated),
-                Some(ToolTextOutput::Block(_)) => Err("media unavailable".to_string()),
+                Some(ToolTextOutput::Block(reason)) => Err(reason),
                 Some(ToolTextOutput::Unchanged) | None => Ok(value.clone()),
             }
         }
@@ -1105,7 +1118,7 @@ fn handle_bridge_request(
             match mask_tool_text_output(HookProvider::Claude, session, value)? {
                 ToolTextOutput::Unchanged => Ok(value.clone()),
                 ToolTextOutput::Updated(updated) => Ok(updated),
-                ToolTextOutput::Block(_) => Err("output unavailable".to_string()),
+                ToolTextOutput::Block(reason) => Err(reason),
             }
         }
         _ => Err("invalid bridge request".to_string()),
@@ -1775,23 +1788,17 @@ enum WindowsShellCompletion {
 #[derive(Default)]
 struct WindowsShellLine {
     units: Vec<(String, String, String)>,
-    cursor: usize,
 }
 
 #[cfg(windows)]
 impl WindowsShellLine {
     fn push_typed(&mut self, text: &str) {
-        self.units.insert(
-            self.cursor,
-            (text.to_string(), text.to_string(), String::new()),
-        );
-        self.cursor += 1;
+        self.units
+            .push((text.to_string(), text.to_string(), String::new()));
     }
 
     fn push_paste(&mut self, raw: String, visible: String, injected_prefix: String) {
-        self.units
-            .insert(self.cursor, (raw, visible, injected_prefix));
-        self.cursor += 1;
+        self.units.push((raw, visible, injected_prefix));
     }
 
     fn raw(&self) -> String {
@@ -1805,57 +1812,6 @@ impl WindowsShellLine {
             .collect()
     }
 
-    fn visible_before_cursor(&self) -> String {
-        self.units[..self.cursor]
-            .iter()
-            .map(|(_, visible, _)| visible.as_str())
-            .collect()
-    }
-
-    fn contains_protected_paste(&self) -> bool {
-        self.units.iter().any(|(_, _, prefix)| !prefix.is_empty())
-    }
-
-    fn replace_with_raw(&mut self, raw: &str) {
-        self.clear();
-        for ch in raw.chars() {
-            let mut encoded = [0u8; 4];
-            self.push_typed(ch.encode_utf8(&mut encoded));
-        }
-    }
-
-    fn move_left(&mut self) -> bool {
-        if self.cursor == 0 {
-            return false;
-        }
-        self.cursor -= 1;
-        true
-    }
-
-    fn move_right(&mut self) -> bool {
-        if self.cursor >= self.units.len() {
-            return false;
-        }
-        self.cursor += 1;
-        true
-    }
-
-    fn move_home(&mut self) -> bool {
-        if self.cursor == 0 {
-            return false;
-        }
-        self.cursor = 0;
-        true
-    }
-
-    fn move_end(&mut self) -> bool {
-        if self.cursor == self.units.len() {
-            return false;
-        }
-        self.cursor = self.units.len();
-        true
-    }
-
     fn take_injected_prefixes(&mut self) -> String {
         let mut out = String::new();
         for (_, _, prefix) in &mut self.units {
@@ -1865,27 +1821,13 @@ impl WindowsShellLine {
         out
     }
 
-    fn backspace(&mut self) -> bool {
-        if self.cursor == 0 {
-            return false;
-        }
-        self.cursor -= 1;
-        let (mut raw, mut visible, mut prefix) = self.units.remove(self.cursor);
+    fn backspace(&mut self) -> Option<usize> {
+        let (mut raw, mut visible, mut prefix) = self.units.pop()?;
+        let width = visible.chars().count();
         raw.zeroize();
         visible.zeroize();
         prefix.zeroize();
-        true
-    }
-
-    fn delete(&mut self) -> bool {
-        if self.cursor >= self.units.len() {
-            return false;
-        }
-        let (mut raw, mut visible, mut prefix) = self.units.remove(self.cursor);
-        raw.zeroize();
-        visible.zeroize();
-        prefix.zeroize();
-        true
+        Some(width)
     }
 
     fn clear(&mut self) {
@@ -1895,68 +1837,6 @@ impl WindowsShellLine {
             prefix.zeroize();
         }
         self.units.clear();
-        self.cursor = 0;
-    }
-}
-
-#[cfg(windows)]
-#[derive(Default)]
-struct WindowsShellHistory {
-    entries: Vec<Zeroizing<String>>,
-    index: Option<usize>,
-    draft: Zeroizing<String>,
-}
-
-#[cfg(windows)]
-impl WindowsShellHistory {
-    fn record(&mut self, command: &str, sensitive: bool) {
-        self.index = None;
-        self.draft.zeroize();
-        if sensitive || command.trim().is_empty() || command.contains(['\r', '\n']) {
-            return;
-        }
-        if self
-            .entries
-            .last()
-            .is_some_and(|entry| entry.as_str() == command)
-        {
-            return;
-        }
-        self.entries.push(Zeroizing::new(command.to_string()));
-        if self.entries.len() > 100 {
-            self.entries.remove(0);
-        }
-    }
-
-    fn previous(&mut self, current: &str) -> Option<String> {
-        if self.entries.is_empty() {
-            return None;
-        }
-        let next = match self.index {
-            Some(index) => index.saturating_sub(1),
-            None => {
-                self.draft.zeroize();
-                self.draft.push_str(current);
-                self.entries.len() - 1
-            }
-        };
-        self.index = Some(next);
-        Some(self.entries[next].to_string())
-    }
-
-    fn next(&mut self) -> Option<String> {
-        let index = self.index?;
-        if index + 1 < self.entries.len() {
-            self.index = Some(index + 1);
-            return Some(self.entries[index + 1].to_string());
-        }
-        self.index = None;
-        Some(self.draft.to_string())
-    }
-
-    fn edited(&mut self) {
-        self.index = None;
-        self.draft.zeroize();
     }
 }
 
@@ -1976,8 +1856,6 @@ fn pump_windows_shell_input(
         .to_string_lossy()
         .into_owned();
     let mut line = WindowsShellLine::default();
-    let mut history = WindowsShellHistory::default();
-    print_windows_shell_welcome()?;
     print_windows_shell_prompt(&cwd)?;
     loop {
         if let Some(status) = child
@@ -2003,7 +1881,6 @@ fn pump_windows_shell_input(
                 match event.code {
                     KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                         line.clear();
-                        history.edited();
                         print!("^C\r\n");
                         print_windows_shell_prompt(&cwd)?;
                     }
@@ -2014,7 +1891,11 @@ fn pump_windows_shell_input(
                             crossterm::cursor::MoveTo(0, 0)
                         )
                         .map_err(|e| format!("could not clear shell display: {e}"))?;
-                        redraw_windows_shell_line(&cwd, &line)?;
+                        print_windows_shell_prompt(&cwd)?;
+                        print!("{}", line.visible());
+                        std::io::stdout()
+                            .flush()
+                            .map_err(|e| format!("could not render shell input: {e}"))?;
                     }
                     KeyCode::Char('d')
                         if event.modifiers.contains(KeyModifiers::CONTROL)
@@ -2034,7 +1915,6 @@ fn pump_windows_shell_input(
                             .flush()
                             .map_err(|e| format!("could not render shell input: {e}"))?;
                         let mut paste = protector.prepare_paste(&raw)?;
-                        history.record(&raw, paste.changed);
                         raw.zeroize();
                         let mut child_command = line.take_injected_prefixes();
                         child_command.push_str(&paste.child);
@@ -2071,58 +1951,19 @@ fn pump_windows_shell_input(
                         let mut encoded = [0u8; 4];
                         let text = ch.encode_utf8(&mut encoded);
                         line.push_typed(text);
-                        history.edited();
-                        redraw_windows_shell_line(&cwd, &line)?;
+                        print!("{text}");
+                        std::io::stdout()
+                            .flush()
+                            .map_err(|e| format!("could not render shell input: {e}"))?;
                     }
                     KeyCode::Backspace => {
-                        if line.backspace() {
-                            history.edited();
-                            redraw_windows_shell_line(&cwd, &line)?;
-                        }
-                    }
-                    KeyCode::Delete => {
-                        if line.delete() {
-                            history.edited();
-                            redraw_windows_shell_line(&cwd, &line)?;
-                        }
-                    }
-                    KeyCode::Left => {
-                        if line.move_left() {
-                            redraw_windows_shell_line(&cwd, &line)?;
-                        }
-                    }
-                    KeyCode::Right => {
-                        if line.move_right() {
-                            redraw_windows_shell_line(&cwd, &line)?;
-                        }
-                    }
-                    KeyCode::Home => {
-                        if line.move_home() {
-                            redraw_windows_shell_line(&cwd, &line)?;
-                        }
-                    }
-                    KeyCode::End => {
-                        if line.move_end() {
-                            redraw_windows_shell_line(&cwd, &line)?;
-                        }
-                    }
-                    KeyCode::Up => {
-                        if !line.contains_protected_paste() {
-                            let mut current = line.raw();
-                            let previous = history.previous(&current);
-                            current.zeroize();
-                            if let Some(mut command) = previous {
-                                line.replace_with_raw(&command);
-                                command.zeroize();
-                                redraw_windows_shell_line(&cwd, &line)?;
+                        if let Some(width) = line.backspace() {
+                            for _ in 0..width {
+                                print!("\x08 \x08");
                             }
-                        }
-                    }
-                    KeyCode::Down => {
-                        if let Some(mut command) = history.next() {
-                            line.replace_with_raw(&command);
-                            command.zeroize();
-                            redraw_windows_shell_line(&cwd, &line)?;
+                            std::io::stdout()
+                                .flush()
+                                .map_err(|e| format!("could not render shell input: {e}"))?;
                         }
                     }
                     _ => {}
@@ -2130,13 +1971,16 @@ fn pump_windows_shell_input(
             }
             crossterm::event::Event::Paste(mut text) => {
                 let paste = protector.prepare_paste(&text)?;
+                let visible = single_line_shell_display(&paste.visible);
                 line.push_paste(
                     std::mem::take(&mut text),
-                    single_line_shell_display(&paste.visible),
+                    visible.clone(),
                     paste.injected_prefix,
                 );
-                history.edited();
-                redraw_windows_shell_line(&cwd, &line)?;
+                print!("{visible}");
+                std::io::stdout()
+                    .flush()
+                    .map_err(|e| format!("could not render pasted input: {e}"))?;
             }
             _ => {}
         }
@@ -2265,46 +2109,10 @@ fn forward_windows_running_input(
 #[cfg(windows)]
 fn print_windows_shell_prompt(cwd: &str) -> Result<(), String> {
     let display = compact_windows_shell_cwd(cwd);
-    use crossterm::style::{Attribute, Color, Print, ResetColor, SetAttribute, SetForegroundColor};
-    crossterm::queue!(
-        std::io::stdout(),
-        Print("PS "),
-        SetForegroundColor(Color::Cyan),
-        Print(&display),
-        ResetColor,
-        Print(" "),
-        SetForegroundColor(Color::Green),
-        SetAttribute(Attribute::Bold),
-        Print("›"),
-        SetAttribute(Attribute::Reset),
-        ResetColor,
-        Print(" ")
-    )
-    .map_err(|e| format!("could not render shell prompt: {e}"))?;
+    print!("PS {display}> ");
     std::io::stdout()
         .flush()
         .map_err(|e| format!("could not render shell prompt: {e}"))
-}
-
-#[cfg(windows)]
-fn print_windows_shell_welcome() -> Result<(), String> {
-    use crossterm::style::{Attribute, Color, Print, ResetColor, SetAttribute, SetForegroundColor};
-    crossterm::queue!(
-        std::io::stdout(),
-        SetForegroundColor(Color::Cyan),
-        SetAttribute(Attribute::Bold),
-        Print("pentect shell"),
-        SetAttribute(Attribute::Reset),
-        ResetColor,
-        Print("  ·  protected PowerShell\r\n"),
-        SetForegroundColor(Color::DarkGrey),
-        Print("↑↓ history  ←→ edit  Ctrl+C clear  Ctrl+D exit\r\n"),
-        ResetColor
-    )
-    .map_err(|e| format!("could not render shell welcome: {e}"))?;
-    std::io::stdout()
-        .flush()
-        .map_err(|e| format!("could not render shell welcome: {e}"))
 }
 
 #[cfg(windows)]
@@ -2327,38 +2135,6 @@ fn compact_windows_shell_cwd_with_home(cwd: &str, home: &str) -> String {
         })
         .map(|tail| format!("~{tail}"))
         .unwrap_or_else(|| cwd.to_string())
-}
-
-#[cfg(windows)]
-fn redraw_windows_shell_line(cwd: &str, line: &WindowsShellLine) -> Result<(), String> {
-    use crossterm::cursor::MoveToColumn;
-    use crossterm::style::Print;
-    use crossterm::terminal::{Clear, ClearType};
-
-    crossterm::queue!(
-        std::io::stdout(),
-        MoveToColumn(0),
-        Clear(ClearType::CurrentLine)
-    )
-    .map_err(|e| format!("could not redraw shell input: {e}"))?;
-    print_windows_shell_prompt(cwd)?;
-    crossterm::queue!(std::io::stdout(), Print(line.visible()))
-        .map_err(|e| format!("could not redraw shell input: {e}"))?;
-    let prompt_width = windows_shell_prompt_width(cwd);
-    let input_width = line.visible_before_cursor().chars().count();
-    let column = prompt_width
-        .saturating_add(input_width)
-        .min(u16::MAX as usize) as u16;
-    crossterm::queue!(std::io::stdout(), MoveToColumn(column))
-        .map_err(|e| format!("could not position shell cursor: {e}"))?;
-    std::io::stdout()
-        .flush()
-        .map_err(|e| format!("could not redraw shell input: {e}"))
-}
-
-#[cfg(windows)]
-fn windows_shell_prompt_width(cwd: &str) -> usize {
-    6 + compact_windows_shell_cwd(cwd).chars().count()
 }
 
 #[cfg(windows)]
@@ -4558,26 +4334,28 @@ fn before_tool_updated_input(
         }
     }
     validate_masked_write_before_tool(session, tool_name, tool_input)?;
-    if let Some(command) = tool_input.get("command").and_then(Value::as_str) {
-        if let Some(reason) = pentect_human_only_command_reason(command) {
-            return Err(reason);
-        }
-        if codex_exec_proxy_should_own_shell_tool(provider) {
-            return Ok((tool_input.clone(), false));
-        }
-        let command = canonical_hook_shell_command(command)?;
-        let mut updated = tool_input.clone();
-        if let Some(object) = updated.as_object_mut() {
-            object.insert(
-                "command".to_string(),
-                Value::String(wrap_shell_command(
-                    provider,
-                    session_name,
-                    tool_name,
-                    &command,
-                )?),
-            );
-            return Ok((updated, true));
+    if is_shell_tool_name(tool_name) {
+        if let Some(command) = tool_input.get("command").and_then(Value::as_str) {
+            if let Some(reason) = pentect_human_only_command_reason(command) {
+                return Err(reason);
+            }
+            if codex_exec_proxy_should_own_shell_tool(provider) {
+                return Ok((tool_input.clone(), false));
+            }
+            let command = canonical_hook_shell_command(command)?;
+            let mut updated = tool_input.clone();
+            if let Some(object) = updated.as_object_mut() {
+                object.insert(
+                    "command".to_string(),
+                    Value::String(wrap_shell_command(
+                        provider,
+                        session_name,
+                        tool_name,
+                        &command,
+                    )?),
+                );
+                return Ok((updated, true));
+            }
         }
     }
     Ok((tool_input.clone(), false))
@@ -4605,26 +4383,28 @@ fn before_tool_updated_input_lazy(
         }
         validate_masked_write_before_tool(&session, tool_name, tool_input)?;
     }
-    if let Some(command) = tool_input.get("command").and_then(Value::as_str) {
-        if let Some(reason) = pentect_human_only_command_reason(command) {
-            return Err(reason);
-        }
-        if codex_exec_proxy_should_own_shell_tool(provider) {
-            return Ok((tool_input.clone(), false));
-        }
-        let command = canonical_hook_shell_command(command)?;
-        let mut updated = tool_input.clone();
-        if let Some(object) = updated.as_object_mut() {
-            object.insert(
-                "command".to_string(),
-                Value::String(wrap_shell_command(
-                    provider,
-                    session_name,
-                    tool_name,
-                    &command,
-                )?),
-            );
-            return Ok((updated, true));
+    if is_shell_tool_name(tool_name) {
+        if let Some(command) = tool_input.get("command").and_then(Value::as_str) {
+            if let Some(reason) = pentect_human_only_command_reason(command) {
+                return Err(reason);
+            }
+            if codex_exec_proxy_should_own_shell_tool(provider) {
+                return Ok((tool_input.clone(), false));
+            }
+            let command = canonical_hook_shell_command(command)?;
+            let mut updated = tool_input.clone();
+            if let Some(object) = updated.as_object_mut() {
+                object.insert(
+                    "command".to_string(),
+                    Value::String(wrap_shell_command(
+                        provider,
+                        session_name,
+                        tool_name,
+                        &command,
+                    )?),
+                );
+                return Ok((updated, true));
+            }
         }
     }
     Ok((tool_input.clone(), false))
@@ -4668,7 +4448,7 @@ fn codex_exec_proxy_owns_shell_output(provider: HookProvider, tool_name: &str) -
 fn is_shell_tool_name(tool_name: &str) -> bool {
     matches!(
         tool_name.to_ascii_lowercase().as_str(),
-        "bash" | "shell" | "exec" | "run_command"
+        "bash" | "powershell" | "powershell_command" | "shell" | "exec" | "run_command"
     )
 }
 
@@ -5540,8 +5320,7 @@ fn same_shell_agent_wrapper(
         )),
         ScriptShell::PowerShell => Ok(powershell_same_shell_wrapper(
             suffix,
-            &target_shell_pentect_command(shell, &script_args),
-            &target_shell_pentect_command(shell, &stream_args),
+            &powershell_agent_script_fetch(suffix, id),
         )),
         ScriptShell::Native => Err("same-shell wrapper requires a known shell".to_string()),
     }
@@ -5554,7 +5333,7 @@ fn target_shell_pentect_command(shell: ScriptShell, args: &[String]) -> String {
     };
     let mut command = match shell {
         ScriptShell::Bash => String::from("\"${PENTECT_BIN}\""),
-        ScriptShell::PowerShell | ScriptShell::Native => String::from("& $env:PENTECT_BIN"),
+        ScriptShell::PowerShell | ScriptShell::Native => String::from("$env:PENTECT_BIN"),
     };
     for arg in args {
         command.push(' ');
@@ -5579,17 +5358,28 @@ fn bash_same_shell_wrapper(
     )
 }
 
-fn powershell_same_shell_wrapper(
-    suffix: &str,
-    script_command: &str,
-    stream_command: &str,
-) -> String {
+fn powershell_same_shell_wrapper(suffix: &str, script_command: &str) -> String {
     let script = format!("__pentect_script_{suffix}");
     let status = format!("__pentect_status_{suffix}");
-    let final_status = format!("__pentect_final_status_{suffix}");
-    let stream_status = format!("__pentect_stream_status_{suffix}");
+    let success = format!("__pentect_success_{suffix}");
+    let native_status = format!("__pentect_native_status_{suffix}");
     format!(
-        "${script} = (& {script_command} | Out-String); if ($LASTEXITCODE -ne 0) {{ exit $LASTEXITCODE }}; $global:{status} = 0; ${script} += \"`n`$global:{status} = if (`$?) {{ 0 }} elseif (`$LASTEXITCODE -is [int] -and `$LASTEXITCODE -ne 0) {{ `$LASTEXITCODE }} else {{ 1 }}\"; & {{ try {{ Invoke-Expression ${script} }} catch {{ Write-Error -ErrorRecord $_; $global:{status} = 1 }} }} 2>&1 | Out-String -Stream | & {stream_command}; ${stream_status} = $LASTEXITCODE; ${script} = $null; if ($global:{status} -eq 0 -and ${stream_status} -ne 0) {{ $global:{status} = ${stream_status} }}; ${final_status} = $global:{status}; Remove-Variable {status} -Scope Global -ErrorAction SilentlyContinue; exit ${final_status}"
+        "${script} = (& {script_command} | Out-String); ${status} = 0; try {{ $global:LASTEXITCODE = 0; Invoke-Expression ${script}; ${success} = $?; ${native_status} = $LASTEXITCODE; if (${native_status} -is [int] -and ${native_status} -ne 0) {{ ${status} = ${native_status} }} elseif (-not ${success}) {{ ${status} = 1 }} }} catch {{ Write-Error -ErrorRecord $_; ${status} = 1 }}; ${script} = $null; if (${status} -ne 0) {{ exit ${status} }}"
+    )
+}
+
+fn powershell_agent_script_fetch(suffix: &str, id: &str) -> String {
+    format!(
+        "{{ ${client} = [System.Net.Sockets.TcpClient]::new(); ${reader} = $null; ${writer} = $null; try {{ ${address} = $env:PENTECT_MEMORY_STORE_ADDR -split ':', 2; if (${address}.Count -ne 2) {{ throw 'session unavailable' }}; ${client}.Connect(${address}[0], [int]${address}[1]); ${stream} = ${client}.GetStream(); ${writer} = [System.IO.StreamWriter]::new(${stream}, [System.Text.UTF8Encoding]::new($false), 1024, $true); ${reader} = [System.IO.StreamReader]::new(${stream}, [System.Text.Encoding]::UTF8, $false, 1024, $true); ${writer}.NewLine = \"`n\"; ${writer}.WriteLine(\"$env:PENTECT_MEMORY_STORE_TOKEN`tSCRIPT_RENDER`t{id}\"); ${writer}.Flush(); ${response} = ${reader}.ReadLine(); ${fields} = ${response} -split \"`t\", 2; if (${fields}.Count -ne 2 -or ${fields}[0] -ne 'OK') {{ throw 'script unavailable' }}; ${decoded} = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(${fields}[1])); ${separator} = ${decoded}.IndexOf([char]0); if (${separator} -lt 0) {{ throw 'script unavailable' }}; ${decoded}.Substring(${separator} + 1) }} finally {{ if (${reader}) {{ ${reader}.Dispose() }}; if (${writer}) {{ ${writer}.Dispose() }}; ${client}.Dispose(); ${response} = $null; ${fields} = $null; ${decoded} = $null }} }}",
+        client = format!("__pentect_client_{suffix}"),
+        reader = format!("__pentect_reader_{suffix}"),
+        writer = format!("__pentect_writer_{suffix}"),
+        address = format!("__pentect_address_{suffix}"),
+        stream = format!("__pentect_network_{suffix}"),
+        response = format!("__pentect_response_{suffix}"),
+        fields = format!("__pentect_fields_{suffix}"),
+        decoded = format!("__pentect_decoded_{suffix}"),
+        separator = format!("__pentect_separator_{suffix}"),
     )
 }
 
@@ -5698,7 +5488,10 @@ fn after_tool_output(provider: HookProvider, updated_output: Value) -> Value {
         }),
         HookProvider::Codex => json!({
             "decision": "block",
-            "reason": stringify_tool_output(&updated_output)
+            "reason": format!(
+                "Tool completed. Protected output:\n{}",
+                stringify_tool_output(&updated_output)
+            )
         }),
     }
 }
@@ -5706,7 +5499,9 @@ fn after_tool_output(provider: HookProvider, updated_output: Value) -> Value {
 fn after_tool_block_output(_provider: HookProvider, reason: &str) -> Value {
     json!({
         "decision": "block",
-        "reason": reason
+        "reason": format!(
+            "Tool completed, but its output was unavailable. Check side effects before retrying.\n{reason}"
+        )
     })
 }
 
@@ -5791,7 +5586,7 @@ fn append_image_mask_notes(mut value: Value, notes: &[String]) -> Value {
     if notes.is_empty() {
         return value;
     }
-    let text = format!("Pentect image masks\n{}", notes.join("\n"));
+    let text = format!("Masked regions\n{}", notes.join("\n"));
     if append_text_block_to_content(&mut value, &text) {
         return value;
     }
@@ -5882,18 +5677,7 @@ fn image_tool_result_block_reason(
 
 fn unsupported_tool_result_reason(value: &Value) -> Option<String> {
     if contains_unsupported_media_result(value) {
-        return Some(
-            "Pentect blocked non-text media output because media masking is not active yet."
-                .to_string(),
-        );
-    }
-    // TODO(side-effect-audit): replace this with explicit secret side-effect tracking
-    // for clipboard/download/GUI-save destinations when those surfaces exist.
-    if contains_unobserved_side_effect_result(value) {
-        return Some(
-            "Pentect blocked clipboard/download output because that side effect bypasses the hook boundary."
-                .to_string(),
-        );
+        return Some("Media output unavailable because it could not be inspected.".to_string());
     }
     None
 }
@@ -5908,19 +5692,6 @@ fn contains_unsupported_media_result(value: &Value) -> bool {
             key_marks_media_value(&key, item)
                 || string_media_field(&key, item)
                 || contains_unsupported_media_result(item)
-        }),
-    }
-}
-
-fn contains_unobserved_side_effect_result(value: &Value) -> bool {
-    match value {
-        Value::String(_) | Value::Number(_) | Value::Bool(_) | Value::Null => false,
-        Value::Array(items) => items.iter().any(contains_unobserved_side_effect_result),
-        Value::Object(map) => map.iter().any(|(key, item)| {
-            let key = normalized_json_key(key);
-            key_marks_unobserved_side_effect(&key, item)
-                || string_side_effect_field(&key, item)
-                || contains_unobserved_side_effect_result(item)
         }),
     }
 }
@@ -5958,32 +5729,6 @@ fn looks_like_media_reference(text: &str) -> bool {
 fn is_unsupported_media_mime(text: &str) -> bool {
     let value = text.trim().to_ascii_lowercase();
     value.starts_with("audio/") || value.starts_with("video/") || value == "application/pdf"
-}
-
-fn key_marks_unobserved_side_effect(key: &str, value: &Value) -> bool {
-    matches!(
-        key,
-        "clipboard"
-            | "clipboardtext"
-            | "clipboardcontent"
-            | "download"
-            | "downloadpath"
-            | "downloadurl"
-            | "downloadedfile"
-            | "savedfile"
-            | "savedpath"
-    ) && !empty_json_value(value)
-}
-
-fn string_side_effect_field(key: &str, value: &Value) -> bool {
-    let Some(text) = value.as_str() else {
-        return false;
-    };
-    matches!(key, "type" | "kind")
-        && matches!(
-            normalized_json_key(text).as_str(),
-            "clipboard" | "download" | "guisave" | "savedfile"
-        )
 }
 
 fn empty_json_value(value: &Value) -> bool {

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -5574,7 +5574,7 @@ fn bash_same_shell_wrapper(
     let stream_status = format!("_pentect_stream_status_{suffix}");
     let script = format!("_pentect_script_{suffix}");
     format!(
-        "(exec 9> >({stream_command}); {stream_pid}=$!; exec 1>/dev/null 2>/dev/null; {script}=\"$({script_command} 2>&9)\"; {status}=$?; if [ \"${status}\" -eq 0 ]; then eval \"${script}\" 1>&9 2>&9; {status}=$?; fi; unset {script}; printf '%s\\n' {marker} >&9; exec 9>&-; wait \"${stream_pid}\"; {stream_status}=$?; if [ \"${status}\" -eq 0 ] && [ \"${stream_status}\" -ne 0 ]; then {status}=${stream_status}; fi; exit \"${status}\")",
+        "(exec 9> >({stream_command}); {stream_pid}=$!; exec 1>/dev/null 2>/dev/null; {script}=\"$({script_command} 2>&9)\"; {status}=$?; if [ \"${status}\" -eq 0 ]; then eval \"${script}\" 1>&9 2>&9; {status}=$?; fi; unset {script}; printf '%s\\n' {marker} >&9; exec 9>&-; if [ -n \"${stream_pid}\" ]; then wait \"${stream_pid}\"; {stream_status}=$?; else {stream_status}=0; fi; if [ \"${stream_status}\" -eq 127 ]; then {stream_status}=0; fi; if [ \"${status}\" -eq 0 ] && [ \"${stream_status}\" -ne 0 ]; then {status}=${stream_status}; fi; exit \"${status}\")",
         marker = shell_quote_unix(end_marker),
     )
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -5569,12 +5569,12 @@ fn bash_same_shell_wrapper(
     script_command: &str,
     stream_command: &str,
 ) -> String {
-    let stream_pid = format!("_pentect_stream_pid_{suffix}");
     let status = format!("_pentect_status_{suffix}");
     let stream_status = format!("_pentect_stream_status_{suffix}");
+    let pipe_status = format!("_pentect_pipe_status_{suffix}");
     let script = format!("_pentect_script_{suffix}");
     format!(
-        "(exec 9> >({stream_command}); {stream_pid}=$!; exec 1>/dev/null 2>/dev/null; {script}=\"$({script_command} 2>&9)\"; {status}=$?; if [ \"${status}\" -eq 0 ]; then eval \"${script}\" 1>&9 2>&9; {status}=$?; fi; unset {script}; printf '%s\\n' {marker} >&9; exec 9>&-; if [ -n \"${stream_pid}\" ]; then wait \"${stream_pid}\"; {stream_status}=$?; else {stream_status}=0; fi; if [ \"${stream_status}\" -eq 127 ]; then {stream_status}=0; fi; if [ \"${status}\" -eq 0 ] && [ \"${stream_status}\" -ne 0 ]; then {status}=${stream_status}; fi; exit \"${status}\")",
+        "(set +x; {script}=\"$({script_command} 2>&1)\"; {status}=$?; if [ \"${status}\" -ne 0 ]; then printf '%s\\n' \"${script}\" | {stream_command}; unset {script}; exit \"${status}\"; fi; {{ eval \"${script}\"; {status}=$?; printf '%s\\n' {marker}; exit \"${status}\"; }} 2>&1 | {stream_command}; {pipe_status}=(\"${{PIPESTATUS[@]}}\"); unset {script}; {status}=\"${{{pipe_status}[0]}}\"; {stream_status}=\"${{{pipe_status}[1]}}\"; if [ \"${status}\" -eq 0 ] && [ \"${stream_status}\" -ne 0 ]; then {status}=${stream_status}; fi; exit \"${status}\")",
         marker = shell_quote_unix(end_marker),
     )
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -21,14 +21,11 @@ mod shell;
 
 pub use activity_log::record_scan as record_scan_activity;
 pub use delegated_process_host::{
-    is_host as delegated_process_host_owned_by, is_running as delegated_process_host_running,
-    persistent_candidate_is_running as persistent_process_host_running,
+    contains_host as delegated_process_host_contains, is_host as delegated_process_host_owned_by,
+    is_running as delegated_process_host_running, matches_host as delegated_process_host_matches,
+    persistent_candidate_is_running as persistent_process_host_running, process_host_root,
     register_candidate as register_process_host_candidate,
     unregister_candidate as unregister_process_host_candidate,
-};
-use delegated_process_host::{
-    ENV_READ_TOKEN as PROCESS_HOST_READ_TOKEN_ENV, ENV_ROOT as PROCESS_HOST_ROOT_ENV,
-    ENV_WRITE_TOKEN as PROCESS_HOST_WRITE_TOKEN_ENV,
 };
 use masking::{
     contains_unresolved_masked_handle, env_alias_recovery, is_ascii_word_char, is_env_name_byte,
@@ -36,7 +33,10 @@ use masking::{
 };
 #[cfg(test)]
 use masking::{first_reusable_env_name, mask_live_output, mask_tool_output};
-pub use memory_store::{open_memory_store_lease, MemoryStoreLease};
+pub use memory_store::{
+    active_memory_store_ready, is_pentect_control_env_name, memory_store_ready,
+    open_memory_store_lease, pentect_control_env_names, MemoryStoreLease,
+};
 use memory_store::{MemoryStore, MemoryStoreClient, ENV_ADDR, ENV_TOKEN};
 pub use output_remask::ActiveTerminalOutputRemasker;
 use pentect_core::{
@@ -973,18 +973,12 @@ fn handle_bridge_request(
 }
 
 fn bridge_session_value() -> Result<Value, String> {
+    if !agent_launch_proof_valid() {
+        return Err("bridge unavailable".to_string());
+    }
     let required = [
         ("PENTECT_MEMORY_STORE_ADDR", ENV_ADDR),
         ("PENTECT_MEMORY_STORE_TOKEN", ENV_TOKEN),
-        (
-            "PENTECT_PROCESS_HOST_READ_TOKEN",
-            PROCESS_HOST_READ_TOKEN_ENV,
-        ),
-        (
-            "PENTECT_PROCESS_HOST_WRITE_TOKEN",
-            PROCESS_HOST_WRITE_TOKEN_ENV,
-        ),
-        ("PENTECT_PROCESS_HOST_ROOT", PROCESS_HOST_ROOT_ENV),
         ("PENTECT_AGENT_LAUNCHED", PENTECT_AGENT_LAUNCHED_ENV),
     ];
     let mut environment = serde_json::Map::new();
@@ -1109,25 +1103,34 @@ fn resolve_path_in_place(store: &MemoryStore, path: &Path) -> Result<(), String>
     Ok(())
 }
 
-fn apply_child_env_overlays(command: &mut Command, env: &[(String, String)], session: &str) {
+fn apply_child_env_overlays(command: &mut Command, env: &[(String, String)], _session: &str) {
+    remove_pentect_control_env(command);
     command.env_remove(ENV_ADDR);
     command.env_remove(ENV_TOKEN);
-    command.env_remove(PROCESS_HOST_READ_TOKEN_ENV);
-    command.env_remove(PROCESS_HOST_WRITE_TOKEN_ENV);
-    command.env_remove(PROCESS_HOST_ROOT_ENV);
+    command.env_remove("PENTECT_PROCESS_HOST_READ_TOKEN");
+    command.env_remove("PENTECT_PROCESS_HOST_WRITE_TOKEN");
+    command.env_remove("PENTECT_PROCESS_HOST_ROOT");
     command.env_remove(PENTECT_AGENT_LAUNCHED_ENV);
     apply_env_bindings(command, env);
-    apply_pentect_session(command, session);
+}
+
+fn remove_pentect_control_env(command: &mut Command) {
+    for name in pentect_control_env_names() {
+        command.env_remove(name);
+    }
+    for (name, _) in std::env::vars_os() {
+        if name.to_str().is_some_and(is_pentect_control_env_name) {
+            command.env_remove(name);
+        }
+    }
 }
 
 fn apply_env_bindings(command: &mut Command, env: &[(String, String)]) {
     for (name, value) in env {
-        command.env(name, value);
+        if !is_pentect_control_env_name(name) {
+            command.env(name, value);
+        }
     }
-}
-
-fn apply_pentect_session(command: &mut Command, session: &str) {
-    command.env("PENTECT_SESSION", session);
 }
 
 fn requested_env_bindings(
@@ -2389,6 +2392,9 @@ fn replace_masked_handles_with_env_refs(
 }
 
 fn apply_active_memory_store_env(command: &mut Command) {
+    if !active_memory_store_ready() {
+        return;
+    }
     let (Some(addr), Some(token)) = (std::env::var_os(ENV_ADDR), std::env::var_os(ENV_TOKEN))
     else {
         return;
@@ -2398,47 +2404,31 @@ fn apply_active_memory_store_env(command: &mut Command) {
     }
     command.env(ENV_ADDR, addr);
     command.env(ENV_TOKEN, &token);
-    apply_process_host_env(command);
     command.env(PENTECT_AGENT_LAUNCHED_ENV, token);
 }
 
-fn apply_process_host_env(command: &mut Command) {
-    for name in [
-        PROCESS_HOST_READ_TOKEN_ENV,
-        PROCESS_HOST_WRITE_TOKEN_ENV,
-        PROCESS_HOST_ROOT_ENV,
-    ] {
-        if let Some(value) = std::env::var_os(name) {
-            if !value.is_empty() {
-                command.env(name, value);
-            }
+fn apply_shell_env_builder(command: &mut CommandBuilder, _session: &str, shim: &ShellShimDir) {
+    for name in pentect_control_env_names() {
+        command.env_remove(name);
+    }
+    for (name, _) in std::env::vars_os() {
+        if name.to_str().is_some_and(is_pentect_control_env_name) {
+            command.env_remove(name);
         }
     }
-}
-
-fn apply_shell_env_builder(command: &mut CommandBuilder, session: &str, shim: &ShellShimDir) {
     command.env_remove(ENV_ADDR);
     command.env_remove(ENV_TOKEN);
-    command.env_remove(PROCESS_HOST_READ_TOKEN_ENV);
-    command.env_remove(PROCESS_HOST_WRITE_TOKEN_ENV);
-    command.env_remove(PROCESS_HOST_ROOT_ENV);
+    command.env_remove("PENTECT_PROCESS_HOST_ROOT");
     command.env_remove(PENTECT_AGENT_LAUNCHED_ENV);
-    command.env("PENTECT_SESSION", session);
-    if let (Some(addr), Some(token)) = (std::env::var_os(ENV_ADDR), std::env::var_os(ENV_TOKEN)) {
+    if active_memory_store_ready() {
+        let (Some(addr), Some(token)) = (std::env::var_os(ENV_ADDR), std::env::var_os(ENV_TOKEN))
+        else {
+            shim.apply_to_builder(command);
+            return;
+        };
         if !addr.is_empty() && !token.is_empty() {
             command.env(ENV_ADDR, addr);
             command.env(ENV_TOKEN, &token);
-            for name in [
-                PROCESS_HOST_READ_TOKEN_ENV,
-                PROCESS_HOST_WRITE_TOKEN_ENV,
-                PROCESS_HOST_ROOT_ENV,
-            ] {
-                if let Some(value) = std::env::var_os(name) {
-                    if !value.is_empty() {
-                        command.env(name, value);
-                    }
-                }
-            }
             command.env(PENTECT_AGENT_LAUNCHED_ENV, token);
         }
     }
@@ -3114,9 +3104,6 @@ impl HookOpts {
         if let Some(session) = &self.session {
             return Ok(session.clone());
         }
-        if let Ok(session) = std::env::var("PENTECT_SESSION") {
-            return checked_session_name(&session).map_err(|e| e.to_string());
-        }
         let _ = input;
         default_session_name()
     }
@@ -3305,10 +3292,7 @@ fn decode_script_base64(value: &str) -> Result<String, String> {
 }
 
 fn default_session_name() -> Result<String, String> {
-    match std::env::var("PENTECT_SESSION") {
-        Ok(value) => checked_session_name(&value).map_err(|e| e.to_string()),
-        Err(_) => default_directory_session_name(),
-    }
+    default_directory_session_name()
 }
 
 fn default_directory_session_name() -> Result<String, String> {

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -5569,13 +5569,12 @@ fn bash_same_shell_wrapper(
     script_command: &str,
     stream_command: &str,
 ) -> String {
-    let stream_fd = format!("_pentect_stream_fd_{suffix}");
     let stream_pid = format!("_pentect_stream_pid_{suffix}");
     let status = format!("_pentect_status_{suffix}");
     let stream_status = format!("_pentect_stream_status_{suffix}");
     let script = format!("_pentect_script_{suffix}");
     format!(
-        "(exec {{{stream_fd}}}> >({stream_command}); {stream_pid}=$!; exec 1>/dev/null 2>/dev/null; {script}=\"$({script_command} 2>&${stream_fd})\"; {status}=$?; if [ \"${status}\" -eq 0 ]; then eval \"${script}\" 1>&${stream_fd} 2>&${stream_fd}; {status}=$?; fi; unset {script}; printf '%s\\n' {marker} >&${stream_fd}; exec {{{stream_fd}}}>&-; wait \"${stream_pid}\"; {stream_status}=$?; if [ \"${status}\" -eq 0 ] && [ \"${stream_status}\" -ne 0 ]; then {status}=${stream_status}; fi; exit \"${status}\")",
+        "(exec 9> >({stream_command}); {stream_pid}=$!; exec 1>/dev/null 2>/dev/null; {script}=\"$({script_command} 2>&9)\"; {status}=$?; if [ \"${status}\" -eq 0 ]; then eval \"${script}\" 1>&9 2>&9; {status}=$?; fi; unset {script}; printf '%s\\n' {marker} >&9; exec 9>&-; wait \"${stream_pid}\"; {stream_status}=$?; if [ \"${status}\" -eq 0 ] && [ \"${stream_status}\" -ne 0 ]; then {status}=${stream_status}; fi; exit \"${status}\")",
         marker = shell_quote_unix(end_marker),
     )
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -57,12 +57,14 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 const MAX_INPUT_BYTES: usize = 32 * 1024 * 1024;
 const DEFAULT_SESSION: &str = "default";
 const PENTECT_AGENT_LAUNCHED_ENV: &str = "PENTECT_AGENT_LAUNCHED";
 const PENTECT_CODEX_EXEC_PROXY_ENV: &str = "PENTECT_CODEX_EXEC_PROXY";
+const PENTECT_EXTENSION_CONFIGS_ENV: &str = "PENTECT_EXTENSION_CONFIGS";
+const PENTECT_EXTENSION_ADAPTERS_ENV: &str = "PENTECT_EXTENSION_ADAPTERS";
 const LIVE_MASK_CHUNK_BYTES: usize = 64 * 1024;
 const LIVE_MASK_CHUNK_LINES: usize = 2048;
 const ACTIVE_TOOL_OUTPUT_CACHE_LIMIT: usize = 128;
@@ -82,10 +84,11 @@ pub fn agent_contract_instructions(environment_prefix: &str) -> String {
             "- You may read, fetch, transform, store, sync, and use user-authorized secrets. Pentect is the safety layer; raw secret values must not reach chat.\n",
             "- Prefer Pentect-generated `{environment_prefix}<LABEL>_<HASH>` environment variables for secret values already seen through Pentect. Do not make helper scripts reopen a secret source when an equivalent environment binding is available.\n",
             "- When a source has not been seen yet, read it once with a normal protected command. Then use the generated `{environment_prefix}...` environment variable in later commands.\n",
-            "- Masked handles like `<<NAME_hash>>` work only in this running Pentect-launched session. Use `$env:{environment_prefix}NAME_hash` on PowerShell or `${environment_prefix}NAME_hash` on Unix.\n",
+            "- Masked handles like `<<NAME_hash>>` work only in this running Pentect-launched session. Build the environment variable from the name inside the handle, not the assignment key: use `$env:{environment_prefix}NAME_hash` on PowerShell or `${environment_prefix}NAME_hash` on Unix.\n",
             "- `pentect view '<handle>'` shows only label, hash, and length. Use handles or generated env vars instead of printing raw values.\n",
             "- Use the current shell syntax. On PowerShell use PowerShell commands and `$env:{environment_prefix}...`; on Unix use POSIX commands and `${environment_prefix}...`.\n",
             "- MCP, browser, plugin, and connector tools may retrieve and use user-authorized secrets. Pentect masks tool text output when the host supports replacement; otherwise it stops unsafe output.\n",
+            "- A masked handle shown inside stdout, stderr, or an error is display-time redaction after the command ran. It does not mean the command received the handle; do not retry solely because an error echoes one.\n",
             "- Default builds check image output with OS OCR on Windows/macOS and bundled OCR on Linux.\n",
             "- For user-requested storage, write only to the exact requested local file, credential store, service, authenticated account, or destination; print only non-secret verification.\n",
             "- Do not disclose raw secrets in chat, logs, screenshots, encodings, chunks, prefixes/suffixes, third-party destinations, public locations, or unrelated persistent services.\n",
@@ -120,6 +123,8 @@ pub fn run_from(args: Vec<String>) -> i32 {
         Some("hook") => cmd_hook(&args),
         Some("bridge") => cmd_bridge(&args),
         Some("memory-store") => cmd_memory_store(&args),
+        Some("__agent-script") => cmd_agent_script(&args),
+        Some("__agent-stream") => cmd_agent_stream(&args),
         Some("purge") => cmd_purge(&args),
         _ => {
             usage();
@@ -308,6 +313,7 @@ pub fn preflight_exec_server_process_start_from_active_memory_store(
     let opts = ExecOpts {
         session: session_name,
         live: false,
+        script_shell: ScriptShell::Native,
         mode: argv_mode,
     };
     prepare_exec_secret_inputs(&store, &opts)?;
@@ -751,6 +757,133 @@ fn cmd_memory_store(args: &[String]) -> i32 {
     }
 }
 
+fn cmd_agent_script(args: &[String]) -> i32 {
+    let opts = match AgentScriptOpts::parse(args) {
+        Ok(opts) => opts,
+        Err(error) => return die(&error),
+    };
+    let Some(client) = MemoryStoreClient::from_env() else {
+        return die("agent script requires a running Pentect session");
+    };
+    let mut rendered = match take_rendered_agent_script(&client, &opts) {
+        Ok(rendered) => rendered,
+        Err(error) => return die(&error),
+    };
+    print!("{}", rendered.as_str());
+    let result = std::io::stdout().flush();
+    rendered.zeroize();
+    match result {
+        Ok(()) => 0,
+        Err(error) => die(format!("could not write agent script: {error}")),
+    }
+}
+
+fn take_rendered_agent_script(
+    client: &MemoryStoreClient,
+    opts: &AgentScriptOpts,
+) -> Result<Zeroizing<String>, String> {
+    let (shell, masked_script) = match client.take_agent_script(&opts.id) {
+        Ok(pending) => pending,
+        Err(error) => return Err(error.to_string()),
+    };
+    let session = match Session::open_capability(&opts.session) {
+        Ok(session) => session,
+        Err(error) => return Err(error.to_string()),
+    };
+    let store = MemoryStore::for_session(&session);
+    let mode = ExecMode::Shell(masked_script.to_string());
+    let mut resolved = resolve_command_text(&store, masked_script.as_str())?;
+    if let Err(error) = register_local_file_inputs(&store, &resolved) {
+        resolved.zeroize();
+        return Err(error);
+    }
+    let mut env = match requested_env_bindings(&store, &mode) {
+        Ok(env) => env,
+        Err(error) => {
+            resolved.zeroize();
+            return Err(error);
+        }
+    };
+    let rendered = match render_agent_script(&shell, &env, &resolved) {
+        Ok(rendered) => rendered,
+        Err(error) => {
+            resolved.zeroize();
+            zeroize_env_bindings(&mut env);
+            return Err(error);
+        }
+    };
+    resolved.zeroize();
+    zeroize_env_bindings(&mut env);
+    Ok(Zeroizing::new(rendered))
+}
+
+fn cmd_agent_stream(args: &[String]) -> i32 {
+    let opts = match AgentStreamOpts::parse(args) {
+        Ok(opts) => opts,
+        Err(error) => return die(&error),
+    };
+    if MemoryStoreClient::from_env().is_none() {
+        return die("agent stream requires a running Pentect session");
+    }
+    let session = match Session::open_capability(&opts.session) {
+        Ok(session) => session,
+        Err(error) => return die(&error),
+    };
+    let mut masker = match OutputMasker::new_shared(MemoryStore::for_session(&session)) {
+        Ok(masker) => masker,
+        Err(error) => return die(&error),
+    };
+    if let Err(error) = stream_masked_reader(&mut masker, std::io::stdin(), opts.target)
+        .and_then(|_| masker.flush())
+    {
+        return die(&error);
+    }
+    0
+}
+
+fn render_agent_script(
+    shell: &str,
+    env: &[(String, String)],
+    resolved: &str,
+) -> Result<String, String> {
+    let mut rendered = String::new();
+    match shell {
+        "bash" => {
+            for (name, value) in env {
+                if !looks_like_env_name(name) || is_pentect_control_env_name(name) {
+                    continue;
+                }
+                rendered.push_str("export ");
+                rendered.push_str(name);
+                rendered.push('=');
+                rendered.push_str(&shell_quote_unix(value));
+                rendered.push('\n');
+            }
+        }
+        "powershell" => {
+            for (name, value) in env {
+                if !looks_like_env_name(name) || is_pentect_control_env_name(name) {
+                    continue;
+                }
+                rendered.push_str("$env:");
+                rendered.push_str(name);
+                rendered.push_str(" = ");
+                rendered.push_str(&powershell_word(value));
+                rendered.push('\n');
+            }
+        }
+        _ => return Err("agent script shell is invalid".to_string()),
+    }
+    rendered.push_str(resolved);
+    Ok(rendered)
+}
+
+fn zeroize_env_bindings(env: &mut [(String, String)]) {
+    for (_, value) in env {
+        value.zeroize();
+    }
+}
+
 fn prepare_exec_secret_inputs(store: &MemoryStore, opts: &ExecOpts) -> Result<(), String> {
     if let ExecMode::Shell(command) = &opts.mode {
         let command = resolve_command_text(store, command)?;
@@ -976,29 +1109,37 @@ fn bridge_session_value() -> Result<Value, String> {
     if !agent_launch_proof_valid() {
         return Err("bridge unavailable".to_string());
     }
-    let required = [
-        ("PENTECT_MEMORY_STORE_ADDR", ENV_ADDR),
-        ("PENTECT_MEMORY_STORE_TOKEN", ENV_TOKEN),
-        ("PENTECT_AGENT_LAUNCHED", PENTECT_AGENT_LAUNCHED_ENV),
-    ];
-    let mut environment = serde_json::Map::new();
-    for (output_name, env_name) in required {
-        let value = std::env::var(env_name).map_err(|_| "bridge unavailable".to_string())?;
-        if value.is_empty() {
-            return Err("bridge unavailable".to_string());
-        }
-        environment.insert(output_name.to_string(), Value::String(value));
-    }
-    if let Ok(value) = std::env::var("PENTECT_BIN") {
-        if !value.is_empty() {
-            environment.insert("PENTECT_BIN".to_string(), Value::String(value));
-        }
-    }
+    let environment = bridge_owned_environment(|name| std::env::var(name).ok())?;
     let prefix = config::environment_variable_prefix()?;
     Ok(json!({
         "contract": agent_contract_instructions(&prefix),
         "environment": environment,
     }))
+}
+
+fn bridge_owned_environment(
+    mut read: impl FnMut(&str) -> Option<String>,
+) -> Result<serde_json::Map<String, Value>, String> {
+    let mut environment = serde_json::Map::new();
+    for name in [ENV_ADDR, ENV_TOKEN, PENTECT_AGENT_LAUNCHED_ENV] {
+        let value = read(name).ok_or_else(|| "bridge unavailable".to_string())?;
+        if value.is_empty() {
+            return Err("bridge unavailable".to_string());
+        }
+        environment.insert(name.to_string(), Value::String(value));
+    }
+    for name in [
+        "PENTECT_BIN",
+        PENTECT_EXTENSION_CONFIGS_ENV,
+        PENTECT_EXTENSION_ADAPTERS_ENV,
+    ] {
+        if let Some(value) = read(name) {
+            if !value.is_empty() {
+                environment.insert(name.to_string(), Value::String(value));
+            }
+        }
+    }
+    Ok(environment)
 }
 
 fn open_hook_session(cli: bool, session_name: &str) -> Result<Session, String> {
@@ -1034,7 +1175,7 @@ fn run_resolved_command(
             let command = resolve_command_text(store, command)?;
             register_local_file_inputs(store, &command)?;
             let env = requested_env_bindings(store, &opts.mode)?;
-            run_shell_script(&command, &env, &opts.session)
+            run_shell_script(&command, &env, &opts.session, opts.script_shell)
         }
         ExecMode::Stdin => Err("internal error: exec stdin was not prepared".to_string()),
     }
@@ -1059,7 +1200,7 @@ fn run_resolved_command_live(store: &MemoryStore, opts: &ExecOpts) -> Result<Exi
             let command = resolve_command_text(store, command)?;
             register_local_file_inputs(store, &command)?;
             let env = requested_env_bindings(store, &opts.mode)?;
-            let mut shell = shell_script_command();
+            let mut shell = shell_script_command(opts.script_shell)?;
             apply_child_env_overlays(&mut shell, &env, &opts.session);
             run_live_command(shell, Some(&command), store.clone())
         }
@@ -1166,9 +1307,7 @@ fn referenced_env_names(mode: &ExecMode) -> BTreeSet<String> {
             collect_powershell_env_provider_refs(command, &mut names);
             collect_printenv_refs(command, &mut names);
             collect_percent_env_refs(command, &mut names);
-            if !cfg!(windows) {
-                collect_bare_dollar_env_refs(command, &mut names);
-            }
+            collect_bare_dollar_env_refs(command, &mut names);
         }
         ExecMode::Stdin => {}
         ExecMode::Program(args) => {
@@ -1373,8 +1512,9 @@ fn run_shell_script(
     script: &str,
     env: &[(String, String)],
     session: &str,
+    script_shell: ScriptShell,
 ) -> Result<std::process::Output, String> {
-    let mut command = shell_script_command();
+    let mut command = shell_script_command(script_shell)?;
     apply_child_env_overlays(&mut command, env, session);
     let mut child = command
         .stdin(Stdio::piped())
@@ -1457,9 +1597,723 @@ fn run_live_command(
 fn run_masked_shell(store: MemoryStore, opts: &ShellOpts) -> Result<i32, String> {
     let shim = ShellShimDir::install()?;
     if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+        #[cfg(windows)]
+        if opts.program.is_none() {
+            return run_masked_windows_powershell(store, opts, &shim);
+        }
         run_masked_shell_pty(store, opts, &shim)
     } else {
         run_masked_shell_pipe(store, opts, &shim)
+    }
+}
+
+#[cfg(windows)]
+const WINDOWS_SHELL_HOST_SCRIPT: &str = concat!(
+    "$marker=$env:PENTECT_SHELL_COMMAND_MARKER;",
+    "while (($line=[Console]::In.ReadLine()) -ne $null) {",
+    "try {",
+    "$text=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($line));",
+    "Invoke-Expression $text *>&1 | Out-String -Stream | ForEach-Object { [Console]::Out.WriteLine($_) }",
+    "} catch {",
+    "$message=$_ | Out-String;[Console]::Out.WriteLine($message)",
+    "};",
+    "$cwd=[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes((Get-Location).Path));",
+    "[Console]::Out.WriteLine($marker+$cwd);[Console]::Out.Flush()",
+    "}"
+);
+
+#[cfg(windows)]
+fn run_masked_windows_powershell(
+    store: MemoryStore,
+    opts: &ShellOpts,
+    shim: &ShellShimDir,
+) -> Result<i32, String> {
+    let marker = windows_shell_marker()?;
+    let mut command = Command::new(windows_powershell_path());
+    command
+        .arg("-NoLogo")
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .arg("-Command")
+        .arg(WINDOWS_SHELL_HOST_SCRIPT);
+    apply_child_env_overlays(&mut command, &[], &opts.session);
+    apply_active_memory_store_env(&mut command);
+    command.env("PENTECT_SHELL_COMMAND_MARKER", &marker);
+    shim.apply_to_command(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("could not start PowerShell: {e}"))?;
+    let mut child_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "could not open PowerShell stdin".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "could not capture PowerShell stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "could not capture PowerShell stderr".to_string())?;
+    let (completion_tx, completion_rx) = mpsc::channel();
+    let stdout_store = store.clone();
+    let stdout_marker = marker.clone();
+    let stdout_thread = std::thread::spawn(move || {
+        stream_windows_shell_stdout(stdout_store, stdout, &stdout_marker, completion_tx)
+    });
+    let stderr_store = store.clone();
+    let stderr_thread = std::thread::spawn(move || {
+        let mut masker = OutputMasker::new_deferred(stderr_store)?;
+        stream_masked_reader(&mut masker, stderr, StreamTarget::Stderr)?;
+        masker.flush()
+    });
+    let status = pump_windows_shell_input(&mut child, &mut child_stdin, store, &completion_rx)?;
+    drop(child_stdin);
+    join_stream_thread(stdout_thread)?;
+    join_stream_thread(stderr_thread)?;
+    Ok(exit_code(status))
+}
+
+#[cfg(windows)]
+fn windows_shell_marker() -> Result<String, String> {
+    let mut random = [0u8; 16];
+    getrandom::getrandom(&mut random)
+        .map_err(|e| format!("could not create shell protocol marker: {e}"))?;
+    Ok(format!(
+        "__PENTECT_COMMAND_DONE_{}__",
+        data_encoding::HEXLOWER.encode(&random)
+    ))
+}
+
+#[cfg(windows)]
+fn stream_windows_shell_stdout(
+    store: MemoryStore,
+    stdout: std::process::ChildStdout,
+    marker: &str,
+    completion_tx: mpsc::Sender<String>,
+) -> Result<(), String> {
+    let mut reader = BufReader::new(stdout);
+    let mut masker = OutputMasker::new_deferred(store)?;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = reader
+            .read_line(&mut line)
+            .map_err(|e| format!("could not read PowerShell output: {e}"))?;
+        if read == 0 {
+            break;
+        }
+        if let Some(start) = line.find(marker) {
+            let prefix = &line[..start];
+            if !prefix.is_empty() {
+                let mut chunk = prefix.to_string();
+                flush_masked_chunk(
+                    &mut masker,
+                    StreamTarget::Stdout,
+                    &mut chunk,
+                    live_output_kind(prefix),
+                )?;
+            }
+            let encoded = line[start + marker.len()..].trim_end_matches(['\r', '\n']);
+            let cwd = data_encoding::BASE64
+                .decode(encoded.as_bytes())
+                .ok()
+                .and_then(|bytes| String::from_utf8(bytes).ok())
+                .ok_or_else(|| "PowerShell returned an invalid working directory".to_string())?;
+            if completion_tx.send(cwd).is_err() {
+                break;
+            }
+            continue;
+        }
+        let kind = live_output_kind(&line);
+        flush_masked_chunk(&mut masker, StreamTarget::Stdout, &mut line, kind)?;
+    }
+    masker.flush()
+}
+
+#[cfg(windows)]
+#[derive(Default)]
+struct WindowsShellLine {
+    units: Vec<(String, String, String)>,
+    cursor: usize,
+}
+
+#[cfg(windows)]
+impl WindowsShellLine {
+    fn push_typed(&mut self, text: &str) {
+        self.units.insert(
+            self.cursor,
+            (text.to_string(), text.to_string(), String::new()),
+        );
+        self.cursor += 1;
+    }
+
+    fn push_paste(&mut self, raw: String, visible: String, injected_prefix: String) {
+        self.units
+            .insert(self.cursor, (raw, visible, injected_prefix));
+        self.cursor += 1;
+    }
+
+    fn raw(&self) -> String {
+        self.units.iter().map(|(raw, _, _)| raw.as_str()).collect()
+    }
+
+    fn visible(&self) -> String {
+        self.units
+            .iter()
+            .map(|(_, visible, _)| visible.as_str())
+            .collect()
+    }
+
+    fn visible_before_cursor(&self) -> String {
+        self.units[..self.cursor]
+            .iter()
+            .map(|(_, visible, _)| visible.as_str())
+            .collect()
+    }
+
+    fn contains_protected_paste(&self) -> bool {
+        self.units.iter().any(|(_, _, prefix)| !prefix.is_empty())
+    }
+
+    fn replace_with_raw(&mut self, raw: &str) {
+        self.clear();
+        for ch in raw.chars() {
+            let mut encoded = [0u8; 4];
+            self.push_typed(ch.encode_utf8(&mut encoded));
+        }
+    }
+
+    fn move_left(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        self.cursor -= 1;
+        true
+    }
+
+    fn move_right(&mut self) -> bool {
+        if self.cursor >= self.units.len() {
+            return false;
+        }
+        self.cursor += 1;
+        true
+    }
+
+    fn move_home(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        self.cursor = 0;
+        true
+    }
+
+    fn move_end(&mut self) -> bool {
+        if self.cursor == self.units.len() {
+            return false;
+        }
+        self.cursor = self.units.len();
+        true
+    }
+
+    fn take_injected_prefixes(&mut self) -> String {
+        let mut out = String::new();
+        for (_, _, prefix) in &mut self.units {
+            out.push_str(prefix);
+            prefix.zeroize();
+        }
+        out
+    }
+
+    fn backspace(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        self.cursor -= 1;
+        let (mut raw, mut visible, mut prefix) = self.units.remove(self.cursor);
+        raw.zeroize();
+        visible.zeroize();
+        prefix.zeroize();
+        true
+    }
+
+    fn delete(&mut self) -> bool {
+        if self.cursor >= self.units.len() {
+            return false;
+        }
+        let (mut raw, mut visible, mut prefix) = self.units.remove(self.cursor);
+        raw.zeroize();
+        visible.zeroize();
+        prefix.zeroize();
+        true
+    }
+
+    fn clear(&mut self) {
+        for (raw, visible, prefix) in &mut self.units {
+            raw.zeroize();
+            visible.zeroize();
+            prefix.zeroize();
+        }
+        self.units.clear();
+        self.cursor = 0;
+    }
+}
+
+#[cfg(windows)]
+#[derive(Default)]
+struct WindowsShellHistory {
+    entries: Vec<Zeroizing<String>>,
+    index: Option<usize>,
+    draft: Zeroizing<String>,
+}
+
+#[cfg(windows)]
+impl WindowsShellHistory {
+    fn record(&mut self, command: &str, sensitive: bool) {
+        self.index = None;
+        self.draft.zeroize();
+        if sensitive || command.trim().is_empty() || command.contains(['\r', '\n']) {
+            return;
+        }
+        if self
+            .entries
+            .last()
+            .is_some_and(|entry| entry.as_str() == command)
+        {
+            return;
+        }
+        self.entries.push(Zeroizing::new(command.to_string()));
+        if self.entries.len() > 100 {
+            self.entries.remove(0);
+        }
+    }
+
+    fn previous(&mut self, current: &str) -> Option<String> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        let next = match self.index {
+            Some(index) => index.saturating_sub(1),
+            None => {
+                self.draft.zeroize();
+                self.draft.push_str(current);
+                self.entries.len() - 1
+            }
+        };
+        self.index = Some(next);
+        Some(self.entries[next].to_string())
+    }
+
+    fn next(&mut self) -> Option<String> {
+        let index = self.index?;
+        if index + 1 < self.entries.len() {
+            self.index = Some(index + 1);
+            return Some(self.entries[index + 1].to_string());
+        }
+        self.index = None;
+        Some(self.draft.to_string())
+    }
+
+    fn edited(&mut self) {
+        self.index = None;
+        self.draft.zeroize();
+    }
+}
+
+#[cfg(windows)]
+fn pump_windows_shell_input(
+    child: &mut std::process::Child,
+    child_stdin: &mut std::process::ChildStdin,
+    store: MemoryStore,
+    completion_rx: &mpsc::Receiver<String>,
+) -> Result<ExitStatus, String> {
+    let _raw = RawModeGuard::enable()?;
+    let _paste = BracketedPasteGuard::enable()?;
+    let mut protector = ShellInputProtector::new(store)?;
+    let mut cwd = std::env::current_dir()
+        .map_err(|e| format!("could not read current directory: {e}"))?
+        .to_string_lossy()
+        .into_owned();
+    let mut line = WindowsShellLine::default();
+    let mut history = WindowsShellHistory::default();
+    print_windows_shell_welcome()?;
+    print_windows_shell_prompt(&cwd)?;
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| format!("could not poll PowerShell: {e}"))?
+        {
+            line.clear();
+            return Ok(status);
+        }
+        if !crossterm::event::poll(Duration::from_millis(50))
+            .map_err(|e| format!("could not read terminal input: {e}"))?
+        {
+            continue;
+        }
+        match crossterm::event::read().map_err(|e| format!("could not read terminal input: {e}"))? {
+            crossterm::event::Event::Key(event)
+                if matches!(
+                    event.kind,
+                    crossterm::event::KeyEventKind::Press | crossterm::event::KeyEventKind::Repeat
+                ) =>
+            {
+                use crossterm::event::{KeyCode, KeyModifiers};
+                match event.code {
+                    KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {
+                        line.clear();
+                        history.edited();
+                        print!("^C\r\n");
+                        print_windows_shell_prompt(&cwd)?;
+                    }
+                    KeyCode::Char('l') if event.modifiers.contains(KeyModifiers::CONTROL) => {
+                        crossterm::execute!(
+                            std::io::stdout(),
+                            crossterm::terminal::Clear(crossterm::terminal::ClearType::All),
+                            crossterm::cursor::MoveTo(0, 0)
+                        )
+                        .map_err(|e| format!("could not clear shell display: {e}"))?;
+                        redraw_windows_shell_line(&cwd, &line)?;
+                    }
+                    KeyCode::Char('d')
+                        if event.modifiers.contains(KeyModifiers::CONTROL)
+                            && line.units.is_empty() =>
+                    {
+                        child
+                            .kill()
+                            .map_err(|e| format!("could not stop PowerShell: {e}"))?;
+                        return child
+                            .wait()
+                            .map_err(|e| format!("could not wait for PowerShell: {e}"));
+                    }
+                    KeyCode::Enter | KeyCode::Char('\r') | KeyCode::Char('\n') => {
+                        let mut raw = line.raw();
+                        print!("\r\n");
+                        std::io::stdout()
+                            .flush()
+                            .map_err(|e| format!("could not render shell input: {e}"))?;
+                        let mut paste = protector.prepare_paste(&raw)?;
+                        history.record(&raw, paste.changed);
+                        raw.zeroize();
+                        let mut child_command = line.take_injected_prefixes();
+                        child_command.push_str(&paste.child);
+                        line.clear();
+                        let mut encoded = data_encoding::BASE64.encode(child_command.as_bytes());
+                        child_stdin
+                            .write_all(encoded.as_bytes())
+                            .and_then(|_| child_stdin.write_all(b"\n"))
+                            .and_then(|_| child_stdin.flush())
+                            .map_err(|e| format!("could not write PowerShell input: {e}"))?;
+                        encoded.zeroize();
+                        child_command.zeroize();
+                        paste.child.zeroize();
+                        paste.injected_prefix.zeroize();
+                        match wait_for_windows_shell_completion(child, child_stdin, completion_rx)?
+                        {
+                            Some(next_cwd) => {
+                                cwd.zeroize();
+                                cwd = next_cwd;
+                                print_windows_shell_prompt(&cwd)?;
+                            }
+                            None => {
+                                return child
+                                    .wait()
+                                    .map_err(|e| format!("could not wait for PowerShell: {e}"));
+                            }
+                        }
+                    }
+                    KeyCode::Char(ch) => {
+                        let mut encoded = [0u8; 4];
+                        let text = ch.encode_utf8(&mut encoded);
+                        line.push_typed(text);
+                        history.edited();
+                        redraw_windows_shell_line(&cwd, &line)?;
+                    }
+                    KeyCode::Backspace => {
+                        if line.backspace() {
+                            history.edited();
+                            redraw_windows_shell_line(&cwd, &line)?;
+                        }
+                    }
+                    KeyCode::Delete => {
+                        if line.delete() {
+                            history.edited();
+                            redraw_windows_shell_line(&cwd, &line)?;
+                        }
+                    }
+                    KeyCode::Left => {
+                        if line.move_left() {
+                            redraw_windows_shell_line(&cwd, &line)?;
+                        }
+                    }
+                    KeyCode::Right => {
+                        if line.move_right() {
+                            redraw_windows_shell_line(&cwd, &line)?;
+                        }
+                    }
+                    KeyCode::Home => {
+                        if line.move_home() {
+                            redraw_windows_shell_line(&cwd, &line)?;
+                        }
+                    }
+                    KeyCode::End => {
+                        if line.move_end() {
+                            redraw_windows_shell_line(&cwd, &line)?;
+                        }
+                    }
+                    KeyCode::Up => {
+                        if !line.contains_protected_paste() {
+                            let mut current = line.raw();
+                            let previous = history.previous(&current);
+                            current.zeroize();
+                            if let Some(mut command) = previous {
+                                line.replace_with_raw(&command);
+                                command.zeroize();
+                                redraw_windows_shell_line(&cwd, &line)?;
+                            }
+                        }
+                    }
+                    KeyCode::Down => {
+                        if let Some(mut command) = history.next() {
+                            line.replace_with_raw(&command);
+                            command.zeroize();
+                            redraw_windows_shell_line(&cwd, &line)?;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            crossterm::event::Event::Paste(mut text) => {
+                let paste = protector.prepare_paste(&text)?;
+                line.push_paste(
+                    std::mem::take(&mut text),
+                    single_line_shell_display(&paste.visible),
+                    paste.injected_prefix,
+                );
+                history.edited();
+                redraw_windows_shell_line(&cwd, &line)?;
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(windows)]
+fn wait_for_windows_shell_completion(
+    child: &mut std::process::Child,
+    child_stdin: &mut std::process::ChildStdin,
+    completion_rx: &mpsc::Receiver<String>,
+) -> Result<Option<String>, String> {
+    loop {
+        match completion_rx.try_recv() {
+            Ok(cwd) => return Ok(Some(cwd)),
+            Err(mpsc::TryRecvError::Empty) => {
+                if child
+                    .try_wait()
+                    .map_err(|e| format!("could not poll PowerShell: {e}"))?
+                    .is_some()
+                {
+                    return Ok(None);
+                }
+            }
+            Err(mpsc::TryRecvError::Disconnected) => return Ok(None),
+        }
+        if crossterm::event::poll(Duration::from_millis(50))
+            .map_err(|e| format!("could not read terminal input: {e}"))?
+        {
+            let event = crossterm::event::read()
+                .map_err(|e| format!("could not read terminal input: {e}"))?;
+            forward_windows_running_input(event, child_stdin)?;
+        }
+    }
+}
+
+#[cfg(windows)]
+fn forward_windows_running_input(
+    event: crossterm::event::Event,
+    child_stdin: &mut dyn Write,
+) -> Result<(), String> {
+    use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
+
+    let bytes = match event {
+        Event::Paste(text) => text.into_bytes(),
+        Event::Key(event) if matches!(event.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
+            match event.code {
+                KeyCode::Char(ch) if event.modifiers.contains(KeyModifiers::CONTROL) => {
+                    let lower = ch.to_ascii_lowercase();
+                    if lower.is_ascii_alphabetic()
+                        || matches!(lower, '@' | '[' | '\\' | ']' | '^' | '_')
+                    {
+                        vec![(lower.to_ascii_uppercase() as u8) & 0x1f]
+                    } else {
+                        Vec::new()
+                    }
+                }
+                KeyCode::Char(ch) => {
+                    let mut encoded = [0u8; 4];
+                    let text = ch.encode_utf8(&mut encoded);
+                    if event.modifiers.contains(KeyModifiers::ALT) {
+                        let mut bytes = Vec::with_capacity(text.len() + 1);
+                        bytes.push(0x1b);
+                        bytes.extend_from_slice(text.as_bytes());
+                        bytes
+                    } else {
+                        text.as_bytes().to_vec()
+                    }
+                }
+                KeyCode::Enter => b"\r\n".to_vec(),
+                KeyCode::Backspace => vec![0x08],
+                KeyCode::Tab => vec![0x09],
+                KeyCode::BackTab => b"\x1b[Z".to_vec(),
+                KeyCode::Esc => vec![0x1b],
+                KeyCode::Left => b"\x1b[D".to_vec(),
+                KeyCode::Right => b"\x1b[C".to_vec(),
+                KeyCode::Up => b"\x1b[A".to_vec(),
+                KeyCode::Down => b"\x1b[B".to_vec(),
+                KeyCode::Home => b"\x1b[H".to_vec(),
+                KeyCode::End => b"\x1b[F".to_vec(),
+                KeyCode::Delete => b"\x1b[3~".to_vec(),
+                KeyCode::Insert => b"\x1b[2~".to_vec(),
+                KeyCode::PageUp => b"\x1b[5~".to_vec(),
+                KeyCode::PageDown => b"\x1b[6~".to_vec(),
+                _ => Vec::new(),
+            }
+        }
+        _ => Vec::new(),
+    };
+    if bytes.is_empty() {
+        return Ok(());
+    }
+    child_stdin
+        .write_all(&bytes)
+        .and_then(|_| child_stdin.flush())
+        .map_err(|e| format!("could not write PowerShell input: {e}"))
+}
+
+#[cfg(windows)]
+fn print_windows_shell_prompt(cwd: &str) -> Result<(), String> {
+    let display = compact_windows_shell_cwd(cwd);
+    use crossterm::style::{Attribute, Color, Print, ResetColor, SetAttribute, SetForegroundColor};
+    crossterm::queue!(
+        std::io::stdout(),
+        Print("PS "),
+        SetForegroundColor(Color::Cyan),
+        Print(&display),
+        ResetColor,
+        Print(" "),
+        SetForegroundColor(Color::Green),
+        SetAttribute(Attribute::Bold),
+        Print("›"),
+        SetAttribute(Attribute::Reset),
+        ResetColor,
+        Print(" ")
+    )
+    .map_err(|e| format!("could not render shell prompt: {e}"))?;
+    std::io::stdout()
+        .flush()
+        .map_err(|e| format!("could not render shell prompt: {e}"))
+}
+
+#[cfg(windows)]
+fn print_windows_shell_welcome() -> Result<(), String> {
+    use crossterm::style::{Attribute, Color, Print, ResetColor, SetAttribute, SetForegroundColor};
+    crossterm::queue!(
+        std::io::stdout(),
+        SetForegroundColor(Color::Cyan),
+        SetAttribute(Attribute::Bold),
+        Print("pentect shell"),
+        SetAttribute(Attribute::Reset),
+        ResetColor,
+        Print("  ·  protected PowerShell\r\n"),
+        SetForegroundColor(Color::DarkGrey),
+        Print("↑↓ history  ←→ edit  Ctrl+C clear  Ctrl+D exit\r\n"),
+        ResetColor
+    )
+    .map_err(|e| format!("could not render shell welcome: {e}"))?;
+    std::io::stdout()
+        .flush()
+        .map_err(|e| format!("could not render shell welcome: {e}"))
+}
+
+#[cfg(windows)]
+fn compact_windows_shell_cwd(cwd: &str) -> String {
+    let Some(home) = std::env::var_os("USERPROFILE") else {
+        return cwd.to_string();
+    };
+    compact_windows_shell_cwd_with_home(cwd, &home.to_string_lossy())
+}
+
+#[cfg(windows)]
+fn compact_windows_shell_cwd_with_home(cwd: &str, home: &str) -> String {
+    if cwd.eq_ignore_ascii_case(home) {
+        return "~".to_string();
+    }
+    cwd.get(home.len()..)
+        .filter(|tail| {
+            cwd[..home.len()].eq_ignore_ascii_case(home)
+                && (tail.starts_with('\\') || tail.starts_with('/'))
+        })
+        .map(|tail| format!("~{tail}"))
+        .unwrap_or_else(|| cwd.to_string())
+}
+
+#[cfg(windows)]
+fn redraw_windows_shell_line(cwd: &str, line: &WindowsShellLine) -> Result<(), String> {
+    use crossterm::cursor::MoveToColumn;
+    use crossterm::style::Print;
+    use crossterm::terminal::{Clear, ClearType};
+
+    crossterm::queue!(
+        std::io::stdout(),
+        MoveToColumn(0),
+        Clear(ClearType::CurrentLine)
+    )
+    .map_err(|e| format!("could not redraw shell input: {e}"))?;
+    print_windows_shell_prompt(cwd)?;
+    crossterm::queue!(std::io::stdout(), Print(line.visible()))
+        .map_err(|e| format!("could not redraw shell input: {e}"))?;
+    let prompt_width = windows_shell_prompt_width(cwd);
+    let input_width = line.visible_before_cursor().chars().count();
+    let column = prompt_width
+        .saturating_add(input_width)
+        .min(u16::MAX as usize) as u16;
+    crossterm::queue!(std::io::stdout(), MoveToColumn(column))
+        .map_err(|e| format!("could not position shell cursor: {e}"))?;
+    std::io::stdout()
+        .flush()
+        .map_err(|e| format!("could not redraw shell input: {e}"))
+}
+
+#[cfg(windows)]
+fn windows_shell_prompt_width(cwd: &str) -> usize {
+    6 + compact_windows_shell_cwd(cwd).chars().count()
+}
+
+#[cfg(windows)]
+fn single_line_shell_display(text: &str) -> String {
+    text.replace("\r\n", " ↵ ").replace(['\r', '\n'], " ↵ ")
+}
+
+#[cfg(windows)]
+struct BracketedPasteGuard;
+
+#[cfg(windows)]
+impl BracketedPasteGuard {
+    fn enable() -> Result<Self, String> {
+        crossterm::execute!(std::io::stdout(), crossterm::event::EnableBracketedPaste)
+            .map_err(|e| format!("could not enable protected paste: {e}"))?;
+        Ok(Self)
+    }
+}
+
+#[cfg(windows)]
+impl Drop for BracketedPasteGuard {
+    fn drop(&mut self) {
+        let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableBracketedPaste);
     }
 }
 
@@ -2848,8 +3702,18 @@ fn live_status(message: &str) {
     anstream::eprintln!("\x1b[36;1mpentect live\x1b[0m {message}");
 }
 
+fn shell_script_command(script_shell: ScriptShell) -> Result<Command, String> {
+    match script_shell {
+        ScriptShell::Native => Ok(native_shell_script_command()),
+        ScriptShell::Bash => Err(
+            "Bash scripts must run inside the host Bash tool through a Pentect hook".to_string(),
+        ),
+        ScriptShell::PowerShell => Ok(powershell_script_command()),
+    }
+}
+
 #[cfg(windows)]
-fn shell_script_command() -> Command {
+fn powershell_script_command() -> Command {
     let shell = std::env::var_os("SystemRoot")
         .map(PathBuf::from)
         .map(|root| {
@@ -2866,7 +3730,19 @@ fn shell_script_command() -> Command {
 }
 
 #[cfg(not(windows))]
-fn shell_script_command() -> Command {
+fn powershell_script_command() -> Command {
+    let mut command = Command::new("pwsh");
+    command.arg("-NoProfile").arg("-Command").arg("-");
+    command
+}
+
+#[cfg(windows)]
+fn native_shell_script_command() -> Command {
+    powershell_script_command()
+}
+
+#[cfg(not(windows))]
+fn native_shell_script_command() -> Command {
     let shell = if Path::new("/bin/sh").is_file() {
         PathBuf::from("/bin/sh")
     } else {
@@ -3112,7 +3988,34 @@ impl HookOpts {
 struct ExecOpts {
     session: String,
     live: bool,
+    script_shell: ScriptShell,
     mode: ExecMode,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScriptShell {
+    Native,
+    Bash,
+    PowerShell,
+}
+
+impl ScriptShell {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "native" => Ok(Self::Native),
+            "bash" => Ok(Self::Bash),
+            "powershell" => Ok(Self::PowerShell),
+            _ => Err("exec --script-shell requires native, bash, or powershell".to_string()),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Bash => "bash",
+            Self::PowerShell => "powershell",
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -3132,9 +4035,67 @@ struct ResolveOpts {
     mode: ResolveMode,
 }
 
+struct AgentScriptOpts {
+    session: String,
+    id: String,
+}
+
+struct AgentStreamOpts {
+    session: String,
+    target: StreamTarget,
+}
+
 enum ResolveMode {
     Files(Vec<PathBuf>),
     Stdin,
+}
+
+impl AgentScriptOpts {
+    fn parse(args: &[String]) -> Result<Self, String> {
+        let mut session = default_session_name()?;
+        let mut id = None;
+        let mut i = 2;
+        while i < args.len() {
+            match args[i].as_str() {
+                "--session" => {
+                    session = checked_session_name(&value(args, &mut i, "--session")?)
+                        .map_err(|error| error.to_string())?;
+                }
+                flag if flag.starts_with("--") => return Err(format!("unknown option: {flag}")),
+                value if id.is_none() => {
+                    id = Some(value.to_string());
+                    i += 1;
+                }
+                value => return Err(format!("unexpected agent script argument: {value}")),
+            }
+        }
+        Ok(Self {
+            session,
+            id: id.ok_or_else(|| "agent script requires an id".to_string())?,
+        })
+    }
+}
+
+impl AgentStreamOpts {
+    fn parse(args: &[String]) -> Result<Self, String> {
+        let mut session = default_session_name()?;
+        let mut target = StreamTarget::Stdout;
+        let mut i = 2;
+        while i < args.len() {
+            match args[i].as_str() {
+                "--session" => {
+                    session = checked_session_name(&value(args, &mut i, "--session")?)
+                        .map_err(|error| error.to_string())?;
+                }
+                "--stderr" => {
+                    target = StreamTarget::Stderr;
+                    i += 1;
+                }
+                flag => return Err(format!("unknown option: {flag}")),
+            }
+        }
+        Ok(Self { session, target })
+    }
 }
 
 impl ResolveOpts {
@@ -3202,6 +4163,7 @@ impl ExecOpts {
         let mut session = default_session_name()?;
         let mut live = false;
         let mut stdin = false;
+        let mut script_shell = ScriptShell::Native;
         let mut i = 2;
         while i < args.len() {
             match args[i].as_str() {
@@ -3215,6 +4177,9 @@ impl ExecOpts {
                 "--stdin" => {
                     stdin = true;
                     i += 1;
+                }
+                "--script-shell" => {
+                    script_shell = ScriptShell::parse(&value(args, &mut i, "--script-shell")?)?;
                 }
                 "--script-b64" => {
                     if stdin {
@@ -3231,6 +4196,7 @@ impl ExecOpts {
                     return Ok(Self {
                         session: checked_session_name(&session).map_err(|e| e.to_string())?,
                         live,
+                        script_shell,
                         mode: ExecMode::Shell(script),
                     });
                 }
@@ -3250,6 +4216,7 @@ impl ExecOpts {
                     return Ok(Self {
                         session: checked_session_name(&session).map_err(|e| e.to_string())?,
                         live,
+                        script_shell: ScriptShell::Native,
                         mode: ExecMode::Program(command),
                     });
                 }
@@ -3261,6 +4228,7 @@ impl ExecOpts {
                     return Ok(Self {
                         session: checked_session_name(&session).map_err(|e| e.to_string())?,
                         live,
+                        script_shell,
                         mode: ExecMode::Shell(args[i..].join(" ")),
                     });
                 }
@@ -3270,6 +4238,7 @@ impl ExecOpts {
             return Ok(Self {
                 session: checked_session_name(&session).map_err(|e| e.to_string())?,
                 live,
+                script_shell,
                 mode: ExecMode::Stdin,
             });
         }
@@ -3285,7 +4254,7 @@ fn prepare_stdin_exec_opts(mut opts: ExecOpts) -> Result<ExecOpts, String> {
 }
 
 fn decode_script_base64(value: &str) -> Result<String, String> {
-    let bytes = data_encoding::BASE64
+    let bytes = data_encoding::BASE64URL_NOPAD
         .decode(value.as_bytes())
         .map_err(|_| "exec --script-b64 requires valid base64".to_string())?;
     String::from_utf8(bytes).map_err(|_| "exec --script-b64 requires UTF-8 text".to_string())
@@ -3484,7 +4453,12 @@ fn before_tool_updated_input(
         if let Some(object) = updated.as_object_mut() {
             object.insert(
                 "command".to_string(),
-                Value::String(wrap_shell_command(provider, session_name, &command)?),
+                Value::String(wrap_shell_command(
+                    provider,
+                    session_name,
+                    tool_name,
+                    &command,
+                )?),
             );
             return Ok((updated, true));
         }
@@ -3526,7 +4500,12 @@ fn before_tool_updated_input_lazy(
         if let Some(object) = updated.as_object_mut() {
             object.insert(
                 "command".to_string(),
-                Value::String(wrap_shell_command(provider, session_name, &command)?),
+                Value::String(wrap_shell_command(
+                    provider,
+                    session_name,
+                    tool_name,
+                    &command,
+                )?),
             );
             return Ok((updated, true));
         }
@@ -4284,7 +5263,19 @@ fn extract_pentect_exec_shell_payload(command: &str) -> Option<String> {
             "--live" => {
                 rest = rest[word_end..].trim_start();
             }
+            "--script-shell" => {
+                let (value, _, value_end) = next_shell_word(rest, word_end)?;
+                ScriptShell::parse(&value).ok()?;
+                rest = rest[value_end..].trim_start();
+            }
             "--stdin" => return None,
+            "--script-b64" => {
+                let (payload, _, payload_end) = next_shell_word(rest, word_end)?;
+                if !rest[payload_end..].trim().is_empty() {
+                    return None;
+                }
+                return decode_script_base64(&payload).ok();
+            }
             "--shell" => {
                 return Some(unquote_wrapped_shell_arg(rest[word_end..].trim_start()));
             }
@@ -4380,21 +5371,117 @@ fn unquote_wrapped_shell_arg(value: &str) -> String {
 }
 
 fn wrap_shell_command(
-    _provider: HookProvider,
+    provider: HookProvider,
     session_name: &str,
+    tool_name: &str,
     masked_command: &str,
 ) -> Result<String, String> {
+    let shell = script_shell_for_tool(tool_name);
+    if matches!(provider, HookProvider::Claude | HookProvider::Generic)
+        && matches!(shell, ScriptShell::Bash | ScriptShell::PowerShell)
+    {
+        if let Some(client) = MemoryStoreClient::from_env() {
+            let id = client
+                .put_agent_script(shell.as_str(), masked_command)
+                .map_err(|error| error.to_string())?;
+            return same_shell_agent_wrapper(shell, session_name, &id);
+        }
+    }
     let mut args = vec!["exec".to_string()];
     add_non_default_session(&mut args, session_name);
-    args.push(exec_shell_argument(masked_command));
+    args.push("--script-shell".to_string());
+    args.push(shell.as_str().to_string());
+    args.push("--script-b64".to_string());
+    args.push(data_encoding::BASE64URL_NOPAD.encode(masked_command.as_bytes()));
     Ok(visible_pentect_command(&args))
 }
 
-fn exec_shell_argument(command: &str) -> String {
-    if command.starts_with('-') {
-        format!(" {command}")
-    } else {
-        command.to_string()
+fn same_shell_agent_wrapper(
+    shell: ScriptShell,
+    session_name: &str,
+    id: &str,
+) -> Result<String, String> {
+    let suffix = id
+        .get(..12)
+        .filter(|value| value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .ok_or_else(|| "agent script id is invalid".to_string())?;
+    let mut script_args = vec!["__agent-script".to_string(), id.to_string()];
+    let mut stream_args = vec!["__agent-stream".to_string()];
+    add_non_default_session(&mut script_args, session_name);
+    add_non_default_session(&mut stream_args, session_name);
+    match shell {
+        ScriptShell::Bash => Ok(bash_same_shell_wrapper(
+            suffix,
+            &target_shell_pentect_command(shell, &script_args),
+            &target_shell_pentect_command(shell, &stream_args),
+            &target_shell_pentect_command(
+                shell,
+                &stream_args
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once("--stderr".to_string()))
+                    .collect::<Vec<_>>(),
+            ),
+        )),
+        ScriptShell::PowerShell => Ok(powershell_same_shell_wrapper(
+            suffix,
+            &target_shell_pentect_command(shell, &script_args),
+            &target_shell_pentect_command(shell, &stream_args),
+        )),
+        ScriptShell::Native => Err("same-shell wrapper requires a known shell".to_string()),
+    }
+}
+
+fn target_shell_pentect_command(shell: ScriptShell, args: &[String]) -> String {
+    let quote = match shell {
+        ScriptShell::Bash => shell_quote_unix,
+        ScriptShell::PowerShell | ScriptShell::Native => powershell_word,
+    };
+    let mut command = String::from("pentect");
+    for arg in args {
+        command.push(' ');
+        command.push_str(&quote(arg));
+    }
+    command
+}
+
+fn bash_same_shell_wrapper(
+    suffix: &str,
+    script_command: &str,
+    stdout_command: &str,
+    stderr_command: &str,
+) -> String {
+    let out_fd = format!("_pentect_out_fd_{suffix}");
+    let err_fd = format!("_pentect_err_fd_{suffix}");
+    let out_pid = format!("_pentect_out_pid_{suffix}");
+    let err_pid = format!("_pentect_err_pid_{suffix}");
+    let status = format!("_pentect_status_{suffix}");
+    let out_status = format!("_pentect_out_status_{suffix}");
+    let err_status = format!("_pentect_err_status_{suffix}");
+    format!(
+        "exec {{{out_fd}}}> >({stdout_command}); {out_pid}=$!; exec {{{err_fd}}}> >({stderr_command}); {err_pid}=$!; (eval \"$({script_command})\") 1>&${out_fd} 2>&${err_fd}; {status}=$?; exec {{{out_fd}}}>&-; exec {{{err_fd}}}>&-; wait \"${out_pid}\"; {out_status}=$?; wait \"${err_pid}\"; {err_status}=$?; if [ \"${status}\" -eq 0 ] && [ \"${out_status}\" -ne 0 ]; then {status}=${out_status}; fi; if [ \"${status}\" -eq 0 ] && [ \"${err_status}\" -ne 0 ]; then {status}=${err_status}; fi; (exit \"${status}\")"
+    )
+}
+
+fn powershell_same_shell_wrapper(
+    suffix: &str,
+    script_command: &str,
+    stream_command: &str,
+) -> String {
+    let script = format!("__pentect_script_{suffix}");
+    let status = format!("__pentect_status_{suffix}");
+    let final_status = format!("__pentect_final_status_{suffix}");
+    let stream_status = format!("__pentect_stream_status_{suffix}");
+    format!(
+        "${script} = (& {script_command} | Out-String); if ($LASTEXITCODE -ne 0) {{ exit $LASTEXITCODE }}; $global:{status} = 0; ${script} += \"`n`$global:{status} = if (`$?) {{ 0 }} elseif (`$LASTEXITCODE -is [int] -and `$LASTEXITCODE -ne 0) {{ `$LASTEXITCODE }} else {{ 1 }}\"; & {{ try {{ Invoke-Expression ${script} }} catch {{ Write-Error -ErrorRecord $_; $global:{status} = 1 }} }} 2>&1 | Out-String -Stream | & {stream_command}; ${stream_status} = $LASTEXITCODE; ${script} = $null; if ($global:{status} -eq 0 -and ${stream_status} -ne 0) {{ $global:{status} = ${stream_status} }}; ${final_status} = $global:{status}; Remove-Variable {status} -Scope Global -ErrorAction SilentlyContinue; exit ${final_status}"
+    )
+}
+
+fn script_shell_for_tool(tool_name: &str) -> ScriptShell {
+    match tool_name.to_ascii_lowercase().as_str() {
+        "bash" => ScriptShell::Bash,
+        "powershell" => ScriptShell::PowerShell,
+        _ => ScriptShell::Native,
     }
 }
 

--- a/crates/pentect-runtime/src/memory_store.rs
+++ b/crates/pentect-runtime/src/memory_store.rs
@@ -110,26 +110,67 @@ fn resolve_with_recoveries(recoveries: &[Recovery], text: &str) -> String {
 
 fn is_reserved_child_env_name(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
-    matches!(
-        lower.as_str(),
-        "path"
-            | "pathext"
-            | "systemroot"
-            | "windir"
-            | "comspec"
-            | "temp"
-            | "tmp"
-            | "userprofile"
-            | "home"
-            | "shell"
-            | "term"
-            | "lang"
-            | "lc_all"
-            | "tmpdir"
-            | "pentect_bin"
-            | "pentect_home"
-            | "pentect_session"
-    )
+    is_pentect_control_env_name(&lower)
+        || matches!(
+            lower.as_str(),
+            "path"
+                | "pathext"
+                | "systemroot"
+                | "windir"
+                | "comspec"
+                | "temp"
+                | "tmp"
+                | "userprofile"
+                | "home"
+                | "shell"
+                | "term"
+                | "lang"
+                | "lc_all"
+                | "tmpdir"
+        )
+}
+
+/// These names control Pentect itself. Secret aliases may use the `PENTECT_`
+/// prefix, so the boundary is an explicit case-insensitive list rather than a
+/// blanket prefix ban.
+const PENTECT_CONTROL_ENV_NAMES: &[&str] = &[
+    "PENTECT_BIN",
+    "PENTECT_AGENT_LAUNCHED",
+    "PENTECT_MEMORY_STORE_ADDR",
+    "PENTECT_MEMORY_STORE_TOKEN",
+    "PENTECT_PROCESS_HOST_ROOT",
+    "PENTECT_PROCESS_HOST_READ_TOKEN",
+    "PENTECT_PROCESS_HOST_WRITE_TOKEN",
+    "PENTECT_EXTENSION_CONFIGS",
+    "PENTECT_EXTENSION_ADAPTERS",
+    "PENTECT_EXTENSION_NAME",
+    "PENTECT_EXTENSION_DATA_DIR",
+    "PENTECT_EXTENSION_CACHE_DIR",
+    "PENTECT_EXTENSION_CONFIG",
+    "PENTECT_CODEX_EXEC_PROXY",
+    "PENTECT_CODEX_APP_SERVER_PROXY",
+    "PENTECT_EXEC_PROXY_DEBUG",
+    "PENTECT_APP_PROXY_DEBUG",
+    "PENTECT_AGENT_CONTRACT",
+    "PENTECT_STATUS_LINE",
+    "PENTECT_HOME",
+    "PENTECT_SESSION",
+    "PENTECT_SHELL",
+    "PENTECT_SHELL_BIN",
+    "PENTECT_FILE_POINTER_MANAGER_DIR",
+    "PENTECT_CODEX",
+    "PENTECT_CLAUDE",
+    "PENTECT_OPENCODE",
+];
+
+pub fn pentect_control_env_names() -> &'static [&'static str] {
+    PENTECT_CONTROL_ENV_NAMES
+}
+
+pub fn is_pentect_control_env_name(name: &str) -> bool {
+    PENTECT_CONTROL_ENV_NAMES
+        .iter()
+        .any(|reserved| name.eq_ignore_ascii_case(reserved))
 }
 
 #[derive(Clone, Debug)]
@@ -166,7 +207,15 @@ impl MemoryStoreClient {
     pub(crate) fn from_env() -> Option<Self> {
         let addr = std::env::var(ENV_ADDR).ok()?;
         let token = std::env::var(ENV_TOKEN).ok()?;
-        if addr.is_empty() || token.is_empty() {
+        let launch_proof = std::env::var("PENTECT_AGENT_LAUNCHED").ok()?;
+        let root = crate::delegated_process_host::process_host_root().ok()?;
+        if !valid_runtime_token(&token)
+            || launch_proof != token
+            || !addr
+                .parse::<std::net::SocketAddr>()
+                .is_ok_and(|addr| addr.ip().is_loopback())
+            || !crate::delegated_process_host::contains_host(&root, &addr, &token)
+        {
             return None;
         }
         Some(Self::new(addr, token))
@@ -186,17 +235,17 @@ impl MemoryStoreClient {
 
     pub(crate) fn snapshot(&self) -> Result<MemoryStoreSnapshot> {
         let line = self.request("SNAPSHOT", "")?;
-        let fields = response_fields(&line)?;
-        if fields.len() != 3 || fields[0] != "OK" {
-            bail!("memory store snapshot response is malformed");
-        }
-        let key = decode_key_hex(fields[1])?;
-        let recovery_blob = data_encoding::BASE64
-            .decode(fields[2].as_bytes())
-            .context("memory store snapshot is not valid base64")?;
-        let recovery = Recovery::load(&recovery_blob, &key)
-            .map_err(|e| anyhow!("memory store snapshot is invalid: {e}"))?;
-        Ok(MemoryStoreSnapshot { key, recovery })
+        decode_snapshot_response(&line)
+    }
+
+    pub(crate) fn snapshot_once(&self, timeout: Duration) -> Result<MemoryStoreSnapshot> {
+        let line = self.request_once_with_timeout("SNAPSHOT", "", timeout)?;
+        decode_snapshot_response(&line)
+    }
+
+    pub(crate) fn masked_count_once(&self, timeout: Duration) -> Result<u64> {
+        let line = self.request_once_with_timeout("COUNT", "", timeout)?;
+        decode_masked_count_response(&line)
     }
 
     pub(crate) fn key(&self) -> Result<[u8; 32]> {
@@ -221,13 +270,7 @@ impl MemoryStoreClient {
 
     pub(crate) fn masked_count(&self) -> Result<u64> {
         let line = self.request("COUNT", "")?;
-        let fields = response_fields(&line)?;
-        if fields.len() != 2 || fields[0] != "OK" {
-            bail!("memory store count response is malformed");
-        }
-        fields[1]
-            .parse::<u64>()
-            .context("memory store masked count is not a number")
+        decode_masked_count_response(&line)
     }
 
     pub(crate) fn add_masked_count(&self, count: u64) -> Result<()> {
@@ -288,20 +331,33 @@ impl MemoryStoreClient {
     }
 
     fn request_once(&self, command: &str, payload: &str) -> Result<String> {
+        self.request_once_with_timeout(command, payload, REQUEST_TIMEOUT)
+    }
+
+    fn request_once_with_timeout(
+        &self,
+        command: &str,
+        payload: &str,
+        timeout: Duration,
+    ) -> Result<String> {
         let mut connection = self
             .connection
             .lock()
             .map_err(|_| anyhow!("memory store connection lock poisoned"))?;
         if connection.is_none() {
-            let stream = TcpStream::connect(&self.addr)
+            let addr = self
+                .addr
+                .parse::<std::net::SocketAddr>()
+                .with_context(|| format!("invalid memory store address: {}", self.addr))?;
+            let stream = TcpStream::connect_timeout(&addr, timeout)
                 .with_context(|| format!("could not connect to memory store at {}", self.addr))?;
-            let _ = stream.set_read_timeout(Some(REQUEST_TIMEOUT));
-            let _ = stream.set_write_timeout(Some(REQUEST_TIMEOUT));
             *connection = Some(BufReader::new(stream));
         }
         let reader = connection
             .as_mut()
             .ok_or_else(|| anyhow!("memory store connection unavailable"))?;
+        let _ = reader.get_mut().set_read_timeout(Some(timeout));
+        let _ = reader.get_mut().set_write_timeout(Some(timeout));
         writeln!(reader.get_mut(), "{}\t{}\t{}", self.token, command, payload)
             .and_then(|_| reader.get_mut().flush())
             .context("could not send memory store request")?;
@@ -317,6 +373,34 @@ impl MemoryStoreClient {
         }
         Ok(line)
     }
+}
+
+fn decode_snapshot_response(line: &str) -> Result<MemoryStoreSnapshot> {
+    let fields = response_fields(line)?;
+    if fields.len() != 3 || fields[0] != "OK" {
+        bail!("memory store snapshot response is malformed");
+    }
+    let key = decode_key_hex(fields[1])?;
+    let recovery_blob = data_encoding::BASE64
+        .decode(fields[2].as_bytes())
+        .context("memory store snapshot is not valid base64")?;
+    let recovery = Recovery::load(&recovery_blob, &key)
+        .map_err(|e| anyhow!("memory store snapshot is invalid: {e}"))?;
+    Ok(MemoryStoreSnapshot { key, recovery })
+}
+
+fn decode_masked_count_response(line: &str) -> Result<u64> {
+    let fields = response_fields(line)?;
+    if fields.len() != 2 || fields[0] != "OK" {
+        bail!("memory store count response is malformed");
+    }
+    fields[1]
+        .parse::<u64>()
+        .context("memory store masked count is not a number")
+}
+
+fn valid_runtime_token(token: &str) -> bool {
+    token.len() == TOKEN_BYTES * 2 && token.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 impl Drop for MemoryStoreClient {
@@ -347,6 +431,15 @@ pub fn open_memory_store_lease(addr: &str, token: &str) -> Result<MemoryStoreLea
     let _ = stream.set_read_timeout(None);
     let _ = stream.set_write_timeout(None);
     Ok(MemoryStoreLease { _stream: stream })
+}
+
+pub fn memory_store_ready(addr: &str, token: &str) -> bool {
+    let client = MemoryStoreClient::new(addr.to_string(), token.to_string());
+    client.masked_count().is_ok()
+}
+
+pub fn active_memory_store_ready() -> bool {
+    MemoryStoreClient::from_env().is_some_and(|client| client.masked_count().is_ok())
 }
 
 pub(crate) fn serve_memory_store() -> i32 {
@@ -738,6 +831,15 @@ mod tests {
         for _ in 0..1_000 {
             assert_eq!(client.masked_count().unwrap(), 0);
         }
+    }
+
+    #[test]
+    fn readiness_rejects_stale_or_incorrect_store_details() {
+        let token = "test-token-ready".to_string();
+        let addr = spawn_test_memory_store(token.clone());
+        assert!(memory_store_ready(&addr, &token));
+        assert!(!memory_store_ready(&addr, "wrong-token"));
+        assert!(!memory_store_ready("127.0.0.1:9", &token));
     }
 
     #[test]

--- a/crates/pentect-runtime/src/memory_store.rs
+++ b/crates/pentect-runtime/src/memory_store.rs
@@ -327,7 +327,9 @@ impl MemoryStoreClient {
         bytes.extend_from_slice(script.as_bytes());
         let payload = data_encoding::BASE64.encode(&bytes);
         bytes.zeroize();
-        let line = self.request("SCRIPT_PUT", &payload)?;
+        // Script IDs are single-use capabilities. Retrying a put after the
+        // server committed it can create an unreachable duplicate.
+        let line = self.request_once("SCRIPT_PUT", &payload)?;
         let fields = response_fields(&line)?;
         if fields.len() != 2 || fields[0] != "OK" || !valid_runtime_token(fields[1]) {
             bail!("memory store script response is malformed");
@@ -336,7 +338,7 @@ impl MemoryStoreClient {
     }
 
     pub(crate) fn take_agent_script(&self, id: &str) -> Result<(String, Zeroizing<String>)> {
-        self.take_agent_script_with("SCRIPT_TAKE", id)
+        self.take_agent_script_with("SCRIPT_TAKE", id, false)
     }
 
     #[cfg(test)]
@@ -344,15 +346,22 @@ impl MemoryStoreClient {
         &self,
         id: &str,
     ) -> Result<(String, Zeroizing<String>)> {
-        self.take_agent_script_with("SCRIPT_RENDER", id)
+        self.take_agent_script_with("SCRIPT_RENDER", id, true)
     }
 
     fn take_agent_script_with(
         &self,
         operation: &str,
         id: &str,
+        retry: bool,
     ) -> Result<(String, Zeroizing<String>)> {
-        let line = Zeroizing::new(self.request(operation, id)?);
+        // Taking consumes the capability, while test-only rendering is an
+        // idempotent read and may safely use the generic reconnect path.
+        let line = Zeroizing::new(if retry {
+            self.request(operation, id)?
+        } else {
+            self.request_once(operation, id)?
+        });
         let fields = response_fields(&line)?;
         if fields.len() != 2 || fields[0] != "OK" {
             bail!("memory store script response is malformed");

--- a/crates/pentect-runtime/src/memory_store.rs
+++ b/crates/pentect-runtime/src/memory_store.rs
@@ -3,11 +3,11 @@ use crate::session::Session;
 use crate::Result;
 use anyhow::{anyhow, bail, Context};
 use pentect_core::{Config, Recovery};
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use zeroize::{Zeroize, Zeroizing};
 
 pub(crate) const ENV_ADDR: &str = "PENTECT_MEMORY_STORE_ADDR";
@@ -18,6 +18,9 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_ACTIVITY_EVENTS: usize = 4_096;
 const MAX_ACTIVITY_EVENT_BYTES: usize = 16 * 1024;
 const MAX_ACTIVITY_POLL_EVENTS: usize = 256;
+const MAX_AGENT_SCRIPTS: usize = 128;
+const MAX_AGENT_SCRIPT_BYTES: usize = 4 * 1024 * 1024;
+const AGENT_SCRIPT_TTL: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub(crate) struct MemoryStore {
@@ -195,6 +198,13 @@ struct MemoryStoreState {
     masked_count: u64,
     activity: VecDeque<(u64, String)>,
     next_activity_id: u64,
+    agent_scripts: HashMap<String, AgentScript>,
+}
+
+struct AgentScript {
+    shell: String,
+    script: Zeroizing<String>,
+    expires_at: Instant,
 }
 
 impl Drop for MemoryStoreState {
@@ -266,6 +276,46 @@ impl MemoryStoreClient {
         } else {
             bail!("memory store add response is malformed")
         }
+    }
+
+    pub(crate) fn put_agent_script(&self, shell: &str, script: &str) -> Result<String> {
+        if script.len() > MAX_AGENT_SCRIPT_BYTES {
+            bail!("agent script exceeds {MAX_AGENT_SCRIPT_BYTES} bytes");
+        }
+        let mut bytes = Vec::with_capacity(shell.len() + script.len() + 1);
+        bytes.extend_from_slice(shell.as_bytes());
+        bytes.push(0);
+        bytes.extend_from_slice(script.as_bytes());
+        let payload = data_encoding::BASE64.encode(&bytes);
+        bytes.zeroize();
+        let line = self.request("SCRIPT_PUT", &payload)?;
+        let fields = response_fields(&line)?;
+        if fields.len() != 2 || fields[0] != "OK" || !valid_runtime_token(fields[1]) {
+            bail!("memory store script response is malformed");
+        }
+        Ok(fields[1].to_string())
+    }
+
+    pub(crate) fn take_agent_script(&self, id: &str) -> Result<(String, Zeroizing<String>)> {
+        let line = Zeroizing::new(self.request("SCRIPT_TAKE", id)?);
+        let fields = response_fields(&line)?;
+        if fields.len() != 2 || fields[0] != "OK" {
+            bail!("memory store script response is malformed");
+        }
+        let bytes = Zeroizing::new(
+            data_encoding::BASE64
+                .decode(fields[1].as_bytes())
+                .context("memory store script response is not valid base64")?,
+        );
+        let separator = bytes
+            .iter()
+            .position(|byte| *byte == 0)
+            .ok_or_else(|| anyhow!("memory store script response is malformed"))?;
+        let shell = String::from_utf8(bytes[..separator].to_vec())
+            .context("memory store script shell is not UTF-8")?;
+        let script = String::from_utf8(bytes[separator + 1..].to_vec())
+            .context("memory store script is not UTF-8")?;
+        Ok((shell, Zeroizing::new(script)))
     }
 
     pub(crate) fn masked_count(&self) -> Result<u64> {
@@ -468,6 +518,7 @@ fn serve_memory_store_inner() -> Result<()> {
         masked_count: 0,
         activity: VecDeque::with_capacity(MAX_ACTIVITY_EVENTS),
         next_activity_id: 1,
+        agent_scripts: HashMap::new(),
     }));
     println!(
         "{}",
@@ -524,6 +575,7 @@ pub(crate) fn spawn_test_memory_store_with_activity(
         masked_count: 0,
         activity: VecDeque::with_capacity(MAX_ACTIVITY_EVENTS),
         next_activity_id: 1,
+        agent_scripts: HashMap::new(),
     }));
     let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
     let addr = listener.local_addr().unwrap().to_string();
@@ -584,6 +636,12 @@ fn handle_client(
             [provided_token, "ADD_COUNT", payload] if *provided_token == token => {
                 add_masked_count_request(state, payload)
             }
+            [provided_token, "SCRIPT_PUT", payload] if *provided_token == token => {
+                put_agent_script_request(state, payload)
+            }
+            [provided_token, "SCRIPT_TAKE", id] if *provided_token == token => {
+                take_agent_script_request(state, id)
+            }
             [provided_token, "LEASE", ""] if *provided_token == token => {
                 exit_on_disconnect = true;
                 Ok("OK".to_string())
@@ -605,9 +663,11 @@ fn handle_client(
         };
         let stream = reader.get_mut();
         match response {
-            Ok(line) => writeln!(stream, "{line}")
-                .and_then(|_| stream.flush())
-                .context("could not write memory store response")?,
+            Ok(mut line) => {
+                let result = writeln!(stream, "{line}").and_then(|_| stream.flush());
+                line.zeroize();
+                result.context("could not write memory store response")?;
+            }
             Err(error) => writeln!(stream, "ERR\t{}", sanitize_field(&error.to_string()))
                 .and_then(|_| stream.flush())
                 .context("could not write memory store error")?,
@@ -667,6 +727,73 @@ fn add_masked_count_request(state: &Arc<Mutex<MemoryStoreState>>, payload: &str)
         .map_err(|_| anyhow!("memory store lock poisoned"))?;
     guard.masked_count = guard.masked_count.saturating_add(count);
     Ok("OK".to_string())
+}
+
+fn put_agent_script_request(state: &Arc<Mutex<MemoryStoreState>>, payload: &str) -> Result<String> {
+    let mut bytes = data_encoding::BASE64
+        .decode(payload.as_bytes())
+        .context("agent script payload is not valid base64")?;
+    let separator = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .ok_or_else(|| anyhow!("agent script payload is malformed"))?;
+    if bytes.len().saturating_sub(separator + 1) > MAX_AGENT_SCRIPT_BYTES {
+        bytes.zeroize();
+        bail!("agent script exceeds {MAX_AGENT_SCRIPT_BYTES} bytes");
+    }
+    let shell = String::from_utf8(bytes[..separator].to_vec())
+        .context("agent script shell is not UTF-8")?;
+    if !matches!(shell.as_str(), "bash" | "powershell" | "native") {
+        bytes.zeroize();
+        bail!("agent script shell is invalid");
+    }
+    let script =
+        String::from_utf8(bytes[separator + 1..].to_vec()).context("agent script is not UTF-8")?;
+    bytes.zeroize();
+
+    let mut guard = state
+        .lock()
+        .map_err(|_| anyhow!("memory store lock poisoned"))?;
+    let now = Instant::now();
+    guard
+        .agent_scripts
+        .retain(|_, pending| pending.expires_at > now);
+    if guard.agent_scripts.len() >= MAX_AGENT_SCRIPTS {
+        bail!("too many pending agent scripts");
+    }
+    let id = random_token_hex()?;
+    guard.agent_scripts.insert(
+        id.clone(),
+        AgentScript {
+            shell,
+            script: Zeroizing::new(script),
+            expires_at: now + AGENT_SCRIPT_TTL,
+        },
+    );
+    Ok(format!("OK\t{id}"))
+}
+
+fn take_agent_script_request(state: &Arc<Mutex<MemoryStoreState>>, id: &str) -> Result<String> {
+    if !valid_runtime_token(id) {
+        bail!("agent script id is invalid");
+    }
+    let mut guard = state
+        .lock()
+        .map_err(|_| anyhow!("memory store lock poisoned"))?;
+    let pending = guard
+        .agent_scripts
+        .remove(id)
+        .ok_or_else(|| anyhow!("agent script is unavailable"))?;
+    if pending.expires_at <= Instant::now() {
+        bail!("agent script expired");
+    }
+    let mut bytes = Vec::with_capacity(pending.shell.len() + pending.script.len() + 1);
+    bytes.extend_from_slice(pending.shell.as_bytes());
+    bytes.push(0);
+    bytes.extend_from_slice(pending.script.as_bytes());
+    let payload = data_encoding::BASE64.encode(&bytes);
+    bytes.zeroize();
+    Ok(format!("OK\t{payload}"))
 }
 
 fn add_activity_request(state: &Arc<Mutex<MemoryStoreState>>, payload: &str) -> Result<String> {
@@ -825,6 +952,19 @@ mod tests {
     }
 
     #[test]
+    fn agent_scripts_are_memory_only_and_single_use() {
+        let token = "test-token-script".to_string();
+        let client = MemoryStoreClient::new(spawn_test_memory_store(token.clone()), token);
+        let id = client
+            .put_agent_script("bash", "printf '%s' \"$PENTECT_SECRET_deadbeef\"")
+            .unwrap();
+        let (shell, script) = client.take_agent_script(&id).unwrap();
+        assert_eq!(shell, "bash");
+        assert_eq!(script.as_str(), "printf '%s' \"$PENTECT_SECRET_deadbeef\"");
+        assert!(client.take_agent_script(&id).is_err());
+    }
+
+    #[test]
     fn client_reuses_one_connection_for_repeated_output_checks() {
         let token = "test-token-persistent".to_string();
         let client = MemoryStoreClient::new(spawn_test_memory_store(token.clone()), token);
@@ -882,6 +1022,7 @@ mod tests {
             masked_count: 0,
             activity: VecDeque::with_capacity(MAX_ACTIVITY_EVENTS),
             next_activity_id: 1,
+            agent_scripts: HashMap::new(),
         }));
         let payload = data_encoding::BASE64.encode(br#"{"action":"mask"}"#);
         for _ in 0..=MAX_ACTIVITY_EVENTS {

--- a/crates/pentect-runtime/src/memory_store.rs
+++ b/crates/pentect-runtime/src/memory_store.rs
@@ -6,7 +6,7 @@ use pentect_core::{Config, Recovery};
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, Instant};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -192,6 +192,45 @@ pub struct MemoryStoreLease {
     _stream: TcpStream,
 }
 
+pub struct InProcessMemoryStore {
+    addr: String,
+    token: Zeroizing<String>,
+    process_host_read_token: Zeroizing<String>,
+    process_host_write_token: Zeroizing<String>,
+    shutdown: Option<mpsc::Sender<()>>,
+    server_thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for InProcessMemoryStore {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+            let _ = TcpStream::connect(&self.addr);
+        }
+        if let Some(thread) = self.server_thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl InProcessMemoryStore {
+    pub fn addr(&self) -> &str {
+        &self.addr
+    }
+
+    pub fn token(&self) -> &str {
+        self.token.as_str()
+    }
+
+    pub fn process_host_read_token(&self) -> &str {
+        self.process_host_read_token.as_str()
+    }
+
+    pub fn process_host_write_token(&self) -> &str {
+        self.process_host_write_token.as_str()
+    }
+}
+
 struct MemoryStoreState {
     key: [u8; 32],
     recovery: Recovery,
@@ -297,7 +336,23 @@ impl MemoryStoreClient {
     }
 
     pub(crate) fn take_agent_script(&self, id: &str) -> Result<(String, Zeroizing<String>)> {
-        let line = Zeroizing::new(self.request("SCRIPT_TAKE", id)?);
+        self.take_agent_script_with("SCRIPT_TAKE", id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_rendered_agent_script(
+        &self,
+        id: &str,
+    ) -> Result<(String, Zeroizing<String>)> {
+        self.take_agent_script_with("SCRIPT_RENDER", id)
+    }
+
+    fn take_agent_script_with(
+        &self,
+        operation: &str,
+        id: &str,
+    ) -> Result<(String, Zeroizing<String>)> {
+        let line = Zeroizing::new(self.request(operation, id)?);
         let fields = response_fields(&line)?;
         if fields.len() != 2 || fields[0] != "OK" {
             bail!("memory store script response is malformed");
@@ -552,6 +607,59 @@ fn serve_memory_store_inner() -> Result<()> {
     Ok(())
 }
 
+pub fn start_in_process_memory_store() -> Result<InProcessMemoryStore> {
+    let listener =
+        TcpListener::bind(("127.0.0.1", 0)).context("could not bind memory store listener")?;
+    let addr = listener
+        .local_addr()
+        .context("could not read memory store address")?
+        .to_string();
+    let token = Zeroizing::new(random_token_hex()?);
+    let process_host_read_token = Zeroizing::new(random_token_hex()?);
+    let process_host_write_token = Zeroizing::new(random_token_hex()?);
+    let key = Config::generate().key;
+    let state = Arc::new(Mutex::new(MemoryStoreState {
+        key,
+        recovery: Recovery::empty_for_key(&key),
+        masked_count: 0,
+        activity: VecDeque::with_capacity(MAX_ACTIVITY_EVENTS),
+        next_activity_id: 1,
+        agent_scripts: HashMap::new(),
+    }));
+    let server_token = Arc::new(Zeroizing::new(token.to_string()));
+    let server_read_token = Arc::new(Zeroizing::new(process_host_read_token.to_string()));
+    let server_write_token = Arc::new(Zeroizing::new(process_host_write_token.to_string()));
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+    let server_thread = std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            if shutdown_rx.try_recv().is_ok() {
+                break;
+            }
+            let state = Arc::clone(&state);
+            let token = Arc::clone(&server_token);
+            let read_token = Arc::clone(&server_read_token);
+            let write_token = Arc::clone(&server_write_token);
+            std::thread::spawn(move || {
+                let _ = handle_client(
+                    stream,
+                    token.as_str(),
+                    read_token.as_str(),
+                    write_token.as_str(),
+                    &state,
+                );
+            });
+        }
+    });
+    Ok(InProcessMemoryStore {
+        addr,
+        token,
+        process_host_read_token,
+        process_host_write_token,
+        shutdown: Some(shutdown_tx),
+        server_thread: Some(server_thread),
+    })
+}
+
 #[cfg(test)]
 pub(crate) fn spawn_test_memory_store(token: String) -> String {
     let read_token = format!("{token}-activity-read");
@@ -641,6 +749,9 @@ fn handle_client(
             }
             [provided_token, "SCRIPT_TAKE", id] if *provided_token == token => {
                 take_agent_script_request(state, id)
+            }
+            [provided_token, "SCRIPT_RENDER", id] if *provided_token == token => {
+                render_agent_script_request(state, id)
             }
             [provided_token, "LEASE", ""] if *provided_token == token => {
                 exit_on_disconnect = true;
@@ -774,6 +885,55 @@ fn put_agent_script_request(state: &Arc<Mutex<MemoryStoreState>>, payload: &str)
 }
 
 fn take_agent_script_request(state: &Arc<Mutex<MemoryStoreState>>, id: &str) -> Result<String> {
+    let pending = take_pending_agent_script(state, id)?;
+    encode_agent_script_response(&pending.shell, pending.script.as_str())
+}
+
+fn render_agent_script_request(state: &Arc<Mutex<MemoryStoreState>>, id: &str) -> Result<String> {
+    let pending = take_pending_agent_script(state, id)?;
+    let guard = state
+        .lock()
+        .map_err(|_| anyhow!("memory store lock poisoned"))?;
+    let recovery = &guard.recovery;
+    let mode = crate::ExecMode::Shell(pending.script.to_string());
+    let resolved = Zeroizing::new(recovery.resolve(pending.script.as_str()));
+    if crate::contains_unresolved_masked_handle(resolved.as_str()) {
+        bail!("unknown masked handle");
+    }
+    let names = crate::referenced_env_names(&mode);
+    let mut bindings = BTreeMap::new();
+    for placeholder in recovery.placeholders() {
+        if !is_env_alias_placeholder(&placeholder) {
+            continue;
+        }
+        let record = recovery.resolve(&placeholder);
+        let Some((name, handle)) = decode_env_alias_record(&record) else {
+            continue;
+        };
+        let lower = name.to_ascii_lowercase();
+        if !names.contains(&lower) || is_reserved_child_env_name(name) {
+            continue;
+        }
+        let value = recovery.resolve(handle);
+        if value != handle {
+            bindings.insert(lower, (name.to_string(), value));
+        }
+    }
+    let rendered = Zeroizing::new(
+        crate::render_agent_script(
+            &pending.shell,
+            &bindings.into_values().collect::<Vec<_>>(),
+            resolved.as_str(),
+        )
+        .map_err(anyhow::Error::msg)?,
+    );
+    encode_agent_script_response(&pending.shell, rendered.as_str())
+}
+
+fn take_pending_agent_script(
+    state: &Arc<Mutex<MemoryStoreState>>,
+    id: &str,
+) -> Result<AgentScript> {
     if !valid_runtime_token(id) {
         bail!("agent script id is invalid");
     }
@@ -787,10 +947,14 @@ fn take_agent_script_request(state: &Arc<Mutex<MemoryStoreState>>, id: &str) -> 
     if pending.expires_at <= Instant::now() {
         bail!("agent script expired");
     }
-    let mut bytes = Vec::with_capacity(pending.shell.len() + pending.script.len() + 1);
-    bytes.extend_from_slice(pending.shell.as_bytes());
+    Ok(pending)
+}
+
+fn encode_agent_script_response(shell: &str, script: &str) -> Result<String> {
+    let mut bytes = Vec::with_capacity(shell.len() + script.len() + 1);
+    bytes.extend_from_slice(shell.as_bytes());
     bytes.push(0);
-    bytes.extend_from_slice(pending.script.as_bytes());
+    bytes.extend_from_slice(script.as_bytes());
     let payload = data_encoding::BASE64.encode(&bytes);
     bytes.zeroize();
     Ok(format!("OK\t{payload}"))
@@ -898,6 +1062,14 @@ mod tests {
             snapshot.recovery.resolve(&masked),
             "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n"
         );
+    }
+
+    #[test]
+    fn in_process_memory_store_starts_without_a_child_process() {
+        let server = start_in_process_memory_store().unwrap();
+        assert!(memory_store_ready(server.addr(), server.token()));
+        assert_eq!(server.token().len(), 64);
+        drop(server);
     }
 
     #[test]

--- a/crates/pentect-runtime/src/output_remask.rs
+++ b/crates/pentect-runtime/src/output_remask.rs
@@ -1,8 +1,10 @@
 use crate::memory_store::MemoryStoreClient;
 use pentect_core::{recovery::RecoveryStreamRemasker, Recovery};
+use std::time::Duration;
 use zeroize::Zeroize;
 
 const MAX_PENDING_CONTROL_BYTES: usize = 1024 * 1024;
+const TERMINAL_MEMORY_STORE_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub struct ActiveTerminalOutputRemasker {
     client: Option<MemoryStoreClient>,
@@ -19,8 +21,12 @@ impl ActiveTerminalOutputRemasker {
                 terminal: TerminalOutputRemasker::default(),
             });
         };
-        let observed_masked_count = client.masked_count().map_err(|error| error.to_string())?;
-        let snapshot = client.snapshot().map_err(|error| error.to_string())?;
+        let observed_masked_count = client
+            .masked_count_once(TERMINAL_MEMORY_STORE_TIMEOUT)
+            .map_err(|error| error.to_string())?;
+        let snapshot = client
+            .snapshot_once(TERMINAL_MEMORY_STORE_TIMEOUT)
+            .map_err(|error| error.to_string())?;
         Ok(Self {
             client: Some(client),
             observed_masked_count,
@@ -38,15 +44,23 @@ impl ActiveTerminalOutputRemasker {
         Ok(self.terminal.finish())
     }
 
+    pub fn finish_after_error(&mut self) -> Vec<u8> {
+        self.terminal.finish()
+    }
+
     fn refresh(&mut self) -> Result<(), String> {
         let Some(client) = &self.client else {
             return Ok(());
         };
-        let count = client.masked_count().map_err(|error| error.to_string())?;
+        let count = client
+            .masked_count_once(TERMINAL_MEMORY_STORE_TIMEOUT)
+            .map_err(|error| error.to_string())?;
         if count == self.observed_masked_count {
             return Ok(());
         }
-        let snapshot = client.snapshot().map_err(|error| error.to_string())?;
+        let snapshot = client
+            .snapshot_once(TERMINAL_MEMORY_STORE_TIMEOUT)
+            .map_err(|error| error.to_string())?;
         self.terminal.merge_recovery(&snapshot.recovery);
         self.observed_masked_count = count;
         Ok(())
@@ -57,8 +71,15 @@ impl ActiveTerminalOutputRemasker {
 struct TerminalOutputRemasker {
     matcher: RecoveryStreamRemasker,
     pending: Vec<u8>,
+    string_control: Option<StringControl>,
     alternate_screen: bool,
     alternate_keyboard_depth: usize,
+}
+
+#[derive(Clone, Copy)]
+enum StringControl {
+    Osc,
+    Other,
 }
 
 impl TerminalOutputRemasker {
@@ -66,6 +87,7 @@ impl TerminalOutputRemasker {
         Self {
             matcher: recovery.stream_remasker(),
             pending: Vec::new(),
+            string_control: None,
             alternate_screen: false,
             alternate_keyboard_depth: 0,
         }
@@ -80,6 +102,29 @@ impl TerminalOutputRemasker {
         let mut out = Vec::with_capacity(bytes.len());
         let mut cursor = 0usize;
         while cursor < self.pending.len() {
+            if let Some(kind) = self.string_control {
+                let end = match kind {
+                    StringControl::Osc => osc_end(&self.pending, cursor),
+                    StringControl::Other => string_control_end(&self.pending, cursor),
+                };
+                if let Some((payload_end, sequence_end)) = end {
+                    out.extend(self.matcher.push_text(&self.pending[cursor..payload_end]));
+                    out.extend(
+                        self.matcher
+                            .push_boundary_control(&self.pending[payload_end..sequence_end]),
+                    );
+                    self.string_control = None;
+                    cursor = sequence_end;
+                    continue;
+                }
+                let safe_end = cursor + streamable_control_payload_len(&self.pending[cursor..]);
+                if safe_end == cursor {
+                    break;
+                }
+                out.extend(self.matcher.push_text(&self.pending[cursor..safe_end]));
+                cursor = safe_end;
+                continue;
+            }
             let byte = self.pending[cursor];
             if byte == 0x1b {
                 let Some(next) = self.pending.get(cursor + 1).copied() else {
@@ -101,43 +146,20 @@ impl TerminalOutputRemasker {
                         cursor = end + 1;
                     }
                     b']' => {
-                        let Some((payload_end, sequence_end)) = osc_end(&self.pending, cursor + 2)
-                        else {
-                            break;
-                        };
                         out.extend(
                             self.matcher
                                 .push_boundary_control(&self.pending[cursor..cursor + 2]),
                         );
-                        out.extend(
-                            self.matcher
-                                .push_text(&self.pending[cursor + 2..payload_end]),
-                        );
-                        out.extend(
-                            self.matcher
-                                .push_boundary_control(&self.pending[payload_end..sequence_end]),
-                        );
-                        cursor = sequence_end;
+                        self.string_control = Some(StringControl::Osc);
+                        cursor += 2;
                     }
                     b'P' | b'X' | b'^' | b'_' => {
-                        let Some((payload_end, sequence_end)) =
-                            string_control_end(&self.pending, cursor + 2)
-                        else {
-                            break;
-                        };
                         out.extend(
                             self.matcher
                                 .push_boundary_control(&self.pending[cursor..cursor + 2]),
                         );
-                        out.extend(
-                            self.matcher
-                                .push_text(&self.pending[cursor + 2..payload_end]),
-                        );
-                        out.extend(
-                            self.matcher
-                                .push_boundary_control(&self.pending[payload_end..sequence_end]),
-                        );
-                        cursor = sequence_end;
+                        self.string_control = Some(StringControl::Other);
+                        cursor += 2;
                     }
                     _ => {
                         out.extend(
@@ -165,43 +187,21 @@ impl TerminalOutputRemasker {
                 continue;
             }
             if byte == 0x9d {
-                let Some((payload_end, sequence_end)) = osc_end(&self.pending, cursor + 1) else {
-                    break;
-                };
                 out.extend(
                     self.matcher
                         .push_boundary_control(&self.pending[cursor..cursor + 1]),
                 );
-                out.extend(
-                    self.matcher
-                        .push_text(&self.pending[cursor + 1..payload_end]),
-                );
-                out.extend(
-                    self.matcher
-                        .push_boundary_control(&self.pending[payload_end..sequence_end]),
-                );
-                cursor = sequence_end;
+                self.string_control = Some(StringControl::Osc);
+                cursor += 1;
                 continue;
             }
             if matches!(byte, 0x90 | 0x98 | 0x9e | 0x9f) {
-                let Some((payload_end, sequence_end)) =
-                    string_control_end(&self.pending, cursor + 1)
-                else {
-                    break;
-                };
                 out.extend(
                     self.matcher
                         .push_boundary_control(&self.pending[cursor..cursor + 1]),
                 );
-                out.extend(
-                    self.matcher
-                        .push_text(&self.pending[cursor + 1..payload_end]),
-                );
-                out.extend(
-                    self.matcher
-                        .push_boundary_control(&self.pending[payload_end..sequence_end]),
-                );
-                cursor = sequence_end;
+                self.string_control = Some(StringControl::Other);
+                cursor += 1;
                 continue;
             }
             if is_terminal_control(byte) {
@@ -225,7 +225,7 @@ impl TerminalOutputRemasker {
             self.pending[remaining..].zeroize();
             self.pending.truncate(remaining);
         }
-        if self.pending.len() > MAX_PENDING_CONTROL_BYTES {
+        if self.string_control.is_none() && self.pending.len() > MAX_PENDING_CONTROL_BYTES {
             self.pending.zeroize();
             self.pending.clear();
             return Err("terminal output control sequence exceeds 1 MiB".to_string());
@@ -279,10 +279,17 @@ impl TerminalOutputRemasker {
 
     fn finish(&mut self) -> Vec<u8> {
         let mut out = Vec::new();
-        if !self.pending.is_empty() {
+        if self.string_control.is_some() && !self.pending.is_empty() {
             out.extend(self.matcher.push_text(&self.pending));
+        }
+        if !self.pending.is_empty() {
             self.pending.zeroize();
             self.pending.clear();
+        }
+        if self.string_control.take().is_some() {
+            // A child can exit mid-OSC/DCS. Closing it here keeps the parent's
+            // terminal restore sequence from becoming control-string payload.
+            out.extend(self.matcher.push_boundary_control(b"\x1b\\"));
         }
         out.extend(self.matcher.finish());
         out
@@ -423,6 +430,30 @@ fn string_control_end(bytes: &[u8], start: usize) -> Option<(usize, usize)> {
     None
 }
 
+fn streamable_control_payload_len(bytes: &[u8]) -> usize {
+    let utf8_suffix = incomplete_utf8_suffix_len(bytes);
+    let escape_suffix = usize::from(bytes.last() == Some(&0x1b));
+    bytes.len().saturating_sub(utf8_suffix.max(escape_suffix))
+}
+
+fn incomplete_utf8_suffix_len(bytes: &[u8]) -> usize {
+    let start = bytes.len().saturating_sub(3);
+    for index in (start..bytes.len()).rev() {
+        let Some(width) = utf8_sequence_width(bytes[index]) else {
+            continue;
+        };
+        let available = bytes.len() - index;
+        if available < width
+            && bytes[index + 1..]
+                .iter()
+                .all(|byte| (0x80..=0xbf).contains(byte))
+        {
+            return available;
+        }
+    }
+    0
+}
+
 fn is_terminal_control(byte: u8) -> bool {
     (byte < 0x20 && !matches!(byte, b'\r' | b'\n' | b'\t'))
         || byte == 0x7f
@@ -506,11 +537,53 @@ mod tests {
     fn c1_string_terminators_do_not_hold_following_output() {
         let mut remasker = TerminalOutputRemasker::new(&recovery());
         let mut out = remasker.push(b"\x9d0;title").unwrap();
-        assert!(out.is_empty());
         out.extend(remasker.push(b"\x9cafter\x90payload").unwrap());
         out.extend(remasker.push(b"\x9cmore").unwrap());
         out.extend(remasker.finish());
         assert_eq!(out, b"\x9d0;title\x9cafter\x90payload\x9cmore");
+    }
+
+    #[test]
+    fn large_control_strings_are_streamed_without_ending_the_session() {
+        let secret = b"sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+        let mut input = b"\x1b]1337;File=".to_vec();
+        input.extend(std::iter::repeat_n(b'a', MAX_PENDING_CONTROL_BYTES * 2));
+        input.extend_from_slice(secret);
+        input.extend_from_slice(b"\x1b\\after");
+
+        let mut remasker = TerminalOutputRemasker::new(&recovery());
+        let mut out = Vec::new();
+        for chunk in input.chunks(8192) {
+            out.extend(remasker.push(chunk).unwrap());
+        }
+        out.extend(remasker.finish());
+
+        assert!(!out.windows(secret.len()).any(|window| window == secret));
+        assert!(out
+            .windows(b"<<OPENAI_API_KEY_0011223344556677>>".len())
+            .any(|window| { window == b"<<OPENAI_API_KEY_0011223344556677>>" }));
+        assert!(out.ends_with(b"\x1b\\after"));
+    }
+
+    #[test]
+    fn unfinished_control_strings_are_closed_before_parent_output() {
+        for introducer in [b"\x1b]".as_slice(), b"\x1bP", b"\x9d", b"\x90"] {
+            let mut remasker = TerminalOutputRemasker::new(&recovery());
+            let mut out = remasker.push(introducer).unwrap();
+            out.extend(remasker.push(b"partial title").unwrap());
+            out.extend(remasker.finish());
+            assert!(out.ends_with(b"\x1b\\"), "{out:?}");
+        }
+    }
+
+    #[test]
+    fn unfinished_non_string_controls_are_not_forwarded() {
+        for sequence in [b"\x1b".as_slice(), b"\x1b[?1049", b"\x9b31"] {
+            let mut remasker = TerminalOutputRemasker::new(&recovery());
+            let mut out = remasker.push(sequence).unwrap();
+            out.extend(remasker.finish());
+            assert!(out.is_empty(), "{out:?}");
+        }
     }
 
     #[test]

--- a/crates/pentect-runtime/src/output_remask.rs
+++ b/crates/pentect-runtime/src/output_remask.rs
@@ -257,11 +257,11 @@ impl TerminalOutputRemasker {
                 *alternate_screen = false;
                 *alternate_keyboard_depth = 0;
             }
-        } else if is_win32_input_mode(sequence) {
-            out.extend(matcher.push_boundary_control(&[]));
         } else if is_sgr(sequence) {
             out.extend(matcher.push_control(sequence));
         } else {
+            // Nested ConPTY handshakes such as ?9001 must reach the parent
+            // terminal so both PTYs use the same keyboard encoding.
             out.extend(matcher.push_boundary_control(sequence));
         }
         if *alternate_screen {
@@ -310,10 +310,6 @@ fn is_sgr(sequence: &[u8]) -> bool {
     };
     body.iter()
         .all(|byte| byte.is_ascii_digit() || matches!(byte, b';' | b':'))
-}
-
-fn is_win32_input_mode(sequence: &[u8]) -> bool {
-    csi_body(sequence).is_some_and(|body| matches!(body, b"?9001h" | b"?9001l"))
 }
 
 fn alternate_screen_change(sequence: &[u8]) -> Option<bool> {
@@ -674,13 +670,13 @@ mod tests {
     }
 
     #[test]
-    fn nested_win32_input_mode_does_not_escape_the_proxy() {
+    fn nested_win32_input_mode_reaches_the_parent_terminal() {
         let mut remasker = TerminalOutputRemasker::new(&recovery());
         let mut out = remasker
             .push(b"before\x1b[?9001hready\x1b[?9001lafter")
             .unwrap();
         out.extend(remasker.finish());
-        assert_eq!(out, b"beforereadyafter");
+        assert_eq!(out, b"before\x1b[?9001hready\x1b[?9001lafter");
     }
 
     #[test]

--- a/crates/pentect-runtime/src/session.rs
+++ b/crates/pentect-runtime/src/session.rs
@@ -130,9 +130,7 @@ impl Drop for Session {
 
 pub(crate) fn session_root(name: &str) -> Result<PathBuf> {
     let name = checked_session_name(name)?;
-    let base = std::env::var_os("PENTECT_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(PENTECT_DIR).join(AGENT_DIR));
+    let base = PathBuf::from(PENTECT_DIR).join(AGENT_DIR);
     Ok(base.join(name))
 }
 

--- a/crates/pentect-runtime/src/shell.rs
+++ b/crates/pentect-runtime/src/shell.rs
@@ -49,11 +49,11 @@ pub(crate) fn powershell_word(value: &str) -> String {
     if is_simple_shell_word(value) {
         value.to_string()
     } else {
-        powershell_quote(value)
+        powershell_string_literal(value)
     }
 }
 
-fn powershell_quote(value: &str) -> String {
+pub(crate) fn powershell_string_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -21,50 +21,8 @@ fn windows_shell_line_keeps_raw_and_visible_paste_separate() {
     assert!(line
         .take_injected_prefixes()
         .starts_with("$env:PENTECT_RUNPOD_API_KEY_deadbeef="));
-    assert!(line.backspace());
+    assert!(line.backspace().is_some());
     assert_eq!(line.raw(), "echo ");
-}
-
-#[cfg(windows)]
-#[test]
-fn windows_shell_line_edits_at_the_cursor() {
-    let mut line = WindowsShellLine::default();
-    for ch in ["a", "b", "c"] {
-        line.push_typed(ch);
-    }
-    assert!(line.move_left());
-    assert!(line.move_left());
-    line.push_typed("X");
-    assert_eq!(line.raw(), "aXbc");
-    assert_eq!(line.visible_before_cursor(), "aX");
-    assert!(line.delete());
-    assert_eq!(line.raw(), "aXc");
-    assert!(line.backspace());
-    assert_eq!(line.raw(), "ac");
-    assert!(line.move_home());
-    assert!(line.delete());
-    assert_eq!(line.raw(), "c");
-    assert!(line.move_end());
-    line.push_typed("!");
-    assert_eq!(line.raw(), "c!");
-}
-
-#[cfg(windows)]
-#[test]
-fn windows_shell_history_restores_drafts_and_skips_sensitive_commands() {
-    let mut history = WindowsShellHistory::default();
-    history.record("Get-Location", false);
-    history.record("Get-ChildItem", false);
-    history.record("Write-Output secret", true);
-
-    assert_eq!(history.previous("draft"), Some("Get-ChildItem".to_string()));
-    assert_eq!(
-        history.previous("ignored"),
-        Some("Get-Location".to_string())
-    );
-    assert_eq!(history.next(), Some("Get-ChildItem".to_string()));
-    assert_eq!(history.next(), Some("draft".to_string()));
-    assert_eq!(history.entries.len(), 2);
 }
 
 #[cfg(windows)]
@@ -1038,7 +996,7 @@ fn bridge_session_exports_only_the_owned_runtime_session() {
     assert!(session["contract"]
         .as_str()
         .unwrap()
-        .contains("Pentect agent contract"));
+        .contains("Session rules"));
     let environment = session["environment"].as_object().unwrap();
     assert_eq!(environment.len(), 4);
     for name in [ENV_ADDR, ENV_TOKEN, PENTECT_AGENT_LAUNCHED_ENV] {
@@ -1086,6 +1044,24 @@ fn bridge_line_reader_discards_oversized_request() {
         BridgeLine::Ready
     ));
     assert_eq!(line, b"{}\n");
+}
+
+#[test]
+fn bridge_error_preserves_phase_and_execution_state() {
+    let mut output = Vec::new();
+    write_bridge_response(
+        &mut output,
+        json!(7),
+        "after",
+        Err("Media output unavailable.".to_string()),
+    )
+    .unwrap();
+    let response: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(response["ok"], false);
+    assert_eq!(response["error"]["code"], "output_unavailable");
+    assert_eq!(response["error"]["phase"], "after");
+    assert_eq!(response["error"]["executed"], true);
+    assert_eq!(response["error"]["message"], "Media output unavailable.");
 }
 
 #[test]
@@ -2283,7 +2259,8 @@ fn tool_text_output_masks_mcp_connector_and_plugin_envelopes() {
     let output = handle_hook(HookProvider::Generic, "t", &session, blocked).unwrap();
     assert_eq!(output["decision"], "block");
     let reason = output["reason"].as_str().unwrap();
-    assert!(reason.contains("non-text media"), "{reason}");
+    assert!(reason.starts_with("Tool completed"), "{reason}");
+    assert!(reason.contains("Media output unavailable"), "{reason}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -2366,7 +2343,7 @@ fn claude_posttool_redacts_secret_qr_image_instead_of_blocking() {
     assert!(output.get("decision").is_none(), "{output}");
     let updated = &output["hookSpecificOutput"]["updatedToolOutput"];
     let rendered = serde_json::to_string(updated).unwrap();
-    assert!(rendered.contains("Pentect image masks"), "{rendered}");
+    assert!(rendered.contains("Masked regions"), "{rendered}");
     assert!(rendered.contains("[1] OPENAI_API_KEY"), "{rendered}");
     assert!(
         rendered.contains("\"mimeType\":\"image/png\""),
@@ -2405,10 +2382,11 @@ fn codex_posttool_still_blocks_secret_qr_image() {
 }
 
 #[test]
-fn posttool_blocks_clipboard_and_download_side_effect_outputs() {
-    let (root, session) = empty_session("hook-post-side-effect-block");
+fn posttool_masks_clipboard_text_without_misreporting_completed_side_effects() {
+    let (root, session) = empty_session("hook-post-side-effect-mask");
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
     for response in [
-        json!({"clipboardText": "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX"}),
+        json!({"clipboardText": format!("OPENAI_API_KEY={raw}")}),
         json!({"downloadPath": "C:\\Users\\demo\\Downloads\\secret.txt"}),
     ] {
         let input = json!({
@@ -2417,9 +2395,11 @@ fn posttool_blocks_clipboard_and_download_side_effect_outputs() {
             "tool_response": response
         });
         let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
-        assert_eq!(output["decision"], "block", "{output}");
-        let reason = output["reason"].as_str().unwrap();
-        assert!(reason.contains("clipboard/download"), "{reason}");
+        assert!(output.get("decision").is_none(), "{output}");
+        assert!(
+            !serde_json::to_string(&output).unwrap().contains(raw),
+            "{output}"
+        );
     }
     let _ = std::fs::remove_dir_all(root);
 }
@@ -3985,6 +3965,139 @@ fn pretool_wraps_plain_shell_commands_for_every_provider() {
 }
 
 #[test]
+fn claude_pretool_wraps_powershell_and_injects_prompt_binding() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("hook-pre-powershell-binding");
+    let producer = Session::open_capability(DEFAULT_SESSION).unwrap();
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let masked = mask_prompt_text_into_active_memory_store(&format!("OPENAI_API_KEY={raw}"))
+        .unwrap()
+        .unwrap();
+    let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+    let env_name = pentect_env_name_for_handle(&handle);
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "PowerShell",
+        "tool_input": {
+            "command": format!("Write-Output $env:{env_name}")
+        }
+    });
+    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &producer, input).unwrap();
+    let command = output["hookSpecificOutput"]["updatedInput"]["command"]
+        .as_str()
+        .unwrap();
+    assert!(command.contains("Invoke-Expression"), "{command}");
+    let id = powershell_agent_script_id_from_wrapper(command);
+    let client = MemoryStoreClient::from_env().unwrap();
+    let (shell, rendered) = client.take_rendered_agent_script(&id).unwrap();
+    assert_eq!(shell, "powershell");
+    assert!(
+        rendered.contains(&format!("$env:{env_name} = ")),
+        "{rendered:?}"
+    );
+    assert!(
+        rendered.contains(&format!("$env:{env_name} = '{raw}'")),
+        "{rendered:?}"
+    );
+    assert!(rendered.contains(raw), "{rendered:?}");
+}
+
+#[cfg(windows)]
+#[test]
+fn claude_powershell_wrapper_preserves_command_output() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("hook-powershell-output");
+    let session = Session::open_capability(DEFAULT_SESSION).unwrap();
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let masked = mask_prompt_text_into_active_memory_store(&format!("OPENAI_API_KEY={raw}"))
+        .unwrap()
+        .unwrap();
+    let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+    let env_name = pentect_env_name_for_handle(&handle);
+    let input = || {
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "PowerShell",
+            "tool_input": {
+                "command": format!(
+                    "Write-Output 'BEFORE'; Write-Output \"OPENAI_API_KEY=$env:{env_name}\"; Write-Output 'AFTER'"
+                )
+            }
+        })
+    };
+    let fetch = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input()).unwrap();
+    let fetch_command = fetch["hookSpecificOutput"]["updatedInput"]["command"]
+        .as_str()
+        .unwrap();
+    let fetch_id = powershell_agent_script_id_from_wrapper(fetch_command);
+    let fetch_output = Command::new(windows_powershell_path())
+        .arg("-NoProfile")
+        .arg("-Command")
+        .arg(format!(
+            "& {}",
+            powershell_agent_script_fetch("0123456789ab", &fetch_id)
+        ))
+        .output()
+        .unwrap();
+    assert!(fetch_output.status.success(), "{fetch_output:?}");
+    let fetched = String::from_utf8_lossy(&fetch_output.stdout);
+    assert!(fetched.contains("BEFORE"), "{fetch_output:?}");
+    assert!(fetched.contains(raw), "{fetch_output:?}");
+    assert!(fetched.contains("AFTER"), "{fetch_output:?}");
+
+    let before = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input()).unwrap();
+    let command = before["hookSpecificOutput"]["updatedInput"]["command"]
+        .as_str()
+        .unwrap();
+    let output = Command::new(windows_powershell_path())
+        .arg("-NoProfile")
+        .arg("-Command")
+        .arg(command)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("BEFORE"), "{output:?}");
+    assert!(stdout.contains(raw), "{output:?}");
+    assert!(stdout.contains("AFTER"), "{output:?}");
+
+    let after = handle_hook(
+        HookProvider::Claude,
+        DEFAULT_SESSION,
+        &session,
+        json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "PowerShell",
+            "tool_response": { "stdout": stdout.as_ref(), "stderr": "" }
+        }),
+    )
+    .unwrap();
+    let protected = after["hookSpecificOutput"]["updatedToolOutput"]["stdout"]
+        .as_str()
+        .unwrap();
+    assert!(protected.contains("BEFORE"), "{protected}");
+    assert!(!protected.contains(raw), "{protected}");
+    assert!(protected.contains("<<OPENAI_API_KEY_"), "{protected}");
+    assert!(protected.contains("AFTER"), "{protected}");
+}
+
+#[test]
+fn pretool_does_not_treat_mcp_command_fields_as_shell_commands() {
+    let (root, session) = empty_session("hook-pre-mcp-command-field");
+    let input = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "mcp__service__invoke",
+        "tool_input": {
+            "command": "remote-operation",
+            "argument": "value"
+        }
+    });
+    let output = handle_hook(HookProvider::Claude, DEFAULT_SESSION, &session, input).unwrap();
+    assert_eq!(output, json!({}));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn codex_app_server_proxy_wraps_shell_even_when_exec_proxy_is_enabled() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     std::env::set_var("PENTECT_CODEX_APP_SERVER_PROXY", "1");
@@ -4197,10 +4310,11 @@ fn claude_powershell_uses_current_shell_without_child_shell_discovery() {
     )
     .unwrap();
     assert!(command.contains("Invoke-Expression"), "{command}");
-    assert!(command.contains("__agent-script"), "{command}");
-    assert!(command.contains("__agent-stream"), "{command}");
+    assert!(command.contains("SCRIPT_RENDER"), "{command}");
+    assert!(!command.contains("__agent-stream"), "{command}");
     assert!(!command.contains("powershell.exe"), "{command}");
     assert!(!command.contains("--script-shell"), "{command}");
+    assert!(!command.contains("& &"), "{command}");
 }
 
 #[test]
@@ -4226,7 +4340,6 @@ fn powershell_same_shell_wrapper_preserves_native_exit_code() {
     let wrapper = powershell_same_shell_wrapper(
         "0123456789ab",
         "cmd /D /S /C 'echo Write-Output same-shell; cmd /D /S /C exit 7'",
-        "cmd /D /S /C more",
     );
     let output = Command::new(windows_powershell_path())
         .arg("-NoProfile")
@@ -4237,6 +4350,29 @@ fn powershell_same_shell_wrapper_preserves_native_exit_code() {
     assert_eq!(output.status.code(), Some(7), "{output:?}");
     assert!(
         String::from_utf8_lossy(&output.stdout).contains("same-shell"),
+        "{output:?}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn powershell_same_shell_wrapper_preserves_script_fetch_failure() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("hook-powershell-fetch-failure");
+    let id = "0".repeat(64);
+    let wrapper = powershell_same_shell_wrapper(
+        "0123456789ab",
+        &powershell_agent_script_fetch("0123456789ab", &id),
+    );
+    let output = Command::new(windows_powershell_path())
+        .arg("-NoProfile")
+        .arg("-Command")
+        .arg(&wrapper)
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "{output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("script unavailable"),
         "{output:?}"
     );
 }
@@ -4445,6 +4581,10 @@ fn codex_posttool_blocks_with_masked_feedback() {
     let output = handle_hook(HookProvider::Codex, "t", &session, input).unwrap();
     assert_eq!(output["decision"], "block");
     let reason = output["reason"].as_str().unwrap();
+    assert!(
+        reason.starts_with("Tool completed. Protected output:"),
+        "{reason}"
+    );
     assert!(reason.contains("<<OPENAI_API_KEY_"), "{reason}");
     assert!(!reason.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"), "{reason}");
     assert!(output.get("hookSpecificOutput").is_none(), "{output}");
@@ -4543,6 +4683,18 @@ fn agent_script_id_from_wrapper(command: &str) -> String {
         .filter(|id| id.bytes().all(|byte| byte.is_ascii_hexdigit()))
         .map(str::to_string)
         .unwrap_or_else(|| panic!("missing agent script id in {command}"))
+}
+
+fn powershell_agent_script_id_from_wrapper(command: &str) -> String {
+    let marker = "SCRIPT_RENDER`t";
+    let tail = command
+        .split_once(marker)
+        .map(|(_, tail)| tail)
+        .unwrap_or_else(|| panic!("missing memory script fetch in {command}"));
+    tail.get(..64)
+        .filter(|id| id.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .map(str::to_string)
+        .unwrap_or_else(|| panic!("invalid agent script id in {command}"))
 }
 
 fn masked_handle_from_assignment(masked: &str, key: &str) -> String {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -4157,6 +4157,7 @@ fn hook_bash_transport_keeps_shell_syntax_and_environment_aliases() {
     let command =
         wrap_shell_command(HookProvider::Claude, DEFAULT_SESSION, "Bash", &script).unwrap();
     assert!(command.contains("eval"), "{command}");
+    assert!(!command.contains("exec {"), "{command}");
     assert!(command.contains("__agent-script"), "{command}");
     assert!(command.contains("__agent-stream"), "{command}");
     assert!(!command.contains("--script-shell"), "{command}");

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -100,6 +100,7 @@ fn windows_shell_host_preserves_state_without_terminal_control_sequences() {
     use std::process::Stdio;
 
     let marker = windows_shell_marker().unwrap();
+    let drain_marker = windows_shell_marker().unwrap();
     let mut child = Command::new(windows_powershell_path())
         .arg("-NoLogo")
         .arg("-NoProfile")
@@ -107,6 +108,7 @@ fn windows_shell_host_preserves_state_without_terminal_control_sequences() {
         .arg("-Command")
         .arg(WINDOWS_SHELL_HOST_SCRIPT)
         .env("PENTECT_SHELL_COMMAND_MARKER", &marker)
+        .env("PENTECT_SHELL_DRAIN_MARKER", &drain_marker)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -115,28 +117,36 @@ fn windows_shell_host_preserves_state_without_terminal_control_sequences() {
     let mut stdin = child.stdin.take().unwrap();
     let mut stdout = BufReader::new(child.stdout.take().unwrap());
 
-    for command in [
+    let mut output = String::new();
+    for (index, command) in [
         "$global:PentectShellState=41",
         "Write-Output ($global:PentectShellState + 1)",
-    ] {
+    ]
+    .into_iter()
+    .enumerate()
+    {
         writeln!(
             stdin,
             "{}",
             data_encoding::BASE64.encode(command.as_bytes())
         )
         .unwrap();
+        if index == 0 {
+            writeln!(stdin, "stale interactive input").unwrap();
+        }
         stdin.flush().unwrap();
-    }
-
-    let mut output = String::new();
-    let mut completions = 0;
-    while completions < 2 {
-        let mut line = String::new();
-        assert_ne!(stdout.read_line(&mut line).unwrap(), 0);
-        if line.contains(&marker) {
-            completions += 1;
-        } else {
-            output.push_str(&line);
+        loop {
+            let mut line = String::new();
+            assert_ne!(stdout.read_line(&mut line).unwrap(), 0);
+            if line.contains(&format!("{marker}DRAIN")) {
+                writeln!(stdin).unwrap();
+                writeln!(stdin, "{drain_marker}").unwrap();
+                stdin.flush().unwrap();
+            } else if line.contains(&marker) {
+                break;
+            } else {
+                output.push_str(&line);
+            }
         }
     }
 
@@ -4233,15 +4243,36 @@ fn running_windows_shell_forwards_interactive_input() {
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
     let mut output = Vec::new();
-    forward_windows_running_input(Event::Paste("secret text".to_string()), &mut output).unwrap();
+    let mut input = WindowsRunningInput::default();
+    forward_windows_running_input(
+        Event::Paste("secret texx".to_string()),
+        &mut output,
+        &mut input,
+    )
+    .unwrap();
+    forward_windows_running_input(
+        Event::Key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+        &mut output,
+        &mut input,
+    )
+    .unwrap();
+    forward_windows_running_input(
+        Event::Key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+        &mut output,
+        &mut input,
+    )
+    .unwrap();
+    forward_windows_running_input(Event::Paste("xt".to_string()), &mut output, &mut input).unwrap();
     forward_windows_running_input(
         Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
         &mut output,
+        &mut input,
     )
     .unwrap();
     forward_windows_running_input(
         Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
         &mut output,
+        &mut input,
     )
     .unwrap();
     assert_eq!(output, b"secret text\r\n\x03");
@@ -4252,9 +4283,11 @@ fn bash_same_shell_wrapper_preserves_output_and_exit_code() {
     let Some(bash) = bash_for_wrapper_test() else {
         return;
     };
+    let marker = "__PENTECT_STREAM_END_test__";
     let source = "printf '%s\\n' same-shell; exit 7";
     let script_command = format!("printf %s {}", shell_quote_unix(source));
-    let wrapper = bash_same_shell_wrapper("0123456789ab", &script_command, "cat", "cat >&2");
+    let stream = format!("sed -n {}", shell_quote_unix(&format!("/{marker}/q;p")));
+    let wrapper = bash_same_shell_wrapper("0123456789ab", marker, &script_command, &stream);
     let output = Command::new(bash).arg("-c").arg(&wrapper).output().unwrap();
     assert_eq!(output.status.code(), Some(7), "{output:?}");
     assert_eq!(
@@ -4262,6 +4295,40 @@ fn bash_same_shell_wrapper_preserves_output_and_exit_code() {
         "same-shell",
         "{output:?}"
     );
+}
+
+#[test]
+#[cfg(not(windows))]
+fn bash_same_shell_wrapper_does_not_wait_for_background_output_holders() {
+    let Some(bash) = bash_for_wrapper_test() else {
+        return;
+    };
+    let marker = "__PENTECT_STREAM_END_background_test__";
+    let source = "printf 'foreground\\n'; (sleep 5; printf 'background\\n') &";
+    let script_command = format!("printf %s {}", shell_quote_unix(source));
+    let stream = format!("sed -n {}", shell_quote_unix(&format!("/{marker}/q;p")));
+    let wrapper = bash_same_shell_wrapper("0123456789ab", marker, &script_command, &stream);
+    let started = std::time::Instant::now();
+    let output = Command::new(bash).arg("-c").arg(&wrapper).output().unwrap();
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+    assert!(started.elapsed() < Duration::from_secs(2), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "foreground",
+        "{output:?}"
+    );
+}
+
+#[test]
+fn bash_same_shell_wrapper_preserves_script_fetch_failure() {
+    let Some(bash) = bash_for_wrapper_test() else {
+        return;
+    };
+    let marker = "__PENTECT_STREAM_END_fetch_failure__";
+    let stream = format!("sed -n {}", shell_quote_unix(&format!("/{marker}/q;p")));
+    let wrapper = bash_same_shell_wrapper("0123456789ab", marker, "false", &stream);
+    let output = Command::new(bash).arg("-c").arg(&wrapper).output().unwrap();
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
 }
 
 #[cfg(windows)]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -4,38 +4,6 @@ static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(windows)]
 #[test]
-fn windows_shell_line_keeps_raw_and_visible_paste_separate() {
-    let mut line = WindowsShellLine::default();
-    line.push_typed("echo ");
-    line.push_paste(
-        "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef".to_string(),
-        "$env:PENTECT_RUNPOD_API_KEY_deadbeef".to_string(),
-        "$env:PENTECT_RUNPOD_API_KEY_deadbeef='secret'; ".to_string(),
-    );
-
-    assert_eq!(
-        line.raw(),
-        "echo rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"
-    );
-    assert_eq!(line.visible(), "echo $env:PENTECT_RUNPOD_API_KEY_deadbeef");
-    assert!(line
-        .take_injected_prefixes()
-        .starts_with("$env:PENTECT_RUNPOD_API_KEY_deadbeef="));
-    assert!(line.backspace().is_some());
-    assert_eq!(line.raw(), "echo ");
-}
-
-#[cfg(windows)]
-#[test]
-fn windows_shell_paste_display_keeps_the_prompt_on_one_line() {
-    assert_eq!(
-        single_line_shell_display("Write-Output one\r\nWrite-Output two\n"),
-        "Write-Output one ↵ Write-Output two ↵ "
-    );
-}
-
-#[cfg(windows)]
-#[test]
 fn windows_shell_prompt_compacts_only_home_and_its_descendants() {
     assert_eq!(
         compact_windows_shell_cwd_with_home(r"C:\Users\yun40\Desktop\pentect", r"C:\Users\yun40"),
@@ -49,6 +17,111 @@ fn windows_shell_prompt_compacts_only_home_and_its_descendants() {
         compact_windows_shell_cwd_with_home(r"C:\Users\yun400\work", r"C:\Users\yun40"),
         r"C:\Users\yun400\work"
     );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_repairs_stale_virtual_terminal_input_mode() {
+    use windows_sys::Win32::System::Console::{
+        ENABLE_ECHO_INPUT, ENABLE_EXTENDED_FLAGS, ENABLE_LINE_INPUT, ENABLE_MOUSE_INPUT,
+        ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT,
+    };
+
+    let repaired =
+        windows_shell_sane_input_mode(ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_MOUSE_INPUT);
+    assert_eq!(repaired & ENABLE_VIRTUAL_TERMINAL_INPUT, 0);
+    assert_eq!(repaired & ENABLE_MOUSE_INPUT, 0);
+    for required in [
+        ENABLE_PROCESSED_INPUT,
+        ENABLE_LINE_INPUT,
+        ENABLE_ECHO_INPUT,
+        ENABLE_EXTENDED_FLAGS,
+    ] {
+        assert_ne!(repaired & required, 0);
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_routes_interactive_agents_outside_the_protocol_pipe() {
+    assert!(is_windows_shell_interactive_agent_command("codex"));
+    assert!(is_windows_shell_interactive_agent_command(
+        "claude --resume"
+    ));
+    assert!(is_windows_shell_interactive_agent_command("opencode"));
+    assert_eq!(
+        windows_shell_interactive_agent_args("claude --resume").unwrap(),
+        ["claude", "--resume"]
+    );
+    assert!(!is_windows_shell_interactive_agent_command("codex; whoami"));
+    assert!(!is_windows_shell_interactive_agent_command(
+        "Write-Output codex"
+    ));
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_history_excludes_protected_commands() {
+    assert!(windows_shell_history_is_safe("git status", false));
+    assert!(!windows_shell_history_is_safe(
+        "Write-Output rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef",
+        true
+    ));
+    assert!(!windows_shell_history_is_safe(
+        "$env:PENTECT_SECRET_deadbeef",
+        false
+    ));
+    assert!(!windows_shell_history_is_safe(
+        "Write-Output <<SECRET_deadbeef>>",
+        false
+    ));
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_display_never_renders_the_pasted_secret() {
+    let (root, session) = empty_session("windows-shell-safe-display");
+    let store = MemoryStore::for_session(&session);
+    let display = WindowsShellDisplay::new(store).unwrap();
+    let raw = "Write-Output rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let rendered = Highlighter::highlight(&display, raw, raw.len()).into_owned();
+
+    assert!(!rendered.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"));
+    assert!(rendered.contains("$env:PENTECT_"), "{rendered}");
+    assert_eq!(rendered.chars().count(), raw.chars().count());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_env_reference_injects_its_recovered_value() {
+    let (root, session) = empty_session("windows-shell-env-injection");
+    let store = MemoryStore::for_session(&session);
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let mut preview = ShellInputProtector::new(store.clone()).unwrap();
+    let displayed = preview.prepare_paste(raw).unwrap();
+    assert!(displayed.visible.starts_with("$env:PENTECT_SECRET_"));
+
+    let mut executor = ShellInputProtector::new(store).unwrap();
+    let mut submitted = executor.prepare_paste(&displayed.visible).unwrap();
+    assert!(submitted.child.contains(raw), "{}", submitted.child);
+    assert!(
+        submitted.child.ends_with(&displayed.visible),
+        "{}",
+        submitted.child
+    );
+    let output = Command::new(windows_powershell_path())
+        .arg("-NoLogo")
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .arg("-Command")
+        .arg(&submitted.child)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), raw);
+    submitted.child.zeroize();
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[cfg(windows)]
@@ -432,21 +505,19 @@ fn windows_shell_keeps_previewed_secret_assignment_until_submit() {
     let store = MemoryStore::for_session(&session);
     let mut protector = ShellInputProtector::new(store).unwrap();
     let raw = "Write-Output sk-ABCDEFGHIJKLMNOPQRSTUVWX";
-    let preview = protector.prepare_paste(raw).unwrap();
-    let mut line = WindowsShellLine::default();
-    line.push_paste(raw.to_string(), preview.visible, preview.injected_prefix);
-
-    let submitted = protector.prepare_paste(&line.raw()).unwrap();
-    assert!(submitted.injected_prefix.is_empty());
-    let mut child_command = line.take_injected_prefixes();
-    child_command.push_str(&submitted.child);
+    let mut submitted = protector.prepare_paste(raw).unwrap();
     assert!(
-        child_command.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"),
-        "{child_command}"
+        submitted.child.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"),
+        "{}",
+        submitted.child
     );
-    assert!(child_command.contains("$env:PENTECT_"), "{child_command}");
-    assert!(!line.visible().contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"));
-    child_command.zeroize();
+    assert!(
+        submitted.child.contains("$env:PENTECT_"),
+        "{}",
+        submitted.child
+    );
+    assert!(!submitted.visible.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"));
+    submitted.child.zeroize();
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -780,15 +851,11 @@ fn read_dotenv_masks_all_values() {
     assert!(!result.masked.contains("114514810"), "{}", result.masked);
     assert!(!result.masked.contains("hello world"), "{}", result.masked);
     assert!(
-        result.masked.contains("TEST_SECRET=<<SECRET_"),
+        result.masked.contains("TEST_SECRET=<<TEST_SECRET_"),
         "{}",
         result.masked
     );
-    assert!(
-        result.masked.contains("NOTE=<<SECRET_"),
-        "{}",
-        result.masked
-    );
+    assert!(result.masked.contains("NOTE=<<NOTE_"), "{}", result.masked);
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -1194,8 +1261,8 @@ fn exec_auto_binds_masked_env_output_in_running_session() {
         masked.contains("RUNPOD_API_KEY=<<RUNPOD_API_KEY_"),
         "{masked}"
     );
-    assert!(masked.contains("TEST_SECRET=<<SECRET_"), "{masked}");
-    assert!(masked.contains("NOTE=<<SECRET_"), "{masked}");
+    assert!(masked.contains("TEST_SECRET=<<TEST_SECRET_"), "{masked}");
+    assert!(masked.contains("NOTE=<<NOTE_"), "{masked}");
     let runpod_handle = masked_handle_from_assignment(&masked, "RUNPOD_API_KEY");
     let runpod_pentect_env = pentect_env_name_for_handle(&runpod_handle);
     let test_secret_env =
@@ -1358,11 +1425,8 @@ fn auto_env_bindings_do_not_override_baseline_environment() {
     let session = Session::open_capability_at(&root, "t").unwrap();
     let output = "PATH=sk-ABCDEFGHIJKLMNOPQRSTUVWX\nPENTECT_MEMORY_STORE_TOKEN=sk-ZZZZZZZZZZZZZZZZZZZZ\nDUMMY_SECRET=sk-YYYYYYYYYYYYYYYYYYYY\n";
     let masked = mask_tool_output(&session, output).unwrap();
-    assert!(masked.contains("PATH=<<OPENAI_API_KEY_"), "{masked}");
-    assert!(
-        masked.contains("DUMMY_SECRET=<<OPENAI_API_KEY_"),
-        "{masked}"
-    );
+    assert!(masked.contains("PATH=<<PATH_"), "{masked}");
+    assert!(masked.contains("DUMMY_SECRET=<<DUMMY_SECRET_"), "{masked}");
 
     let store = MemoryStore::for_session(&session);
     let env = store.auto_env_bindings().unwrap();
@@ -1375,7 +1439,7 @@ fn auto_env_bindings_do_not_override_baseline_environment() {
     );
     assert!(
         env.iter()
-            .any(|(name, value)| name.starts_with("PENTECT_OPENAI_API_KEY_")
+            .any(|(name, value)| name.starts_with("PENTECT_DUMMY_SECRET_")
                 && value == "sk-YYYYYYYYYYYYYYYYYYYY"),
         "{env:?}"
     );
@@ -2050,7 +2114,7 @@ fn mcp_style_tool_result_masks_content_and_structured_content() {
     let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
     let updated = &output["hookSpecificOutput"]["updatedToolOutput"];
     let rendered = serde_json::to_string(updated).unwrap();
-    assert!(rendered.contains("<<RUNPOD_API_KEY_"), "{rendered}");
+    assert!(rendered.contains("<<SECRET_"), "{rendered}");
     assert!(rendered.contains("<<OPENAI_API_KEY_"), "{rendered}");
     assert!(!rendered.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"));
     assert!(!rendered.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"));
@@ -2110,7 +2174,7 @@ fn generic_posttool_masks_external_tool_response_aliases() {
     let output = handle_hook(HookProvider::Generic, "t", &session, input).unwrap();
     let updated = &output["hookSpecificOutput"]["updatedToolOutput"];
     let rendered = serde_json::to_string(updated).unwrap();
-    assert!(rendered.contains("<<RUNPOD_API_KEY_"), "{rendered}");
+    assert!(rendered.contains("<<SECRET_"), "{rendered}");
     assert!(rendered.contains("<<OPENAI_API_KEY_"), "{rendered}");
     assert!(!rendered.contains(raw_runpod), "{rendered}");
     assert!(!rendered.contains(raw_openai), "{rendered}");
@@ -2526,10 +2590,7 @@ fn browser_api_key_issue_flow_masks_value_and_keeps_capability_usable() {
     let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
     let rendered = serde_json::to_string(&output).unwrap();
     assert!(!rendered.contains(raw), "{rendered}");
-    assert!(
-        rendered.contains("RUNPOD_API_KEY=<<RUNPOD_API_KEY_"),
-        "{rendered}"
-    );
+    assert!(rendered.contains("RUNPOD_API_KEY=<<SECRET_"), "{rendered}");
     assert!(rendered.contains("Create API key"), "{rendered}");
     assert!(
         rendered.contains("Use this key to call the health endpoint."),
@@ -2541,7 +2602,7 @@ fn browser_api_key_issue_flow_masks_value_and_keeps_capability_usable() {
     let env_name = env
         .iter()
         .find_map(|(name, value)| {
-            (name.starts_with("PENTECT_RUNPOD_API_KEY_") && value == raw).then(|| name.clone())
+            (name.starts_with("PENTECT_SECRET_") && value == raw).then(|| name.clone())
         })
         .unwrap_or_else(|| panic!("missing RUNPOD capability in {env:?}"));
     let command = if cfg!(windows) {
@@ -2560,7 +2621,7 @@ fn browser_api_key_issue_flow_masks_value_and_keeps_capability_usable() {
     assert!(stdout.contains(raw), "{stdout}");
     let safe = mask_tool_output(&session, &stdout).unwrap();
     assert!(!safe.contains(raw), "{safe}");
-    assert!(safe.contains("<<RUNPOD_API_KEY_"), "{safe}");
+    assert!(safe.contains("<<SECRET_"), "{safe}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -2784,8 +2845,8 @@ fn env_like_tool_output_masks_all_env_values() {
     assert!(!masked.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"));
     assert!(!masked.contains("114514810"), "{masked}");
     assert!(!masked.contains("hello world"), "{masked}");
-    assert!(masked.contains("TEST_SECRET=<<SECRET_"), "{masked}");
-    assert!(masked.contains("NOTE=<<SECRET_"), "{masked}");
+    assert!(masked.contains("TEST_SECRET=<<TEST_SECRET_"), "{masked}");
+    assert!(masked.contains("NOTE=<<NOTE_"), "{masked}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -2981,8 +3042,8 @@ fn metadata_assignment_output_does_not_pollute_recovery() {
         masked.contains("RUNPOD_API_KEY=<<RUNPOD_API_KEY_"),
         "{masked}"
     );
-    assert!(masked.contains("TEST_SECRET=<<SECRET_"), "{masked}");
-    assert!(masked.contains("NOTE=<<SECRET_"), "{masked}");
+    assert!(masked.contains("TEST_SECRET=<<TEST_SECRET_"), "{masked}");
+    assert!(masked.contains("NOTE=<<NOTE_"), "{masked}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -2991,7 +3052,7 @@ fn live_single_assignment_output_masks_value() {
     let (root, session) = empty_session("exec-live-single-assignment");
     let masked = mask_live_output(&session, "NOTE=hello world\n").unwrap();
     assert!(!masked.contains("hello world"), "{masked}");
-    assert!(masked.contains("NOTE=<<SECRET_"), "{masked}");
+    assert!(masked.contains("NOTE=<<NOTE_"), "{masked}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -4377,47 +4438,6 @@ fn powershell_same_shell_wrapper_preserves_script_fetch_failure() {
     );
 }
 
-#[cfg(windows)]
-#[test]
-fn running_windows_shell_forwards_interactive_input() {
-    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-
-    let mut output = Vec::new();
-    let mut input = WindowsRunningInput::default();
-    forward_windows_running_input(
-        Event::Paste("secret texx".to_string()),
-        &mut output,
-        &mut input,
-    )
-    .unwrap();
-    forward_windows_running_input(
-        Event::Key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
-        &mut output,
-        &mut input,
-    )
-    .unwrap();
-    forward_windows_running_input(
-        Event::Key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
-        &mut output,
-        &mut input,
-    )
-    .unwrap();
-    forward_windows_running_input(Event::Paste("xt".to_string()), &mut output, &mut input).unwrap();
-    forward_windows_running_input(
-        Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
-        &mut output,
-        &mut input,
-    )
-    .unwrap();
-    forward_windows_running_input(
-        Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
-        &mut output,
-        &mut input,
-    )
-    .unwrap();
-    assert_eq!(output, b"secret text\r\n\x03");
-}
-
 #[test]
 fn bash_same_shell_wrapper_preserves_output_and_exit_code() {
     let Some(bash) = bash_for_wrapper_test() else {
@@ -4565,7 +4585,7 @@ fn hook_text_masks_runpod_token_as_plain_text() {
     let raw = concat!("RUNPOD=", "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef");
     let masked = mask_tool_output(&session, raw).unwrap();
     assert!(!masked.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"));
-    assert!(masked.contains("<<RUNPOD_API_KEY_"), "{masked}");
+    assert!(masked.contains("<<SECRET_"), "{masked}");
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -4332,6 +4332,28 @@ fn bash_same_shell_wrapper_preserves_script_fetch_failure() {
     assert_eq!(output.status.code(), Some(1), "{output:?}");
 }
 
+#[test]
+fn bash_same_shell_wrapper_ignores_unwaitable_process_substitution_status() {
+    let Some(bash) = bash_for_wrapper_test() else {
+        return;
+    };
+    let marker = "__PENTECT_STREAM_END_unwaitable_test__";
+    let source = "printf 'same-shell\\n'";
+    let script_command = format!("printf %s {}", shell_quote_unix(source));
+    let stream = format!(
+        "sed -n {}; exit 127",
+        shell_quote_unix(&format!("/{marker}/q;p"))
+    );
+    let wrapper = bash_same_shell_wrapper("0123456789ab", marker, &script_command, &stream);
+    let output = Command::new(bash).arg("-c").arg(&wrapper).output().unwrap();
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "same-shell",
+        "{output:?}"
+    );
+}
+
 #[cfg(windows)]
 fn bash_for_wrapper_test() -> Option<PathBuf> {
     std::env::var_os("CLAUDE_CODE_GIT_BASH_PATH")

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1007,8 +1007,10 @@ fn bridge_masks_prompt_wraps_shell_and_masks_result() {
     )
     .unwrap();
     let command = before["command"].as_str().unwrap();
-    assert!(command.contains("pentect"), "{command}");
-    assert!(command.contains("exec"), "{command}");
+    assert!(command.contains("PENTECT_BIN"), "{command}");
+    assert!(command.contains("__agent-script"), "{command}");
+    assert!(command.contains("__agent-stream"), "{command}");
+    assert!(!command.contains("pentect exec"), "{command}");
 
     let after = handle_bridge_request(
         &session,
@@ -4158,6 +4160,7 @@ fn hook_bash_transport_keeps_shell_syntax_and_environment_aliases() {
         wrap_shell_command(HookProvider::Claude, DEFAULT_SESSION, "Bash", &script).unwrap();
     assert!(command.contains("eval"), "{command}");
     assert!(!command.contains("exec {"), "{command}");
+    assert!(!command.contains("> >("), "{command}");
     assert!(command.contains("__agent-script"), "{command}");
     assert!(command.contains("__agent-stream"), "{command}");
     assert!(!command.contains("--script-shell"), "{command}");
@@ -4333,20 +4336,20 @@ fn bash_same_shell_wrapper_preserves_script_fetch_failure() {
 }
 
 #[test]
-fn bash_same_shell_wrapper_ignores_unwaitable_process_substitution_status() {
+fn bash_same_shell_wrapper_waits_for_stream_and_preserves_its_failure() {
     let Some(bash) = bash_for_wrapper_test() else {
         return;
     };
-    let marker = "__PENTECT_STREAM_END_unwaitable_test__";
+    let marker = "__PENTECT_STREAM_END_failure_test__";
     let source = "printf 'same-shell\\n'";
     let script_command = format!("printf %s {}", shell_quote_unix(source));
     let stream = format!(
-        "sed -n {}; exit 127",
+        "sed -n {}; sleep 0.1; exit 23",
         shell_quote_unix(&format!("/{marker}/q;p"))
     );
     let wrapper = bash_same_shell_wrapper("0123456789ab", marker, &script_command, &stream);
     let output = Command::new(bash).arg("-c").arg(&wrapper).output().unwrap();
-    assert_eq!(output.status.code(), Some(0), "{output:?}");
+    assert_eq!(output.status.code(), Some(23), "{output:?}");
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
         "same-shell",

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2,6 +2,150 @@ use super::*;
 
 static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+#[cfg(windows)]
+#[test]
+fn windows_shell_line_keeps_raw_and_visible_paste_separate() {
+    let mut line = WindowsShellLine::default();
+    line.push_typed("echo ");
+    line.push_paste(
+        "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef".to_string(),
+        "$env:PENTECT_RUNPOD_API_KEY_deadbeef".to_string(),
+        "$env:PENTECT_RUNPOD_API_KEY_deadbeef='secret'; ".to_string(),
+    );
+
+    assert_eq!(
+        line.raw(),
+        "echo rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"
+    );
+    assert_eq!(line.visible(), "echo $env:PENTECT_RUNPOD_API_KEY_deadbeef");
+    assert!(line
+        .take_injected_prefixes()
+        .starts_with("$env:PENTECT_RUNPOD_API_KEY_deadbeef="));
+    assert!(line.backspace());
+    assert_eq!(line.raw(), "echo ");
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_line_edits_at_the_cursor() {
+    let mut line = WindowsShellLine::default();
+    for ch in ["a", "b", "c"] {
+        line.push_typed(ch);
+    }
+    assert!(line.move_left());
+    assert!(line.move_left());
+    line.push_typed("X");
+    assert_eq!(line.raw(), "aXbc");
+    assert_eq!(line.visible_before_cursor(), "aX");
+    assert!(line.delete());
+    assert_eq!(line.raw(), "aXc");
+    assert!(line.backspace());
+    assert_eq!(line.raw(), "ac");
+    assert!(line.move_home());
+    assert!(line.delete());
+    assert_eq!(line.raw(), "c");
+    assert!(line.move_end());
+    line.push_typed("!");
+    assert_eq!(line.raw(), "c!");
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_history_restores_drafts_and_skips_sensitive_commands() {
+    let mut history = WindowsShellHistory::default();
+    history.record("Get-Location", false);
+    history.record("Get-ChildItem", false);
+    history.record("Write-Output secret", true);
+
+    assert_eq!(history.previous("draft"), Some("Get-ChildItem".to_string()));
+    assert_eq!(
+        history.previous("ignored"),
+        Some("Get-Location".to_string())
+    );
+    assert_eq!(history.next(), Some("Get-ChildItem".to_string()));
+    assert_eq!(history.next(), Some("draft".to_string()));
+    assert_eq!(history.entries.len(), 2);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_paste_display_keeps_the_prompt_on_one_line() {
+    assert_eq!(
+        single_line_shell_display("Write-Output one\r\nWrite-Output two\n"),
+        "Write-Output one ↵ Write-Output two ↵ "
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_prompt_compacts_only_home_and_its_descendants() {
+    assert_eq!(
+        compact_windows_shell_cwd_with_home(r"C:\Users\yun40\Desktop\pentect", r"C:\Users\yun40"),
+        r"~\Desktop\pentect"
+    );
+    assert_eq!(
+        compact_windows_shell_cwd_with_home(r"c:\users\YUN40", r"C:\Users\yun40"),
+        "~"
+    );
+    assert_eq!(
+        compact_windows_shell_cwd_with_home(r"C:\Users\yun400\work", r"C:\Users\yun40"),
+        r"C:\Users\yun400\work"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_shell_host_preserves_state_without_terminal_control_sequences() {
+    use std::io::{BufRead, Write};
+    use std::process::Stdio;
+
+    let marker = windows_shell_marker().unwrap();
+    let mut child = Command::new(windows_powershell_path())
+        .arg("-NoLogo")
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .arg("-Command")
+        .arg(WINDOWS_SHELL_HOST_SCRIPT)
+        .env("PENTECT_SHELL_COMMAND_MARKER", &marker)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    for command in [
+        "$global:PentectShellState=41",
+        "Write-Output ($global:PentectShellState + 1)",
+    ] {
+        writeln!(
+            stdin,
+            "{}",
+            data_encoding::BASE64.encode(command.as_bytes())
+        )
+        .unwrap();
+        stdin.flush().unwrap();
+    }
+
+    let mut output = String::new();
+    let mut completions = 0;
+    while completions < 2 {
+        let mut line = String::new();
+        assert_ne!(stdout.read_line(&mut line).unwrap(), 0);
+        if line.contains(&marker) {
+            completions += 1;
+        } else {
+            output.push_str(&line);
+        }
+    }
+
+    assert!(output.lines().any(|line| line.trim() == "42"), "{output:?}");
+    assert!(!output.contains('\u{1b}'), "{output:?}");
+    drop(stdin);
+    assert!(child.wait().unwrap().success());
+}
+
 struct ActiveMemoryStoreEnv {
     candidate: std::path::PathBuf,
     base: std::path::PathBuf,
@@ -313,6 +457,31 @@ fn shell_secret_paste_replaces_visible_value_with_env_ref() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+#[cfg(windows)]
+#[test]
+fn windows_shell_keeps_previewed_secret_assignment_until_submit() {
+    let (root, session) = empty_session("windows-shell-preview-submit");
+    let store = MemoryStore::for_session(&session);
+    let mut protector = ShellInputProtector::new(store).unwrap();
+    let raw = "Write-Output sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let preview = protector.prepare_paste(raw).unwrap();
+    let mut line = WindowsShellLine::default();
+    line.push_paste(raw.to_string(), preview.visible, preview.injected_prefix);
+
+    let submitted = protector.prepare_paste(&line.raw()).unwrap();
+    assert!(submitted.injected_prefix.is_empty());
+    let mut child_command = line.take_injected_prefixes();
+    child_command.push_str(&submitted.child);
+    assert!(
+        child_command.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"),
+        "{child_command}"
+    );
+    assert!(child_command.contains("$env:PENTECT_"), "{child_command}");
+    assert!(!line.visible().contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"));
+    child_command.zeroize();
+    let _ = std::fs::remove_dir_all(root);
+}
+
 #[test]
 fn shell_secret_paste_uses_explicit_environment_prefix() {
     let (root, session) = empty_session("shell-paste-custom-prefix");
@@ -482,7 +651,7 @@ fn exec_parse_accepts_stdin_mode_without_shell_text() {
 #[test]
 fn exec_parse_accepts_base64_script_mode() {
     let script = "Write-Output \"日本語|OK\"";
-    let encoded = data_encoding::BASE64.encode(script.as_bytes());
+    let encoded = data_encoding::BASE64URL_NOPAD.encode(script.as_bytes());
     let args = strings(["pentect", "exec", "--script-b64", &encoded]);
     let opts = ExecOpts::parse(&args).unwrap();
     assert!(matches!(opts.mode, ExecMode::Shell(command) if command == script));
@@ -675,6 +844,7 @@ fn exec_allows_secret_file_reads_because_output_is_remasked() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
     let output = run_resolved_command(&store, &opts).unwrap();
@@ -710,6 +880,7 @@ fn exec_registers_referenced_local_files_as_env_capabilities() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
     run_resolved_command(&store, &opts).unwrap();
@@ -753,6 +924,7 @@ fn exec_inherits_parent_environment_and_masks_output() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        script_shell: ScriptShell::Native,
         mode,
     };
     let output = run_resolved_command(&store, &opts);
@@ -867,6 +1039,26 @@ fn bridge_session_exports_only_the_owned_runtime_session() {
 }
 
 #[test]
+fn bridge_owned_environment_preserves_only_verified_extension_state() {
+    let values = HashMap::from([
+        (ENV_ADDR, "127.0.0.1:1234"),
+        (ENV_TOKEN, "memory-token"),
+        (PENTECT_AGENT_LAUNCHED_ENV, "launch-proof"),
+        ("PENTECT_BIN", "pentect-bin"),
+        (PENTECT_EXTENSION_CONFIGS_ENV, "configs"),
+        (PENTECT_EXTENSION_ADAPTERS_ENV, "adapters"),
+        ("PENTECT_PROCESS_HOST_ROOT", "untrusted"),
+    ]);
+    let environment =
+        bridge_owned_environment(|name| values.get(name).map(|value| (*value).to_string()))
+            .unwrap();
+    assert_eq!(environment.len(), 6);
+    assert_eq!(environment[PENTECT_EXTENSION_CONFIGS_ENV], "configs");
+    assert_eq!(environment[PENTECT_EXTENSION_ADAPTERS_ENV], "adapters");
+    assert!(!environment.contains_key("PENTECT_PROCESS_HOST_ROOT"));
+}
+
+#[test]
 fn bridge_line_reader_discards_oversized_request() {
     let mut input = vec![b'x'; 9];
     input.extend_from_slice(b"\n{}\n");
@@ -961,6 +1153,7 @@ fn exec_capability_env_does_not_shadow_parent_environment() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        script_shell: ScriptShell::Native,
         mode,
     };
     let output = run_resolved_command(&store, &opts);
@@ -988,6 +1181,7 @@ fn exec_resolves_masked_handle_in_command_text() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
 
@@ -1055,6 +1249,7 @@ fn exec_auto_binds_masked_env_output_in_running_session() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
     let output = run_resolved_command(&store, &opts).unwrap();
@@ -1095,6 +1290,19 @@ fn env_alias_recovery_uses_explicit_prefix() {
             "<<OPENAI_API_KEY_0123456789abcdef>>".to_string()
         )]
     );
+}
+
+#[test]
+fn output_keeps_generated_environment_alias_references_readable() {
+    let (root, session) = empty_session("output-env-alias-reference");
+    let alias = "PENTECT_RUNPOD_API_KEY_80fba8fb9b3928a8";
+    let output = format!(
+        "At line:1 char:1\n+ $env:{alias}\n+ ${alias}\n+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+    );
+    let masked = mask_tool_output(&session, &output).unwrap();
+    assert!(masked.contains(alias), "{masked}");
+    assert!(!masked.contains("<<LIKELY_SECRET_"), "{masked}");
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1252,6 +1460,7 @@ fn exec_auto_binds_generic_masked_handles_as_pentect_env_vars() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
     let output = run_resolved_command(&store, &opts).unwrap();
@@ -2237,6 +2446,7 @@ fn mcp_structured_secret_can_be_used_as_pentect_env_capability() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
     let output = run_resolved_command(&store, &opts).unwrap();
@@ -2350,6 +2560,7 @@ fn browser_api_key_issue_flow_masks_value_and_keeps_capability_usable() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
     let output = run_resolved_command(&store, &opts).unwrap();
@@ -3031,9 +3242,7 @@ fn claude_pretool_wraps_plain_shell_command() {
         .unwrap();
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
-    assert!(command.contains("Get-Content"), "{command}");
-    assert!(command.contains(".\\.env"), "{command}");
-    assert!(!command.contains("--shell-b64"), "{command}");
+    assert_eq!(wrapped_payload(command), r"Get-Content .\.env");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -3135,7 +3344,7 @@ fn pretool_wraps_pentect_read_from_ai_hooks() {
     assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
-    assert!(command.contains("read"), "{command}");
+    assert_eq!(wrapped_payload(command), r"pentect read .\.env");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -3155,7 +3364,7 @@ fn pretool_wraps_pentect_resolve() {
         .unwrap();
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
-    assert!(command.contains("resolve"), "{command}");
+    assert_eq!(wrapped_payload(command), r"pentect resolve .\.env.prod");
     assert_eq!(command.matches(" exec ").count(), 1, "{command}");
     let _ = std::fs::remove_dir_all(root);
 }
@@ -3525,8 +3734,7 @@ fn pretool_canonicalizes_quoted_pentect_exec_shell_command() {
         .unwrap();
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
-    assert!(!command.contains("--shell"), "{command}");
-    assert!(command.contains("Get-Content"), "{command}");
+    assert_eq!(wrapped_payload(command), r"Get-Content .\.env");
     assert_eq!(command.matches(" exec ").count(), 1, "{command}");
     let _ = std::fs::remove_dir_all(root);
 }
@@ -3546,7 +3754,10 @@ fn pretool_wraps_pentect_exec_with_trailing_shell_escape() {
         .as_str()
         .unwrap();
     assert!(command.contains(" exec "), "{command}");
-    assert!(command.contains("echo ok; Write-Output"), "{command}");
+    assert_eq!(
+        wrapped_payload(command),
+        "echo ok; Write-Output OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX"
+    );
     assert!(!command.contains("pentect exec -- echo ok"), "{command}");
     assert_eq!(command.matches(" exec ").count(), 1, "{command}");
     let _ = std::fs::remove_dir_all(root);
@@ -3567,7 +3778,7 @@ fn pretool_rewraps_pentect_exec_live_command() {
         .as_str()
         .unwrap();
     assert!(command.contains(" exec "), "{command}");
-    assert!(command.contains("Write-Output hi"), "{command}");
+    assert_eq!(wrapped_payload(command), "Write-Output hi");
     assert!(!command.contains("pentect exec --live"), "{command}");
     let _ = std::fs::remove_dir_all(root);
 }
@@ -3587,7 +3798,7 @@ fn pretool_rewraps_pentect_exec_dollar_substitution_as_inert_payload() {
         .as_str()
         .unwrap();
     assert!(command.contains(" exec "), "{command}");
-    assert!(command.contains("echo $(python exfil.py)"), "{command}");
+    assert_eq!(wrapped_payload(command), "echo $(python exfil.py)");
     assert!(!command.contains("pentect exec -- echo $("), "{command}");
     let _ = std::fs::remove_dir_all(root);
 }
@@ -3608,7 +3819,7 @@ fn pretool_collapses_nested_pentect_exec_shell_commands() {
         .unwrap();
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
-    assert!(command.contains("Get-Content"), "{command}");
+    assert_eq!(wrapped_payload(command), r"Get-Content .\.env");
     assert!(!command.contains("pentect exec 'pentect exec"), "{command}");
     assert!(
         !command.contains("pentect exec \"pentect exec"),
@@ -3635,7 +3846,7 @@ fn pretool_collapses_nested_pentect_read_command() {
         .unwrap();
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
-    assert!(command.contains("read"), "{command}");
+    assert_eq!(wrapped_payload(command), r"pentect read .\.env");
     assert_eq!(command.matches(" exec ").count(), 1, "{command}");
     let _ = std::fs::remove_dir_all(root);
 }
@@ -3656,7 +3867,7 @@ fn pretool_collapses_nested_pentect_resolve() {
         .unwrap();
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
-    assert!(command.contains("resolve"), "{command}");
+    assert_eq!(wrapped_payload(command), r"pentect resolve .\.env.prod");
     assert!(
         !command.contains("pentect exec \"pentect resolve"),
         "{command}"
@@ -3681,9 +3892,10 @@ fn pretool_canonicalizes_pentect_exec_shell_commands() {
         .unwrap();
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
-    assert!(!command.contains("--shell"), "{command}");
-    assert!(command.contains("Test-Path"), "{command}");
-    assert!(command.contains("missing"), "{command}");
+    assert_eq!(
+        wrapped_payload(command),
+        "if (!(Test-Path -LiteralPath $path)) { Write-Output \"missing\"; exit 0 }"
+    );
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -3701,11 +3913,11 @@ fn pretool_preserves_powershell_sensitive_regex_pipe_in_visible_exec() {
     let command = output["hookSpecificOutput"]["updatedInput"]["command"]
         .as_str()
         .unwrap();
-    assert!(
-        command.contains("TOKEN_ALPHA|TOKEN_BETA|TOKEN_GAMMA"),
-        "{command}"
-    );
     assert!(command.starts_with("pentect exec "), "{command}");
+    assert_eq!(
+        wrapped_payload(command),
+        r#"rg -n "TOKEN_ALPHA|TOKEN_BETA|TOKEN_GAMMA" -S ."#
+    );
     assert!(!command.contains("agent exec"), "{command}");
     assert!(!command.contains("--stdin"), "{command}");
     assert!(!command.contains("$env:PENTECT_BIN"), "{command}");
@@ -3728,8 +3940,8 @@ fn pretool_keeps_non_ascii_payloads_readable_in_visible_exec() {
         .as_str()
         .unwrap();
     assert!(command.starts_with("pentect exec "), "{command}");
-    assert!(command.contains("日本語|OK"), "{command}");
-    assert!(!command.contains("--script-b64"), "{command}");
+    assert_eq!(wrapped_payload(command), "Write-Output \"日本語|OK\"");
+    assert!(command.contains("--script-b64"), "{command}");
     assert!(!command.contains("--stdin"), "{command}");
     assert!(!command.contains("@'\n"), "{command}");
     let _ = std::fs::remove_dir_all(root);
@@ -3755,8 +3967,7 @@ fn pretool_wraps_plain_shell_commands_for_every_provider() {
             .as_str()
             .unwrap();
         assert!(command.contains("exec"), "{command}");
-        assert!(command.contains("echo hello"), "{command}");
-        assert!(!command.contains("--shell-b64"), "{command}");
+        assert_eq!(wrapped_payload(command), "echo hello");
         let _ = std::fs::remove_dir_all(root);
     }
 }
@@ -3786,7 +3997,7 @@ fn codex_app_server_proxy_wraps_shell_even_when_exec_proxy_is_enabled() {
         .as_str()
         .unwrap();
     assert!(command.starts_with("pentect exec "), "{command}");
-    assert!(command.contains("$env:OPENAI_API_KEY"), "{command}");
+    assert_eq!(wrapped_payload(command), "Write-Output $env:OPENAI_API_KEY");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -3810,7 +4021,8 @@ fn codex_exec_proxy_keeps_plain_shell_unwrapped_without_app_server_proxy() {
 
 #[test]
 fn display_command_without_pentect_exec_wrapper_returns_shell_payload() {
-    let wrapped = wrap_shell_command(HookProvider::Codex, DEFAULT_SESSION, "cat .env").unwrap();
+    let wrapped =
+        wrap_shell_command(HookProvider::Codex, DEFAULT_SESSION, "Bash", "cat .env").unwrap();
     assert_eq!(
         display_command_without_pentect_exec_wrapper(&wrapped).as_deref(),
         Some("cat .env")
@@ -3837,8 +4049,7 @@ fn pretool_wraps_camel_case_external_tool_input() {
         .unwrap();
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
-    assert!(command.contains("Get-Content"), "{command}");
-    assert!(!command.contains("--shell-b64"), "{command}");
+    assert_eq!(wrapped_payload(command), r"Get-Content .\.env");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -3858,34 +4069,219 @@ fn pretool_non_default_session_is_inserted_before_command() {
         .unwrap();
     assert!(command.contains("--session"), "{command}");
     assert!(command.contains("project-a"), "{command}");
-    assert!(command.contains("echo hello"), "{command}");
-    assert!(!command.contains("--shell-b64"), "{command}");
+    assert!(command.contains("--script-shell bash"), "{command}");
+    assert_eq!(wrapped_payload(command), "echo hello");
     let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
 fn implicit_directory_session_is_not_rendered_in_wrapped_command() {
     let implicit = default_directory_session_name().unwrap();
-    let command = wrap_shell_command(HookProvider::Claude, &implicit, "echo hello").unwrap();
+    let command =
+        wrap_shell_command(HookProvider::Claude, &implicit, "Bash", "echo hello").unwrap();
     assert!(command.contains("pentect"), "{command}");
     assert!(command.contains("exec"), "{command}");
     assert!(!command.contains("--session"), "{command}");
-    assert!(command.contains("echo hello"), "{command}");
+    assert_eq!(wrapped_payload(&command), "echo hello");
 }
 
 #[test]
-fn visible_exec_wrapper_is_short_and_user_facing() {
-    let command = wrap_shell_command(HookProvider::Codex, DEFAULT_SESSION, "cat .env").unwrap();
-    assert_eq!(command, "pentect exec 'cat .env'");
+fn hook_exec_wrapper_is_lossless_and_display_decodable() {
+    let command =
+        wrap_shell_command(HookProvider::Codex, DEFAULT_SESSION, "Bash", "cat .env").unwrap();
+    assert!(command.contains("--script-shell bash"), "{command}");
+    assert_eq!(wrapped_payload(&command), "cat .env");
     assert!(!command.contains("agent exec"), "{command}");
     assert!(!command.contains("PENTECT_BIN"), "{command}");
     assert!(!command.contains("--stdin"), "{command}");
 
-    let command = wrap_shell_command(HookProvider::Codex, DEFAULT_SESSION, "--version").unwrap();
-    assert_eq!(command, "pentect exec ' --version'");
-    let args = strings(["pentect", "exec", " --version"]);
+    let command =
+        wrap_shell_command(HookProvider::Codex, DEFAULT_SESSION, "Bash", "--version").unwrap();
+    assert_eq!(wrapped_payload(&command), "--version");
+    let encoded = data_encoding::BASE64URL_NOPAD.encode(b"--version");
+    let args = strings(["pentect", "exec", "--script-b64", &encoded]);
     let opts = ExecOpts::parse(&args).unwrap();
-    assert!(matches!(opts.mode, ExecMode::Shell(command) if command == " --version"));
+    assert!(matches!(opts.mode, ExecMode::Shell(command) if command == "--version"));
+}
+
+#[test]
+fn hook_shell_transport_round_trips_powershell_without_outer_shell_quoting() {
+    let script = concat!(
+        "$token = $env:PENTECT_KAGGLE_API_TOKEN_deadbeef; ",
+        "$parts = $token -split ':'; ",
+        "$headers = @{ Authorization = \"Bearer $env:PENTECT_RUNPOD_API_KEY_deadbeef\"; ",
+        "\"Content-Type\" = \"application/json\" }; ",
+        "Invoke-RestMethod -Uri \"https://api.runpod.ai/v2/pods?page=1&pageSize=1\" ",
+        "-Headers $headers`n"
+    );
+    let command =
+        wrap_shell_command(HookProvider::Claude, DEFAULT_SESSION, "PowerShell", script).unwrap();
+
+    assert_eq!(wrapped_payload(&command), script);
+    assert!(
+        command
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b' ')),
+        "{command}"
+    );
+
+    let args = command
+        .split_whitespace()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let opts = ExecOpts::parse(&args).unwrap();
+    assert_eq!(opts.script_shell, ScriptShell::PowerShell);
+    assert!(matches!(opts.mode, ExecMode::Shell(decoded) if decoded == script));
+}
+
+#[test]
+fn hook_bash_transport_keeps_shell_syntax_and_environment_aliases() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("hook-shared-env-alias");
+    let producer = Session::open_capability(DEFAULT_SESSION).unwrap();
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let masked = mask_tool_output(&producer, &format!("RUNPOD_API_KEY={raw}\n")).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "RUNPOD_API_KEY");
+    let env_name = pentect_env_name_for_handle(&handle);
+    let script = format!("false || true\nprintf '%s' \"${env_name}\"");
+    let command =
+        wrap_shell_command(HookProvider::Claude, DEFAULT_SESSION, "Bash", &script).unwrap();
+    assert!(command.contains("eval"), "{command}");
+    assert!(command.contains("__agent-script"), "{command}");
+    assert!(command.contains("__agent-stream"), "{command}");
+    assert!(!command.contains("--script-shell"), "{command}");
+    assert!(!command.contains(raw), "{command}");
+
+    let id = agent_script_id_from_wrapper(&command);
+    let client = MemoryStoreClient::from_env().unwrap();
+    let rendered = take_rendered_agent_script(
+        &client,
+        &AgentScriptOpts {
+            session: DEFAULT_SESSION.to_string(),
+            id: id.clone(),
+        },
+    )
+    .unwrap();
+    assert!(rendered.contains("false || true"), "{rendered:?}");
+    assert!(
+        rendered.contains(&format!("export {env_name}=")),
+        "{rendered:?}"
+    );
+    assert!(rendered.contains(raw), "{rendered:?}");
+    assert!(client.take_agent_script(&id).is_err());
+}
+
+#[test]
+fn claude_powershell_uses_current_shell_without_child_shell_discovery() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("hook-powershell-same-shell");
+    let command = wrap_shell_command(
+        HookProvider::Claude,
+        DEFAULT_SESSION,
+        "PowerShell",
+        "Write-Output 'ok'",
+    )
+    .unwrap();
+    assert!(command.contains("Invoke-Expression"), "{command}");
+    assert!(command.contains("__agent-script"), "{command}");
+    assert!(command.contains("__agent-stream"), "{command}");
+    assert!(!command.contains("powershell.exe"), "{command}");
+    assert!(!command.contains("--script-shell"), "{command}");
+}
+
+#[test]
+fn generic_bridge_bash_uses_the_host_shell() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("hook-generic-same-shell");
+    let command = wrap_shell_command(
+        HookProvider::Generic,
+        DEFAULT_SESSION,
+        "bash",
+        "printf '%s\\n' ok",
+    )
+    .unwrap();
+    assert!(command.contains("eval"), "{command}");
+    assert!(command.contains("__agent-script"), "{command}");
+    assert!(command.contains("__agent-stream"), "{command}");
+    assert!(!command.contains("--script-shell"), "{command}");
+}
+
+#[cfg(windows)]
+#[test]
+fn powershell_same_shell_wrapper_preserves_native_exit_code() {
+    let wrapper = powershell_same_shell_wrapper(
+        "0123456789ab",
+        "cmd /D /S /C 'echo Write-Output same-shell; cmd /D /S /C exit 7'",
+        "cmd /D /S /C more",
+    );
+    let output = Command::new(windows_powershell_path())
+        .arg("-NoProfile")
+        .arg("-Command")
+        .arg(&wrapper)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(7), "{output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("same-shell"),
+        "{output:?}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn running_windows_shell_forwards_interactive_input() {
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+    let mut output = Vec::new();
+    forward_windows_running_input(Event::Paste("secret text".to_string()), &mut output).unwrap();
+    forward_windows_running_input(
+        Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        &mut output,
+    )
+    .unwrap();
+    forward_windows_running_input(
+        Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+        &mut output,
+    )
+    .unwrap();
+    assert_eq!(output, b"secret text\r\n\x03");
+}
+
+#[test]
+fn bash_same_shell_wrapper_preserves_output_and_exit_code() {
+    let Some(bash) = bash_for_wrapper_test() else {
+        return;
+    };
+    let source = "printf '%s\\n' same-shell; exit 7";
+    let script_command = format!("printf %s {}", shell_quote_unix(source));
+    let wrapper = bash_same_shell_wrapper("0123456789ab", &script_command, "cat", "cat >&2");
+    let output = Command::new(bash).arg("-c").arg(&wrapper).output().unwrap();
+    assert_eq!(output.status.code(), Some(7), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "same-shell",
+        "{output:?}"
+    );
+}
+
+#[cfg(windows)]
+fn bash_for_wrapper_test() -> Option<PathBuf> {
+    std::env::var_os("CLAUDE_CODE_GIT_BASH_PATH")
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+        .or_else(|| {
+            [
+                PathBuf::from(r"C:\Program Files\Git\bin\bash.exe"),
+                PathBuf::from(r"C:\Program Files (x86)\Git\bin\bash.exe"),
+            ]
+            .into_iter()
+            .find(|path| path.is_file())
+        })
+}
+
+#[cfg(not(windows))]
+fn bash_for_wrapper_test() -> Option<PathBuf> {
+    Some(PathBuf::from("bash"))
 }
 
 #[test]
@@ -3903,12 +4299,12 @@ fn claude_pretool_wraps_masked_shell_command() {
         .as_str()
         .unwrap();
     assert!(command.contains("exec"), "{command}");
-    assert!(!command.contains("--shell-b64"), "{command}");
+    let payload = wrapped_payload(command);
     assert!(
         !command.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"),
         "{command}"
     );
-    assert!(command.contains("<<OPENAI_API_KEY_"), "{command}");
+    assert!(payload.contains("<<OPENAI_API_KEY_"), "{payload}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -4037,6 +4433,23 @@ fn enter_temp_cwd(root: &Path) -> TestCwd {
 
 fn strings<const N: usize>(items: [&str; N]) -> Vec<String> {
     items.into_iter().map(str::to_string).collect()
+}
+
+fn wrapped_payload(command: &str) -> String {
+    display_command_without_pentect_exec_wrapper(command)
+        .unwrap_or_else(|| panic!("missing Pentect exec payload in {command}"))
+}
+
+fn agent_script_id_from_wrapper(command: &str) -> String {
+    let marker = "__agent-script ";
+    let tail = command
+        .split_once(marker)
+        .map(|(_, tail)| tail)
+        .unwrap_or_else(|| panic!("missing agent script helper in {command}"));
+    tail.get(..64)
+        .filter(|id| id.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .map(str::to_string)
+        .unwrap_or_else(|| panic!("missing agent script id in {command}"))
 }
 
 fn masked_handle_from_assignment(masked: &str, key: &str) -> String {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2,6 +2,87 @@ use super::*;
 
 static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+struct ActiveMemoryStoreEnv {
+    candidate: std::path::PathBuf,
+    base: std::path::PathBuf,
+    runtime_env_name: &'static str,
+    previous_runtime_env: Option<std::ffi::OsString>,
+}
+
+impl ActiveMemoryStoreEnv {
+    fn start(name: &str) -> (Self, String, String) {
+        let token = data_encoding::HEXLOWER.encode(&Config::generate().key);
+        let read_token = data_encoding::HEXLOWER.encode(&Config::generate().key);
+        let write_token = data_encoding::HEXLOWER.encode(&Config::generate().key);
+        let addr = memory_store::spawn_test_memory_store_with_activity(
+            token.clone(),
+            read_token.clone(),
+            write_token.clone(),
+        );
+        let base = temp_root(name);
+        let (runtime_env_name, root) = test_process_host_root(&base);
+        let previous_runtime_env = std::env::var_os(runtime_env_name);
+        std::env::set_var(runtime_env_name, &base);
+        let candidate = register_process_host_candidate(
+            &root,
+            &addr,
+            &token,
+            &read_token,
+            &write_token,
+            std::process::id(),
+            false,
+        )
+        .unwrap()
+        .unwrap();
+        for (env_name, value) in [
+            (ENV_ADDR, addr.as_str()),
+            (ENV_TOKEN, token.as_str()),
+            (PENTECT_AGENT_LAUNCHED_ENV, token.as_str()),
+        ] {
+            std::env::set_var(env_name, value);
+        }
+        (
+            Self {
+                candidate,
+                base,
+                runtime_env_name,
+                previous_runtime_env,
+            },
+            addr,
+            token,
+        )
+    }
+}
+
+impl Drop for ActiveMemoryStoreEnv {
+    fn drop(&mut self) {
+        for name in [ENV_ADDR, ENV_TOKEN, PENTECT_AGENT_LAUNCHED_ENV] {
+            std::env::remove_var(name);
+        }
+        unregister_process_host_candidate(&self.candidate);
+        match self.previous_runtime_env.take() {
+            Some(value) => std::env::set_var(self.runtime_env_name, value),
+            None => std::env::remove_var(self.runtime_env_name),
+        }
+        let _ = std::fs::remove_dir_all(&self.base);
+    }
+}
+
+#[cfg(windows)]
+fn test_process_host_root(base: &std::path::Path) -> (&'static str, std::path::PathBuf) {
+    ("LOCALAPPDATA", base.join("pentect"))
+}
+
+#[cfg(target_os = "macos")]
+fn test_process_host_root(base: &std::path::Path) -> (&'static str, std::path::PathBuf) {
+    ("HOME", base.join("Library").join("Caches").join("pentect"))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn test_process_host_root(base: &std::path::Path) -> (&'static str, std::path::PathBuf) {
+    ("XDG_RUNTIME_DIR", base.join("pentect"))
+}
+
 #[test]
 fn shell_pty_size_tracks_the_real_terminal_before_fallbacks() {
     assert_eq!(
@@ -360,6 +441,9 @@ fn pty_terminal_queries_are_answered_without_reaching_output() {
 #[test]
 fn child_env_overlays_strip_memory_store_credentials() {
     let mut cmd = Command::new("echo");
+    for name in pentect_control_env_names() {
+        cmd.env(name, "attacker-selected-value");
+    }
     apply_child_env_overlays(&mut cmd, &[], "demo");
     let envs: Vec<_> = cmd
         .get_envs()
@@ -370,37 +454,15 @@ fn child_env_overlays_strip_memory_store_credentials() {
             )
         })
         .collect();
-    assert!(
-        matches!(
-            envs.iter()
-                .find(|(name, _)| name == "PENTECT_MEMORY_STORE_ADDR"),
-            Some((_, None))
-        ),
-        "{envs:?}"
-    );
-    assert!(
-        matches!(
-            envs.iter()
-                .find(|(name, _)| name == "PENTECT_MEMORY_STORE_TOKEN"),
-            Some((_, None))
-        ),
-        "{envs:?}"
-    );
-    assert!(
-        matches!(
-            envs.iter()
-                .find(|(name, _)| name == "PENTECT_AGENT_LAUNCHED"),
-            Some((_, None))
-        ),
-        "{envs:?}"
-    );
-    assert!(
-        matches!(
-            envs.iter().find(|(name, _)| name == "PENTECT_SESSION"),
-            Some((_, Some(value))) if value == "demo"
-        ),
-        "{envs:?}"
-    );
+    for reserved in pentect_control_env_names() {
+        assert!(
+            matches!(
+                envs.iter().find(|(name, _)| name == reserved),
+                Some((_, None))
+            ),
+            "{reserved}: {envs:?}"
+        );
+    }
 }
 
 #[test]
@@ -532,8 +594,9 @@ fn session_does_not_create_key_or_recovery_dir() {
 #[test]
 fn default_session_root_lives_under_pentect_dir() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
-    std::env::remove_var("PENTECT_HOME");
+    std::env::set_var("PENTECT_HOME", "attacker-selected-directory");
     let root = session_root("demo").unwrap();
+    std::env::remove_var("PENTECT_HOME");
     assert_eq!(root, PathBuf::from(".pentect").join("agent").join("demo"));
 }
 
@@ -706,18 +769,7 @@ fn exec_inherits_parent_environment_and_masks_output() {
 #[test]
 fn active_tool_output_masker_reuses_in_memory_state() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
-    let token = "active-masker-token".to_string();
-    let addr = memory_store::spawn_test_memory_store(token.clone());
-    struct EnvCleanup;
-    impl Drop for EnvCleanup {
-        fn drop(&mut self) {
-            std::env::remove_var(ENV_ADDR);
-            std::env::remove_var(ENV_TOKEN);
-        }
-    }
-    let _cleanup = EnvCleanup;
-    std::env::set_var(ENV_ADDR, addr);
-    std::env::set_var(ENV_TOKEN, token);
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-masker");
 
     let client = MemoryStoreClient::from_env().unwrap();
     let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
@@ -747,18 +799,7 @@ fn active_tool_output_masker_reuses_in_memory_state() {
 #[test]
 fn bridge_masks_prompt_wraps_shell_and_masks_result() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
-    let token = "bridge-mask-token".to_string();
-    let addr = memory_store::spawn_test_memory_store(token.clone());
-    struct EnvCleanup;
-    impl Drop for EnvCleanup {
-        fn drop(&mut self) {
-            std::env::remove_var(ENV_ADDR);
-            std::env::remove_var(ENV_TOKEN);
-        }
-    }
-    let _cleanup = EnvCleanup;
-    std::env::set_var(ENV_ADDR, addr);
-    std::env::set_var(ENV_TOKEN, token);
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("bridge-mask");
 
     let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
     let session = Session::open_capability(DEFAULT_SESSION).unwrap();
@@ -806,35 +847,8 @@ fn bridge_masks_prompt_wraps_shell_and_masks_result() {
 #[test]
 fn bridge_session_exports_only_the_owned_runtime_session() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
-    struct EnvCleanup;
-    impl Drop for EnvCleanup {
-        fn drop(&mut self) {
-            for name in [
-                ENV_ADDR,
-                ENV_TOKEN,
-                PROCESS_HOST_READ_TOKEN_ENV,
-                PROCESS_HOST_WRITE_TOKEN_ENV,
-                PROCESS_HOST_ROOT_ENV,
-                PENTECT_AGENT_LAUNCHED_ENV,
-                "PENTECT_BIN",
-            ] {
-                std::env::remove_var(name);
-            }
-        }
-    }
-    let _cleanup = EnvCleanup;
-    let values = [
-        (ENV_ADDR, "127.0.0.1:12345"),
-        (ENV_TOKEN, "session-token"),
-        (PROCESS_HOST_READ_TOKEN_ENV, "read-token"),
-        (PROCESS_HOST_WRITE_TOKEN_ENV, "write-token"),
-        (PROCESS_HOST_ROOT_ENV, "/tmp/pentect"),
-        (PENTECT_AGENT_LAUNCHED_ENV, "session-token"),
-        ("PENTECT_BIN", "/tmp/pentect-bin"),
-    ];
-    for (name, value) in values {
-        std::env::set_var(name, value);
-    }
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("bridge-session");
+    std::env::set_var("PENTECT_BIN", "/tmp/pentect-bin");
 
     let session = bridge_session_value().unwrap();
     assert!(session["contract"]
@@ -842,10 +856,14 @@ fn bridge_session_exports_only_the_owned_runtime_session() {
         .unwrap()
         .contains("Pentect agent contract"));
     let environment = session["environment"].as_object().unwrap();
-    assert_eq!(environment.len(), values.len());
-    for (name, value) in values {
-        assert_eq!(environment[name], value);
+    assert_eq!(environment.len(), 4);
+    for name in [ENV_ADDR, ENV_TOKEN, PENTECT_AGENT_LAUNCHED_ENV] {
+        assert_eq!(environment[name], std::env::var(name).unwrap());
     }
+    assert!(!environment.contains_key("PENTECT_PROCESS_HOST_READ_TOKEN"));
+    assert!(!environment.contains_key("PENTECT_PROCESS_HOST_WRITE_TOKEN"));
+    assert_eq!(environment["PENTECT_BIN"], "/tmp/pentect-bin");
+    std::env::remove_var("PENTECT_BIN");
 }
 
 #[test]
@@ -869,18 +887,7 @@ fn bridge_line_reader_discards_oversized_request() {
 #[test]
 fn prompt_masked_env_is_available_to_exec_proxy_without_visible_pentect_exec() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
-    let token = "prompt-exec-proxy-token".to_string();
-    let addr = memory_store::spawn_test_memory_store(token.clone());
-    struct EnvCleanup;
-    impl Drop for EnvCleanup {
-        fn drop(&mut self) {
-            std::env::remove_var(ENV_ADDR);
-            std::env::remove_var(ENV_TOKEN);
-        }
-    }
-    let _cleanup = EnvCleanup;
-    std::env::set_var(ENV_ADDR, addr);
-    std::env::set_var(ENV_TOKEN, token);
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("prompt-exec-proxy");
 
     let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
     let prompt = mask_prompt_text_into_active_memory_store(&format!("OPENAI_API_KEY={raw}"))
@@ -918,18 +925,7 @@ fn prompt_masked_env_is_available_to_exec_proxy_without_visible_pentect_exec() {
 #[test]
 fn prompt_masking_uses_strict_input_detection_for_env_lines_in_prose() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
-    let token = "prompt-strict-token".to_string();
-    let addr = memory_store::spawn_test_memory_store(token.clone());
-    struct EnvCleanup;
-    impl Drop for EnvCleanup {
-        fn drop(&mut self) {
-            std::env::remove_var(ENV_ADDR);
-            std::env::remove_var(ENV_TOKEN);
-        }
-    }
-    let _cleanup = EnvCleanup;
-    std::env::set_var(ENV_ADDR, addr);
-    std::env::set_var(ENV_TOKEN, token);
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("prompt-strict");
 
     let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
     let prompt = format!(
@@ -1164,7 +1160,7 @@ fn exec_injects_powershell_env_provider_references() {
 fn auto_env_bindings_do_not_override_baseline_environment() {
     let root = temp_root("capability-reserved-env-binding");
     let session = Session::open_capability_at(&root, "t").unwrap();
-    let output = "PATH=sk-ABCDEFGHIJKLMNOPQRSTUVWX\nDUMMY_SECRET=sk-YYYYYYYYYYYYYYYYYYYY\n";
+    let output = "PATH=sk-ABCDEFGHIJKLMNOPQRSTUVWX\nPENTECT_MEMORY_STORE_TOKEN=sk-ZZZZZZZZZZZZZZZZZZZZ\nDUMMY_SECRET=sk-YYYYYYYYYYYYYYYYYYYY\n";
     let masked = mask_tool_output(&session, output).unwrap();
     assert!(masked.contains("PATH=<<OPENAI_API_KEY_"), "{masked}");
     assert!(
@@ -1175,8 +1171,10 @@ fn auto_env_bindings_do_not_override_baseline_environment() {
     let store = MemoryStore::for_session(&session);
     let env = store.auto_env_bindings().unwrap();
     assert!(
-        !env.iter()
-            .any(|(name, _)| matches!(name.as_str(), "PATH" | "DUMMY_SECRET")),
+        !env.iter().any(|(name, _)| matches!(
+            name.as_str(),
+            "PATH" | "PENTECT_MEMORY_STORE_TOKEN" | "DUMMY_SECRET"
+        )),
         "{env:?}"
     );
     assert!(
@@ -1267,13 +1265,13 @@ fn exec_auto_binds_generic_masked_handles_as_pentect_env_vars() {
 }
 
 #[test]
-fn child_commands_receive_pentect_session_name() {
-    let mut command = Command::new("dummy");
-    apply_pentect_session(&mut command, "child-session");
-    assert!(command.get_envs().any(|(name, value)| {
-        name == "PENTECT_SESSION"
-            && value.is_some_and(|value| value.to_string_lossy() == "child-session")
-    }));
+fn session_environment_name_is_reserved_for_internal_use() {
+    assert!(is_pentect_control_env_name("PENTECT_SESSION"));
+    assert!(is_pentect_control_env_name("pentect_session"));
+    let mut names = pentect_control_env_names().to_vec();
+    names.sort_unstable();
+    names.dedup();
+    assert_eq!(names.len(), pentect_control_env_names().len());
 }
 
 #[test]
@@ -3063,17 +3061,61 @@ fn require_pentect_rejects_matching_env_without_live_memory_store() {
 }
 
 #[test]
+fn reserved_control_environment_cannot_redirect_an_active_store() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("control-env-redirect");
+    assert!(active_memory_store_ready());
+
+    std::env::set_var(
+        "PENTECT_PROCESS_HOST_ROOT",
+        temp_root("attacker-selected-root"),
+    );
+    std::env::set_var("PENTECT_PROCESS_HOST_READ_TOKEN", "attacker-selected-token");
+    std::env::set_var(
+        "PENTECT_PROCESS_HOST_WRITE_TOKEN",
+        "attacker-selected-token",
+    );
+
+    assert!(active_memory_store_ready());
+    assert!(MemoryStoreClient::from_env().is_some());
+    let environment = bridge_session_value().unwrap()["environment"]
+        .as_object()
+        .unwrap()
+        .clone();
+    assert!(!environment.contains_key("PENTECT_PROCESS_HOST_ROOT"));
+    assert!(!environment.contains_key("PENTECT_PROCESS_HOST_READ_TOKEN"));
+    assert!(!environment.contains_key("PENTECT_PROCESS_HOST_WRITE_TOKEN"));
+
+    std::env::remove_var("PENTECT_PROCESS_HOST_ROOT");
+    std::env::remove_var("PENTECT_PROCESS_HOST_READ_TOKEN");
+    std::env::remove_var("PENTECT_PROCESS_HOST_WRITE_TOKEN");
+}
+
+#[test]
+fn replaced_runtime_credentials_cannot_impersonate_the_active_store() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, addr, token) = ActiveMemoryStoreEnv::start("credential-redirect");
+    assert!(active_memory_store_ready());
+
+    let replacement = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    std::env::set_var(ENV_TOKEN, replacement);
+    std::env::set_var(PENTECT_AGENT_LAUNCHED_ENV, replacement);
+    assert!(MemoryStoreClient::from_env().is_none());
+
+    std::env::set_var(ENV_TOKEN, &token);
+    std::env::set_var(PENTECT_AGENT_LAUNCHED_ENV, &token);
+    std::env::set_var(ENV_ADDR, "127.0.0.1:9");
+    assert!(MemoryStoreClient::from_env().is_none());
+
+    std::env::set_var(ENV_ADDR, addr);
+    assert!(MemoryStoreClient::from_env().is_some());
+}
+
+#[test]
 fn require_pentect_allows_wrapped_agent_with_memory_store_proof() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
-    let token = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    let addr = memory_store::spawn_test_memory_store(token.to_string());
-    std::env::set_var(PENTECT_AGENT_LAUNCHED_ENV, token);
-    std::env::set_var(ENV_TOKEN, token);
-    std::env::set_var(ENV_ADDR, addr);
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("launch-proof");
     ensure_pentect_agent_launch_required(HookProvider::Claude, true).unwrap();
-    std::env::remove_var(PENTECT_AGENT_LAUNCHED_ENV);
-    std::env::remove_var(ENV_TOKEN);
-    std::env::remove_var(ENV_ADDR);
 }
 
 #[test]

--- a/extensions/jp-pii/extension.toml
+++ b/extensions/jp-pii/extension.toml
@@ -1,0 +1,3 @@
+schema = "pentect.extension.v1"
+name = "jp-pii"
+description = "Context-aware Japanese PII rules."

--- a/extensions/openai-privacy-filter/extension.toml
+++ b/extensions/openai-privacy-filter/extension.toml
@@ -1,0 +1,3 @@
+schema = "pentect.extension.v1"
+name = "openai-privacy-filter"
+description = "Local privacy-filter model adapter."

--- a/extensions/pii-ner/extension.toml
+++ b/extensions/pii-ner/extension.toml
@@ -1,0 +1,14 @@
+schema = "pentect.extension.v1"
+name = "pii-ner"
+description = "Local ONNX PII named-entity recognition adapter."
+
+[[artifact]]
+name = "pentect-pii-ner"
+repository = "EdamAme-x/pentect"
+destination = "bin/pentect-pii-ner"
+
+[artifact.assets]
+windows-x86_64 = "pentect-pii-ner-windows-x86_64.exe"
+linux-x86_64 = "pentect-pii-ner-linux-x86_64"
+macos-x86_64 = "pentect-pii-ner-macos-x86_64"
+macos-aarch64 = "pentect-pii-ner-macos-aarch64"

--- a/integrations/pi/extensions/pentect.js
+++ b/integrations/pi/extensions/pentect.js
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { delimiter, dirname } from "node:path";
 import {
   createBashTool,
   createLocalBashOperations,
@@ -11,14 +12,16 @@ const SAFE_RESULT = {
   isError: true,
 };
 const BRIDGE_REQUEST_TIMEOUT_MS = 10_000;
-const SESSION_ENVIRONMENT = new Set([
+const REQUIRED_SESSION_ENVIRONMENT = [
   "PENTECT_BIN",
   "PENTECT_MEMORY_STORE_ADDR",
   "PENTECT_MEMORY_STORE_TOKEN",
-  "PENTECT_PROCESS_HOST_READ_TOKEN",
-  "PENTECT_PROCESS_HOST_WRITE_TOKEN",
-  "PENTECT_PROCESS_HOST_ROOT",
   "PENTECT_AGENT_LAUNCHED",
+];
+const SESSION_ENVIRONMENT = new Set([
+  ...REQUIRED_SESSION_ENVIRONMENT,
+  "PENTECT_EXTENSION_CONFIGS",
+  "PENTECT_EXTENSION_ADAPTERS",
 ]);
 
 function replaceObject(target, source) {
@@ -27,7 +30,7 @@ function replaceObject(target, source) {
 }
 
 function createPentectBridge() {
-  const child = spawn(process.env.PENTECT_BIN || "pentect", ["bridge"], {
+  const child = spawn("pentect", ["bridge"], {
     stdio: ["pipe", "pipe", "ignore"],
     windowsHide: true,
   });
@@ -121,6 +124,20 @@ function createPentectBridge() {
   };
 }
 
+function protectedChildEnvironment(optionsEnvironment, sessionEnvironment) {
+  const environment = { ...process.env, ...optionsEnvironment };
+  for (const name of Object.keys(environment)) {
+    if (name.toUpperCase().startsWith("PENTECT_")) delete environment[name];
+  }
+  Object.assign(environment, sessionEnvironment);
+  const pathName =
+    Object.keys(environment).find((name) => name.toUpperCase() === "PATH") ||
+    "PATH";
+  const currentPath = environment[pathName] || "";
+  environment[pathName] = `${dirname(sessionEnvironment.PENTECT_BIN)}${delimiter}${currentPath}`;
+  return environment;
+}
+
 function readSessionEnvironment(values) {
   if (!values || typeof values !== "object" || Array.isArray(values)) {
     throw new Error("Pentect returned an invalid session");
@@ -130,8 +147,7 @@ function readSessionEnvironment(values) {
       throw new Error("Pentect returned an invalid session");
     }
   }
-  for (const required of SESSION_ENVIRONMENT) {
-    if (required === "PENTECT_BIN") continue;
+  for (const required of REQUIRED_SESSION_ENVIRONMENT) {
     if (typeof values[required] !== "string" || !values[required]) {
       throw new Error("Pentect returned an incomplete session");
     }
@@ -160,11 +176,11 @@ export default function pentectExtension(pi) {
         throw new Error("Pentect rejected the command");
       }
       if (!sessionEnvironment) throw new Error("Pentect unavailable");
-      // The bridge wraps the command with `pentect exec`, which masks each
-      // streamed chunk before Pi's onData callback receives it.
+      // The bridge keeps execution in Pi's Bash and masks each streamed chunk
+      // before Pi's onData callback receives it.
       return localBash.exec(next.command, cwd, {
         ...options,
-        env: { ...options.env, ...sessionEnvironment },
+        env: protectedChildEnvironment(options.env, sessionEnvironment),
       });
     },
   };

--- a/integrations/pi/extensions/pentect.js
+++ b/integrations/pi/extensions/pentect.js
@@ -5,12 +5,7 @@ import {
   createLocalBashOperations,
 } from "@earendil-works/pi-coding-agent";
 
-const SAFE_TEXT = "[Pentect: content unavailable]";
-const SAFE_RESULT = {
-  content: [{ type: "text", text: SAFE_TEXT }],
-  details: undefined,
-  isError: true,
-};
+const SAFE_TEXT = "[Content unavailable]";
 const BRIDGE_REQUEST_TIMEOUT_MS = 10_000;
 const REQUIRED_SESSION_ENVIRONMENT = [
   "PENTECT_BIN",
@@ -69,8 +64,15 @@ function createPentectBridge() {
       if (!waiter) continue;
       pending.delete(response.id);
       clearTimeout(waiter.timer);
-      if (response.ok) waiter.resolve(response.value);
-      else waiter.reject(new Error("Pentect rejected the operation"));
+      if (response.ok) {
+        waiter.resolve(response.value);
+      } else {
+        const error = new Error(response.error?.message || "Operation unavailable");
+        error.code = response.error?.code;
+        error.phase = response.error?.phase;
+        error.executed = response.error?.executed === true;
+        waiter.reject(error);
+      }
     }
   });
   child.on("error", fail);
@@ -236,8 +238,8 @@ export default function pentectExtension(pi) {
       });
       replaceObject(event.input, next);
       return {};
-    } catch {
-      return { block: true, reason: "Pentect unavailable" };
+    } catch (error) {
+      return { block: true, reason: error?.message || "Tool unavailable" };
     }
   });
 
@@ -252,8 +254,19 @@ export default function pentectExtension(pi) {
           isError: event.isError,
         },
       });
-    } catch {
-      return SAFE_RESULT;
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: error?.executed
+              ? "Tool completed, but its output was unavailable. Check side effects before retrying."
+              : SAFE_TEXT,
+          },
+        ],
+        details: event.details,
+        isError: event.isError,
+      };
     }
   });
 

--- a/integrations/pi/extensions/pentect.js
+++ b/integrations/pi/extensions/pentect.js
@@ -182,7 +182,7 @@ export default function pentectExtension(pi) {
       // before Pi's onData callback receives it.
       return localBash.exec(next.command, cwd, {
         ...options,
-        env: protectedChildEnvironment(options.env, sessionEnvironment),
+        env: protectedChildEnvironment(options?.env, sessionEnvironment),
       });
     },
   };

--- a/integrations/pi/test/extension.test.js
+++ b/integrations/pi/test/extension.test.js
@@ -72,7 +72,7 @@ test(
       const contract = (
         await pi.emit("before_agent_start", { systemPrompt: "Pi" })
       )[0].systemPrompt;
-      assert.match(contract, /Pentect agent contract/);
+      assert.match(contract, /Session rules/);
 
       const raw = ["sk-", "ABCDEFGHIJKLMNOPQRSTUVWX"].join("");
       const input = (
@@ -119,6 +119,32 @@ test(
       assert.doesNotMatch(renderedConnector, new RegExp(raw));
       assert.match(renderedConnector, /<<OPENAI_API_KEY_[a-f0-9]+>>/);
       assert.equal(connector.isError, false);
+
+      const remoteInput = { command: "remote-operation", argument: "value" };
+      const remoteBefore = (
+        await pi.emit("tool_call", {
+          toolName: "mcp__service__invoke",
+          input: remoteInput,
+        })
+      )[0];
+      assert.deepEqual(remoteBefore, {});
+      assert.deepEqual(remoteInput, {
+        command: "remote-operation",
+        argument: "value",
+      });
+
+      const unavailable = (
+        await pi.emit("tool_result", {
+          toolName: "connector",
+          input: {},
+          content: [{ type: "audio", data: "opaque" }],
+          details: { requestId: "done" },
+          isError: false,
+        })
+      )[0];
+      assert.equal(unavailable.isError, false);
+      assert.deepEqual(unavailable.details, { requestId: "done" });
+      assert.match(unavailable.content[0].text, /Tool completed/);
     } finally {
       await pi.emit("session_shutdown", { reason: "quit" });
       if (originalBin === undefined) delete process.env.PENTECT_BIN;

--- a/integrations/pi/test/extension.test.js
+++ b/integrations/pi/test/extension.test.js
@@ -54,7 +54,7 @@ test(
   async () => {
     const originalBin = process.env.PENTECT_BIN;
     const originalPath = process.env.PATH;
-    process.env.PENTECT_BIN = e2eBin;
+    process.env.PENTECT_BIN = join(tmpdir(), "untrusted-pentect-bin");
     process.env.PATH = `${dirname(e2eBin)}${delimiter}${originalPath || ""}`;
     const pi = new TestPi();
     pentectExtension(pi);
@@ -91,10 +91,7 @@ test(
 
       const handle = input.text.split("=")[1];
       const alias = `PENTECT_${handle.slice(2, -2)}`;
-      const command =
-        process.platform === "win32"
-          ? `Write-Output $env:${alias}`
-          : `printf '%s\\n' "$${alias}"`;
+      const command = `printf '%s\\n' "$${alias}"`;
       const updates = [];
       const toolInput = { command };
       const result = await pi.tools.get("bash").execute(
@@ -155,7 +152,7 @@ test(
             env: {
               ...process.env,
               PATH: `${dirname(e2eBin)}${delimiter}${process.env.PATH || ""}`,
-              PENTECT_BIN: e2eBin,
+              PENTECT_BIN: join(agentDir, "untrusted-pentect-bin"),
               PI_CODING_AGENT_DIR: agentDir,
             },
             stdio: ["pipe", "pipe", "pipe"],

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -1,0 +1,65 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repository = 'EdamAme-x/pentect'
+$baseUrl = "https://github.com/$repository/releases/latest/download"
+$architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+if ($architecture -ne 'X64') {
+    throw "pentect: unsupported Windows architecture: $architecture"
+}
+$asset = 'pentect-windows-x86_64.exe'
+
+$installDir = if ($env:PENTECT_INSTALL_DIR) {
+    $env:PENTECT_INSTALL_DIR
+} else {
+    Join-Path $env:LOCALAPPDATA 'Pentect\bin'
+}
+$destination = Join-Path $installDir 'pentect.exe'
+
+if ($env:PENTECT_INSTALL_DRY_RUN -eq '1') {
+    Write-Output "asset=$asset"
+    Write-Output "install=$destination"
+    return
+}
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("pentect-install-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $tempDir | Out-Null
+try {
+    $binaryPath = Join-Path $tempDir $asset
+    $checksumPath = "$binaryPath.sha256"
+    Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/$asset" -OutFile $binaryPath
+    Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/$asset.sha256" -OutFile $checksumPath
+
+    $expected = ((Get-Content -Raw -LiteralPath $checksumPath) -split '\s+')[0].ToLowerInvariant()
+    if ($expected -notmatch '^[0-9a-f]{64}$') {
+        throw 'pentect: release checksum is invalid'
+    }
+    $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $binaryPath).Hash.ToLowerInvariant()
+    if ($actual -ne $expected) {
+        throw "pentect: release checksum mismatch (expected $expected, received $actual)"
+    }
+
+    New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+    $staged = Join-Path $installDir 'pentect.install.exe'
+    Copy-Item -LiteralPath $binaryPath -Destination $staged -Force
+    if (Test-Path -LiteralPath $destination) {
+        $backup = Join-Path $installDir 'pentect.previous.exe'
+        Copy-Item -LiteralPath $destination -Destination $backup -Force
+    }
+    Move-Item -LiteralPath $staged -Destination $destination -Force
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $pathParts = @($userPath -split ';' | Where-Object { $_ })
+    if (-not ($pathParts | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') })) {
+        $nextPath = (@($pathParts) + $installDir) -join ';'
+        [Environment]::SetEnvironmentVariable('Path', $nextPath, 'User')
+    }
+    if (-not (($env:Path -split ';') | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') })) {
+        $env:Path = "$installDir;$env:Path"
+    }
+    Write-Output "pentect: installed $destination"
+} finally {
+    if (Test-Path -LiteralPath $tempDir) {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force
+    }
+}

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -eu
+
+repository="EdamAme-x/pentect"
+base_url="https://github.com/$repository/releases/latest/download"
+
+os=$(uname -s)
+arch=$(uname -m)
+case "$os:$arch" in
+  Linux:x86_64|Linux:amd64)
+    asset="pentect-linux-x86_64"
+    ;;
+  Darwin:x86_64|Darwin:amd64)
+    asset="pentect-macos-x86_64"
+    ;;
+  Darwin:arm64|Darwin:aarch64)
+    asset="pentect-macos-aarch64"
+    ;;
+  *)
+    echo "pentect: unsupported platform: $os/$arch" >&2
+    exit 1
+    ;;
+esac
+
+install_dir=${PENTECT_INSTALL_DIR:-"$HOME/.local/bin"}
+destination="$install_dir/pentect"
+
+if [ "${PENTECT_INSTALL_DRY_RUN:-0}" = "1" ]; then
+  printf 'asset=%s\ninstall=%s\n' "$asset" "$destination"
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "pentect: curl is required" >&2
+  exit 1
+fi
+
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/pentect-install.XXXXXX")
+cleanup() {
+  rm -rf "$temp_dir"
+}
+trap cleanup 0 HUP INT TERM
+
+curl -fL --proto '=https' --tlsv1.2 \
+  "$base_url/$asset" \
+  -o "$temp_dir/$asset"
+curl -fL --proto '=https' --tlsv1.2 \
+  "$base_url/$asset.sha256" \
+  -o "$temp_dir/$asset.sha256"
+
+expected=$(awk 'NR == 1 { print tolower($1) }' "$temp_dir/$asset.sha256")
+case "$expected" in
+  *[!0-9a-f]*|'')
+    echo "pentect: release checksum is invalid" >&2
+    exit 1
+    ;;
+esac
+if [ "${#expected}" -ne 64 ]; then
+  echo "pentect: release checksum is invalid" >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual=$(sha256sum "$temp_dir/$asset" | awk '{ print tolower($1) }')
+elif command -v shasum >/dev/null 2>&1; then
+  actual=$(shasum -a 256 "$temp_dir/$asset" | awk '{ print tolower($1) }')
+else
+  echo "pentect: sha256sum or shasum is required" >&2
+  exit 1
+fi
+if [ "$actual" != "$expected" ]; then
+  echo "pentect: release checksum mismatch" >&2
+  exit 1
+fi
+
+mkdir -p "$install_dir"
+staged="$install_dir/.pentect.install.$$"
+cp "$temp_dir/$asset" "$staged"
+chmod 0755 "$staged"
+mv -f "$staged" "$destination"
+
+echo "pentect: installed $destination"
+case ":${PATH:-}:" in
+  *":$install_dir:"*) ;;
+  *) echo "pentect: add $install_dir to PATH" ;;
+esac


### PR DESCRIPTION
## Summary
- close partial terminal controls and stop PTY writes before restoring the parent terminal
- clean up one-shot process hosts on every CLI exit path
- reject replaced Pentect control environment values and stop forwarding activity credentials
- centralize and strip reserved environment names at child boundaries

## Verification
- cargo clippy -p pentect-cli -p pentect-runtime --all-targets --all-features -j 2 -- -D warnings
- 178 pentect CLI unit tests
- PTY dimension/control integration tests
- process-host lifecycle and handoff integration tests
- release Claude headless E2E with forged PENTECT_* environment values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved stripping/verification of Pentect control environment variables during proxy/tool execution.
  * Strengthened memory-store credential validation, readiness checks, and single-use agent script handling; tighter environment reference entropy suppression.
* **Reliability**
  * Better process-host cleanup (including on startup failure) and narrowed host handoff eligibility.
  * Added timeout-based memory-store request handling and stricter runtime-token validation.
* **Terminal Experience**
  * Enhanced PTY streaming for large control sequences, plus improved Windows VT/backspace normalization and nested terminal behavior.
* **Error Handling**
  * More consistent CLI exit behavior and structured bridge/tool error payloads; issue URLs now use a compact title-only format.
* **New Features**
  * Added extension `github:` shorthand and new `extensions` config/setup/update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->