### PR TITLE
Release v0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.6"
+version = "0.0.7"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Publishes the merged security hardening as Pentect v0.0.7. The only changes are the CLI package and lockfile version bump; security, OCR, dependency audit, and full-feature checks passed on PR #112.