### PR TITLE
feat: harden plugin execution and provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      backfill_tag:
+        description: Existing release tag whose assets should receive attestations
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,7 +20,7 @@ concurrency:
 
 jobs:
   verify:
-    if: github.repository == 'EdamAme-x/pentect'
+    if: github.repository == 'EdamAme-x/pentect' && github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -58,6 +64,10 @@ jobs:
 
   build:
     needs: verify
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -112,6 +122,12 @@ jobs:
           Copy-Item '${{ matrix.helper_binary }}' $helperDestination
           $helperHash = (Get-FileHash -Algorithm SHA256 $helperDestination).Hash.ToLowerInvariant()
           "$helperHash  $helperAsset" | Set-Content -NoNewline -Encoding utf8 "$helperDestination.sha256"
+      - name: Attest release binaries
+        uses: actions/attest-build-provenance@e3fe62ef559997059fe8380e7d2b4c909e2d65f4 # v3
+        with:
+          subject-path: |
+            dist/${{ matrix.asset }}
+            dist/${{ matrix.helper_asset }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.asset }}
@@ -145,3 +161,38 @@ jobs:
               --title "Pentect $GITHUB_REF_NAME" \
               --repo "$GITHUB_REPOSITORY"
           fi
+
+  backfill-attestations:
+    if: github.repository == 'EdamAme-x/pentect' && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download existing release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.backfill_tag }}
+        run: |
+          set -euo pipefail
+          mkdir dist
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir dist
+      - name: Verify published checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          for checksum in dist/*.sha256; do
+            (cd dist && sha256sum --check "$(basename "$checksum")")
+          done
+      - name: Attest existing executable assets
+        uses: actions/attest-build-provenance@e3fe62ef559997059fe8380e7d2b4c909e2d65f4 # v3
+        with:
+          subject-path: |
+            dist/pentect-linux-*
+            dist/pentect-macos-*
+            dist/pentect-windows-*
+            dist/pentect-pii-ner-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
-    inputs:
-      backfill_tag:
-        description: Existing release tag whose assets should receive attestations
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -20,7 +14,7 @@ concurrency:
 
 jobs:
   verify:
-    if: github.repository == 'EdamAme-x/pentect' && github.event_name == 'push'
+    if: github.repository == 'EdamAme-x/pentect'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -161,38 +155,3 @@ jobs:
               --title "Pentect $GITHUB_REF_NAME" \
               --repo "$GITHUB_REPOSITORY"
           fi
-
-  backfill-attestations:
-    if: github.repository == 'EdamAme-x/pentect' && github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-    steps:
-      - name: Download existing release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.backfill_tag }}
-        run: |
-          set -euo pipefail
-          mkdir dist
-          gh release download "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --dir dist
-      - name: Verify published checksums
-        shell: bash
-        run: |
-          set -euo pipefail
-          for checksum in dist/*.sha256; do
-            (cd dist && sha256sum --check "$(basename "$checksum")")
-          done
-      - name: Attest existing executable assets
-        uses: actions/attest-build-provenance@e3fe62ef559997059fe8380e7d2b4c909e2d65f4 # v3
-        with:
-          subject-path: |
-            dist/pentect-linux-*
-            dist/pentect-macos-*
-            dist/pentect-windows-*
-            dist/pentect-pii-ner-*

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docs/
 # Rust build output
 /target/
 **/target/
+/sdk/rust/pentect-plugin/Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,8 @@ dependencies = [
  "sha2",
  "simd-json",
  "toml",
+ "wasmi",
+ "wat",
  "windows 0.62.2",
  "windows-sys 0.61.2",
  "zeroize",
@@ -3644,6 +3646,16 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string-interner"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
+
+[[package]]
+name = "string-interner"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad3df9b59e2eded8d825c7c4363ad339a20fb6bc0b9a4778560f518f59910b15"
@@ -4102,7 +4114,7 @@ dependencies = [
  "parking_lot",
  "scan_fmt",
  "smallvec",
- "string-interner",
+ "string-interner 0.20.0",
 ]
 
 [[package]]
@@ -4334,6 +4346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4513,7 +4531,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -4524,8 +4552,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -4542,6 +4570,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2300d0f78cba12f14e29e8dd157ea64050c0a688179aefdb2050105805594a0c"
+dependencies = [
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a8c42a2a76148d43097b1d7cc2a5bf33d5c23bd4dd69015fc887e311767884"
+dependencies = [
+ "string-interner 0.19.0",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9013136083d988725953390bf668b64b7a218fabf26f8b913bbc59546b97ee27"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1fa003f79156f406d62ef0e1464dc03e11ace37170e9fa7524299a75ad8f68"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.13.0",
+ "indexmap",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4551,6 +4629,39 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
+dependencies = [
+ "bitflags 2.13.0",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wast"
+version = "254.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ed4dfc8f6b9fc38b231065e2cdfbf7359af5ab945990abf09658dcc63c3e32"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.254.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7127f7f9b8f127c879991cecd35f494e4628bae1b0874c681414d8d8831e952c"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -4979,9 +5090,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.244.0",
  "wit-parser",
 ]
 
@@ -5000,7 +5111,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ crossterm = "0.28"
 ctrlc = { version = "3.4", features = ["termination"] }
 portable-pty = "0.9.0"
 ed25519-dalek = "2"
+wasmi = { version = "1.1", default-features = false, features = ["std", "extra-checks"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }
 windows = "0.62.2"
 objc2 = { version = "0.6.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ TODO
 - [ ] 止めた後になんか重なる
 
 - [x] pluginsの責務・配布・権限モデルを再設計する
-- [ ] plugin registry・署名付きpublisher identity・OS sandboxを検討する
+- [x] plugin registry・署名付きpublisher identity・capability sandbox
 - [ ] local llm mask exts
 - [ ] app, http host
 - [ ] approval ui?

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.4"
+version = "0.0.5"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -214,7 +214,7 @@ fn help_text() -> &'static str {
         "doctor: readiness\n",
         "update: verified GitHub Release binary\n",
         "uninstall: remove the binary; keep project data\n",
-        "plugins: list, inspect, test, config, setup, update\n",
+        "plugins: list, search, inspect, test, config, setup, update\n",
         "codex-app: launch Codex App through the Responses API gateway\n",
         "claude-app: launch Claude Desktop through the Chat and Anthropic gateways\n",
         "eval: precision, recall\n",

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -154,7 +154,7 @@ fn usage() {
          pentect doctor\n\
          pentect update [VERSION] [--check]\n\
          pentect uninstall\n\
-         pentect plugins list|inspect|test|config|setup|update [NAME]\n\
+         pentect plugins list|search|inspect|test|config|setup|update [NAME]\n\
          pentect eval [--json]\n\
          pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--no-gitignore] [PATH...]\n\
          pentect view <HANDLE>\n\
@@ -193,7 +193,7 @@ fn help_text() -> &'static str {
         "  pentect doctor [--json]\n",
         "  pentect update [VERSION] [--check | --force]\n",
         "  pentect uninstall\n",
-        "  pentect plugins list|inspect|test [NAME|PATH] [--json]\n",
+        "  pentect plugins list|search|inspect|test [NAME|PATH] [--json]\n",
         "  pentect plugins config NAME|PATH [KEY=VALUE | --unset KEY]\n",
         "  pentect plugins setup NAME|PATH [--yes]\n",
         "  pentect plugins update NAME|PATH\n",

--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -33,7 +33,6 @@ pub(crate) struct ActivePlugins {
 #[derive(Debug)]
 pub(crate) struct PluginSource {
     pub(crate) name: String,
-    pub(crate) root: PathBuf,
     pub(crate) manifest_path: Option<PathBuf>,
     pub(crate) repository: Option<String>,
 }
@@ -489,19 +488,8 @@ pub(crate) fn plugin_source(spec: &str) -> Result<PluginSource> {
         };
         let manifest_path = fetch_remote_plugin_file(&manifest_url)?;
         let name = remote_plugin_name(&base)?;
-        let root = manifest_path
-            .as_deref()
-            .and_then(Path::parent)
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| {
-                remote_cache_file(&format!("{base}/config.toml"))
-                    .parent()
-                    .unwrap_or_else(|| Path::new("."))
-                    .to_path_buf()
-            });
         return Ok(PluginSource {
             name,
-            root,
             manifest_path,
             repository,
         });
@@ -533,7 +521,6 @@ pub(crate) fn plugin_source(spec: &str) -> Result<PluginSource> {
             .to_string();
         return Ok(PluginSource {
             name,
-            root,
             manifest_path: manifest.is_file().then_some(manifest),
             repository: None,
         });
@@ -554,7 +541,6 @@ pub(crate) fn plugin_source(spec: &str) -> Result<PluginSource> {
             let manifest = root.join(PLUGIN_MANIFEST_FILE);
             return Ok(PluginSource {
                 name: spec.to_string(),
-                root,
                 manifest_path: manifest.is_file().then_some(manifest),
                 repository,
             });
@@ -562,19 +548,8 @@ pub(crate) fn plugin_source(spec: &str) -> Result<PluginSource> {
     }
     let base = format!("{DEFAULT_REMOTE_PLUGINS_BASE}/{spec}");
     let manifest_path = fetch_remote_plugin_file(&format!("{base}/{PLUGIN_MANIFEST_FILE}"))?;
-    let root = manifest_path
-        .as_deref()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| {
-            remote_cache_file(&format!("{base}/config.toml"))
-                .parent()
-                .unwrap_or_else(|| Path::new("."))
-                .to_path_buf()
-        });
     Ok(PluginSource {
         name: spec.to_string(),
-        root,
         manifest_path,
         repository: Some(DEFAULT_PLUGIN_REPOSITORY.to_string()),
     })

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -161,7 +161,8 @@ struct RegistryPlugin {
     description: String,
     source: String,
     publisher: String,
-    runtime: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runtime: Option<PluginRuntime>,
 }
 
 fn search_plugins(query: Option<&str>, json_output: bool) -> Result<(), String> {
@@ -207,7 +208,11 @@ fn search_plugins(query: Option<&str>, json_output: bool) -> Result<(), String> 
     for plugin in plugins {
         println!(
             "{}: {} [{}; {}]\n  {}",
-            plugin.name, plugin.description, plugin.runtime, plugin.publisher, plugin.source
+            plugin.name,
+            plugin.description,
+            plugin.runtime.map(runtime_name).unwrap_or("declarative"),
+            plugin.publisher,
+            plugin.source
         );
     }
     Ok(())
@@ -548,20 +553,7 @@ fn load_plugin_manifest(source: &plugins::PluginSource) -> Result<Option<PluginM
 
 fn validate_publisher(manifest: &PluginManifest) -> Result<(), String> {
     let workflow = publisher_workflow(manifest)?;
-    if workflow.is_empty()
-        || workflow.len() > 256
-        || workflow.starts_with('/')
-        || workflow.contains('\\')
-        || workflow.split('/').any(|part| {
-            part.is_empty()
-                || part == "."
-                || part == ".."
-                || !part
-                    .chars()
-                    .all(|character| character.is_ascii_alphanumeric() || ".-_".contains(character))
-        })
-        || !workflow.ends_with(".yml") && !workflow.ends_with(".yaml")
-    {
+    if !pentect_agent::valid_plugin_publisher_workflow(workflow) {
         return Err("publisher workflow must be a repository-relative YAML path".to_string());
     }
     Ok(())
@@ -1154,8 +1146,10 @@ fn verify_github_attestation(
     name: &str,
 ) -> Result<(), String> {
     let gh = find_command(Path::new("gh")).ok_or_else(|| {
-        "signed plugin verification requires GitHub CLI (`gh`): https://cli.github.com/".to_string()
+        "signed plugin verification requires GitHub CLI v2.51.0 or newer: https://cli.github.com/"
+            .to_string()
     })?;
+    verify_gh_attestation_version(&gh)?;
     let signer_workflow = format!("{repository}/{workflow}");
     let output = Command::new(gh)
         .arg("attestation")
@@ -1181,6 +1175,29 @@ fn verify_github_attestation(
     } else {
         format!("plugin '{name}' GitHub build attestation failed for {signer_workflow}: {detail}")
     })
+}
+
+fn verify_gh_attestation_version(gh: &Path) -> Result<(), String> {
+    const MINIMUM: semver::Version = semver::Version::new(2, 51, 0);
+    let output = Command::new(gh)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|error| format!("could not inspect GitHub CLI version: {error}"))?;
+    let version = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(2))
+        .and_then(|version| semver::Version::parse(version.trim_start_matches('v')).ok())
+        .ok_or_else(|| {
+            "could not determine GitHub CLI version; v2.51.0 or newer is required".to_string()
+        })?;
+    if version < MINIMUM {
+        return Err(format!(
+            "GitHub CLI v{version} is too old; signed plugin verification requires v{MINIMUM} or newer"
+        ));
+    }
+    Ok(())
 }
 
 fn map_binary_download_error(name: &str, platform: &str, asset: &str, error: String) -> String {

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -4,15 +4,10 @@ use serde_json::json;
 use std::collections::BTreeMap;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, ExitStatus, Stdio};
-use std::time::{Duration, Instant};
+use std::process::{Command, Stdio};
 
 const PLUGIN_BINARY_LOCK_FILE: &str = "binary.lock";
 const PLUGIN_APPROVAL_FILE: &str = "approval.toml";
-const PLUGIN_NAME_ENV: &str = "PENTECT_PLUGIN_NAME";
-const PLUGIN_DATA_DIR_ENV: &str = "PENTECT_PLUGIN_DATA_DIR";
-const PLUGIN_CACHE_DIR_ENV: &str = "PENTECT_PLUGIN_CACHE_DIR";
-const PLUGIN_CONFIG_ENV: &str = "PENTECT_PLUGIN_CONFIG";
 
 pub(crate) fn cmd_plugins(args: &[String]) {
     let opts = match PluginCmd::parse(args) {
@@ -21,6 +16,7 @@ pub(crate) fn cmd_plugins(args: &[String]) {
     };
     let result = match opts.action {
         Action::List => list_plugins(opts.json),
+        Action::Search { query } => search_plugins(query.as_deref(), opts.json),
         Action::Inspect { spec } => inspect_plugin(&spec, opts.json),
         Action::Test { spec } => test_plugin(&spec, opts.json),
         Action::Config { spec, change } => config_plugin(&spec, change, opts.json),
@@ -41,6 +37,7 @@ struct PluginCmd {
 #[derive(Debug)]
 enum Action {
     List,
+    Search { query: Option<String> },
     Inspect { spec: String },
     Test { spec: String },
     Config { spec: String, change: ConfigChange },
@@ -58,7 +55,7 @@ enum ConfigChange {
 impl PluginCmd {
     fn parse(args: &[String]) -> Result<Self, String> {
         let Some(action) = args.get(2).map(String::as_str) else {
-            return Err("plugins list|inspect|test|config|setup|update".to_string());
+            return Err("plugins list|search|inspect|test|config|setup|update".to_string());
         };
         let mut json = false;
         let mut approved = false;
@@ -88,6 +85,15 @@ impl PluginCmd {
                     return Err("plugins list".to_string());
                 }
                 Action::List
+            }
+            "search" => {
+                reject_action_flags(approved, unset.as_deref())?;
+                let query = match values.as_slice() {
+                    [] => None,
+                    [query] => Some(query.clone()),
+                    _ => return Err("plugins search [QUERY]".to_string()),
+                };
+                Action::Search { query }
             }
             "inspect" => {
                 reject_action_flags(approved, unset.as_deref())?;
@@ -138,6 +144,73 @@ impl PluginCmd {
         };
         Ok(Self { action, json })
     }
+}
+
+const BUILTIN_PLUGIN_REGISTRY: &str = include_str!("../../../plugins/registry.toml");
+
+#[derive(Debug, Deserialize)]
+struct PluginRegistry {
+    schema: String,
+    #[serde(default)]
+    plugin: Vec<RegistryPlugin>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RegistryPlugin {
+    name: String,
+    description: String,
+    source: String,
+    publisher: String,
+    runtime: String,
+}
+
+fn search_plugins(query: Option<&str>, json_output: bool) -> Result<(), String> {
+    let registry: PluginRegistry = toml::from_str(BUILTIN_PLUGIN_REGISTRY)
+        .map_err(|error| format!("built-in plugin registry is invalid: {error}"))?;
+    if registry.schema != "pentect.plugin-registry.v1" {
+        return Err("built-in plugin registry schema is unsupported".to_string());
+    }
+    for plugin in &registry.plugin {
+        let expected = format!("github:@{}/", plugin.publisher);
+        if !plugin.source.starts_with(&expected) {
+            return Err(format!(
+                "built-in plugin '{}' source does not match publisher '{}'",
+                plugin.name, plugin.publisher
+            ));
+        }
+    }
+    let query = query.unwrap_or_default().trim().to_ascii_lowercase();
+    let plugins = registry
+        .plugin
+        .into_iter()
+        .filter(|plugin| {
+            query.is_empty()
+                || plugin.name.to_ascii_lowercase().contains(&query)
+                || plugin.description.to_ascii_lowercase().contains(&query)
+                || plugin.publisher.to_ascii_lowercase().contains(&query)
+        })
+        .collect::<Vec<_>>();
+    if json_output {
+        println!(
+            "{}",
+            json!({
+                "schema": registry.schema,
+                "plugins": plugins,
+            })
+        );
+        return Ok(());
+    }
+    if plugins.is_empty() {
+        println!("none");
+        return Ok(());
+    }
+    for plugin in plugins {
+        println!(
+            "{}: {} [{}; {}]\n  {}",
+            plugin.name, plugin.description, plugin.runtime, plugin.publisher, plugin.source
+        );
+    }
+    Ok(())
 }
 
 fn reject_action_flags(approved: bool, unset: Option<&str>) -> Result<(), String> {
@@ -206,7 +279,13 @@ fn inspect_plugin(spec: &str, json_output: bool) -> Result<(), String> {
             .as_deref()
             .or(source.repository.as_deref())
     });
-    let asset = binary.map(|binary| binary_asset(binary, &manifest.as_ref().unwrap().assets));
+    let asset = binary.map(|binary| {
+        binary_asset(
+            binary,
+            plugin_runtime(manifest.as_ref().unwrap()),
+            &manifest.as_ref().unwrap().assets,
+        )
+    });
     if json_output {
         println!(
             "{}",
@@ -219,6 +298,8 @@ fn inspect_plugin(spec: &str, json_output: bool) -> Result<(), String> {
                 "binary": binary,
                 "repository": repository,
                 "asset": asset,
+                "runtime": manifest.as_ref().map(plugin_runtime),
+                "publisher_workflow": manifest.as_ref().and_then(|manifest| manifest.publisher.as_ref()).and_then(|publisher| publisher.workflow.as_deref()),
                 "middleware": manifest.as_ref().and_then(|manifest| manifest.middleware.as_ref()).map(|middleware| json!({
                     "stages": middleware.stages,
                     "permissions": middleware.permissions,
@@ -245,10 +326,21 @@ fn inspect_plugin(spec: &str, json_output: bool) -> Result<(), String> {
         println!("config: {}", display_path(path));
     }
     if let Some(binary) = binary {
+        println!(
+            "runtime: {}",
+            runtime_name(plugin_runtime(manifest.as_ref().unwrap()))
+        );
         println!("platform: {platform}");
         println!("binary: {binary}");
         if let Some(repository) = repository {
             println!("repository: {repository}");
+        }
+        if let Some(workflow) = manifest
+            .as_ref()
+            .and_then(|manifest| manifest.publisher.as_ref())
+            .and_then(|publisher| publisher.workflow.as_deref())
+        {
+            println!("publisher-workflow: {workflow}");
         }
         if let Some(asset) = asset {
             println!("asset: {asset}");
@@ -312,9 +404,10 @@ struct PluginManifest {
     name: Option<String>,
     description: Option<String>,
     #[serde(default)]
-    postscript: Vec<Postscript>,
+    postscript: Vec<toml::Value>,
     binary: Option<String>,
     repository: Option<String>,
+    publisher: Option<PublisherConfig>,
     #[serde(default)]
     assets: BTreeMap<String, String>,
     execution: Option<ExecutionConfig>,
@@ -322,9 +415,15 @@ struct PluginManifest {
 }
 
 #[derive(Debug, Default, Deserialize)]
+struct PublisherConfig {
+    workflow: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
 struct ExecutionConfig {
     #[serde(default, rename = "args")]
-    _args: Vec<String>,
+    args: Vec<String>,
+    runtime: Option<PluginRuntime>,
     mode: Option<String>,
     #[serde(rename = "timeout_ms")]
     _timeout_ms: Option<u64>,
@@ -336,6 +435,39 @@ struct ExecutionConfig {
     _max_spans: Option<usize>,
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum PluginRuntime {
+    #[default]
+    Native,
+    Wasm,
+}
+
+fn plugin_runtime(manifest: &PluginManifest) -> PluginRuntime {
+    manifest
+        .execution
+        .as_ref()
+        .and_then(|execution| execution.runtime)
+        .unwrap_or_else(|| {
+            if manifest
+                .binary
+                .as_deref()
+                .is_some_and(|binary| binary.to_ascii_lowercase().ends_with(".wasm"))
+            {
+                PluginRuntime::Wasm
+            } else {
+                PluginRuntime::Native
+            }
+        })
+}
+
+fn runtime_name(runtime: PluginRuntime) -> &'static str {
+    match runtime {
+        PluginRuntime::Native => "native",
+        PluginRuntime::Wasm => "wasm",
+    }
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct MiddlewareConfig {
     #[serde(default)]
@@ -344,17 +476,6 @@ struct MiddlewareConfig {
     permissions: Vec<String>,
     #[serde(default)]
     required: bool,
-}
-
-#[derive(Debug, Deserialize)]
-struct Postscript {
-    name: Option<String>,
-    command: Vec<String>,
-    #[serde(default)]
-    platforms: Vec<String>,
-    #[serde(default)]
-    permissions: Vec<String>,
-    timeout_ms: Option<u64>,
 }
 
 fn load_plugin_manifest(source: &plugins::PluginSource) -> Result<Option<PluginManifest>, String> {
@@ -376,6 +497,12 @@ fn load_plugin_manifest(source: &plugins::PluginSource) -> Result<Option<PluginM
             manifest.schema.as_deref().unwrap_or_default()
         ));
     }
+    if !manifest.postscript.is_empty() {
+        return Err(
+            "plugin postscripts are not supported; publish setup output as a signed release asset"
+                .to_string(),
+        );
+    }
     if let Some(binary) = manifest.binary.as_deref() {
         let name = manifest
             .name
@@ -383,6 +510,29 @@ fn load_plugin_manifest(source: &plugins::PluginSource) -> Result<Option<PluginM
             .filter(|name| !name.trim().is_empty())
             .unwrap_or(&source.name);
         validate_binary_name(binary, name)?;
+        if plugin_runtime(&manifest) == PluginRuntime::Wasm {
+            let execution = manifest.execution.as_ref();
+            if execution
+                .and_then(|execution| execution.mode.as_deref())
+                .unwrap_or("persistent")
+                != "oneshot"
+            {
+                return Err("WebAssembly plugins require execution.mode = \"oneshot\"".to_string());
+            }
+            if execution.is_some_and(|execution| !execution.args.is_empty()) {
+                return Err("WebAssembly plugins cannot declare execution.args".to_string());
+            }
+            if manifest.middleware.as_ref().is_some_and(|middleware| {
+                middleware
+                    .permissions
+                    .iter()
+                    .any(|permission| matches!(permission.as_str(), "config:read" | "cache:write"))
+            }) {
+                return Err(
+                    "WebAssembly plugins cannot request config:read or cache:write".to_string(),
+                );
+            }
+        }
         if let Some(repository) = manifest
             .repository
             .as_deref()
@@ -390,9 +540,39 @@ fn load_plugin_manifest(source: &plugins::PluginSource) -> Result<Option<PluginM
         {
             update::validate_repository(repository)?;
         }
+        validate_publisher(&manifest)?;
     }
     validate_middleware(&manifest)?;
     Ok(Some(manifest))
+}
+
+fn validate_publisher(manifest: &PluginManifest) -> Result<(), String> {
+    let workflow = publisher_workflow(manifest)?;
+    if workflow.is_empty()
+        || workflow.len() > 256
+        || workflow.starts_with('/')
+        || workflow.contains('\\')
+        || workflow.split('/').any(|part| {
+            part.is_empty()
+                || part == "."
+                || part == ".."
+                || !part
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || ".-_".contains(character))
+        })
+        || !workflow.ends_with(".yml") && !workflow.ends_with(".yaml")
+    {
+        return Err("publisher workflow must be a repository-relative YAML path".to_string());
+    }
+    Ok(())
+}
+
+fn publisher_workflow(manifest: &PluginManifest) -> Result<&str, String> {
+    manifest
+        .publisher
+        .as_ref()
+        .and_then(|publisher| publisher.workflow.as_deref())
+        .ok_or_else(|| "binary plugins require [publisher] workflow".to_string())
 }
 
 fn validate_middleware(manifest: &PluginManifest) -> Result<(), String> {
@@ -643,13 +823,8 @@ fn setup_plugin(spec: &str, approved: bool, json_output: bool) -> Result<(), Str
         .map(sha256_path)
         .transpose()?;
     let name = plugin_name(&source, Some(&manifest));
-    let steps = manifest
-        .postscript
-        .iter()
-        .filter(|step| postscript_matches_platform(step))
-        .collect::<Vec<_>>();
-    if steps.is_empty() && manifest.binary.is_none() {
-        println!("setup: nothing to do for {}", current_platform());
+    if manifest.binary.is_none() {
+        println!("setup: nothing to do");
         return Ok(());
     }
     println!("plugin: {name}");
@@ -666,13 +841,15 @@ fn setup_plugin(spec: &str, approved: bool, json_output: bool) -> Result<(), Str
     );
     if let Some(binary) = manifest.binary.as_deref() {
         let repository = binary_repository(&source, &manifest)?;
-        let asset = binary_asset(binary, &manifest.assets);
+        let runtime = plugin_runtime(&manifest);
+        let asset = binary_asset(binary, runtime, &manifest.assets);
         println!("binary: {binary}");
         println!("  release: github:{repository}");
+        println!("  publisher-workflow: {}", publisher_workflow(&manifest)?);
         println!("  asset: {asset}");
         println!(
             "  destination: {}",
-            binary_destination(&name, binary)?.display()
+            binary_destination(&name, binary, runtime)?.display()
         );
     }
     if let Some(middleware) = &manifest.middleware {
@@ -688,27 +865,28 @@ fn setup_plugin(spec: &str, approved: bool, json_output: bool) -> Result<(), Str
                 .and_then(|execution| execution.mode.as_deref())
                 .unwrap_or("persistent")
         );
-        println!("  trust: executable code (no OS sandbox)");
-    }
-    for (index, step) in steps.iter().enumerate() {
-        validate_postscript(step)?;
         println!(
-            "postscript {}: {}",
-            index + 1,
-            step.name.as_deref().unwrap_or("setup")
+            "  isolation: {}",
+            if plugin_runtime(&manifest) == PluginRuntime::Wasm {
+                "capability sandbox (no host imports)"
+            } else {
+                "trusted native publisher"
+            }
         );
-        println!("  command: {}", display_command(&step.command));
-        println!("  permissions: {}", step.permissions.join(", "));
     }
     if !approved && !confirm_setup()? {
         return Err("plugin setup was not approved".to_string());
     }
     if let Some(binary) = manifest.binary.as_deref() {
         let repository = binary_repository(&source, &manifest)?;
-        install_release_binary(&name, &repository, binary, &manifest.assets)?;
-    }
-    for step in steps {
-        run_postscript(&name, &source.root, step)?;
+        install_release_binary(
+            &name,
+            &repository,
+            binary,
+            plugin_runtime(&manifest),
+            publisher_workflow(&manifest)?,
+            &manifest.assets,
+        )?;
     }
     if manifest.middleware.is_some() {
         let current_hash = source
@@ -777,7 +955,14 @@ fn update_plugin(spec: &str, json_output: bool) -> Result<(), String> {
     };
     let repository = binary_repository(&source, &manifest)?;
     verify_plugin_update_approval(&name, &source, &manifest)?;
-    install_release_binary(&name, &repository, binary, &manifest.assets)?;
+    install_release_binary(
+        &name,
+        &repository,
+        binary,
+        plugin_runtime(&manifest),
+        publisher_workflow(&manifest)?,
+        &manifest.assets,
+    )?;
     // Updating a release binary must not rewrite the user's manifest approval.
     // Keeping the original digest makes any concurrent or later edit require setup again.
     println!("update: complete");
@@ -872,7 +1057,17 @@ fn validate_binary_name(binary: &str, plugin: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn binary_asset(binary: &str, overrides: &BTreeMap<String, String>) -> String {
+fn binary_asset(
+    binary: &str,
+    runtime: PluginRuntime,
+    overrides: &BTreeMap<String, String>,
+) -> String {
+    if runtime == PluginRuntime::Wasm {
+        return overrides
+            .get("wasm32")
+            .cloned()
+            .unwrap_or_else(|| binary.to_string());
+    }
     let platform = binary_platform();
     overrides.get(&platform).cloned().unwrap_or_else(|| {
         let suffix = if platform.starts_with("windows-") && !binary.ends_with(".exe") {
@@ -884,9 +1079,12 @@ fn binary_asset(binary: &str, overrides: &BTreeMap<String, String>) -> String {
     })
 }
 
-fn binary_destination(name: &str, binary: &str) -> Result<PathBuf, String> {
+fn binary_destination(name: &str, binary: &str, runtime: PluginRuntime) -> Result<PathBuf, String> {
     validate_binary_name(binary, name)?;
-    let filename = if cfg!(windows) && !binary.to_ascii_lowercase().ends_with(".exe") {
+    let filename = if runtime == PluginRuntime::Native
+        && cfg!(windows)
+        && !binary.to_ascii_lowercase().ends_with(".exe")
+    {
         format!("{binary}.exe")
     } else {
         binary.to_string()
@@ -899,15 +1097,18 @@ fn install_release_binary(
     name: &str,
     repository: &str,
     binary: &str,
+    runtime: PluginRuntime,
+    publisher_workflow: &str,
     overrides: &BTreeMap<String, String>,
 ) -> Result<(), String> {
     let platform = binary_platform();
-    let asset = binary_asset(binary, overrides);
-    let destination = binary_destination(name, binary)?;
+    let asset = binary_asset(binary, runtime, overrides);
+    let destination = binary_destination(name, binary, runtime)?;
     let download = update::download_latest_release_asset(repository, &asset)
         .map_err(|error| map_binary_download_error(name, &platform, &asset, error))?;
     if destination.is_file() && sha256_path(&destination)? == download.sha256 {
-        write_binary_lock(name, repository, &asset, &download)?;
+        verify_github_attestation(&destination, repository, publisher_workflow, name)?;
+        write_binary_lock(name, repository, publisher_workflow, &asset, &download)?;
         println!("binary {binary}: up to date ({})", download.version);
         return Ok(());
     }
@@ -931,15 +1132,55 @@ fn install_release_binary(
     ));
     std::fs::write(&staged, &download.bytes)
         .map_err(|e| format!("could not stage plugin binary: {e}"))?;
-    mark_binary_executable(&staged)?;
     if sha256_path(&staged)? != download.sha256 {
         let _ = std::fs::remove_file(&staged);
         return Err("staged plugin binary checksum mismatch".to_string());
     }
+    if let Err(error) = verify_github_attestation(&staged, repository, publisher_workflow, name) {
+        let _ = std::fs::remove_file(&staged);
+        return Err(error);
+    }
+    mark_binary_executable(&staged)?;
     replace_binary(&staged, &destination)?;
-    write_binary_lock(name, repository, &asset, &download)?;
+    write_binary_lock(name, repository, publisher_workflow, &asset, &download)?;
     println!("binary {binary}: installed {}", download.version);
     Ok(())
+}
+
+fn verify_github_attestation(
+    path: &Path,
+    repository: &str,
+    workflow: &str,
+    name: &str,
+) -> Result<(), String> {
+    let gh = find_command(Path::new("gh")).ok_or_else(|| {
+        "signed plugin verification requires GitHub CLI (`gh`): https://cli.github.com/".to_string()
+    })?;
+    let signer_workflow = format!("{repository}/{workflow}");
+    let output = Command::new(gh)
+        .arg("attestation")
+        .arg("verify")
+        .arg(path)
+        .arg("--repo")
+        .arg(repository)
+        .arg("--signer-workflow")
+        .arg(&signer_workflow)
+        .arg("--deny-self-hosted-runners")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|error| format!("could not run GitHub attestation verification: {error}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let detail = String::from_utf8_lossy(&output.stderr);
+    let detail = detail.trim();
+    Err(if detail.is_empty() {
+        format!("plugin '{name}' has no valid GitHub build attestation from {signer_workflow}")
+    } else {
+        format!("plugin '{name}' GitHub build attestation failed for {signer_workflow}: {detail}")
+    })
 }
 
 fn map_binary_download_error(name: &str, platform: &str, asset: &str, error: String) -> String {
@@ -954,6 +1195,7 @@ fn map_binary_download_error(name: &str, platform: &str, asset: &str, error: Str
 struct BinaryLock<'a> {
     schema: &'static str,
     repository: &'a str,
+    publisher_workflow: &'a str,
     version: String,
     asset: &'a str,
     sha256: &'a str,
@@ -962,6 +1204,7 @@ struct BinaryLock<'a> {
 fn write_binary_lock(
     name: &str,
     repository: &str,
+    publisher_workflow: &str,
     asset: &str,
     download: &update::DownloadedReleaseAsset,
 ) -> Result<(), String> {
@@ -969,6 +1212,7 @@ fn write_binary_lock(
     let lock = BinaryLock {
         schema: "pentect.plugin-lock.v1",
         repository,
+        publisher_workflow,
         version: download.version.to_string(),
         asset,
         sha256: &download.sha256,
@@ -1028,40 +1272,6 @@ fn mark_binary_executable(_path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn current_platform() -> &'static str {
-    if cfg!(windows) {
-        "windows"
-    } else if cfg!(target_os = "macos") {
-        "macos"
-    } else {
-        "linux"
-    }
-}
-
-fn postscript_matches_platform(step: &Postscript) -> bool {
-    step.platforms.is_empty()
-        || step
-            .platforms
-            .iter()
-            .any(|platform| platform.eq_ignore_ascii_case(current_platform()))
-}
-
-fn validate_postscript(step: &Postscript) -> Result<(), String> {
-    if step.command.is_empty() || step.command.iter().any(|part| part.is_empty()) {
-        return Err("postscript command must be a non-empty string array".to_string());
-    }
-    if step.permissions.is_empty() {
-        return Err("postscript must declare at least one permission".to_string());
-    }
-    const PERMISSIONS: &[&str] = &["filesystem", "network", "process", "environment"];
-    for permission in &step.permissions {
-        if !PERMISSIONS.contains(&permission.as_str()) {
-            return Err(format!("unknown postscript permission: {permission}"));
-        }
-    }
-    Ok(())
-}
-
 fn confirm_setup() -> Result<bool, String> {
     if !std::io::stdin().is_terminal() {
         return Err("plugin setup requires interactive approval or --yes".to_string());
@@ -1076,49 +1286,6 @@ fn confirm_setup() -> Result<bool, String> {
         answer.trim().to_ascii_lowercase().as_str(),
         "y" | "yes"
     ))
-}
-
-fn display_command(command: &[String]) -> String {
-    command
-        .iter()
-        .map(|part| {
-            if part
-                .chars()
-                .all(|ch| ch.is_ascii_alphanumeric() || "-._/:\\".contains(ch))
-            {
-                part.clone()
-            } else {
-                format!("{:?}", part)
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn run_postscript(name: &str, cwd: &Path, step: &Postscript) -> Result<(), String> {
-    let program = plugin_program(&step.command[0], cwd, &plugin_id(name));
-    if find_command(&program).is_none() {
-        return Err(format!("postscript command not found: {}", step.command[0]));
-    }
-    let mut command = plugin_command(&program, &plugin_id(name))?;
-    command
-        .args(&step.command[1..])
-        .current_dir(cwd)
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-    let mut child = command
-        .spawn()
-        .map_err(|e| format!("could not start postscript: {e}"))?;
-    let status = wait_for_plugin_child(
-        &mut child,
-        step.name.as_deref().unwrap_or("postscript"),
-        Duration::from_millis(step.timeout_ms.unwrap_or(120_000)),
-    )?;
-    if !status.success() {
-        return Err(format!("postscript failed: {status}"));
-    }
-    Ok(())
 }
 
 fn active_for_one(spec: &str) -> Result<plugins::ActivePlugins, String> {
@@ -1162,47 +1329,6 @@ fn test_binary(path: &Path) -> Check {
     }
 }
 
-fn wait_for_plugin_child(
-    child: &mut Child,
-    name: &str,
-    timeout: Duration,
-) -> Result<ExitStatus, String> {
-    let start = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return Ok(status),
-            Ok(None) if start.elapsed() >= timeout => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(format!("{name}: timeout"));
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(5)),
-            Err(e) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(format!("{name}: {e}"));
-            }
-        }
-    }
-}
-
-fn plugin_command(program: &Path, id_or_name: &str) -> Result<Command, String> {
-    let mut command = Command::new(program);
-    command.env_clear();
-    for env_name in safe_plugin_env_names() {
-        if let Some(value) = std::env::var_os(env_name) {
-            command.env(env_name, value);
-        }
-    }
-    let id = plugin_id(id_or_name);
-    let dirs = plugin_runtime_dirs(&id)?;
-    command.env(PLUGIN_NAME_ENV, id);
-    command.env(PLUGIN_DATA_DIR_ENV, dirs.data_dir);
-    command.env(PLUGIN_CACHE_DIR_ENV, dirs.cache_dir);
-    command.env(PLUGIN_CONFIG_ENV, dirs.config_file);
-    Ok(command)
-}
-
 fn plugin_runtime_dirs(id_or_name: &str) -> Result<pentect_agent::PluginRuntimeDirs, String> {
     pentect_agent::plugin_runtime_dirs(id_or_name)
 }
@@ -1241,25 +1367,6 @@ fn plugin_id(value: &str) -> String {
         "plugin".to_string()
     } else {
         out
-    }
-}
-
-fn safe_plugin_env_names() -> &'static [&'static str] {
-    if cfg!(windows) {
-        &[
-            "Path",
-            "PATH",
-            "PATHEXT",
-            "SystemRoot",
-            "SYSTEMROOT",
-            "WINDIR",
-            "COMSPEC",
-            "TEMP",
-            "TMP",
-            "USERPROFILE",
-        ]
-    } else {
-        &["PATH", "HOME", "SHELL", "TERM", "LANG", "LC_ALL", "TMPDIR"]
     }
 }
 
@@ -1367,47 +1474,8 @@ impl Check {
     }
 }
 
-fn plugin_program(program: &str, cwd: &Path, id: &str) -> PathBuf {
-    let path = Path::new(program);
-    if path.is_absolute() {
-        return path.to_path_buf();
-    }
-    if looks_like_path_command(program) {
-        return cwd.join(path);
-    }
-    installed_plugin_program(program, id)
-        .or_else(|| plugin_sidecar_program(program))
-        .unwrap_or_else(|| path.to_path_buf())
-}
-
-fn installed_plugin_program(program: &str, id: &str) -> Option<PathBuf> {
-    let bin = plugin_runtime_dirs(id).ok()?.data_dir.join("bin");
-    for name in command_names(program) {
-        let candidate = bin.join(name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
-fn looks_like_path_command(program: &str) -> bool {
-    program.contains('/') || program.contains('\\')
-}
-
-fn plugin_sidecar_program(program: &str) -> Option<PathBuf> {
-    let dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
-    for name in command_names(program) {
-        let candidate = dir.join(name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
 fn find_command(path: &Path) -> Option<PathBuf> {
-    if path.is_file() {
+    if path.is_absolute() && path.is_file() {
         return Some(path.to_path_buf());
     }
     if path.is_absolute()
@@ -1420,6 +1488,9 @@ fn find_command(path: &Path) -> Option<PathBuf> {
     let name = path.to_str()?;
     let paths = std::env::var_os("PATH")?;
     for dir in std::env::split_paths(&paths) {
+        if !dir.is_absolute() {
+            continue;
+        }
         for candidate in command_names(name) {
             let full = dir.join(candidate);
             if full.is_file() {
@@ -1542,56 +1613,20 @@ mod tests {
     }
 
     #[test]
-    fn postscript_requires_declared_known_permissions() {
-        let missing = Postscript {
-            name: None,
-            command: vec!["tool".into()],
-            platforms: Vec::new(),
-            permissions: Vec::new(),
-            timeout_ms: None,
-        };
-        assert!(validate_postscript(&missing).is_err());
-
-        let valid = Postscript {
-            permissions: vec!["network".into(), "filesystem".into()],
-            ..missing
-        };
-        assert!(validate_postscript(&valid).is_ok());
-    }
-
-    #[test]
-    fn postscript_does_not_run_before_approval() {
+    fn postscripts_are_rejected() {
         let root =
-            std::env::temp_dir().join(format!("pentect-plugin-approval-{}", std::process::id()));
+            std::env::temp_dir().join(format!("pentect-plugin-postscript-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
-        let marker = root.join("approved.txt");
-        #[cfg(windows)]
-        let command = r#"["cmd", "/C", "echo approved>approved.txt"]"#;
-        #[cfg(not(windows))]
-        let command = r#"["sh", "-c", "printf approved > approved.txt"]"#;
         std::fs::write(
             root.join("plugin.toml"),
-            format!(
-                r#"
-schema = "pentect.plugin.v1"
-name = "approval-test"
-
-[[postscript]]
-command = {command}
-permissions = ["filesystem", "process"]
-"#
-            ),
+            "schema = \"pentect.plugin.v1\"\nname = \"unsafe\"\n[[postscript]]\ncommand = [\"tool\"]\n",
         )
         .unwrap();
-
-        let spec = root.to_string_lossy();
-        assert!(setup_plugin(&spec, false, false).is_err());
-        assert!(!marker.exists());
-        setup_plugin(&spec, true, false).unwrap();
-        assert_eq!(std::fs::read_to_string(&marker).unwrap().trim(), "approved");
-
-        std::fs::remove_dir_all(root).unwrap();
+        let source = plugins::plugin_source(&root.to_string_lossy()).unwrap();
+        let error = load_plugin_manifest(&source).unwrap_err();
+        let _ = std::fs::remove_dir_all(root);
+        assert!(error.contains("postscripts are not supported"), "{error}");
     }
 
     #[test]
@@ -1602,11 +1637,23 @@ permissions = ["filesystem", "process"]
         } else {
             format!("helper-{platform}")
         };
-        assert_eq!(binary_asset("helper", &BTreeMap::new()), expected);
+        assert_eq!(
+            binary_asset("helper", PluginRuntime::Native, &BTreeMap::new()),
+            expected
+        );
         let overrides = BTreeMap::from([(platform, "custom.bin".to_string())]);
-        assert_eq!(binary_asset("helper", &overrides), "custom.bin");
-        assert!(binary_destination("test", "../outside").is_err());
-        assert!(binary_destination("test", "helper").unwrap().is_absolute());
+        assert_eq!(
+            binary_asset("helper", PluginRuntime::Native, &overrides),
+            "custom.bin"
+        );
+        assert_eq!(
+            binary_asset("helper.wasm", PluginRuntime::Wasm, &BTreeMap::new()),
+            "helper.wasm"
+        );
+        assert!(binary_destination("test", "../outside", PluginRuntime::Native).is_err());
+        assert!(binary_destination("test", "helper", PluginRuntime::Native)
+            .unwrap()
+            .is_absolute());
     }
 
     #[test]
@@ -1631,6 +1678,7 @@ permissions = ["filesystem", "process"]
         let lock = BinaryLock {
             schema: "pentect.plugin-lock.v1",
             repository: "owner/repo",
+            publisher_workflow: ".github/workflows/release.yml",
             version: "v1.2.3".to_string(),
             asset: "helper-linux-x86_64",
             sha256: "0123456789abcdef",
@@ -1638,6 +1686,10 @@ permissions = ["filesystem", "process"]
         let encoded = toml::to_string(&lock).unwrap();
         let decoded: toml::Value = toml::from_str(&encoded).unwrap();
         assert_eq!(decoded["repository"].as_str(), Some("owner/repo"));
+        assert_eq!(
+            decoded["publisher_workflow"].as_str(),
+            Some(".github/workflows/release.yml")
+        );
         assert_eq!(decoded["version"].as_str(), Some("v1.2.3"));
         assert_eq!(decoded["asset"].as_str(), Some("helper-linux-x86_64"));
         assert_eq!(decoded["sha256"].as_str(), Some("0123456789abcdef"));
@@ -1654,12 +1706,11 @@ permissions = ["filesystem", "process"]
         std::fs::create_dir_all(&root).unwrap();
         let manifest_path = root.join(plugins::PLUGIN_MANIFEST_FILE);
         let manifest_source = format!(
-            "schema = \"pentect.plugin.v1\"\nname = \"{name}\"\nbinary = \"helper\"\nrepository = \"owner/repo\"\n[middleware]\nstages = [\"detect\"]\npermissions = [\"input:read\"]\n"
+            "schema = \"pentect.plugin.v1\"\nname = \"{name}\"\nbinary = \"helper\"\nrepository = \"owner/repo\"\n[publisher]\nworkflow = \".github/workflows/release.yml\"\n[middleware]\nstages = [\"detect\"]\npermissions = [\"input:read\"]\n"
         );
         std::fs::write(&manifest_path, &manifest_source).unwrap();
         let source = plugins::PluginSource {
             name: name.clone(),
-            root: root.clone(),
             manifest_path: Some(manifest_path.clone()),
             repository: None,
         };
@@ -1678,68 +1729,6 @@ permissions = ["filesystem", "process"]
         let data_dir = plugin_runtime_dirs(&plugin_id(&name)).unwrap().data_dir;
         let _ = std::fs::remove_dir_all(data_dir);
         let _ = std::fs::remove_dir_all(root);
-    }
-
-    #[test]
-    fn plugin_env_does_not_inherit_memory_store_credentials() {
-        let command = plugin_command(Path::new("echo"), "test-env").unwrap();
-        let names = command
-            .get_envs()
-            .map(|(name, _)| name.to_string_lossy().to_string())
-            .collect::<Vec<_>>();
-
-        assert!(!names.iter().any(|name| name == "PENTECT_MEMORY_STORE_ADDR"));
-        assert!(!names
-            .iter()
-            .any(|name| name == "PENTECT_MEMORY_STORE_TOKEN"));
-        assert!(!names
-            .iter()
-            .any(|name| name == "PENTECT_PROCESS_HOST_READ_TOKEN"));
-        assert!(!names
-            .iter()
-            .any(|name| name == "PENTECT_PROCESS_HOST_WRITE_TOKEN"));
-    }
-
-    #[test]
-    fn plugin_env_exposes_project_scoped_user_data() {
-        let command = plugin_command(Path::new("echo"), "My Ext!").unwrap();
-        let dirs = plugin_runtime_dirs("my-ext").unwrap();
-        let data_dir = dirs.data_dir.to_string_lossy().replace('\\', "/");
-        let cache_dir = dirs.cache_dir.to_string_lossy().replace('\\', "/");
-        let config_file = dirs.config_file.to_string_lossy().replace('\\', "/");
-        let envs = command
-            .get_envs()
-            .map(|(name, value)| {
-                (
-                    name.to_string_lossy().to_string(),
-                    value
-                        .map(|value| value.to_string_lossy().replace('\\', "/"))
-                        .unwrap_or_default(),
-                )
-            })
-            .collect::<std::collections::BTreeMap<_, _>>();
-        assert_eq!(
-            envs.get(PLUGIN_NAME_ENV).map(String::as_str),
-            Some("my-ext")
-        );
-        assert!(
-            envs.get(PLUGIN_DATA_DIR_ENV)
-                .is_some_and(|path| path == &data_dir),
-            "{envs:?}"
-        );
-        assert!(
-            envs.get(PLUGIN_CACHE_DIR_ENV)
-                .is_some_and(|path| path == &cache_dir),
-            "{envs:?}"
-        );
-        assert!(
-            envs.get(PLUGIN_CONFIG_ENV)
-                .is_some_and(|path| path == &config_file),
-            "{envs:?}"
-        );
-        let project = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
-        assert!(!dirs.data_dir.starts_with(project), "{dirs:?}");
-        let _ = std::fs::remove_dir_all(dirs.data_dir);
     }
 
     #[test]
@@ -1784,13 +1773,12 @@ permissions = ["filesystem", "process"]
         std::fs::create_dir_all(&root).unwrap();
         std::fs::write(
             root.join(plugins::PLUGIN_MANIFEST_FILE),
-            "schema = \"pentect.plugin.v1\"\nname = \"local\"\nbinary = \"tool\"\n[middleware]\nstages = [\"detect\"]\npermissions = [\"input:read\"]\n",
+            "schema = \"pentect.plugin.v1\"\nname = \"local\"\nbinary = \"tool\"\n[publisher]\nworkflow = \".github/workflows/release.yml\"\n[middleware]\nstages = [\"detect\"]\npermissions = [\"input:read\"]\n",
         )
         .unwrap();
 
         let source = plugins::PluginSource {
             name: "local".to_string(),
-            root: root.clone(),
             manifest_path: Some(root.join(plugins::PLUGIN_MANIFEST_FILE)),
             repository: None,
         };

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -44,6 +44,7 @@ zeroize = { workspace = true }
 ed25519-dalek = { workspace = true }
 getrandom = { workspace = true }
 jiff = { workspace = true }
+wasmi = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_System_SystemInformation"] }
@@ -84,3 +85,4 @@ rten = { workspace = true, optional = true }
 
 [dev-dependencies]
 rxing = { workspace = true, features = ["encoders"] }
+wat = "1"

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -17,8 +17,8 @@ mod memory_store;
 mod output_remask;
 mod plugin_middleware;
 pub use plugin_middleware::{
-    plugin_runtime_dirs, MiddlewareCoverage, MiddlewareRun, MiddlewareStage, PluginMiddleware,
-    PluginRuntimeDirs, StopOutcome,
+    plugin_runtime_dirs, valid_plugin_publisher_workflow, MiddlewareCoverage, MiddlewareRun,
+    MiddlewareStage, PluginMiddleware, PluginRuntimeDirs, StopOutcome,
 };
 mod session;
 mod shell;

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -404,7 +404,7 @@ impl PluginBinary {
             .as_ref()
             .and_then(|publisher| publisher.workflow.as_deref())
             .ok_or_else(|| format!("plugin '{name}' requires [publisher] workflow"))?;
-        if !valid_publisher_workflow(publisher_workflow) {
+        if !valid_plugin_publisher_workflow(publisher_workflow) {
             return Err(format!(
                 "plugin '{name}' publisher workflow must be a repository-relative YAML path"
             ));
@@ -513,7 +513,7 @@ impl PluginBinary {
             (PluginRuntime::Wasm, _) => self
                 .wasm
                 .as_ref()
-                .expect("WebAssembly program loaded")
+                .ok_or_else(|| format!("plugin '{}' has no WebAssembly program", self.name))?
                 .invoke(&encoded, self.timeout, self.max_output_bytes, &self.name)?,
             (PluginRuntime::Native, ExecutionMode::Persistent) => self.run_persistent(&encoded)?,
             (PluginRuntime::Native, ExecutionMode::Oneshot) => self.run_once(&encoded)?,
@@ -610,7 +610,7 @@ impl PluginBinary {
     }
 }
 
-fn valid_publisher_workflow(workflow: &str) -> bool {
+pub fn valid_plugin_publisher_workflow(workflow: &str) -> bool {
     !workflow.is_empty()
         && workflow.len() <= 256
         && !workflow.starts_with('/')
@@ -677,7 +677,8 @@ const WASM_ABI_ALLOC: &str = "pentect_alloc";
 const WASM_ABI_HANDLE: &str = "pentect_handle";
 const WASM_ABI_MEMORY: &str = "memory";
 const WASM_MAX_MEMORY_BYTES: usize = 64 * 1024 * 1024;
-const WASM_FUEL_PER_MILLISECOND: u64 = 100_000;
+// Fuel is a short scheduling quantum. The wall clock below is authoritative.
+const WASM_FUEL_SLICE: u64 = 100_000;
 
 #[derive(Clone, Debug)]
 struct WasmProgram {
@@ -717,12 +718,8 @@ impl WasmProgram {
             .build();
         let mut store = wasmi::Store::new(&self.engine, limits);
         store.limiter(|limits| limits);
-        let fuel = u64::try_from(timeout.as_millis())
-            .unwrap_or(u64::MAX)
-            .saturating_mul(WASM_FUEL_PER_MILLISECOND)
-            .max(WASM_FUEL_PER_MILLISECOND);
         store
-            .set_fuel(fuel)
+            .set_fuel(WASM_FUEL_SLICE)
             .map_err(|error| format!("plugin '{name}' fuel setup failed: {error}"))?;
         let linker = wasmi::Linker::new(&self.engine);
         let instance = linker
@@ -749,10 +746,35 @@ impl WasmProgram {
         memory
             .write(&mut store, request_offset, request)
             .map_err(|error| format!("plugin '{name}' request write failed: {error}"))?;
-        let packed = handle
-            .call(&mut store, (request_ptr, request_len))
-            .map_err(|error| format!("plugin '{name}' execution failed: {error}"))?
-            as u64;
+        store
+            .set_fuel(WASM_FUEL_SLICE)
+            .map_err(|error| format!("plugin '{name}' fuel setup failed: {error}"))?;
+        let started = Instant::now();
+        let mut call = handle
+            .call_resumable(&mut store, (request_ptr, request_len))
+            .map_err(|error| format!("plugin '{name}' execution failed: {error}"))?;
+        let packed = loop {
+            match call {
+                wasmi::TypedResumableCall::Finished(value) => break value as u64,
+                wasmi::TypedResumableCall::HostTrap(trap) => {
+                    return Err(format!(
+                        "plugin '{name}' host call failed: {}",
+                        trap.host_error()
+                    ));
+                }
+                wasmi::TypedResumableCall::OutOfFuel(pending) => {
+                    if started.elapsed() >= timeout {
+                        return Err(format!("plugin '{name}' timed out"));
+                    }
+                    store
+                        .set_fuel(WASM_FUEL_SLICE.max(pending.required_fuel()))
+                        .map_err(|error| format!("plugin '{name}' fuel resume failed: {error}"))?;
+                    call = pending
+                        .resume(&mut store)
+                        .map_err(|error| format!("plugin '{name}' execution failed: {error}"))?;
+                }
+            }
+        };
         let output_ptr = usize::try_from(packed >> 32)
             .map_err(|_| format!("plugin '{name}' returned an invalid output pointer"))?;
         let output_len = usize::try_from(packed & u64::from(u32::MAX))
@@ -1560,6 +1582,33 @@ mod tests {
             .unwrap();
         let _ = std::fs::remove_file(path);
         assert_eq!(result, output);
+    }
+
+    #[test]
+    fn wasm_plugin_enforces_wall_clock_timeout() {
+        let bytes = wat::parse_str(
+            r#"(module
+                (memory (export "memory") 1)
+                (func (export "pentect_alloc") (param i32) (result i32)
+                    (i32.const 1024))
+                (func (export "pentect_handle") (param i32 i32) (result i64)
+                    (loop (br 0))
+                    (i64.const 0))
+            )"#,
+        )
+        .unwrap();
+        let path = std::env::temp_dir().join(format!(
+            "pentect-plugin-wasm-timeout-{}-{}.wasm",
+            std::process::id(),
+            REQUEST_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&path, bytes).unwrap();
+        let program = WasmProgram::load(&path, "fixture").unwrap();
+        let error = program
+            .invoke(b"{}", Duration::from_millis(1), 4096, "fixture")
+            .unwrap_err();
+        let _ = std::fs::remove_file(path);
+        assert!(error.contains("timed out"), "{error}");
     }
 
     #[cfg(windows)]

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -359,6 +359,8 @@ struct PluginBinary {
     id: String,
     path: PathBuf,
     command: Vec<String>,
+    runtime: PluginRuntime,
+    wasm: Option<WasmProgram>,
     stages: BTreeSet<MiddlewareStage>,
     permissions: BTreeSet<String>,
     required: bool,
@@ -397,9 +399,47 @@ impl PluginBinary {
             .binary
             .filter(|binary| !binary.trim().is_empty())
             .ok_or_else(|| format!("plugin '{name}' requires binary"))?;
+        let publisher_workflow = file
+            .publisher
+            .as_ref()
+            .and_then(|publisher| publisher.workflow.as_deref())
+            .ok_or_else(|| format!("plugin '{name}' requires [publisher] workflow"))?;
+        if !valid_publisher_workflow(publisher_workflow) {
+            return Err(format!(
+                "plugin '{name}' publisher workflow must be a repository-relative YAML path"
+            ));
+        }
         let execution = file.execution.unwrap_or_default();
+        let runtime = execution.runtime.unwrap_or_else(|| {
+            if binary.to_ascii_lowercase().ends_with(".wasm") {
+                PluginRuntime::Wasm
+            } else {
+                PluginRuntime::Native
+            }
+        });
         let mode = execution.mode.unwrap_or_default();
-        let command = binary_command(&name, &binary, execution.args)?;
+        if runtime == PluginRuntime::Wasm && mode != ExecutionMode::Oneshot {
+            return Err(format!(
+                "plugin '{name}' WebAssembly execution requires mode = \"oneshot\""
+            ));
+        }
+        if runtime == PluginRuntime::Wasm
+            && (!execution.args.is_empty()
+                || file.middleware.as_ref().is_some_and(|middleware| {
+                    middleware.permissions.contains(&"config:read".to_string())
+                        || middleware.permissions.contains(&"cache:write".to_string())
+                }))
+        {
+            return Err(format!(
+                "plugin '{name}' WebAssembly execution cannot use args, config:read, or cache:write"
+            ));
+        }
+        let command = binary_command(&name, &binary, execution.args, runtime)?;
+        let wasm = if runtime == PluginRuntime::Wasm {
+            Some(WasmProgram::load(Path::new(&command[0]), &name)?)
+        } else {
+            None
+        };
         let middleware = file
             .middleware
             .ok_or_else(|| format!("plugin '{name}' requires [middleware]"))?;
@@ -426,6 +466,8 @@ impl PluginBinary {
             id,
             path: path.to_path_buf(),
             command,
+            runtime,
+            wasm,
             stages,
             permissions,
             required: middleware.required,
@@ -467,9 +509,14 @@ impl PluginBinary {
         if encoded.len() > self.max_input_bytes {
             return Err(format!("plugin '{}' input exceeds its limit", self.name));
         }
-        let output = match self.mode {
-            ExecutionMode::Persistent => self.run_persistent(&encoded)?,
-            ExecutionMode::Oneshot => self.run_once(&encoded)?,
+        let output = match (self.runtime, self.mode) {
+            (PluginRuntime::Wasm, _) => self
+                .wasm
+                .as_ref()
+                .expect("WebAssembly program loaded")
+                .invoke(&encoded, self.timeout, self.max_output_bytes, &self.name)?,
+            (PluginRuntime::Native, ExecutionMode::Persistent) => self.run_persistent(&encoded)?,
+            (PluginRuntime::Native, ExecutionMode::Oneshot) => self.run_once(&encoded)?,
         };
         let response: PluginResponse = serde_json::from_slice(&output)
             .map_err(|error| format!("plugin '{}' returned invalid JSON: {error}", self.name))?;
@@ -563,6 +610,22 @@ impl PluginBinary {
     }
 }
 
+fn valid_publisher_workflow(workflow: &str) -> bool {
+    !workflow.is_empty()
+        && workflow.len() <= 256
+        && !workflow.starts_with('/')
+        && !workflow.contains('\\')
+        && workflow.split('/').all(|part| {
+            !part.is_empty()
+                && part != "."
+                && part != ".."
+                && part
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || ".-_".contains(character))
+        })
+        && (workflow.ends_with(".yml") || workflow.ends_with(".yaml"))
+}
+
 #[derive(Deserialize)]
 struct PluginApproval {
     schema: String,
@@ -608,6 +671,101 @@ fn verify_plugin_approval(
         ));
     }
     Ok(())
+}
+
+const WASM_ABI_ALLOC: &str = "pentect_alloc";
+const WASM_ABI_HANDLE: &str = "pentect_handle";
+const WASM_ABI_MEMORY: &str = "memory";
+const WASM_MAX_MEMORY_BYTES: usize = 64 * 1024 * 1024;
+const WASM_FUEL_PER_MILLISECOND: u64 = 100_000;
+
+#[derive(Clone, Debug)]
+struct WasmProgram {
+    engine: wasmi::Engine,
+    module: wasmi::Module,
+}
+
+impl WasmProgram {
+    fn load(path: &Path, name: &str) -> Result<Self, String> {
+        let bytes = std::fs::read(path)
+            .map_err(|error| format!("could not read WebAssembly plugin '{name}': {error}"))?;
+        let mut config = wasmi::Config::default();
+        config.consume_fuel(true);
+        let engine = wasmi::Engine::new(&config);
+        let module = wasmi::Module::new(&engine, &bytes[..])
+            .map_err(|error| format!("plugin '{name}' WebAssembly is invalid: {error}"))?;
+        if module.imports().next().is_some() {
+            return Err(format!(
+                "plugin '{name}' WebAssembly must not import host capabilities"
+            ));
+        }
+        Ok(Self { engine, module })
+    }
+
+    fn invoke(
+        &self,
+        request: &[u8],
+        timeout: Duration,
+        max_output_bytes: usize,
+        name: &str,
+    ) -> Result<Vec<u8>, String> {
+        let limits = wasmi::StoreLimitsBuilder::new()
+            .memory_size(WASM_MAX_MEMORY_BYTES)
+            .memories(1)
+            .instances(1)
+            .tables(1)
+            .build();
+        let mut store = wasmi::Store::new(&self.engine, limits);
+        store.limiter(|limits| limits);
+        let fuel = u64::try_from(timeout.as_millis())
+            .unwrap_or(u64::MAX)
+            .saturating_mul(WASM_FUEL_PER_MILLISECOND)
+            .max(WASM_FUEL_PER_MILLISECOND);
+        store
+            .set_fuel(fuel)
+            .map_err(|error| format!("plugin '{name}' fuel setup failed: {error}"))?;
+        let linker = wasmi::Linker::new(&self.engine);
+        let instance = linker
+            .instantiate_and_start(&mut store, &self.module)
+            .map_err(|error| format!("plugin '{name}' WebAssembly start failed: {error}"))?;
+        let memory = instance
+            .get_memory(&store, WASM_ABI_MEMORY)
+            .ok_or_else(|| format!("plugin '{name}' does not export memory"))?;
+        let alloc = instance
+            .get_typed_func::<i32, i32>(&store, WASM_ABI_ALLOC)
+            .map_err(|_| format!("plugin '{name}' does not export {WASM_ABI_ALLOC}(i32) -> i32"))?;
+        let handle = instance
+            .get_typed_func::<(i32, i32), i64>(&store, WASM_ABI_HANDLE)
+            .map_err(|_| {
+                format!("plugin '{name}' does not export {WASM_ABI_HANDLE}(i32, i32) -> i64")
+            })?;
+        let request_len = i32::try_from(request.len())
+            .map_err(|_| format!("plugin '{name}' request is too large"))?;
+        let request_ptr = alloc
+            .call(&mut store, request_len)
+            .map_err(|error| format!("plugin '{name}' allocation failed: {error}"))?;
+        let request_offset = usize::try_from(request_ptr)
+            .map_err(|_| format!("plugin '{name}' returned an invalid allocation"))?;
+        memory
+            .write(&mut store, request_offset, request)
+            .map_err(|error| format!("plugin '{name}' request write failed: {error}"))?;
+        let packed = handle
+            .call(&mut store, (request_ptr, request_len))
+            .map_err(|error| format!("plugin '{name}' execution failed: {error}"))?
+            as u64;
+        let output_ptr = usize::try_from(packed >> 32)
+            .map_err(|_| format!("plugin '{name}' returned an invalid output pointer"))?;
+        let output_len = usize::try_from(packed & u64::from(u32::MAX))
+            .map_err(|_| format!("plugin '{name}' returned an invalid output length"))?;
+        if output_len > max_output_bytes {
+            return Err(format!("plugin '{name}' returned too much output"));
+        }
+        let mut output = vec![0; output_len];
+        memory
+            .read(&store, output_ptr, &mut output)
+            .map_err(|error| format!("plugin '{name}' output read failed: {error}"))?;
+        Ok(output)
+    }
 }
 
 struct PersistentProcess {
@@ -783,8 +941,15 @@ struct PluginFile {
     schema: Option<String>,
     name: Option<String>,
     binary: Option<String>,
+    publisher: Option<PublisherFile>,
     execution: Option<ExecutionFile>,
     middleware: Option<MiddlewareFile>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PublisherFile {
+    workflow: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -792,6 +957,7 @@ struct PluginFile {
 struct ExecutionFile {
     #[serde(default)]
     args: Vec<String>,
+    runtime: Option<PluginRuntime>,
     mode: Option<ExecutionMode>,
     timeout_ms: Option<u64>,
     max_input_bytes: Option<usize>,
@@ -805,6 +971,13 @@ enum ExecutionMode {
     #[default]
     Persistent,
     Oneshot,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum PluginRuntime {
+    Native,
+    Wasm,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1151,7 +1324,12 @@ fn restrict_plugin_directory(_path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn binary_command(name: &str, binary: &str, args: Vec<String>) -> Result<Vec<String>, String> {
+fn binary_command(
+    name: &str,
+    binary: &str,
+    args: Vec<String>,
+    runtime: PluginRuntime,
+) -> Result<Vec<String>, String> {
     if binary.is_empty()
         || binary.len() > 128
         || binary.contains('/')
@@ -1163,7 +1341,10 @@ fn binary_command(name: &str, binary: &str, args: Vec<String>) -> Result<Vec<Str
     {
         return Err(format!("plugin '{name}' has an invalid binary name"));
     }
-    let filename = if cfg!(windows) && !binary.to_ascii_lowercase().ends_with(".exe") {
+    let filename = if runtime == PluginRuntime::Native
+        && cfg!(windows)
+        && !binary.to_ascii_lowercase().ends_with(".exe")
+    {
         format!("{binary}.exe")
     } else {
         binary.to_string()
@@ -1324,6 +1505,8 @@ mod tests {
             id: "fixture".to_string(),
             path: std::env::current_dir().unwrap().join("plugin.toml"),
             command: persistent_fixture_command(),
+            runtime: PluginRuntime::Native,
+            wasm: None,
             stages: BTreeSet::from([MiddlewareStage::ProviderRequest]),
             permissions: BTreeSet::from(["input:read".to_string(), "payload:write".to_string()]),
             required: true,
@@ -1347,6 +1530,36 @@ mod tests {
                 .unwrap();
             assert_eq!(run.payload["sequence"], sequence);
         }
+    }
+
+    #[test]
+    fn wasm_plugin_runs_without_host_capabilities() {
+        let output = br#"{"schema":"pentect.plugin.v1","id":7,"type":"result","action":"next"}"#;
+        let packed = ((2048_u64) << 32) | output.len() as u64;
+        let wat = format!(
+            r#"(module
+                (memory (export "memory") 1)
+                (data (i32.const 2048) "{}")
+                (func (export "pentect_alloc") (param i32) (result i32)
+                    (i32.const 1024))
+                (func (export "pentect_handle") (param i32 i32) (result i64)
+                    (i64.const {packed}))
+            )"#,
+            String::from_utf8_lossy(output).replace('"', "\\22")
+        );
+        let bytes = wat::parse_str(wat).unwrap();
+        let path = std::env::temp_dir().join(format!(
+            "pentect-plugin-wasm-{}-{}.wasm",
+            std::process::id(),
+            REQUEST_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&path, bytes).unwrap();
+        let program = WasmProgram::load(&path, "fixture").unwrap();
+        let result = program
+            .invoke(b"{}", Duration::from_secs(1), 4096, "fixture")
+            .unwrap();
+        let _ = std::fs::remove_file(path);
+        assert_eq!(result, output);
     }
 
     #[cfg(windows)]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -3842,6 +3842,7 @@ fn pretool_non_default_session_is_inserted_before_command() {
 
 #[test]
 fn implicit_directory_session_is_not_rendered_in_wrapped_command() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let implicit = default_directory_session_name().unwrap();
     let command =
         wrap_shell_command(HookProvider::Claude, &implicit, "Bash", "echo hello").unwrap();
@@ -3872,6 +3873,7 @@ fn hook_exec_wrapper_is_lossless_and_display_decodable() {
 
 #[test]
 fn hook_shell_transport_round_trips_powershell_without_outer_shell_quoting() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let script = concat!(
         "$token = $env:PENTECT_KAGGLE_API_TOKEN_deadbeef; ",
         "$parts = $token -split ':'; ",

--- a/guides/plugins.md
+++ b/guides/plugins.md
@@ -1,10 +1,12 @@
 # Plugins
 
-Pentect plugins have two deliberately small forms:
+Pentect plugins have three deliberately small forms:
 
 1. A declarative `plugin.toml` can add regex detectors without executable code.
-2. A binary plugin is persistent middleware that exchanges one JSON object per
-   line over stdin/stdout.
+2. A sandboxed WebAssembly plugin uses a tiny request/response ABI and receives
+   no host imports.
+3. A publisher-trusted native plugin exchanges one JSON object per line over
+   stdin/stdout.
 
 The host owns ordering and the core masking pass. A plugin returns `next` to
 continue, or `stop` with `block`, `respond`, or `handled`. Plugins never call
@@ -18,7 +20,11 @@ name = "company-policy"
 binary = "company-policy"
 repository = "owner/company-policy"
 
+[publisher]
+workflow = ".github/workflows/release.yml"
+
 [execution]
+runtime = "native" # use "wasm" for capability-sandboxed modules
 mode = "persistent" # default; "oneshot" is supported
 timeout_ms = 10000
 max_input_bytes = 262144
@@ -54,13 +60,45 @@ response for each request and flush stdout. The canonical schema and fixtures
 live in [`protocol/`](../protocol/); small Rust, Python, TypeScript, and Go
 helpers live in [`sdk/`](../sdk/).
 
+For an untrusted third-party plugin, publish one portable `.wasm` asset:
+
+```toml
+binary = "company-policy.wasm"
+repository = "owner/company-policy"
+
+[publisher]
+workflow = ".github/workflows/release.yml"
+
+[execution]
+runtime = "wasm"
+mode = "oneshot"
+```
+
+The module exports `memory`, `pentect_alloc(i32) -> i32`, and
+`pentect_handle(i32, i32) -> i64`. The high 32 bits of the result are the
+response pointer and the low 32 bits are its byte length. The Rust SDK's
+`export_wasm_plugin!` macro implements this ABI. WebAssembly plugins cannot
+request `config:read` or `cache:write`; future host capabilities can be added
+without granting ambient filesystem or network access.
+
+Rust publishers set `crate-type = ["cdylib"]`, use
+`pentect_plugin::export_wasm_plugin!(handler)`, and build with:
+
+```text
+cargo build --release --target wasm32-unknown-unknown
+```
+
 ## Security and approval
 
-Executable plugins are trusted native code, not an OS sandbox. `pentect plugins
-setup` shows the binary source, middleware stages, permissions, postscripts,
-and destinations before approval. Approval records the manifest SHA-256;
-changing stages, permissions, or any other manifest content requires approval
-again.
+WebAssembly plugins run in a capability sandbox with a 64 MiB memory ceiling,
+fuel metering, and no filesystem, environment, process, or network imports.
+Native plugins remain an explicit publisher-trusted compatibility path for
+workloads such as local ONNX inference.
+
+`pentect plugins setup` shows the binary source, runtime, middleware stages,
+permissions, and destination before approval. Approval records the manifest
+SHA-256; changing any manifest content requires approval again. Arbitrary
+postscripts are rejected—setup output must be a release asset.
 
 Plugin children receive a cleared environment plus a small platform allowlist.
 They never inherit Pentect's memory-store credentials. `PENTECT_PLUGIN_CONFIG`
@@ -103,12 +141,21 @@ To keep an ordered project-wide list, add it to `.pentect/config.toml`:
 plugins = ["./plugins/company-policy", "company-identifiers"]
 ```
 
-Release binaries are selected by OS and architecture. Unsupported platforms
-produce an explicit missing-asset error rather than compiling on the user's
-machine. Postscripts are separately declared and approved. `plugins update`
-only replaces the release binary described by the exact approved manifest.
-Any manifest change—including its repository, command, stages, or
-permissions—must go through `plugins setup` again.
+Native release binaries are selected by OS and architecture; a WebAssembly
+asset is portable. Unsupported native platforms produce an explicit
+missing-asset error rather than compiling on the user's machine.
+
+Every executable asset must carry GitHub artifact provenance. Setup and update
+verify its Sigstore attestation with `gh`, pinning both the publisher repository
+and the workflow declared in `[publisher]`, and reject attestations from
+self-hosted runners. SHA-256 is still checked for transport corruption.
+`plugins update` only replaces the release binary described by the exact
+approved manifest.
+
+The registry shipped inside the signed Pentect binary is searchable with
+`pentect plugins search [QUERY]`. A plugin does not need to be in that registry:
+any publisher can distribute a `github:@owner/repository/path` spec, provided
+its executable assets carry matching provenance.
 
 The protocol exposes masking, provider, tool, file, finding, and reporting
 stages. HTTP provider requests, JSON responses, completed streaming and

--- a/plugins/openai-privacy-filter/plugin.toml
+++ b/plugins/openai-privacy-filter/plugin.toml
@@ -4,7 +4,11 @@ description = "Local privacy-filter model."
 binary = "pentect-pii-ner"
 repository = "EdamAme-x/pentect"
 
+[publisher]
+workflow = ".github/workflows/release.yml"
+
 [execution]
+runtime = "native"
 mode = "persistent"
 
 [middleware]

--- a/plugins/pii-ner/plugin.toml
+++ b/plugins/pii-ner/plugin.toml
@@ -4,7 +4,11 @@ description = "Local ONNX PII named-entity recognition."
 binary = "pentect-pii-ner"
 repository = "EdamAme-x/pentect"
 
+[publisher]
+workflow = ".github/workflows/release.yml"
+
 [execution]
+runtime = "native"
 mode = "persistent"
 
 [middleware]

--- a/plugins/registry.toml
+++ b/plugins/registry.toml
@@ -5,18 +5,16 @@ name = "example-regex"
 description = "Manifest-only example for deterministic regex detectors."
 source = "github:@EdamAme-x/pentect/plugins/example-regex"
 publisher = "EdamAme-x/pentect"
-runtime = "manifest"
 
 [[plugin]]
 name = "openai-privacy-filter"
 description = "Deterministic privacy policy middleware for OpenAI-compatible traffic."
 source = "github:@EdamAme-x/pentect/plugins/openai-privacy-filter"
 publisher = "EdamAme-x/pentect"
-runtime = "manifest"
 
 [[plugin]]
 name = "pii-ner"
 description = "Local ONNX named-entity recognition maintained by the Pentect publisher."
 source = "github:@EdamAme-x/pentect/plugins/pii-ner"
 publisher = "EdamAme-x/pentect"
-runtime = "trusted_native"
+runtime = "native"

--- a/plugins/registry.toml
+++ b/plugins/registry.toml
@@ -1,0 +1,22 @@
+schema = "pentect.plugin-registry.v1"
+
+[[plugin]]
+name = "example-regex"
+description = "Manifest-only example for deterministic regex detectors."
+source = "github:@EdamAme-x/pentect/plugins/example-regex"
+publisher = "EdamAme-x/pentect"
+runtime = "manifest"
+
+[[plugin]]
+name = "openai-privacy-filter"
+description = "Deterministic privacy policy middleware for OpenAI-compatible traffic."
+source = "github:@EdamAme-x/pentect/plugins/openai-privacy-filter"
+publisher = "EdamAme-x/pentect"
+runtime = "manifest"
+
+[[plugin]]
+name = "pii-ner"
+description = "Local ONNX named-entity recognition maintained by the Pentect publisher."
+source = "github:@EdamAme-x/pentect/plugins/pii-ner"
+publisher = "EdamAme-x/pentect"
+runtime = "trusted_native"

--- a/sdk/rust/pentect-plugin/examples/wasm.rs
+++ b/sdk/rust/pentect-plugin/examples/wasm.rs
@@ -1,0 +1,9 @@
+use pentect_plugin::{Request, Response};
+
+fn handle(request: Request) -> Result<Response, Box<dyn std::error::Error>> {
+    Ok(Response::next(request.id))
+}
+
+pentect_plugin::export_wasm_plugin!(handle);
+
+fn main() {}

--- a/sdk/rust/pentect-plugin/src/lib.rs
+++ b/sdk/rust/pentect-plugin/src/lib.rs
@@ -5,6 +5,8 @@ use serde_json::Value;
 use std::io::{self, BufRead, Write};
 
 pub const SCHEMA: &str = "pentect.plugin.v1";
+#[doc(hidden)]
+pub use serde_json as __serde_json;
 
 pub fn config_path() -> Option<std::path::PathBuf> {
     std::env::var_os("PENTECT_PLUGIN_CONFIG").map(Into::into)
@@ -96,4 +98,38 @@ pub fn serve(
         stdout.flush()?;
     }
     Ok(())
+}
+
+/// Export Pentect's capability-sandboxed WebAssembly ABI for a typed handler.
+///
+/// The resulting module imports nothing from the host. Build the plugin as a
+/// `cdylib` for `wasm32-unknown-unknown` and use `execution.runtime = "wasm"`.
+#[macro_export]
+macro_rules! export_wasm_plugin {
+    ($handler:path) => {
+        #[no_mangle]
+        pub extern "C" fn pentect_alloc(len: i32) -> i32 {
+            let len = usize::try_from(len).expect("negative Pentect input length");
+            let mut input = Vec::<u8>::with_capacity(len);
+            let pointer = input.as_mut_ptr();
+            std::mem::forget(input);
+            pointer as i32
+        }
+
+        #[no_mangle]
+        pub unsafe extern "C" fn pentect_handle(pointer: i32, len: i32) -> i64 {
+            let pointer = usize::try_from(pointer).expect("negative Pentect input pointer");
+            let len = usize::try_from(len).expect("negative Pentect input length");
+            let input = unsafe { Vec::from_raw_parts(pointer as *mut u8, len, len) };
+            let request: $crate::Request = $crate::__serde_json::from_slice(&input)
+                .expect("invalid Pentect request");
+            let response = $handler(request).expect("Pentect plugin handler failed");
+            let mut output =
+                $crate::__serde_json::to_vec(&response).expect("Pentect response failed");
+            let output_pointer = output.as_mut_ptr() as u32;
+            let output_len = u32::try_from(output.len()).expect("Pentect response too large");
+            std::mem::forget(output);
+            (((output_pointer as u64) << 32) | output_len as u64) as i64
+        }
+    };
 }

--- a/sdk/rust/pentect-plugin/src/lib.rs
+++ b/sdk/rust/pentect-plugin/src/lib.rs
@@ -110,25 +110,28 @@ macro_rules! export_wasm_plugin {
         #[no_mangle]
         pub extern "C" fn pentect_alloc(len: i32) -> i32 {
             let len = usize::try_from(len).expect("negative Pentect input length");
-            let mut input = Vec::<u8>::with_capacity(len);
-            let pointer = input.as_mut_ptr();
-            std::mem::forget(input);
-            pointer as i32
+            let input = vec![0_u8; len].into_boxed_slice();
+            std::boxed::Box::into_raw(input) as *mut u8 as i32
         }
 
         #[no_mangle]
         pub unsafe extern "C" fn pentect_handle(pointer: i32, len: i32) -> i64 {
             let pointer = usize::try_from(pointer).expect("negative Pentect input pointer");
             let len = usize::try_from(len).expect("negative Pentect input length");
-            let input = unsafe { Vec::from_raw_parts(pointer as *mut u8, len, len) };
+            let input = unsafe {
+                std::boxed::Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                    pointer as *mut u8,
+                    len,
+                ))
+            };
             let request: $crate::Request = $crate::__serde_json::from_slice(&input)
                 .expect("invalid Pentect request");
             let response = $handler(request).expect("Pentect plugin handler failed");
-            let mut output =
-                $crate::__serde_json::to_vec(&response).expect("Pentect response failed");
-            let output_pointer = output.as_mut_ptr() as u32;
+            let output = $crate::__serde_json::to_vec(&response)
+                .expect("Pentect response failed")
+                .into_boxed_slice();
             let output_len = u32::try_from(output.len()).expect("Pentect response too large");
-            std::mem::forget(output);
+            let output_pointer = std::boxed::Box::into_raw(output) as *mut u8 as u32;
             (((output_pointer as u64) << 32) | output_len as u64) as i64
         }
     };

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -7,7 +7,7 @@ Scope: Rust workspace, shell/runtime IPC, masking pipeline, plugins, installers/
 
 Seven clear security issues were fixed in this review: an unsafe UTF-8 mutation reachable through the public detector API, local memory-store connection/request exhaustion, a project-controlled remote plugin cache, mutable GitHub Actions dependencies, the dependency advisories known at the time of the review, executable-plugin approval bypasses, and project-controlled plugin runtime artifacts. Targeted tests and `cargo check -p pentect-cli` pass.
 
-Executable plugins remain deliberately trusted native code rather than sandboxed code. Their manifest, stages, permissions, postscripts, source repository, and destinations are shown before setup approval. Approval state and installed artifacts are kept outside the repository in project-scoped OS user data. The largest remaining decisions are enforceable postscript sandboxing and independently signed release artifacts.
+Third-party executable plugins can now use a capability-sandboxed WebAssembly runtime with no host imports, bounded memory, and fuel metering. Native plugins remain an explicit publisher-trusted compatibility path. Arbitrary postscripts are rejected. Plugin release assets are verified with GitHub's Sigstore artifact attestations, pinned to the publisher repository and workflow, in addition to SHA-256.
 
 ## Fixed findings
 
@@ -59,17 +59,13 @@ Fixed by moving approval, binaries, configuration, cache, and mutable plugin dat
 
 ## Decisions required
 
-### PNT-SEC-D03 — Postscript permissions are descriptive, not enforced (medium/high)
+### PNT-SEC-D03 — Postscript permissions were descriptive, not enforced (resolved)
 
-The setup prompt displays declared permissions, but approved postscript commands run with the user's normal filesystem, process, and network access. `--yes` intentionally removes the interactive gate.
+Resolved by rejecting arbitrary postscripts. Plugin setup is limited to host-owned installation of a signed release asset.
 
-Recommended decision: either implement enforceable platform sandboxes/capabilities, or rename the field/UI to `declared_permissions` and clearly state that approval grants full user-level execution.
+### PNT-SEC-D04 — Plugin release checksums were not independent signatures (resolved)
 
-### PNT-SEC-D04 — Release checksums are not independent signatures (medium/high)
-
-Install, update, and plugin downloads verify SHA-256, but the checksum and binary come from the same GitHub release. This detects corruption, not compromise of the repository, release workflow, or release token.
-
-Recommended decision: add Sigstore keyless signing/attestations, or choose an offline Ed25519 release key with an explicit rotation and recovery policy.
+Resolved with GitHub Actions keyless artifact attestations. Verification pins the expected repository and signer workflow and denies self-hosted runners; SHA-256 remains a transport-integrity check.
 
 ### PNT-SEC-D05 — Stable machine-scoped handles allow equality correlation (medium/privacy)
 


### PR DESCRIPTION
## Summary
- add a no-host-import WebAssembly capability sandbox with memory and fuel limits
- require GitHub Sigstore provenance pinned to publisher repository/workflow for executable plugin assets
- replace arbitrary postscripts with host-owned signed asset setup
- add a signed built-in plugin registry and `pentect plugins search`
- add Rust WASM ABI helper and document third-party publishing

## Local verification
- `cargo fmt --all -- --check`
- `cargo check -p pentect-cli --no-default-features`
- `cargo clippy -p pentect-cli -p pentect-runtime --no-default-features --all-targets -- -D warnings`
- targeted plugin CLI/runtime tests
- Rust SDK example check

Heavy OCR/all-feature coverage is intentionally left to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin discovery through `plugins search`, with human-readable and JSON output.
  * Added support for sandboxed WebAssembly plugins with runtime and capability validation.
  * Added a built-in plugin registry with initial plugin entries.
  * Added publisher and workflow metadata for plugin verification.

* **Security**
  * Release binaries now include provenance attestations.
  * Plugin installation verifies checksums and publisher attestations.
  * Arbitrary plugin postscripts are rejected.

* **Documentation**
  * Updated plugin guidance to describe runtimes, sandboxing, approvals, and provenance requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->