### PR TITLE
Add versioned installs and self-uninstall

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,38 +125,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
-      - name: Generate version-pinned installers
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 - "$GITHUB_REF_NAME" <<'PY'
-          from pathlib import Path
-          import sys
-
-          tag = sys.argv[1]
-          powershell = Path("tools/install.ps1").read_text(encoding="utf-8")
-          powershell = powershell.replace(
-              "$bundledVersion = ''",
-              f"$bundledVersion = '{tag}'",
-              1,
-          )
-          shell = Path("tools/install.sh").read_text(encoding="utf-8")
-          shell = shell.replace(
-              'bundled_version=""',
-              f'bundled_version="{tag}"',
-              1,
-          )
-          Path("dist/install.ps1").write_text(powershell, encoding="utf-8")
-          Path("dist/install.sh").write_text(shell, encoding="utf-8")
-          PY
-          chmod 0755 dist/install.sh
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,10 +125,38 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
+      - name: Generate version-pinned installers
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - "$GITHUB_REF_NAME" <<'PY'
+          from pathlib import Path
+          import sys
+
+          tag = sys.argv[1]
+          powershell = Path("tools/install.ps1").read_text(encoding="utf-8")
+          powershell = powershell.replace(
+              "$bundledVersion = ''",
+              f"$bundledVersion = '{tag}'",
+              1,
+          )
+          shell = Path("tools/install.sh").read_text(encoding="utf-8")
+          shell = shell.replace(
+              'bundled_version=""',
+              f'bundled_version="{tag}"',
+              1,
+          )
+          Path("dist/install.ps1").write_text(powershell, encoding="utf-8")
+          Path("dist/install.sh").write_text(shell, encoding="utf-8")
+          PY
+          chmod 0755 dist/install.sh
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-pii-ner"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.1"
+version = "0.0.2"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -11,6 +11,7 @@ mod headless;
 mod input;
 mod scan;
 mod terminal;
+mod uninstall;
 mod update;
 
 use input::{decode_utf8_text, ImageOcrInput, InputAdapter, TextInput};
@@ -103,6 +104,7 @@ fn dispatch(args: Vec<String>, inherited_env_is_trusted: bool) -> Option<i32> {
         Some("help" | "--help" | "-h") => cmd_help(),
         Some("version" | "--version" | "-V") => update::cmd_version(),
         Some("update") => update::cmd_update(&args),
+        Some("uninstall") => uninstall::cmd_uninstall(&args),
         Some("__apply-update") => return Some(update::cmd_apply_update(&args)),
         Some("mask") => cmd_mask(&args),
         Some("read") => cmd_read(&args),
@@ -168,7 +170,8 @@ fn usage() {
          pentect shell\n\
          pentect up\n\
          pentect doctor\n\
-         pentect update [--check]\n\
+         pentect update [VERSION] [--check]\n\
+         pentect uninstall\n\
          pentect extensions list|inspect|test|config|setup|update [NAME]\n\
          pentect eval [--json]\n\
          pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--no-gitignore] [PATH...]\n\
@@ -205,7 +208,8 @@ fn help_text() -> &'static str {
         "  pentect shell\n\n",
         "  pentect up\n\n",
         "  pentect doctor [--json]\n",
-        "  pentect update [--check | --force]\n",
+        "  pentect update [VERSION] [--check | --force]\n",
+        "  pentect uninstall\n",
         "  pentect extensions list|inspect|test [NAME|PATH] [--json]\n",
         "  pentect extensions config NAME|PATH [KEY=VALUE | --unset KEY]\n",
         "  pentect extensions setup NAME|PATH [--yes]\n",
@@ -227,6 +231,7 @@ fn help_text() -> &'static str {
         "groups: ~vcs ~deps ~build ~cache ~pentect ~heavy ~all; ! restores\n",
         "doctor: readiness\n",
         "update: verified GitHub Release binary\n",
+        "uninstall: remove the binary; keep project data\n",
         "extensions: list, inspect, test, config, setup, update\n",
         "eval: precision, recall\n",
     )

--- a/crates/pentect-cli/src/uninstall.rs
+++ b/crates/pentect-cli/src/uninstall.rs
@@ -1,0 +1,178 @@
+use std::path::Path;
+
+const INSTALL_MARKER: &str = ".pentect-managed-install.json";
+
+pub(crate) fn cmd_uninstall(args: &[String]) {
+    if let Err(error) = uninstall(args) {
+        crate::die(error);
+    }
+}
+
+fn uninstall(args: &[String]) -> Result<(), String> {
+    if args.len() != 2 {
+        return Err("usage: pentect uninstall".to_string());
+    }
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("could not locate the installed executable: {error}"))?;
+    validate_executable_name(&executable)?;
+    let install_dir = executable
+        .parent()
+        .ok_or_else(|| "installed executable has no parent directory".to_string())?;
+    let marker = install_dir.join(INSTALL_MARKER);
+
+    #[cfg(windows)]
+    {
+        spawn_windows_uninstall_helper(&executable, &marker)?;
+        println!("pentect: uninstall scheduled");
+        println!("pentect: project configuration and extension data were kept");
+    }
+    #[cfg(not(windows))]
+    {
+        remove_update_backups(install_dir, &executable)?;
+        std::fs::remove_file(&executable)
+            .map_err(|error| format!("could not remove '{}': {error}", executable.display()))?;
+        let _ = std::fs::remove_file(&marker);
+        remove_empty_install_dir(install_dir);
+        println!("pentect: uninstalled {}", executable.display());
+        println!("pentect: project configuration and extension data were kept");
+    }
+    Ok(())
+}
+
+fn validate_executable_name(path: &Path) -> Result<(), String> {
+    let name = path.file_name().and_then(|name| name.to_str());
+    if matches!(name, Some("pentect" | "pentect.exe")) {
+        Ok(())
+    } else {
+        Err(format!(
+            "refusing to uninstall unexpected executable '{}'",
+            path.display()
+        ))
+    }
+}
+
+#[cfg(not(windows))]
+fn remove_update_backups(install_dir: &Path, executable: &Path) -> Result<(), String> {
+    let Some(name) = executable.file_name().and_then(|name| name.to_str()) else {
+        return Ok(());
+    };
+    let prefix = format!("{name}.previous-");
+    let entries = std::fs::read_dir(install_dir)
+        .map_err(|error| format!("could not inspect '{}': {error}", install_dir.display()))?;
+    for entry in entries.flatten() {
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|candidate| candidate.starts_with(&prefix))
+        {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn remove_empty_install_dir(install_dir: &Path) {
+    if std::fs::read_dir(install_dir)
+        .ok()
+        .is_some_and(|mut entries| entries.next().is_none())
+    {
+        let _ = std::fs::remove_dir(install_dir);
+    }
+}
+
+#[cfg(windows)]
+fn spawn_windows_uninstall_helper(executable: &Path, marker: &Path) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    use std::process::Command;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    const SCRIPT: &str = r#"param(
+    [Parameter(Mandatory=$true)][int]$ParentPid,
+    [Parameter(Mandatory=$true)][string]$Target,
+    [Parameter(Mandatory=$true)][string]$Marker
+)
+$ErrorActionPreference = 'SilentlyContinue'
+for ($attempt = 0; $attempt -lt 3000; $attempt++) {
+    if (-not (Get-Process -Id $ParentPid -ErrorAction SilentlyContinue)) { break }
+    Start-Sleep -Milliseconds 100
+}
+$installDir = Split-Path -Parent $Target
+$pathAdded = $false
+if (Test-Path -LiteralPath $Marker) {
+    try { $pathAdded = [bool]((Get-Content -Raw -LiteralPath $Marker | ConvertFrom-Json).path_added) } catch {}
+}
+Remove-Item -LiteralPath $Target -Force
+if (Test-Path -LiteralPath $Target) { exit 1 }
+$name = Split-Path -Leaf $Target
+Get-ChildItem -LiteralPath $installDir -Filter "$name.previous-*" -File | Remove-Item -Force
+Remove-Item -LiteralPath $Marker -Force
+if ($pathAdded) {
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $parts = @($userPath -split ';' | Where-Object { $_ -and $_.TrimEnd('\') -ine $installDir.TrimEnd('\') })
+    [Environment]::SetEnvironmentVariable('Path', ($parts -join ';'), 'User')
+}
+if ((Test-Path -LiteralPath $installDir) -and -not (Get-ChildItem -LiteralPath $installDir -Force | Select-Object -First 1)) {
+    Remove-Item -LiteralPath $installDir -Force
+}
+Remove-Item -LiteralPath $PSCommandPath -Force
+"#;
+
+    let helper = std::env::temp_dir().join(format!(
+        "pentect-uninstall-{}-{}.ps1",
+        std::process::id(),
+        timestamp_suffix()
+    ));
+    std::fs::write(&helper, SCRIPT)
+        .map_err(|error| format!("could not create uninstall helper: {error}"))?;
+    Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-WindowStyle",
+            "Hidden",
+            "-File",
+        ])
+        .arg(&helper)
+        .arg("-ParentPid")
+        .arg(std::process::id().to_string())
+        .arg("-Target")
+        .arg(executable)
+        .arg("-Marker")
+        .arg(marker)
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| format!("could not start uninstall helper: {error}"))
+}
+
+#[cfg(windows)]
+fn timestamp_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_accepts_the_public_command_shape() {
+        assert!(uninstall(&["pentect".into()]).is_err());
+        assert!(uninstall(&["pentect".into(), "uninstall".into(), "extra".into()]).is_err());
+    }
+
+    #[test]
+    fn validates_only_pentect_executable_names() {
+        assert!(validate_executable_name(Path::new("pentect")).is_ok());
+        assert!(validate_executable_name(Path::new("pentect.exe")).is_ok());
+        assert!(validate_executable_name(Path::new("other.exe")).is_err());
+    }
+
+    #[test]
+    fn reads_managed_path_ownership_marker() {
+        let marker: serde_json::Value = serde_json::from_str(r#"{"path_added":true}"#).unwrap();
+        assert_eq!(marker["path_added"], true);
+    }
+}

--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -37,6 +37,7 @@ struct ReleaseAsset {
 struct UpdateOptions {
     check: bool,
     force: bool,
+    target: Option<Version>,
 }
 
 pub(crate) fn cmd_version() {
@@ -60,7 +61,16 @@ fn parse_update_options(args: &[String]) -> Result<UpdateOptions, String> {
             "--check" => options.check = true,
             "--force" => options.force = true,
             flag if flag.starts_with('-') => return Err(format!("unknown update option: {flag}")),
-            value => return Err(format!("unexpected update argument: {value}")),
+            value => {
+                if options.target.is_some() {
+                    return Err("update accepts at most one version".to_string());
+                }
+                let value = value.strip_prefix('v').unwrap_or(value);
+                options.target = Some(
+                    Version::parse(value)
+                        .map_err(|error| format!("invalid update version '{value}': {error}"))?,
+                );
+            }
         }
     }
     if options.check && options.force {
@@ -75,15 +85,35 @@ fn update(options: UpdateOptions) -> Result<(), String> {
         .user_agent(USER_AGENT)
         .build()
         .map_err(|e| format!("could not create update client: {e}"))?;
-    let release: Release = get_response(&client, RELEASE_API, MAX_CHECKSUM_BYTES * 16)?;
+    let release_api = options.target.as_ref().map_or_else(
+        || RELEASE_API.to_string(),
+        |version| {
+            format!("https://api.github.com/repos/EdamAme-x/pentect/releases/tags/v{version}")
+        },
+    );
+    let release: Release = get_response(&client, &release_api, MAX_CHECKSUM_BYTES * 16)?;
     if release.draft || release.prerelease {
         return Err("latest GitHub release is not a stable release".to_string());
     }
     let latest = release_version(&release.tag_name)?;
+    if options
+        .target
+        .as_ref()
+        .is_some_and(|target| target != &latest)
+    {
+        return Err(format!(
+            "requested version does not match release tag {}",
+            release.tag_name
+        ));
+    }
     let current = Version::parse(env!("CARGO_PKG_VERSION"))
         .map_err(|e| format!("invalid installed version: {e}"))?;
-    if !options.force && latest <= current {
+    if !options.force && latest == current {
         println!("up to date: {current}");
+        return Ok(());
+    }
+    if options.target.is_none() && !options.force && latest < current {
+        println!("installed version {current} is newer than latest release {latest}");
         return Ok(());
     }
     println!("update available: {current} -> {latest}");
@@ -450,6 +480,11 @@ mod tests {
     fn parses_update_flags() {
         let args = vec!["pentect".into(), "update".into(), "--check".into()];
         assert!(parse_update_options(&args).unwrap().check);
+        let args = vec!["pentect".into(), "update".into(), "v1.2.3".into()];
+        assert_eq!(
+            parse_update_options(&args).unwrap().target,
+            Some(Version::new(1, 2, 3))
+        );
         let args = vec![
             "pentect".into(),
             "update".into(),

--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -33,7 +33,7 @@ struct ReleaseAsset {
     size: u64,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct UpdateOptions {
     check: bool,
     force: bool,

--- a/extensions/pii-ner/adapter/Cargo.toml
+++ b/extensions/pii-ner/adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-pii-ner"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -1,8 +1,22 @@
+param([string]$Version = $env:PENTECT_VERSION)
+
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $repository = 'EdamAme-x/pentect'
-$baseUrl = "https://github.com/$repository/releases/latest/download"
+$bundledVersion = ''
+$requestedVersion = if ($Version) { $Version } elseif ($bundledVersion) { $bundledVersion } else { $null }
+if ($requestedVersion) {
+    $requestedVersion = $requestedVersion.TrimStart('v')
+    if ($requestedVersion -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+        throw "pentect: invalid version: $requestedVersion"
+    }
+    $releaseTag = "v$requestedVersion"
+    $baseUrl = "https://github.com/$repository/releases/download/$releaseTag"
+} else {
+    $releaseTag = 'latest'
+    $baseUrl = "https://github.com/$repository/releases/latest/download"
+}
 $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
 if ($architecture -ne 'X64') {
     throw "pentect: unsupported Windows architecture: $architecture"
@@ -15,9 +29,11 @@ $installDir = if ($env:PENTECT_INSTALL_DIR) {
     Join-Path $env:LOCALAPPDATA 'Pentect\bin'
 }
 $destination = Join-Path $installDir 'pentect.exe'
+$marker = Join-Path $installDir '.pentect-managed-install.json'
 
 if ($env:PENTECT_INSTALL_DRY_RUN -eq '1') {
     Write-Output "asset=$asset"
+    Write-Output "version=$releaseTag"
     Write-Output "install=$destination"
     return
 }
@@ -48,15 +64,23 @@ try {
     }
     Move-Item -LiteralPath $staged -Destination $destination -Force
 
-    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-    $pathParts = @($userPath -split ';' | Where-Object { $_ })
-    if (-not ($pathParts | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') })) {
-        $nextPath = (@($pathParts) + $installDir) -join ';'
-        [Environment]::SetEnvironmentVariable('Path', $nextPath, 'User')
+    $pathAdded = $false
+    if (Test-Path -LiteralPath $marker) {
+        try { $pathAdded = [bool]((Get-Content -Raw -LiteralPath $marker | ConvertFrom-Json).path_added) } catch {}
     }
-    if (-not (($env:Path -split ';') | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') })) {
-        $env:Path = "$installDir;$env:Path"
+    if ($env:PENTECT_INSTALL_SKIP_PATH -ne '1') {
+        $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+        $pathParts = @($userPath -split ';' | Where-Object { $_ })
+        if (-not ($pathParts | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') })) {
+            $nextPath = (@($pathParts) + $installDir) -join ';'
+            [Environment]::SetEnvironmentVariable('Path', $nextPath, 'User')
+            $pathAdded = $true
+        }
+        if (-not (($env:Path -split ';') | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') })) {
+            $env:Path = "$installDir;$env:Path"
+        }
     }
+    @{ version = 1; path_added = $pathAdded } | ConvertTo-Json -Compress | Set-Content -Encoding utf8 -LiteralPath $marker
     Write-Output "pentect: installed $destination"
 } finally {
     if (Test-Path -LiteralPath $tempDir) {

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -4,8 +4,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $repository = 'EdamAme-x/pentect'
-$bundledVersion = ''
-$requestedVersion = if ($Version) { $Version } elseif ($bundledVersion) { $bundledVersion } else { $null }
+$requestedVersion = $Version
 if ($requestedVersion) {
     $requestedVersion = $requestedVersion.TrimStart('v')
     if ($requestedVersion -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -2,7 +2,33 @@
 set -eu
 
 repository="EdamAme-x/pentect"
-base_url="https://github.com/$repository/releases/latest/download"
+bundled_version=""
+version=${PENTECT_VERSION:-$bundled_version}
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ "$#" -ge 2 ] || { echo "pentect: --version requires a value" >&2; exit 1; }
+      version=$2
+      shift 2
+      ;;
+    *)
+      echo "pentect: unknown installer option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+if [ -n "$version" ]; then
+  version=${version#v}
+  if ! printf '%s\n' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+    echo "pentect: invalid version: $version" >&2
+    exit 1
+  fi
+  release_tag="v$version"
+  base_url="https://github.com/$repository/releases/download/$release_tag"
+else
+  release_tag="latest"
+  base_url="https://github.com/$repository/releases/latest/download"
+fi
 
 os=$(uname -s)
 arch=$(uname -m)
@@ -24,9 +50,11 @@ esac
 
 install_dir=${PENTECT_INSTALL_DIR:-"$HOME/.local/bin"}
 destination="$install_dir/pentect"
+marker="$install_dir/.pentect-managed-install.json"
 
 if [ "${PENTECT_INSTALL_DRY_RUN:-0}" = "1" ]; then
   printf 'asset=%s\ninstall=%s\n' "$asset" "$destination"
+  printf 'version=%s\n' "$release_tag"
   exit 0
 fi
 
@@ -78,6 +106,7 @@ staged="$install_dir/.pentect.install.$$"
 cp "$temp_dir/$asset" "$staged"
 chmod 0755 "$staged"
 mv -f "$staged" "$destination"
+printf '%s\n' '{"version":1,"path_added":false}' > "$marker"
 
 echo "pentect: installed $destination"
 case ":${PATH:-}:" in

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -2,8 +2,7 @@
 set -eu
 
 repository="EdamAme-x/pentect"
-bundled_version=""
-version=${PENTECT_VERSION:-$bundled_version}
+version=${PENTECT_VERSION:-}
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --version)


### PR DESCRIPTION
﻿## Summary
- add `pentect uninstall` with Windows self-removal and managed PATH cleanup
- allow `pentect update VERSION`, including explicit downgrades
- allow version-pinned installer invocation
- generate tag-pinned installer scripts as GitHub Release assets

## Validation
- PowerShell installer parsing and version dry-run
- Rust formatting and diff checks
- full Rust/Unix validation delegated to GitHub CI to avoid loading the development PC

Project configuration and extension data are intentionally retained during uninstall.
