### PR TITLE
Speed up releases and clarify installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,9 @@ jobs:
         run: |
           git fetch origin main --no-tags
           $metadata = cargo metadata --no-deps --format-version 1 | ConvertFrom-Json
-          $versions = @(
-            $metadata.packages |
-              Where-Object { $_.name -in @('pentect-cli', 'pentect-pii-ner') } |
-              Select-Object -ExpandProperty version -Unique
-          )
-          if ($versions.Count -ne 1) {
-            throw "pentect-cli and pentect-pii-ner versions must match"
-          }
-          $version = $versions[0]
+          $version = $metadata.packages |
+            Where-Object { $_.name -eq 'pentect-cli' } |
+            Select-Object -ExpandProperty version -First 1
           if ($env:GITHUB_REF_NAME -ne "v$version") {
             throw "tag $env:GITHUB_REF_NAME must match pentect-cli version v$version"
           }
@@ -95,6 +89,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-${{ matrix.asset }}
       - name: Build release binary
         run: cargo build --release --locked -p pentect-cli -p pentect-pii-ner
       - name: Package binary and checksum

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.2"
+version = "0.0.3"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -1,6 +1,7 @@
 param([string]$Version = $env:PENTECT_VERSION)
 
 $ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
 Set-StrictMode -Version Latest
 
 $repository = 'EdamAme-x/pentect'
@@ -40,11 +41,18 @@ if ($env:PENTECT_INSTALL_DRY_RUN -eq '1') {
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("pentect-install-" + [guid]::NewGuid())
 New-Item -ItemType Directory -Path $tempDir | Out-Null
 try {
+    Write-Output 'Pentect installer'
+    Write-Output "  Platform : Windows x64"
+    Write-Output "  Version  : $releaseTag"
+    Write-Output "  Install  : $destination"
+    Write-Output ''
     $binaryPath = Join-Path $tempDir $asset
     $checksumPath = "$binaryPath.sha256"
+    Write-Output "[1/4] Downloading $releaseTag..."
     Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/$asset" -OutFile $binaryPath
     Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/$asset.sha256" -OutFile $checksumPath
 
+    Write-Output '[2/4] Verifying SHA-256...'
     $expected = ((Get-Content -Raw -LiteralPath $checksumPath) -split '\s+')[0].ToLowerInvariant()
     if ($expected -notmatch '^[0-9a-f]{64}$') {
         throw 'pentect: release checksum is invalid'
@@ -54,6 +62,7 @@ try {
         throw "pentect: release checksum mismatch (expected $expected, received $actual)"
     }
 
+    Write-Output '[3/4] Installing binary...'
     New-Item -ItemType Directory -Force -Path $installDir | Out-Null
     $staged = Join-Path $installDir 'pentect.install.exe'
     Copy-Item -LiteralPath $binaryPath -Destination $staged -Force
@@ -67,6 +76,7 @@ try {
     if (Test-Path -LiteralPath $marker) {
         try { $pathAdded = [bool]((Get-Content -Raw -LiteralPath $marker | ConvertFrom-Json).path_added) } catch {}
     }
+    $pathStatus = 'skipped by configuration'
     if ($env:PENTECT_INSTALL_SKIP_PATH -ne '1') {
         $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
         $pathParts = @($userPath -split ';' | Where-Object { $_ })
@@ -74,13 +84,19 @@ try {
             $nextPath = (@($pathParts) + $installDir) -join ';'
             [Environment]::SetEnvironmentVariable('Path', $nextPath, 'User')
             $pathAdded = $true
+            $pathStatus = 'added to user PATH'
+        } else {
+            $pathStatus = 'already on user PATH'
         }
         if (-not (($env:Path -split ';') | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') })) {
             $env:Path = "$installDir;$env:Path"
         }
     }
+    Write-Output "[4/4] PATH: $pathStatus"
     @{ version = 1; path_added = $pathAdded } | ConvertTo-Json -Compress | Set-Content -Encoding utf8 -LiteralPath $marker
-    Write-Output "pentect: installed $destination"
+    Write-Output ''
+    Write-Output "Installed Pentect $releaseTag"
+    Write-Output 'Next: pentect doctor'
 } finally {
     if (Test-Path -LiteralPath $tempDir) {
         Remove-Item -LiteralPath $tempDir -Recurse -Force

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -68,13 +68,20 @@ cleanup() {
 }
 trap cleanup 0 HUP INT TERM
 
-curl -fL --proto '=https' --tlsv1.2 \
+printf 'Pentect installer\n'
+printf '  Platform : %s/%s\n' "$os" "$arch"
+printf '  Version  : %s\n' "$release_tag"
+printf '  Install  : %s\n\n' "$destination"
+
+printf '[1/4] Downloading %s...\n' "$release_tag"
+curl -fsSL --proto '=https' --tlsv1.2 \
   "$base_url/$asset" \
   -o "$temp_dir/$asset"
-curl -fL --proto '=https' --tlsv1.2 \
+curl -fsSL --proto '=https' --tlsv1.2 \
   "$base_url/$asset.sha256" \
   -o "$temp_dir/$asset.sha256"
 
+printf '[2/4] Verifying SHA-256...\n'
 expected=$(awk 'NR == 1 { print tolower($1) }' "$temp_dir/$asset.sha256")
 case "$expected" in
   *[!0-9a-f]*|'')
@@ -100,6 +107,7 @@ if [ "$actual" != "$expected" ]; then
   exit 1
 fi
 
+printf '[3/4] Installing binary...\n'
 mkdir -p "$install_dir"
 staged="$install_dir/.pentect.install.$$"
 cp "$temp_dir/$asset" "$staged"
@@ -107,8 +115,10 @@ chmod 0755 "$staged"
 mv -f "$staged" "$destination"
 printf '%s\n' '{"version":1,"path_added":false}' > "$marker"
 
-echo "pentect: installed $destination"
 case ":${PATH:-}:" in
-  *":$install_dir:"*) ;;
-  *) echo "pentect: add $install_dir to PATH" ;;
+  *":$install_dir:"*) path_status="already on PATH" ;;
+  *) path_status="add $install_dir to PATH" ;;
 esac
+printf '[4/4] PATH: %s\n\n' "$path_status"
+printf 'Installed Pentect %s\n' "$release_tag"
+printf 'Next: pentect doctor\n'


### PR DESCRIPTION
﻿## Summary
- replace slow PowerShell transfer progress with compact four-step installation output
- make POSIX installer downloads quiet and show the same steps
- share release build caches across tags per platform
- decouple CLI and PII sidecar package versions so CLI-only releases do not invalidate the heavy sidecar build

## Validation
- PowerShell parser and pinned-version dry-run
- POSIX shell syntax validation
- full build/test delegated to GitHub CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Pentect to version 0.0.3.
  - Added clearer installation progress updates for Windows and Unix-based systems, including download, verification, installation, and PATH configuration steps.
  - Installers now report whether PATH configuration was added, already present, or skipped.

- **Improvements**
  - Added installation details such as platform, version, and destination.
  - Updated completion messages with a recommendation to run `pentect doctor`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->