### PR TITLE
Stabilize shell bindings, paste handling, and URL masking

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -43,6 +43,7 @@ const PENTECT_AGENT_LAUNCHED_ENV: &str = "PENTECT_AGENT_LAUNCHED";
 const PENTECT_MEMORY_STORE_ADDR_ENV: &str = "PENTECT_MEMORY_STORE_ADDR";
 const PENTECT_MEMORY_STORE_TOKEN_ENV: &str = "PENTECT_MEMORY_STORE_TOKEN";
 const PENTECT_STATUS_LINE_ENV: &str = "PENTECT_STATUS_LINE";
+const PENTECT_SHELL_ENV: &str = "PENTECT_SHELL";
 const PENTECT_DIR: &str = ".pentect";
 const PENTECT_CONFIG_FILE: &str = "config.toml";
 const MEMORY_STORE_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -63,6 +64,9 @@ fn main() {
 }
 
 fn run(args: Vec<String>) -> Option<i32> {
+    if should_passthrough_shell(&args, std::env::var_os(PENTECT_SHELL_ENV).as_deref()) {
+        return Some(0);
+    }
     let inherited_env_is_trusted = pentect_agent::active_memory_store_ready();
     if is_memory_store_server(&args) || !supports_process_host(&args) {
         return dispatch(args, inherited_env_is_trusted);
@@ -160,6 +164,10 @@ fn is_shell_command(args: &[String]) -> bool {
         ),
         (Some("shell"), _) | (Some("agent"), Some("shell"))
     )
+}
+
+fn should_passthrough_shell(args: &[String], shell_marker: Option<&std::ffi::OsStr>) -> bool {
+    is_shell_command(args) && shell_marker == Some(std::ffi::OsStr::new("1"))
 }
 
 fn usage() {
@@ -4648,5 +4656,17 @@ mod tests {
             "shell".into()
         ]));
         assert!(!is_shell_command(&["pentect".into(), "exec".into()]));
+        assert!(should_passthrough_shell(
+            &["pentect".into(), "shell".into()],
+            Some(std::ffi::OsStr::new("1"))
+        ));
+        assert!(should_passthrough_shell(
+            &["pentect".into(), "agent".into(), "shell".into()],
+            Some(std::ffi::OsStr::new("1"))
+        ));
+        assert!(!should_passthrough_shell(
+            &["pentect".into(), "shell".into()],
+            None
+        ));
     }
 }

--- a/crates/pentect-core/src/detect/rule.rs
+++ b/crates/pentect-core/src/detect/rule.rs
@@ -261,13 +261,6 @@ impl RuleDetector {
                 "PHONE_NANP",
                 Medium,
             ),
-            // URL (scheme required, so it doesn't match bare hostnames).
-            (
-                r#"(?i)\b(?:https?|ftp|ftps|wss?)://[^\s"'<>()]*[^\s"'<>().,;:!?]"#,
-                Endpoint,
-                "URL",
-                Medium,
-            ),
             // Context-gated like Presidio: a bare number/ID only fires next to its
             // keyword, so these don't flood. The match includes the keyword.
             (
@@ -762,17 +755,11 @@ mod tests {
     }
 
     #[test]
-    fn url_rule_keeps_sentence_punctuation_literal() {
+    fn public_urls_are_not_builtin_endpoint_findings() {
         let det = RuleDetector::builtin();
         let raw = "see https://example.com/api/issues/1234. next";
         let spans = det.detect(&NormalizedView::build(&region(raw), raw));
-        let Some(span) = spans.iter().find(|s| s.label == "URL") else {
-            panic!("URL should be detected: {spans:?}");
-        };
-        assert_eq!(
-            &raw[span.range.start..span.range.end],
-            "https://example.com/api/issues/1234"
-        );
+        assert!(spans.iter().all(|span| span.label != "URL"), "{spans:?}");
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -1276,12 +1276,10 @@ mod tests {
     }
 
     #[test]
-    fn external_url_still_masks_as_whole_url() {
+    fn public_url_without_sensitive_material_stays_visible() {
         let input = "see https://example.com/api/issues/1234 now";
         let r = m(input);
-        assert!(r.masked.contains("<<URL_"), "{}", r.masked);
-        assert!(!r.masked.contains("example.com"), "{}", r.masked);
-        assert!(!r.masked.contains("/api/issues/1234"), "{}", r.masked);
+        assert_eq!(r.masked, input);
     }
 
     #[test]
@@ -1354,8 +1352,7 @@ mod tests {
         assert!(!internal.masked.contains("1234."), "{}", internal.masked);
 
         let external = m("https://example.com/api/issues/1234.");
-        assert!(external.masked.ends_with('.'), "{}", external.masked);
-        assert!(external.masked.contains("<<URL_"), "{}", external.masked);
+        assert_eq!(external.masked, "https://example.com/api/issues/1234.");
     }
 
     #[test]
@@ -1860,7 +1857,7 @@ mod tests {
         ("IT_FISCAL_CODE", "RSSMRA85T10A562S", Core),
         ("US_DRIVER_LICENSE", "driver's license D1234567", Core),
         ("US_BANK_NUMBER", "account number 1234567890", Core),
-        ("URL", "https://example.com/x", Core),
+        ("URL", "https://example.com/x", Todo),
         ("UK_POSTCODE", "SW1A 1AA", Core),
         ("UK_DRIVING_LICENCE", "MORGA657054SM9IJ", Core),
         ("UK_VEHICLE_REGISTRATION", "reg AB12 CDE", Core),
@@ -1916,7 +1913,7 @@ mod tests {
         ("USDriversLicense", "driver's license D1234567", Core),
         ("USBankAccountNumber", "account number 1234567890", Core),
         ("ItalyFiscalCode", "RSSMRA85T10A562S", Core),
-        ("URL", "https://example.com/x", Core),
+        ("URL", "https://example.com/x", Todo),
         ("FrenchINSEE", "180047509112541", Core),
         ("DateTime", "2025-06-11", Todo),
         ("Age", "35 years old", Plugin),

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1319,17 +1319,29 @@ fn requested_env_bindings(
     if names.is_empty() {
         return Ok(Vec::new());
     }
-    let mut by_name = BTreeMap::new();
+    let prefix = config::environment_variable_prefix()?;
+    Ok(select_referenced_env_bindings(available, &names, &prefix))
+}
+
+fn select_referenced_env_bindings(
+    available: Vec<(String, String)>,
+    referenced: &BTreeSet<String>,
+    prefix: &str,
+) -> Vec<(String, String)> {
+    let mut selected = Vec::new();
     for (name, value) in available {
-        by_name.insert(name.to_ascii_lowercase(), (name, value));
-    }
-    let mut out = Vec::new();
-    for name in names {
-        if let Some(binding) = by_name.get(&name) {
-            out.push(binding.clone());
+        let full_requested = referenced.contains(&name.to_ascii_lowercase());
+        let short = name.strip_prefix(prefix).filter(|short| !short.is_empty());
+        let short_requested = short
+            .is_some_and(|short| short != name && referenced.contains(&short.to_ascii_lowercase()));
+        if full_requested {
+            selected.push((name.clone(), value.clone()));
+        }
+        if short_requested {
+            selected.push((short.unwrap().to_string(), value));
         }
     }
-    Ok(out)
+    selected
 }
 
 fn referenced_env_names(mode: &ExecMode) -> BTreeSet<String> {
@@ -1647,7 +1659,7 @@ const WINDOWS_SHELL_HOST_SCRIPT: &str = concat!(
     "while (($line=[Console]::In.ReadLine()) -ne $null) {",
     "try {",
     "$text=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($line));",
-    "Invoke-Expression $text *>&1 | Out-String -Stream | ForEach-Object { [Console]::Out.WriteLine($_) }",
+    "if (-not [String]::IsNullOrWhiteSpace($text)) { Invoke-Expression $text *>&1 | Out-String -Stream | ForEach-Object { [Console]::Out.WriteLine($_) } }",
     "} catch {",
     "$message=$_ | Out-String;[Console]::Out.WriteLine($message)",
     "};",
@@ -1762,6 +1774,10 @@ fn stream_windows_shell_stdout(
                     live_output_kind(prefix),
                 )?;
             }
+            // Publish handles and their environment aliases before the input
+            // loop exposes the next prompt. Deferred output otherwise keeps a
+            // freshly printed dotenv handle unusable until the shell exits.
+            masker.flush()?;
             let encoded = line[start + marker.len()..].trim_end_matches(['\r', '\n']);
             if encoded == "DRAIN" {
                 if completion_tx
@@ -1845,6 +1861,10 @@ fn pump_windows_shell_input(
             }
             Err(e) => return Err(format!("could not read shell input: {e}")),
         };
+        if raw.trim().is_empty() {
+            raw.zeroize();
+            continue;
+        }
         if let Some(agent_args) = windows_shell_interactive_agent_args(&raw) {
             let mut history_probe = protector.prepare_paste(&raw)?;
             if windows_shell_history_is_safe(&raw, history_probe.changed) {
@@ -1996,15 +2016,13 @@ fn run_windows_shell_interactive_agent(args: &[String], cwd: &str) -> Result<(),
 
 #[cfg(windows)]
 struct WindowsShellDisplay {
-    protector: Mutex<ShellInputProtector>,
     completer: FilenameCompleter,
 }
 
 #[cfg(windows)]
 impl WindowsShellDisplay {
-    fn new(store: MemoryStore) -> Result<Self, String> {
+    fn new(_store: MemoryStore) -> Result<Self, String> {
         Ok(Self {
-            protector: Mutex::new(ShellInputProtector::new(store)?),
             completer: FilenameCompleter::new(),
         })
     }
@@ -2038,27 +2056,9 @@ impl Helper for WindowsShellDisplay {}
 #[cfg(windows)]
 impl Highlighter for WindowsShellDisplay {
     fn highlight<'line>(&self, line: &'line str, _pos: usize) -> std::borrow::Cow<'line, str> {
-        let Ok(mut protector) = self.protector.lock() else {
-            return provisional_shell_secret_display(line)
-                .map(std::borrow::Cow::Owned)
-                .unwrap_or(std::borrow::Cow::Borrowed(line));
-        };
-        let Ok(mut protected) = protector.prepare_paste(line) else {
-            return provisional_shell_secret_display(line)
-                .map(std::borrow::Cow::Owned)
-                .unwrap_or(std::borrow::Cow::Borrowed(line));
-        };
-        if !protected.changed {
-            return provisional_shell_secret_display(line)
-                .map(std::borrow::Cow::Owned)
-                .unwrap_or(std::borrow::Cow::Borrowed(line));
-        }
-        let visible = canonical_shell_secret_display(line, &protected.visible)
-            .unwrap_or_else(|| protected.visible.clone());
-        let display = shell_display_with_same_width(line, &visible);
-        protected.child.zeroize();
-        protected.injected_prefix.zeroize();
-        std::borrow::Cow::Owned(display)
+        provisional_shell_secret_display(line)
+            .map(std::borrow::Cow::Owned)
+            .unwrap_or(std::borrow::Cow::Borrowed(line))
     }
 
     fn highlight_char(
@@ -2069,22 +2069,6 @@ impl Highlighter for WindowsShellDisplay {
     ) -> bool {
         true
     }
-}
-
-#[cfg(windows)]
-fn canonical_shell_secret_display(raw: &str, protected: &str) -> Option<String> {
-    let (start, end) = likely_shell_secret_range(raw)?;
-    let env_start = protected.find("$env:PENTECT_")?;
-    let env_end = protected[env_start..]
-        .bytes()
-        .position(|byte| !is_env_name_byte(byte) && byte != b'$' && byte != b':')
-        .map(|offset| env_start + offset)
-        .unwrap_or(protected.len());
-    let mut display = String::new();
-    display.push_str(&raw[..start]);
-    display.push_str(&protected[env_start..env_end]);
-    display.push_str(&raw[end..]);
-    Some(display)
 }
 
 #[cfg(windows)]
@@ -2119,26 +2103,6 @@ fn likely_shell_secret_range(text: &str) -> Option<(usize, usize)> {
         end = start + offset + ch.len_utf8();
     }
     Some((start, end))
-}
-
-#[cfg(windows)]
-fn shell_display_with_same_width(raw: &str, protected: &str) -> String {
-    let raw_chars = raw.chars().count();
-    let protected_chars = protected.chars().count();
-    if protected_chars <= raw_chars {
-        let mut display = protected.to_string();
-        display.extend(std::iter::repeat_n(' ', raw_chars - protected_chars));
-        return display;
-    }
-    if raw_chars == 0 {
-        return String::new();
-    }
-    let mut display = protected
-        .chars()
-        .take(raw_chars.saturating_sub(1))
-        .collect::<String>();
-    display.push('…');
-    display
 }
 
 #[cfg(windows)]
@@ -3337,6 +3301,21 @@ impl ShellInputProtector {
     }
 
     fn prepare_paste(&mut self, text: &str) -> Result<ProtectedPaste, String> {
+        let referenced = referenced_env_names_in_text(text);
+        let available = self.store.auto_env_bindings().map_err(|e| e.to_string())?;
+        if stale_env_handle(&referenced, &available, self.masker.environment_prefix()) {
+            return Ok(ProtectedPaste {
+                child: self.syntax.stale_handle_error(),
+                visible: text.to_string(),
+                changed: true,
+                injected_prefix: String::new(),
+            });
+        }
+        let selected = select_referenced_env_bindings(
+            available,
+            &referenced,
+            self.masker.environment_prefix(),
+        );
         let masked = self.masker.mask_text(text, live_output_kind(text))?;
         let (mut visible, mut bindings) = replace_masked_handles_with_env_refs(
             &masked,
@@ -3344,6 +3323,7 @@ impl ShellInputProtector {
             self.syntax,
             self.masker.environment_prefix(),
         )?;
+        restore_safe_shell_literals(text, &mut visible, &mut bindings, self.syntax);
         if bindings.len() == 1 {
             if let Some((start, end)) = likely_shell_secret_range(text) {
                 bindings[0].value.zeroize();
@@ -3367,18 +3347,13 @@ impl ShellInputProtector {
             }
             binding.value.zeroize();
         }
-        let referenced = referenced_env_names_in_text(command_text);
-        if !referenced.is_empty() {
-            for (name, mut value) in self.store.auto_env_bindings().map_err(|e| e.to_string())? {
-                if referenced.contains(&name.to_ascii_lowercase())
-                    && self.defined_env.insert(name.clone())
-                {
-                    let assignment = self.syntax.env_assignment(&name, &value);
-                    injected_prefix.push_str(&assignment);
-                    child.push_str(&assignment);
-                }
-                value.zeroize();
+        for (name, mut value) in selected {
+            if self.defined_env.insert(name.clone()) {
+                let assignment = self.syntax.env_assignment(&name, &value);
+                injected_prefix.push_str(&assignment);
+                child.push_str(&assignment);
             }
+            value.zeroize();
         }
         child.push_str(command_text);
         Ok(ProtectedPaste {
@@ -3387,6 +3362,65 @@ impl ShellInputProtector {
             changed: replaced_secret || !injected_prefix.is_empty(),
             injected_prefix,
         })
+    }
+}
+
+fn stale_env_handle(
+    referenced: &BTreeSet<String>,
+    available: &[(String, String)],
+    prefix: &str,
+) -> bool {
+    let mut current = BTreeSet::new();
+    let mut labels = BTreeSet::new();
+    for (name, _) in available {
+        let Some((label, hash)) = env_handle_name_parts(name, prefix) else {
+            continue;
+        };
+        labels.insert(label.clone());
+        current.insert(format!("{label}_{hash}"));
+    }
+    referenced.iter().any(|name| {
+        env_handle_name_parts(name, prefix).is_some_and(|(label, hash)| {
+            labels.contains(&label) && !current.contains(&format!("{label}_{hash}"))
+        })
+    })
+}
+
+fn env_handle_name_parts(name: &str, prefix: &str) -> Option<(String, String)> {
+    let lower = name.to_ascii_lowercase();
+    let prefix = prefix.to_ascii_lowercase();
+    let core = lower.strip_prefix(&prefix).unwrap_or(&lower);
+    let (label, hash) = core.rsplit_once('_')?;
+    if label.is_empty()
+        || hash.len() != 16
+        || !hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || !label
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        return None;
+    }
+    Some((label.to_string(), hash.to_string()))
+}
+
+fn restore_safe_shell_literals(
+    original: &str,
+    visible: &mut String,
+    bindings: &mut Vec<ShellEnvBinding>,
+    syntax: ShellSyntax,
+) {
+    let mut index = 0usize;
+    while index < bindings.len() {
+        let value = bindings[index].value.as_str();
+        let is_existing_env_ref = !referenced_env_names_in_text(value).is_empty();
+        let is_public_url = (value.starts_with("https://") || value.starts_with("http://"))
+            && !value.chars().any(|ch| matches!(ch, '@' | '?' | '#'));
+        if original.contains(value) && (is_existing_env_ref || is_public_url) {
+            let binding = bindings.remove(index);
+            *visible = visible.replace(&syntax.env_ref(&binding.name), &binding.value);
+        } else {
+            index += 1;
+        }
     }
 }
 
@@ -3428,6 +3462,15 @@ impl ShellSyntax {
                 format!("$env:{name}={}; ", powershell_string_literal(value))
             }
             Self::Posix => format!("export {name}={}; ", shell_quote_unix(value)),
+        }
+    }
+
+    fn stale_handle_error(self) -> String {
+        const MESSAGE: &str =
+            "Pentect: stale environment handle; run cat .env again and use the new handle.";
+        match self {
+            Self::PowerShell => format!("Write-Error {}", powershell_string_literal(MESSAGE)),
+            Self::Posix => format!("printf '%s\\n' {} >&2", shell_quote_unix(MESSAGE)),
         }
     }
 }

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -87,7 +87,8 @@ fn windows_shell_display_never_renders_the_pasted_secret() {
     let rendered = Highlighter::highlight(&display, raw, raw.len()).into_owned();
 
     assert!(!rendered.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"));
-    assert!(rendered.contains("$env:PENTECT_"), "{rendered}");
+    assert!(rendered.contains('•'), "{rendered}");
+    assert!(!rendered.contains('…'), "{rendered}");
     assert_eq!(rendered.chars().count(), raw.chars().count());
     let _ = std::fs::remove_dir_all(root);
 }
@@ -150,6 +151,7 @@ fn windows_shell_host_preserves_state_without_terminal_control_sequences() {
 
     let mut output = String::new();
     for (index, command) in [
+        "",
         "$global:PentectShellState=41",
         "Write-Output ($global:PentectShellState + 1)",
     ]
@@ -162,7 +164,7 @@ fn windows_shell_host_preserves_state_without_terminal_control_sequences() {
             data_encoding::BASE64.encode(command.as_bytes())
         )
         .unwrap();
-        if index == 0 {
+        if index == 1 {
             writeln!(stdin, "stale interactive input").unwrap();
         }
         stdin.flush().unwrap();
@@ -182,6 +184,7 @@ fn windows_shell_host_preserves_state_without_terminal_control_sequences() {
     }
 
     assert!(output.lines().any(|line| line.trim() == "42"), "{output:?}");
+    assert!(!output.contains("Cannot bind argument"), "{output:?}");
     assert!(!output.contains('\u{1b}'), "{output:?}");
     drop(stdin);
     assert!(child.wait().unwrap().success());
@@ -1320,6 +1323,122 @@ fn exec_auto_binds_masked_env_output_in_running_session() {
     assert!(!safe.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "{safe}");
     assert!(!safe.contains("114514810"), "{safe}");
     assert!(!safe.contains("hello world"), "{safe}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn handle_core_is_also_a_valid_environment_binding() {
+    let root = temp_root("capability-short-env-binding");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let value = "KGAT_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let masked = mask_tool_output(&session, &format!("KAGGLE_API_TOKEN={value}\n")).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "KAGGLE_API_TOKEN");
+    let short_name = handle
+        .strip_prefix("<<")
+        .and_then(|value| value.strip_suffix(">>"))
+        .unwrap();
+    let store = MemoryStore::for_session(&session);
+
+    let bindings = requested_env_bindings(
+        &store,
+        &ExecMode::Shell(format!("Write-Output $env:{short_name}")),
+    )
+    .unwrap();
+    assert_eq!(bindings, vec![(short_name.to_string(), value.to_string())]);
+
+    let mut protector = ShellInputProtector::new(store).unwrap();
+    let mut protected = protector
+        .prepare_paste(&format!("echo $env:{short_name}"))
+        .unwrap();
+    assert!(protected.child.contains(value), "{}", protected.child);
+    assert!(protected.child.ends_with(&protected.visible));
+    protected.child.zeroize();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn shell_command_keeps_known_env_reference_and_public_url_verbatim() {
+    let root = temp_root("shell-env-reference-command");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let value = "KGAT_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let masked = mask_tool_output(&session, &format!("KAGGLE_API_TOKEN={value}\n")).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "KAGGLE_API_TOKEN");
+    let short_name = handle
+        .strip_prefix("<<")
+        .and_then(|value| value.strip_suffix(">>"))
+        .unwrap();
+    let command = format!(
+        "irm https://www.kaggle.com/api/v1/competitions/list -Headers @{{Authorization=\"Bearer $env:{short_name}\"}}"
+    );
+    let store = MemoryStore::for_session(&session);
+    let mut protector = ShellInputProtector::new(store).unwrap();
+    let mut protected = protector.prepare_paste(&command).unwrap();
+
+    assert_eq!(protected.visible, command);
+    assert!(protected.child.ends_with(&command), "{}", protected.child);
+    assert!(protected.child.contains(value), "{}", protected.child);
+    assert!(
+        !protected.child.contains("PENTECT_URL_"),
+        "{}",
+        protected.child
+    );
+    assert!(
+        !protected.child.contains("PENTECT_KEYED_SECRET_"),
+        "{}",
+        protected.child
+    );
+    protected.child.zeroize();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn stale_shell_handle_fails_before_running_the_command() {
+    let root = temp_root("stale-shell-env-reference");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let value = "KGAT_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let _ = mask_tool_output(&session, &format!("KAGGLE_API_TOKEN={value}\n")).unwrap();
+    let command = concat!(
+        "irm https://www.kaggle.com/api/v1/competitions/list ",
+        "-Headers @{Authorization=\"Bearer $env:KAGGLE_API_TOKEN_b818890b85f7482a\"}"
+    );
+    let store = MemoryStore::for_session(&session);
+    let mut protector = ShellInputProtector::new(store).unwrap();
+    let protected = protector.prepare_paste(command).unwrap();
+
+    assert!(protected.child.contains("stale environment handle"));
+    assert!(protected.child.contains("cat .env"));
+    assert!(!protected.child.contains("Invoke-RestMethod"));
+    assert!(!protected.child.contains("https://www.kaggle.com"));
+    assert!(!protected.child.contains(value));
+    assert_eq!(protected.visible, command);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn deferred_shell_output_publishes_bindings_when_flushed() {
+    let root = temp_root("deferred-shell-env-binding");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let store = MemoryStore::for_session(&session);
+    let value = "KGAT_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let mut masker = OutputMasker::new_deferred(store.clone()).unwrap();
+    let masked = masker
+        .mask_text(
+            &format!("KAGGLE_API_TOKEN={value}\n"),
+            pentect_core::Kind::Env,
+        )
+        .unwrap();
+    let handle = masked_handle_from_assignment(&masked, "KAGGLE_API_TOKEN");
+    let short_name = handle
+        .strip_prefix("<<")
+        .and_then(|value| value.strip_suffix(">>"))
+        .unwrap();
+
+    assert!(store.auto_env_bindings().unwrap().is_empty());
+    masker.flush().unwrap();
+    let bindings =
+        requested_env_bindings(&store, &ExecMode::Shell(format!("echo $env:{short_name}")))
+            .unwrap();
+    assert_eq!(bindings, vec![(short_name.to_string(), value.to_string())]);
     let _ = std::fs::remove_dir_all(root);
 }
 


### PR DESCRIPTION
﻿## What changed

- publish live PowerShell environment bindings at each command boundary
- accept visible handle cores directly as shell environment aliases
- fail closed on a stale handle instead of sending an empty credential
- keep existing environment references intact inside Authorization headers
- stop rewriting public URLs as generic URL handles
- continue masking internal endpoints, URL credentials, and sensitive query values
- keep Windows shell syntax stable while displaying pasted raw secrets as same-width bullets
- make nested pentect shell calls idempotent

## Regression coverage

- stale Kaggle-style handles stop locally with a refresh instruction and make no HTTP request
- current Kaggle-style Invoke-RestMethod commands remain intact
- public URLs stay visible
- internal routes and identifiers remain masked
- credential query parameters remain masked on public URLs
- deferred live output publishes aliases before the next prompt
- nested shell startup passes through

## Validation

Focused core, runtime, and CLI regression tests; clippy with warnings denied; release build; installed-binary SHA-256 verification.
