### PR TITLE
Prepare v0.0.9 CLI release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report reproducible incorrect behavior in Pentect.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Pentect. Remove secrets, tokens, personal data, and private URLs from every field and attachment.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the actual behavior and what you expected instead.
+      placeholder: Pentect did ...; I expected ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: Provide the smallest safe sequence of commands or actions that reproduces the problem.
+      placeholder: |
+        1. Run `pentect ...`
+        2. ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Pentect version
+      placeholder: Output of `pentect --version`
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Operating system, architecture, terminal, and affected integration when relevant.
+      placeholder: Windows 11 x86_64, PowerShell 7, Claude Code
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Sanitized diagnostics
+      description: Add minimal logs or screenshots after confirming they contain no sensitive data.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched for an existing issue.
+          required: true
+        - label: I removed secrets, personal data, and private infrastructure details.
+          required: true
+        - label: This is not a security vulnerability.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/EdamAme-x/pentect/security/advisories/new
+    about: Report vulnerabilities privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Propose a focused improvement to Pentect.
+title: "[Feature]: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem should this solve?
+      description: Explain the user need before describing an implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the smallest useful outcome and, if relevant, an example CLI or config shape.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Note existing workarounds or other designs you considered.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched for an existing issue or discussion.
+          required: true
+        - label: This request does not include secrets or private data.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What
+
+<!-- Briefly describe the user-visible change. -->
+
+## Why
+
+<!-- Link the issue or explain the problem being solved. -->
+
+## Validation
+
+<!-- List focused checks you ran. CI handles the full suite. -->
+
+- [ ] Relevant focused checks pass
+- [ ] User-facing behavior or configuration is documented where needed
+- [ ] No secrets, personal data, generated credentials, or private URLs are included
+- [ ] Security and compatibility impact has been considered
+
+<!-- Call out breaking changes, known limitations, or follow-up work below. Remove this comment if none. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to Pentect
+
+Thanks for contributing. Keep changes focused, explain the user problem, and avoid committing secrets or private data.
+
+## Before opening a change
+
+- Use a bug report for reproducible incorrect behavior and a feature request for new behavior.
+- Report vulnerabilities privately through [GitHub Security Advisories](https://github.com/EdamAme-x/pentect/security/advisories/new).
+- For larger design changes, open an issue before investing in an implementation.
+
+## Pull requests
+
+1. Create a branch from `main`.
+2. Make one focused change and include relevant tests or documentation.
+3. Run the smallest useful local checks; the full suite runs in CI.
+4. Open a pull request and describe what changed, why, and how it was validated.
+
+Useful checks:
+
+```sh
+cargo fmt --all --check
+cargo check --locked -p pentect-cli
+```
+
+Run focused tests for the crate or behavior you changed. Please do not add unrelated cleanup to the same pull request.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security policy
+
+Do not report suspected vulnerabilities in public issues, discussions, logs, or pull requests.
+
+Use [GitHub Security Advisories](https://github.com/EdamAme-x/pentect/security/advisories/new) and include the affected version, impact, and minimal reproduction details. Remove real credentials, personal data, and private infrastructure information before submitting.
+
+Security reports will be reviewed before public disclosure. Public support questions and ordinary bugs should use the issue templates.

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.8"
+version = "0.0.9"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -48,6 +48,7 @@ enum AnthropicEndpoint {
     Messages,
     Files,
     Models,
+    Health,
     Unknown,
 }
 
@@ -119,6 +120,7 @@ struct ProxyState {
     plugins: Arc<StdMutex<pentect_agent::PluginMiddleware>>,
     files: StdMutex<HashMap<String, crate::http_files::Coverage>>,
     requests: Arc<Semaphore>,
+    block_unknown_formats: bool,
 }
 
 impl Drop for ProxyState {
@@ -152,6 +154,7 @@ async fn run_proxy(
         plugins: Arc::new(StdMutex::new(plugins)),
         files: StdMutex::new(HashMap::new()),
         requests: Arc::new(Semaphore::new(32)),
+        block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
     });
     // Keep authentication in the base URL path. Claude settings can replace
     // ANTHROPIC_CUSTOM_HEADERS after process start, so a header token is not
@@ -172,7 +175,9 @@ async fn run_proxy(
                     let mut builder = http1::Builder::new();
                     builder.max_buf_size(64 * 1024).max_headers(128);
                     if let Err(error) = builder.serve_connection(io, service).await {
-                        eprintln!("[pentect] Claude HTTP proxy connection failed: {error}");
+                        if !error.is_incomplete_message() {
+                            eprintln!("[pentect] Claude HTTP proxy connection failed: {error}");
+                        }
                     }
                 });
             }
@@ -219,7 +224,8 @@ async fn proxy_request(
                 || error.starts_with("remote ")
                 || error.starts_with("file upload blocked:")
                 || error.starts_with("Files API upload ")
-                || error.starts_with("plugin blocked:");
+                || error.starts_with("plugin blocked:")
+                || error.starts_with("unknown format blocked:");
             Ok(if local_rejection {
                 owned_text_response(StatusCode::UNPROCESSABLE_ENTITY, &error)
             } else {
@@ -312,8 +318,15 @@ async fn proxy_request_inner(
                 .lock()
                 .map_err(|_| "Claude file registry lock was poisoned".to_string())?
                 .clone();
+            let block_unknown_formats = state.block_unknown_formats;
             let protected = tokio::task::spawn_blocking(move || {
-                protect_anthropic_request_body(&body, &masker, &plugins, &files)
+                protect_anthropic_request_body(
+                    &body,
+                    &masker,
+                    &plugins,
+                    &files,
+                    block_unknown_formats,
+                )
             })
             .await
             .map_err(|_| "Claude request protection task failed".to_string())??;
@@ -580,10 +593,16 @@ fn protect_anthropic_request_body(
     masker: &StdMutex<pentect_agent::ActiveToolOutputMasker>,
     plugins: &StdMutex<pentect_agent::PluginMiddleware>,
     files: &HashMap<String, crate::http_files::Coverage>,
+    block_unknown_formats: bool,
 ) -> Result<ProtectedJsonBody, String> {
     let mut value: Value = match serde_json::from_slice(body) {
         Ok(value) => value,
         Err(error) => {
+            if block_unknown_formats {
+                return Err(format!(
+                    "unknown format blocked: Anthropic request is not valid JSON ({error}); set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
+                ));
+            }
             eprintln!("[pentect] Claude request protection skipped: invalid JSON: {error}");
             return Ok(ProtectedJsonBody {
                 body: body.clone(),
@@ -617,11 +636,19 @@ fn protect_anthropic_request_body(
             })
             .map_err(|error| format!("could not encode plugin response: {error}"));
     }
-    let partial_schema = anthropic_request_has_unknown_content(&value);
+    let unknown_content_kind = anthropic_request_unknown_content_kind(&value);
+    let partial_schema = unknown_content_kind.is_some();
+    if block_unknown_formats && (partial_schema || plugin_partial) {
+        let detail = unknown_content_kind
+            .map(|kind| format!("unsupported content type `{kind}`"))
+            .unwrap_or_else(|| "plugin reported partial coverage".to_string());
+        return Err(format!(
+            "unknown format blocked: Anthropic request contains {detail}; set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
+        ));
+    }
     warn_provider_mcp_credentials(&value);
-    inject_handle_contract(&mut value);
     // Image handling deliberately follows the existing image policy. With
-    // With the default image.unscanned="block", an uninspectable image is an
+    // the default image.unscanned="block", an uninspectable image is an
     // error; users can explicitly choose allow in configuration.
     redact_anthropic_base64_images(&mut value, files)?;
     let mut masker = masker
@@ -641,6 +668,7 @@ fn protect_anthropic_request_body(
             local_response: None,
         });
     }
+    inject_handle_contract_if_needed(&mut value);
     match serde_json::to_vec(&value) {
         Ok(protected) => Ok(ProtectedJsonBody {
             body: Bytes::from(protected),
@@ -662,7 +690,7 @@ fn protect_anthropic_request_body(
     }
 }
 
-fn anthropic_request_has_unknown_content(value: &Value) -> bool {
+fn anthropic_request_unknown_content_kind(value: &Value) -> Option<&str> {
     let mut roots = Vec::new();
     if let Some(system) = value.get("system") {
         roots.push(system);
@@ -670,16 +698,16 @@ fn anthropic_request_has_unknown_content(value: &Value) -> bool {
     if let Some(messages) = value.get("messages").and_then(Value::as_array) {
         roots.extend(messages.iter().filter_map(|message| message.get("content")));
     }
-    roots.into_iter().any(anthropic_content_has_unknown_block)
+    roots
+        .into_iter()
+        .find_map(anthropic_content_unknown_block_kind)
 }
 
-fn anthropic_content_has_unknown_block(value: &Value) -> bool {
-    let Some(blocks) = value.as_array() else {
-        return false;
-    };
-    blocks.iter().any(|block| {
+fn anthropic_content_unknown_block_kind(value: &Value) -> Option<&str> {
+    let blocks = value.as_array()?;
+    blocks.iter().find_map(|block| {
         let Some(kind) = block.get("type").and_then(Value::as_str) else {
-            return true;
+            return Some("<missing>");
         };
         let known = matches!(
             kind,
@@ -694,17 +722,24 @@ fn anthropic_content_has_unknown_block(value: &Value) -> bool {
                 | "server_tool_use"
                 | "mcp_tool_use"
                 | "mcp_tool_result"
+                | "tool_search_tool_result"
                 | "web_search_tool_result"
                 | "web_fetch_tool_result"
                 | "code_execution_tool_result"
                 | "bash_code_execution_tool_result"
                 | "text_editor_code_execution_tool_result"
+                | "connector_text"
+                | "fallback"
         );
-        !known
-            || (kind == "tool_result"
-                && block
-                    .get("content")
-                    .is_some_and(anthropic_content_has_unknown_block))
+        if !known {
+            return Some(kind);
+        }
+        if kind == "tool_result" {
+            return block
+                .get("content")
+                .and_then(anthropic_content_unknown_block_kind);
+        }
+        None
     })
 }
 
@@ -744,14 +779,14 @@ fn inject_handle_contract(value: &mut Value) {
                     && block.get("text").and_then(Value::as_str) == Some(HANDLE_CONTRACT)
             });
             if !already_present {
-                blocks.insert(0, contract);
+                blocks.push(contract);
             }
         }
         Some(Value::String(system)) => {
             let existing = std::mem::take(system);
             value["system"] = Value::Array(vec![
-                contract,
                 serde_json::json!({"type": "text", "text": existing}),
+                contract,
             ]);
         }
         Some(Value::Null) | None => {
@@ -761,6 +796,37 @@ fn inject_handle_contract(value: &mut Value) {
         // an otherwise valid request unusable.
         Some(_) => {}
     }
+}
+
+fn inject_handle_contract_if_needed(value: &mut Value) {
+    if value_contains_handle(value) {
+        inject_handle_contract(value);
+    }
+}
+
+pub(crate) fn value_contains_handle(value: &Value) -> bool {
+    match value {
+        Value::String(text) => text_contains_handle(text),
+        Value::Array(values) => values.iter().any(value_contains_handle),
+        Value::Object(object) => object.values().any(value_contains_handle),
+        _ => false,
+    }
+}
+
+fn text_contains_handle(text: &str) -> bool {
+    let mut offset = 0usize;
+    while let Some(start_rel) = text[offset..].find("<<") {
+        let start = offset + start_rel;
+        let Some(end_rel) = text[start + 2..].find(">>") else {
+            return false;
+        };
+        let end = start + 2 + end_rel + 2;
+        if pentect_core::parse_placeholder(&text[start..end]).is_ok() {
+            return true;
+        }
+        offset = end;
+    }
+    false
 }
 
 type UpstreamByteStream =
@@ -1086,19 +1152,11 @@ fn mask_anthropic_request(
     masker: &mut pentect_agent::ActiveToolOutputMasker,
     files: &HashMap<String, crate::http_files::Coverage>,
 ) -> Result<(), String> {
-    if let Some(system) = value.get_mut("system") {
-        mask_content(system, false, masker, files)?;
-    }
     if let Some(messages) = value.get_mut("messages").and_then(Value::as_array_mut) {
         for message in messages {
             if let Some(content) = message.get_mut("content") {
                 mask_content(content, false, masker, files)?;
             }
-        }
-    }
-    if let Some(tools) = value.get_mut("tools").and_then(Value::as_array_mut) {
-        for tool in tools {
-            mask_tool_definition(tool, masker)?;
         }
     }
     Ok(())
@@ -1209,54 +1267,6 @@ pub(crate) fn redact_inline_image_data(encoded: &str) -> Result<Option<String>, 
     Ok(Some(protected))
 }
 
-fn mask_tool_definition(
-    tool: &mut Value,
-    masker: &mut pentect_agent::ActiveToolOutputMasker,
-) -> Result<(), String> {
-    let Some(tool) = tool.as_object_mut() else {
-        return Ok(());
-    };
-    if let Some(description) = tool.get("description").and_then(Value::as_str) {
-        let mut protected = description.to_string();
-        mask_string(&mut protected, false, masker)?;
-        tool.insert("description".to_string(), Value::String(protected));
-    }
-    if let Some(examples) = tool.get_mut("input_examples") {
-        mask_value_strings(examples, masker)?;
-    }
-    if let Some(schema) = tool.get_mut("input_schema") {
-        mask_json_schema_annotations(schema, masker)?;
-    }
-    Ok(())
-}
-
-fn mask_json_schema_annotations(
-    schema: &mut Value,
-    masker: &mut pentect_agent::ActiveToolOutputMasker,
-) -> Result<(), String> {
-    match schema {
-        Value::Array(values) => {
-            for value in values {
-                mask_json_schema_annotations(value, masker)?;
-            }
-        }
-        Value::Object(object) => {
-            for (key, value) in object {
-                if matches!(
-                    key.as_str(),
-                    "description" | "title" | "default" | "const" | "examples" | "enum"
-                ) {
-                    mask_value_strings(value, masker)?;
-                } else {
-                    mask_json_schema_annotations(value, masker)?;
-                }
-            }
-        }
-        _ => {}
-    }
-    Ok(())
-}
-
 fn mask_content(
     value: &mut Value,
     tool_result: bool,
@@ -1312,11 +1322,14 @@ fn mask_content(
                     | "server_tool_use"
                     | "mcp_tool_use"
                     | "mcp_tool_result"
+                    | "tool_search_tool_result"
                     | "web_search_tool_result"
                     | "web_fetch_tool_result"
                     | "code_execution_tool_result"
                     | "bash_code_execution_tool_result"
-                    | "text_editor_code_execution_tool_result" => {}
+                    | "text_editor_code_execution_tool_result"
+                    | "connector_text"
+                    | "fallback" => {}
                     _ => {
                         if !WARNED_UNKNOWN_CONTENT_BLOCK.swap(true, Ordering::Relaxed) {
                             eprintln!(
@@ -1776,7 +1789,7 @@ fn is_free_form_shell_tool(name: Option<&str>) -> bool {
     })
 }
 
-fn resolve_shell_text_safely<R>(text: &str, resolve: &mut R) -> Result<String, String>
+pub(crate) fn resolve_shell_text_safely<R>(text: &str, resolve: &mut R) -> Result<String, String>
 where
     R: FnMut(&str) -> Result<String, String>,
 {
@@ -1930,6 +1943,8 @@ fn classify_anthropic_endpoint(path_and_query: &str) -> AnthropicEndpoint {
         AnthropicEndpoint::Files
     } else if path.ends_with("/v1/models") || path.contains("/v1/models/") {
         AnthropicEndpoint::Models
+    } else if path == "/api/hello" {
+        AnthropicEndpoint::Health
     } else {
         AnthropicEndpoint::Unknown
     }
@@ -2041,6 +2056,281 @@ fn random_auth_token() -> Result<String, String> {
 mod tests {
     use super::*;
 
+    struct TestEnv {
+        saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+        home: std::path::PathBuf,
+        process_host_candidate: Option<std::path::PathBuf>,
+    }
+
+    impl TestEnv {
+        fn install(store: &pentect_agent::InProcessMemoryStore) -> Self {
+            let names = [
+                "PENTECT_MEMORY_STORE_ADDR",
+                "PENTECT_MEMORY_STORE_TOKEN",
+                "PENTECT_AGENT_LAUNCHED",
+                "PENTECT_HOME",
+                "LOCALAPPDATA",
+            ];
+            let saved = names
+                .into_iter()
+                .map(|name| (name, std::env::var_os(name)))
+                .collect();
+            let nonce = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let home = std::env::temp_dir().join(format!(
+                "pentect-cli-http-e2e-{}-{nonce}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&home).unwrap();
+            std::env::set_var("PENTECT_MEMORY_STORE_ADDR", store.addr());
+            std::env::set_var("PENTECT_MEMORY_STORE_TOKEN", store.token());
+            std::env::set_var("PENTECT_AGENT_LAUNCHED", store.token());
+            std::env::set_var("PENTECT_HOME", &home);
+            std::env::set_var("LOCALAPPDATA", &home);
+            let process_host_candidate = Some(
+                pentect_agent::register_process_host_candidate(
+                    &pentect_agent::process_host_root().unwrap(),
+                    store.addr(),
+                    store.token(),
+                    store.process_host_read_token(),
+                    store.process_host_write_token(),
+                    std::process::id(),
+                )
+                .unwrap(),
+            );
+            Self {
+                saved,
+                home,
+                process_host_candidate,
+            }
+        }
+    }
+
+    impl Drop for TestEnv {
+        fn drop(&mut self) {
+            if let Some(path) = self.process_host_candidate.take() {
+                pentect_agent::unregister_process_host_candidate(&path);
+            }
+            for (name, value) in self.saved.drain(..) {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+            let _ = std::fs::remove_dir_all(&self.home);
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum MockProvider {
+        Anthropic,
+        OpenAi,
+    }
+
+    fn first_valid_handle(text: &str) -> Option<&str> {
+        let mut offset = 0usize;
+        while let Some(start_rel) = text[offset..].find("<<") {
+            let start = offset + start_rel;
+            let end = start + 2 + text[start + 2..].find(">>")? + 2;
+            let candidate = &text[start..end];
+            if pentect_core::parse_placeholder(candidate).is_ok() {
+                return Some(candidate);
+            }
+            offset = end;
+        }
+        None
+    }
+
+    fn mock_upstream(
+        provider: MockProvider,
+    ) -> (
+        String,
+        std::sync::mpsc::Receiver<String>,
+        std::thread::JoinHandle<()>,
+    ) {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let (body_tx, body_rx) = std::sync::mpsc::channel();
+        let thread = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(10)))
+                .unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 8192];
+            let header_end = loop {
+                let read = stream.read(&mut buffer).unwrap();
+                assert!(read > 0, "client closed before sending HTTP headers");
+                request.extend_from_slice(&buffer[..read]);
+                if let Some(at) = request.windows(4).position(|part| part == b"\r\n\r\n") {
+                    break at + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .expect("proxy request must carry Content-Length");
+            while request.len() - header_end < content_length {
+                let read = stream.read(&mut buffer).unwrap();
+                assert!(read > 0, "client closed before sending HTTP body");
+                request.extend_from_slice(&buffer[..read]);
+            }
+            let body = String::from_utf8(request[header_end..header_end + content_length].to_vec())
+                .unwrap();
+            let handle = first_valid_handle(&body)
+                .expect("provider should receive a valid Pentect handle")
+                .to_string();
+            body_tx.send(body).unwrap();
+
+            let (response, content_type) = match provider {
+                MockProvider::Anthropic => (
+                    serde_json::to_vec(&serde_json::json!({
+                        "id": "msg_test",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{
+                            "type": "tool_use",
+                            "id": "tool_test",
+                            "name": "SafeTool",
+                            "input": {"token": handle}
+                        }],
+                        "model": "test",
+                        "stop_reason": "tool_use",
+                        "usage": {"input_tokens": 1, "output_tokens": 1}
+                    }))
+                    .unwrap(),
+                    Some("application/json"),
+                ),
+                MockProvider::OpenAi => {
+                    let event = serde_json::json!({
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "custom_tool_call",
+                            "name": "exec_command",
+                            "input": format!("python hash.py {handle}")
+                        }
+                    });
+                    (
+                        format!("event: response.output_item.done\ndata: {event}\n\n").into_bytes(),
+                        None,
+                    )
+                }
+            };
+            write!(stream, "HTTP/1.1 200 OK\r\n").unwrap();
+            if let Some(content_type) = content_type {
+                write!(stream, "Content-Type: {content_type}\r\n").unwrap();
+            }
+            write!(
+                stream,
+                "Content-Length: {}\r\nConnection: close\r\n\r\n",
+                response.len()
+            )
+            .unwrap();
+            stream.write_all(&response).unwrap();
+            stream.flush().unwrap();
+        });
+        (format!("http://{address}"), body_rx, thread)
+    }
+
+    #[test]
+    fn provider_boundary_masks_plaintext_and_restores_only_tool_arguments() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        // Build the synthetic credential at runtime so repository scanners do
+        // not mistake test data for a committed live credential.
+        let secret = [
+            "rpa_",
+            "ZYXWVUTS",
+            "RQPONMLK",
+            "JIHGFEDC",
+            "BA098765",
+            "4321fedcba",
+        ]
+        .concat();
+        let dotenv = format!("RUNPOD_API_KEY={secret}\n");
+        let mut probe = pentect_agent::ActiveToolOutputMasker::new().unwrap();
+        let protected = probe.mask_prompt_text(&dotenv).unwrap().unwrap();
+        assert!(
+            !protected.contains(secret.as_str()),
+            "dotenv probe was not masked"
+        );
+        assert!(first_valid_handle(&protected).is_some());
+
+        let (anthropic_upstream, anthropic_request, anthropic_thread) =
+            mock_upstream(MockProvider::Anthropic);
+        let anthropic_proxy = ClaudeHttpProxyGuard::start(anthropic_upstream).unwrap();
+        let anthropic_response: Value = reqwest::blocking::Client::new()
+            .post(format!("{}/v1/messages", anthropic_proxy.base_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(
+                serde_json::to_vec(&serde_json::json!({
+                "model": "test",
+                "max_tokens": 32,
+                "messages": [{
+                    "role": "user",
+                    "content": format!("Use this dotenv value:\nRUNPOD_API_KEY={secret}\n")
+                }]
+                }))
+                .unwrap(),
+            )
+            .send()
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .bytes()
+            .map(|body| serde_json::from_slice(&body).unwrap())
+            .unwrap();
+        let provider_body = anthropic_request
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .unwrap();
+        assert!(!provider_body.contains(secret.as_str()));
+        assert!(first_valid_handle(&provider_body).is_some());
+        assert_eq!(anthropic_response["content"][0]["input"]["token"], secret);
+        drop(anthropic_proxy);
+        anthropic_thread.join().unwrap();
+
+        let (openai_upstream, openai_request, openai_thread) = mock_upstream(MockProvider::OpenAi);
+        let openai_proxy =
+            crate::openai_http_proxy::OpenAiHttpProxyGuard::start(openai_upstream).unwrap();
+        let openai_response = reqwest::blocking::Client::new()
+            .post(format!("{}/v1/responses", openai_proxy.base_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(
+                serde_json::to_vec(&serde_json::json!({
+                "model": "test",
+                "stream": true,
+                "input": format!("Use this dotenv value:\nRUNPOD_API_KEY={secret}\n")
+                }))
+                .unwrap(),
+            )
+            .send()
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .text()
+            .unwrap();
+        let provider_body = openai_request
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .unwrap();
+        assert!(!provider_body.contains(secret.as_str()));
+        assert!(first_valid_handle(&provider_body).is_some());
+        assert!(openai_response.contains(&format!("python hash.py {secret}")));
+        assert!(!openai_response.contains("<<PENTECT_E2E_TOKEN_"));
+        drop(openai_proxy);
+        openai_thread.join().unwrap();
+    }
+
     #[test]
     fn sse_parser_preserves_normal_text() {
         let input = concat!(
@@ -2065,6 +2355,10 @@ mod tests {
         assert_eq!(
             classify_anthropic_endpoint("/v1/models/model_123"),
             AnthropicEndpoint::Models
+        );
+        assert_eq!(
+            classify_anthropic_endpoint("/api/hello"),
+            AnthropicEndpoint::Health
         );
         assert_eq!(
             classify_anthropic_endpoint("/v1/messages/batches"),
@@ -2097,14 +2391,89 @@ mod tests {
     fn handle_contract_is_stable_preserves_system_and_is_not_duplicated() {
         let mut request = serde_json::json!({"system": "existing", "messages": []});
         inject_handle_contract(&mut request);
-        assert_eq!(request["system"][0]["text"], HANDLE_CONTRACT);
-        assert_eq!(request["system"][1]["text"], "existing");
+        assert_eq!(request["system"][0]["text"], "existing");
+        assert_eq!(request["system"][1]["text"], HANDLE_CONTRACT);
         inject_handle_contract(&mut request);
         assert_eq!(request["system"].as_array().unwrap().len(), 2);
 
         let mut empty = serde_json::json!({"messages": []});
         inject_handle_contract(&mut empty);
         assert_eq!(empty["system"][0]["text"], HANDLE_CONTRACT);
+    }
+
+    #[test]
+    fn handle_contract_is_added_only_when_a_handle_exists() {
+        let mut clean = serde_json::json!({
+            "system": "existing",
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        inject_handle_contract_if_needed(&mut clean);
+        assert_eq!(clean["system"], "existing");
+
+        let mut protected = serde_json::json!({
+            "system": "existing",
+            "messages": [{
+                "role": "user",
+                "content": "use <<SECRET_0123456789abcdef>>"
+            }]
+        });
+        inject_handle_contract_if_needed(&mut protected);
+        assert_eq!(protected["system"][0]["text"], "existing");
+        assert_eq!(protected["system"][1]["text"], HANDLE_CONTRACT);
+    }
+
+    #[test]
+    fn unknown_anthropic_content_blocks_by_default_and_can_be_allowed() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let body = Bytes::from_static(
+            br#"{"messages":[{"role":"user","content":[{"type":"future_block","data":"opaque"}]}]}"#,
+        );
+        let masker = StdMutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = StdMutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
+        let files = HashMap::new();
+        let error = match protect_anthropic_request_body(&body, &masker, &plugins, &files, true) {
+            Ok(_) => panic!("unknown Anthropic block should be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.starts_with("unknown format blocked:"), "{error}");
+        assert!(error.contains("future_block"), "{error}");
+
+        let allowed =
+            protect_anthropic_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
+        assert_eq!(
+            serde_json::from_slice::<Value>(&allowed.body).unwrap(),
+            serde_json::from_slice::<Value>(&body).unwrap()
+        );
+    }
+
+    #[test]
+    fn current_anthropic_response_blocks_are_known() {
+        let value = serde_json::json!({
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_search_tool_result", "tool_use_id": "srvtoolu_1", "content": {}},
+                    {"type": "connector_text", "text": "working"},
+                    {"type": "fallback", "from": {"model": "a"}, "to": {"model": "b"}}
+                ]
+            }]
+        });
+        assert_eq!(anthropic_request_unknown_content_kind(&value), None);
+    }
+
+    #[test]
+    fn malformed_anthropic_json_obeys_unknown_format_policy() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let body = Bytes::from_static(b"{not-json");
+        let masker = StdMutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = StdMutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
+        let files = HashMap::new();
+        assert!(protect_anthropic_request_body(&body, &masker, &plugins, &files, true).is_err());
+        let allowed =
+            protect_anthropic_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
+        assert_eq!(allowed.body, body);
     }
 
     #[test]

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -1,8 +1,9 @@
-//! Experimental launcher for the unmodified Codex desktop application.
+//! Launcher for the unmodified Codex desktop application.
 //!
-//! The app and its bundled Codex process inherit a loopback-only Responses API
-//! gateway through `OPENAI_BASE_URL`. Pentect never changes the user's Codex
-//! configuration or kills an existing app process.
+//! The app and its bundled Codex process use a loopback-only Responses API
+//! gateway. Pentect temporarily overrides the selected provider in the user's
+//! Codex configuration, restores the exact original when the App exits, and
+//! refuses to launch while another Codex App process is running.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -40,10 +41,10 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
 
     let routing = crate::codex_app_routing(options.upstream)?;
     let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start(routing.upstream)?;
-    let config_override = routing
-        .requires_config_override
-        .then(|| CodexConfigOverride::install(&routing.provider, proxy.base_url()))
-        .transpose()?;
+    let config_override = Some(CodexConfigOverride::install(
+        &routing.provider,
+        proxy.base_url(),
+    )?);
     eprintln!("[pentect] Codex App gateway ready at {}", proxy.base_url());
     if config_override.is_some() {
         eprintln!(
@@ -164,7 +165,7 @@ impl CodexConfigOverride {
                 .parse::<toml_edit::DocumentMut>()
                 .map_err(|error| format!("could not parse '{}': {error}", config.display()))?
         };
-        set_provider_base_url(&mut parsed, provider, gateway)?;
+        set_provider_gateway(&mut parsed, provider, gateway)?;
 
         std::fs::write(&backup, original.as_bytes())
             .map_err(|error| format!("could not back up '{}': {error}", config.display()))?;
@@ -234,13 +235,28 @@ impl Drop for CodexConfigOverride {
     }
 }
 
-fn set_provider_base_url(
+fn set_provider_gateway(
     config: &mut toml_edit::DocumentMut,
     provider: &str,
     gateway: &str,
 ) -> Result<(), String> {
     if provider == "openai" {
-        config["openai_base_url"] = toml_edit::value(gateway);
+        config["model_provider"] = toml_edit::value(crate::CODEX_GATEWAY_PROVIDER);
+        let providers = config
+            .entry("model_providers")
+            .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()))
+            .as_table_mut()
+            .ok_or_else(|| "model_providers is not a TOML table".to_string())?;
+        let mut gateway_provider = toml_edit::Table::new();
+        gateway_provider.insert("name", toml_edit::value("OpenAI through Pentect"));
+        gateway_provider.insert("base_url", toml_edit::value(gateway));
+        gateway_provider.insert("wire_api", toml_edit::value("responses"));
+        gateway_provider.insert("requires_openai_auth", toml_edit::value(true));
+        gateway_provider.insert("supports_websockets", toml_edit::value(false));
+        providers.insert(
+            crate::CODEX_GATEWAY_PROVIDER,
+            toml_edit::Item::Table(gateway_provider),
+        );
         return Ok(());
     }
     let providers = config
@@ -254,6 +270,7 @@ fn set_provider_base_url(
         .as_table_mut()
         .ok_or_else(|| "selected model provider is not a TOML table".to_string())?;
     provider.insert("base_url", toml_edit::value(gateway));
+    provider.insert("supports_websockets", toml_edit::value(false));
     Ok(())
 }
 
@@ -509,7 +526,7 @@ base_url = "https://other.example/v1"
 "#
         .parse()
         .unwrap();
-        set_provider_base_url(&mut config, "proxy", "http://127.0.0.1:47781").unwrap();
+        set_provider_gateway(&mut config, "proxy", "http://127.0.0.1:47781").unwrap();
         assert_eq!(
             config["model_providers"]["proxy"]["base_url"].as_str(),
             Some("http://127.0.0.1:47781")
@@ -517,6 +534,10 @@ base_url = "https://other.example/v1"
         assert_eq!(
             config["model_providers"]["other"]["base_url"].as_str(),
             Some("https://other.example/v1")
+        );
+        assert_eq!(
+            config["model_providers"]["proxy"]["supports_websockets"].as_bool(),
+            Some(false)
         );
     }
 
@@ -526,14 +547,23 @@ base_url = "https://other.example/v1"
             "# keep this comment\n[model_providers.proxy]\nbase_url = \"https://old.example/v1\"\n"
                 .parse::<toml_edit::DocumentMut>()
                 .unwrap();
-        set_provider_base_url(&mut config, "openai", "http://127.0.0.1:47781").unwrap();
+        set_provider_gateway(&mut config, "openai", "http://127.0.0.1:47781").unwrap();
         let encoded = config.to_string();
 
         assert!(encoded.contains("# keep this comment"), "{encoded}");
         let parsed = encoded.parse::<toml::Value>().unwrap();
         assert_eq!(
-            parsed["openai_base_url"].as_str(),
+            parsed["model_provider"].as_str(),
+            Some(crate::CODEX_GATEWAY_PROVIDER)
+        );
+        assert_eq!(
+            parsed["model_providers"][crate::CODEX_GATEWAY_PROVIDER]["base_url"].as_str(),
             Some("http://127.0.0.1:47781")
+        );
+        assert_eq!(
+            parsed["model_providers"][crate::CODEX_GATEWAY_PROVIDER]["supports_websockets"]
+                .as_bool(),
+            Some(false)
         );
     }
 

--- a/crates/pentect-cli/src/http_files.rs
+++ b/crates/pentect-cli/src/http_files.rs
@@ -406,6 +406,7 @@ mod tests {
 
     #[test]
     fn multipart_parser_blocks_an_unavailable_masker_upload() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let body = Bytes::from_static(
             b"--boundary\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nuser_data\r\n--boundary\r\nContent-Disposition: form-data; name=\"file\"; filename=\"notes.txt\"\r\nContent-Type: text/plain\r\n\r\nhello\r\n--boundary--\r\n",
         );

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -30,6 +30,9 @@ use zeroize::Zeroize;
 
 pub(crate) type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 
+#[cfg(test)]
+pub(crate) static TEST_PROCESS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Refuse oversized input rather than emit partially-masked output (a masked
 /// head plus a raw tail would leak the tail).
 const MAX_INPUT_BYTES: usize = 32 * 1024 * 1024;
@@ -150,6 +153,8 @@ fn usage() {
          pentect uninstall\n\
          pentect plugins add|remove|list|search|inspect|test|config|setup|update [NAME]\n\
          pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--no-gitignore] [PATH...]\n\
+         pentect mask [TEXT]\n\
+         pentect read PATH\n\
          pentect view <HANDLE>\n\
          pentect resolve [PATH...]\n\
          pentect log [--json]\n\
@@ -189,8 +194,12 @@ fn help_text() -> &'static str {
         "  pentect plugins setup NAME|PATH [--yes]\n",
         "  pentect plugins update [NAME|PATH] [--yes]\n",
         "  pentect scan [--binary skip|text] [--exclude PATTERN|~GROUP|!PATTERN] [--no-gitignore] [PATH...]\n\n",
+        "  pentect mask [TEXT]\n",
+        "  pentect read PATH\n",
         "  pentect view '<HANDLE>'\n\n",
+        "  pentect resolve [PATH...]\n",
         "  pentect log [--json]\n\n",
+        "mask: mask text from arguments or stdin\n",
         "exec: masked stdout/stderr\n",
         "read: masked file preview\n",
         "view: handle\n",
@@ -805,17 +814,7 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
     let routing = codex_effective_routing(opts)?;
     let mut args = opts.tool_args.clone();
     if opts.dry_run {
-        args.splice(
-            0..0,
-            [
-                "--config".to_string(),
-                format!(
-                    "{}={}",
-                    routing.config_key,
-                    toml_string("<pentect-gateway>")
-                ),
-            ],
-        );
+        args.extend(routing.gateway_args("<pentect-gateway>"));
         print_dry_run(&opts.command, &args);
         return Ok(success_status());
     }
@@ -823,18 +822,11 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
     let active_plugins = agent_tool_plugins(opts)?;
     let memory_store = start_memory_store(pentect)?;
     let _parent_env = agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
-    let http_proxy = openai_http_proxy::OpenAiHttpProxyGuard::start(routing.upstream)?;
-    args.splice(
-        0..0,
-        [
-            "--config".to_string(),
-            format!(
-                "{}={}",
-                routing.config_key,
-                toml_string(http_proxy.base_url())
-            ),
-        ],
-    );
+    let http_proxy = openai_http_proxy::OpenAiHttpProxyGuard::start(routing.upstream.clone())?;
+    // These overrides are appended so a caller-supplied routing override
+    // cannot bypass the local gateway. Codex accepts global config flags after
+    // its subcommand and uses the last value for duplicate keys.
+    args.extend(routing.gateway_args(http_proxy.base_url()));
 
     let mut cmd = Command::new(&opts.command);
     clear_pentect_control_env(&mut cmd);
@@ -1845,7 +1837,46 @@ fn codex_home_dir() -> Result<PathBuf, String> {
 
 struct CodexHttpRouting {
     upstream: String,
-    config_key: String,
+    provider: String,
+}
+
+const CODEX_GATEWAY_PROVIDER: &str = "pentect-openai-gateway";
+
+impl CodexHttpRouting {
+    fn gateway_args(&self, gateway: &str) -> Vec<String> {
+        let entries = if self.provider == "openai" {
+            vec![
+                format!("model_provider={}", toml_string(CODEX_GATEWAY_PROVIDER)),
+                format!(
+                    "model_providers.{CODEX_GATEWAY_PROVIDER}.name={}",
+                    toml_string("OpenAI through Pentect")
+                ),
+                format!(
+                    "model_providers.{CODEX_GATEWAY_PROVIDER}.base_url={}",
+                    toml_string(gateway)
+                ),
+                format!(
+                    "model_providers.{CODEX_GATEWAY_PROVIDER}.wire_api={}",
+                    toml_string("responses")
+                ),
+                format!("model_providers.{CODEX_GATEWAY_PROVIDER}.requires_openai_auth=true"),
+                format!("model_providers.{CODEX_GATEWAY_PROVIDER}.supports_websockets=false"),
+            ]
+        } else {
+            let provider = codex_toml_key_segment(&self.provider);
+            vec![
+                format!(
+                    "model_providers.{provider}.base_url={}",
+                    toml_string(gateway)
+                ),
+                format!("model_providers.{provider}.supports_websockets=false"),
+            ]
+        };
+        entries
+            .into_iter()
+            .flat_map(|entry| ["--config".to_string(), entry])
+            .collect()
+    }
 }
 
 fn codex_effective_routing(opts: &AgentToolOpts) -> Result<CodexHttpRouting, String> {
@@ -1906,16 +1937,27 @@ fn codex_effective_routing(opts: &AgentToolOpts) -> Result<CodexHttpRouting, Str
                 "could not determine upstream for Codex provider '{provider}'; pass `pentect codex --upstream URL -- ...`"
             )
         })?;
-    Ok(CodexHttpRouting {
-        upstream,
-        config_key,
-    })
+    if provider != "openai" {
+        let wire_api = config
+            .get("model_providers")
+            .and_then(toml::Value::as_table)
+            .and_then(|providers| providers.get(&provider))
+            .and_then(toml::Value::as_table)
+            .and_then(|provider| provider.get("wire_api"))
+            .and_then(toml::Value::as_str)
+            .unwrap_or("responses");
+        if wire_api != "responses" {
+            return Err(format!(
+                "Codex provider '{provider}' uses unsupported wire_api '{wire_api}'; Pentect supports Responses-compatible providers"
+            ));
+        }
+    }
+    Ok(CodexHttpRouting { upstream, provider })
 }
 
 pub(crate) struct CodexAppRouting {
     upstream: String,
     provider: String,
-    requires_config_override: bool,
 }
 
 /// Resolve the App's selected provider without changing user configuration.
@@ -1954,7 +1996,6 @@ pub(crate) fn codex_app_routing(explicit: Option<String>) -> Result<CodexAppRout
             .and_then(toml::Value::as_str)
             .map(str::to_owned)
     };
-    let requires_config_override = provider != "openai" || configured_upstream.is_some();
     let upstream = explicit
         .or(configured_upstream)
         .or_else(|| (provider == "openai").then(|| nonempty_env("OPENAI_BASE_URL")).flatten())
@@ -1970,11 +2011,7 @@ pub(crate) fn codex_app_routing(explicit: Option<String>) -> Result<CodexAppRout
                 "could not determine upstream for Codex App provider '{provider}'; pass --upstream URL"
             )
         })?;
-    Ok(CodexAppRouting {
-        upstream,
-        provider,
-        requires_config_override,
-    })
+    Ok(CodexAppRouting { upstream, provider })
 }
 
 fn load_codex_user_config(args: &[String]) -> Result<toml::Value, String> {
@@ -2376,11 +2413,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn help_lists_only_active_agent_integrations() {
+    fn help_lists_public_commands_and_only_active_agent_integrations() {
         let help = help_text();
         assert!(help.contains("pentect codex|claude"));
         assert!(help.contains("pentect codex app"));
         assert!(help.contains("pentect claude app"));
+        assert!(help.contains("pentect mask [TEXT]"));
+        assert!(help.contains("pentect read PATH"));
+        assert!(help.contains("pentect resolve [PATH...]"));
         assert!(!help.contains("opencode"));
         assert!(!help.contains("pentect shell"));
         assert!(!help.contains("\n  pentect up\n"));

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -101,6 +101,7 @@ struct ProxyState {
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
     files: Mutex<HashMap<String, crate::http_files::Coverage>>,
     requests: Arc<Semaphore>,
+    block_unknown_formats: bool,
 }
 
 impl Drop for ProxyState {
@@ -133,6 +134,7 @@ async fn run_proxy(
         plugins: Arc::new(Mutex::new(plugins)),
         files: Mutex::new(HashMap::new()),
         requests: Arc::new(Semaphore::new(32)),
+        block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
     });
     let _ = ready_tx.send(Ok(local_base_url));
 
@@ -154,7 +156,9 @@ async fn run_proxy(
                         .serve_connection(io, service)
                         .await
                     {
-                        eprintln!("[pentect] OpenAI HTTP gateway connection failed: {error}");
+                        if !error.is_incomplete_message() {
+                            eprintln!("[pentect] OpenAI HTTP gateway connection failed: {error}");
+                        }
                     }
                 });
             }
@@ -202,7 +206,8 @@ async fn proxy_request(
                 || error.starts_with("OpenAI file ")
                 || error.starts_with("file upload blocked:")
                 || error.starts_with("Files API upload ")
-                || error.starts_with("plugin blocked:");
+                || error.starts_with("plugin blocked:")
+                || error.starts_with("unknown format blocked:");
             Ok(if local_rejection {
                 owned_text_response(StatusCode::UNPROCESSABLE_ENTITY, &error)
             } else {
@@ -224,12 +229,13 @@ async fn proxy_request_inner(
     let Some(path_and_query) = authenticated_request_path(request_path, &state.auth) else {
         return Ok(text_response(StatusCode::FORBIDDEN, "Forbidden"));
     };
-    let responses_path = is_responses_path(path_and_query);
     let method = request.method().clone();
+    let responses_path = method == hyper::Method::POST && is_responses_path(path_and_query);
     let files_upload = method == hyper::Method::POST && is_files_collection_path(path_and_query);
     let upstream_url = join_upstream_url(&state.upstream, path_and_query)?;
     let headers = request.headers().clone();
     let mut request_coverage = None;
+    let mut request_streaming = false;
     let body = if responses_path || files_upload {
         let body = match Limited::new(request.into_body(), MAX_HTTP_BODY_BYTES)
             .collect()
@@ -273,6 +279,10 @@ async fn proxy_request_inner(
             request_coverage = Some(protected.coverage);
             reqwest::Body::from(protected.body)
         } else {
+            request_streaming = serde_json::from_slice::<Value>(&body)
+                .ok()
+                .and_then(|value| value.get("stream").and_then(Value::as_bool))
+                .unwrap_or(false);
             let original = resolve_openai_file_references(body, state, &headers).await?;
             let original = resolve_openai_remote_files(original).await?;
             let masker = Arc::clone(&state.masker);
@@ -282,8 +292,15 @@ async fn proxy_request_inner(
                 .lock()
                 .map_err(|_| "OpenAI file registry lock was poisoned".to_string())?
                 .clone();
+            let block_unknown_formats = state.block_unknown_formats;
             let protected = tokio::task::spawn_blocking(move || {
-                protect_openai_request_body(&original, &masker, &plugins, &files)
+                protect_openai_request_body(
+                    &original,
+                    &masker,
+                    &plugins,
+                    &files,
+                    block_unknown_formats,
+                )
             })
             .await
             .map_err(|_| "OpenAI request protection task failed".to_string())??;
@@ -324,11 +341,21 @@ async fn proxy_request_inner(
     {
         return Err("OpenAI upstream returned an unsupported content encoding".to_string());
     }
-    let is_event_stream = response_headers
+    let response_media_type = response_headers
         .get(hyper::header::CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.split(';').next())
-        .is_some_and(|value| value.trim().eq_ignore_ascii_case("text/event-stream"));
+        .map(str::trim);
+    // Some Responses-compatible upstreams omit Content-Type. The request's
+    // explicit stream flag is authoritative in that case.
+    let is_event_stream = response_media_type
+        .is_some_and(|value| value.eq_ignore_ascii_case("text/event-stream"))
+        || (responses_path && request_streaming && response_media_type.is_none());
+    let is_json_response =
+        response_media_type.is_some_and(|value| {
+            value.eq_ignore_ascii_case("application/json")
+                || value.to_ascii_lowercase().ends_with("+json")
+        }) || (responses_path && !request_streaming && response_media_type.is_none());
     let mut builder = Response::builder().status(status);
     let connection_headers = connection_named_headers(&response_headers);
     for (name, value) in &response_headers {
@@ -374,7 +401,7 @@ async fn proxy_request_inner(
             }
         }
     }
-    let response_body = if responses_path && status.is_success() {
+    let response_body = if responses_path && status.is_success() && is_json_response {
         let response_body = run_response_plugins(response_body, &state.plugins, "openai")?;
         match rewrite_openai_json_response(&response_body) {
             Ok(rewritten) => Bytes::from(rewritten),
@@ -439,7 +466,10 @@ fn run_openai_tool_plugins(
                 .is_some_and(|kind| {
                     matches!(
                         kind,
-                        "function_call" | "response.function_call_arguments.done"
+                        "function_call"
+                            | "custom_tool_call"
+                            | "response.function_call_arguments.done"
+                            | "response.custom_tool_call_input.done"
                     )
                 })
                 && ["arguments", "input"]
@@ -484,10 +514,16 @@ fn protect_openai_request_body(
     masker: &Mutex<pentect_agent::ActiveToolOutputMasker>,
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
     files: &HashMap<String, crate::http_files::Coverage>,
+    block_unknown_formats: bool,
 ) -> Result<ProtectedJsonBody, String> {
     let mut value: Value = match serde_json::from_slice(body) {
         Ok(value) => value,
         Err(error) => {
+            if block_unknown_formats {
+                return Err(format!(
+                    "unknown format blocked: OpenAI request is not valid JSON ({error}); set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
+                ));
+            }
             eprintln!("[pentect] OpenAI request protection skipped: invalid JSON: {error}");
             return Ok(ProtectedJsonBody {
                 body: body.clone(),
@@ -521,8 +557,16 @@ fn protect_openai_request_body(
             })
             .map_err(|error| format!("could not encode plugin response: {error}"));
     }
-    let partial_schema = openai_request_has_unknown_content(&value);
-    inject_handle_contract(&mut value);
+    let unknown_content_kind = openai_request_unknown_content_kind(&value);
+    let partial_schema = unknown_content_kind.is_some();
+    if block_unknown_formats && (partial_schema || plugin_partial) {
+        let detail = unknown_content_kind
+            .map(|kind| format!("unsupported content type `{kind}`"))
+            .unwrap_or_else(|| "plugin reported partial coverage".to_string());
+        return Err(format!(
+            "unknown format blocked: OpenAI request contains {detail}; set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
+        ));
+    }
     let mut masker = masker
         .lock()
         .map_err(|_| "OpenAI request masker lock was poisoned".to_string())?;
@@ -536,6 +580,9 @@ fn protect_openai_request_body(
             coverage: crate::http_files::Coverage::Partial,
             local_response: None,
         });
+    }
+    if crate::claude_http_proxy::value_contains_handle(&value) {
+        inject_handle_contract(&mut value);
     }
     serde_json::to_vec(&value)
         .map(|body| ProtectedJsonBody {
@@ -768,46 +815,61 @@ fn resolve_openai_remote_file_values(
     })
 }
 
-fn openai_request_has_unknown_content(value: &Value) -> bool {
-    fn visit(value: &Value) -> bool {
+fn openai_request_unknown_content_kind(value: &Value) -> Option<&str> {
+    fn visit(value: &Value) -> Option<&str> {
         match value {
-            Value::Array(items) => items.iter().any(visit),
+            Value::Array(items) => items.iter().find_map(visit),
             Value::Object(object) => {
                 if let Some(kind) = object.get("type").and_then(Value::as_str) {
                     if !matches!(
                         kind,
                         "message"
+                            | "additional_tools"
+                            | "agent_message"
                             | "input_text"
                             | "output_text"
                             | "input_image"
                             | "input_file"
+                            | "encrypted_content"
+                            | "summary_text"
+                            | "reasoning_text"
+                            | "text"
+                            | "local_shell_call"
                             | "function_call"
                             | "function_call_output"
                             | "custom_tool_call"
                             | "custom_tool_call_output"
+                            | "tool_search_call"
+                            | "tool_search_output"
+                            | "web_search_call"
+                            | "image_generation_call"
                             | "computer_call"
                             | "computer_call_output"
                             | "reasoning"
+                            | "compaction"
+                            | "compaction_summary"
+                            | "compaction_trigger"
+                            | "context_compaction"
                     ) {
-                        return true;
+                        return Some(kind);
                     }
                 }
                 ["content", "input", "output"]
                     .into_iter()
                     .filter_map(|key| object.get(key))
-                    .any(visit)
+                    .find_map(visit)
             }
-            _ => false,
+            _ => None,
         }
     }
-    value.get("input").is_some_and(visit)
+    value.get("input").and_then(visit)
 }
 
 fn inject_handle_contract(value: &mut Value) {
     match value.get_mut("instructions") {
         Some(Value::String(instructions)) if !instructions.contains(HANDLE_CONTRACT) => {
             let existing = std::mem::take(instructions);
-            *instructions = format!("{HANDLE_CONTRACT}\n\n{existing}");
+            *instructions = format!("{existing}\n\n{HANDLE_CONTRACT}");
         }
         Some(Value::Null) | None => {
             value["instructions"] = Value::String(HANDLE_CONTRACT.to_string());
@@ -821,16 +883,8 @@ fn mask_openai_request(
     masker: &mut pentect_agent::ActiveToolOutputMasker,
     files: &HashMap<String, crate::http_files::Coverage>,
 ) -> Result<(), String> {
-    if let Some(Value::String(instructions)) = value.get_mut("instructions") {
-        mask_text(instructions, false, masker)?;
-    }
     if let Some(input) = value.get_mut("input") {
         mask_openai_input(input, false, masker, files)?;
-    }
-    if let Some(tools) = value.get_mut("tools").and_then(Value::as_array_mut) {
-        for tool in tools {
-            mask_schema_annotations(tool, masker)?;
-        }
     }
     Ok(())
 }
@@ -973,56 +1027,6 @@ fn unscanned_image_policy() -> Result<(), String> {
     }
 }
 
-fn mask_schema_annotations(
-    value: &mut Value,
-    masker: &mut pentect_agent::ActiveToolOutputMasker,
-) -> Result<(), String> {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                mask_schema_annotations(value, masker)?;
-            }
-        }
-        Value::Object(object) => {
-            for (key, value) in object {
-                if matches!(
-                    key.as_str(),
-                    "description" | "title" | "default" | "const" | "examples" | "enum"
-                ) {
-                    mask_all_strings(value, false, masker)?;
-                } else {
-                    mask_schema_annotations(value, masker)?;
-                }
-            }
-        }
-        _ => {}
-    }
-    Ok(())
-}
-
-fn mask_all_strings(
-    value: &mut Value,
-    tool_result: bool,
-    masker: &mut pentect_agent::ActiveToolOutputMasker,
-) -> Result<(), String> {
-    match value {
-        Value::String(text) => mask_text(text, tool_result, masker),
-        Value::Array(values) => {
-            for value in values {
-                mask_all_strings(value, tool_result, masker)?;
-            }
-            Ok(())
-        }
-        Value::Object(object) => {
-            for value in object.values_mut() {
-                mask_all_strings(value, tool_result, masker)?;
-            }
-            Ok(())
-        }
-        _ => Ok(()),
-    }
-}
-
 fn mask_text(
     text: &mut String,
     tool_result: bool,
@@ -1058,11 +1062,22 @@ where
                     matches!(
                         kind,
                         "function_call"
+                            | "custom_tool_call"
                             | "response.function_call_arguments.done"
                             | "response.custom_tool_call_input.done"
                     )
                 });
             if is_function_call {
+                let is_custom_call =
+                    object
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .is_some_and(|kind| {
+                            matches!(
+                                kind,
+                                "custom_tool_call" | "response.custom_tool_call_input.done"
+                            )
+                        });
                 let tool_name = object
                     .get("name")
                     .and_then(Value::as_str)
@@ -1076,11 +1091,18 @@ where
                     });
                 for key in ["arguments", "input"] {
                     if let Some(Value::String(arguments)) = object.get_mut(key) {
-                        *arguments = crate::claude_http_proxy::resolve_tool_input_json(
-                            arguments,
-                            tool_name.as_deref(),
-                            resolve,
-                        )?;
+                        *arguments = if is_custom_call && key == "input" {
+                            // Custom tools carry completed free-form input rather than
+                            // JSON arguments. Resolve only shell-safe token values so a
+                            // represented value cannot inject syntax into the tool call.
+                            crate::claude_http_proxy::resolve_shell_text_safely(arguments, resolve)?
+                        } else {
+                            crate::claude_http_proxy::resolve_tool_input_json(
+                                arguments,
+                                tool_name.as_deref(),
+                                resolve,
+                            )?
+                        };
                     }
                 }
             }
@@ -1263,6 +1285,7 @@ fn contains_completed_function_call(value: &Value) -> bool {
                         matches!(
                             kind,
                             "function_call"
+                                | "custom_tool_call"
                                 | "response.function_call_arguments.done"
                                 | "response.custom_tool_call_input.done"
                         )
@@ -1502,6 +1525,106 @@ mod tests {
             value["output"][0]["arguments"],
             r#"{"command":"echo safe-secret-token"}"#
         );
+    }
+
+    #[test]
+    fn completed_custom_tool_input_is_restored_but_text_is_not() {
+        let mut value = serde_json::json!({
+            "type": "response.output_item.done",
+            "item": {
+                "type": "custom_tool_call",
+                "name": "exec_command",
+                "input": "python hash.py <<SECRET_0123456789abcdef>>"
+            },
+            "visible_text": "keep <<SECRET_0123456789abcdef>>"
+        });
+        assert!(contains_completed_function_call(&value));
+        let mut resolve =
+            |text: &str| Ok(text.replace("<<SECRET_0123456789abcdef>>", "safe-secret-token"));
+        rewrite_function_calls(&mut value, &mut resolve).unwrap();
+        assert_eq!(value["item"]["input"], "python hash.py safe-secret-token");
+        assert_eq!(value["visible_text"], "keep <<SECRET_0123456789abcdef>>");
+    }
+
+    #[test]
+    fn unknown_openai_content_blocks_by_default_and_can_be_allowed() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let body = Bytes::from_static(br#"{"input":[{"type":"future_block","data":"opaque"}]}"#);
+        let masker = Mutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
+        let files = HashMap::new();
+        let error = match protect_openai_request_body(&body, &masker, &plugins, &files, true) {
+            Ok(_) => panic!("unknown OpenAI block should be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.starts_with("unknown format blocked:"), "{error}");
+        assert!(error.contains("future_block"), "{error}");
+
+        let allowed = protect_openai_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
+        assert_eq!(
+            serde_json::from_slice::<Value>(&allowed.body).unwrap(),
+            serde_json::from_slice::<Value>(&body).unwrap()
+        );
+    }
+
+    #[test]
+    fn current_codex_response_items_are_known() {
+        let value = serde_json::json!({
+            "input": [
+                {
+                    "type": "additional_tools",
+                    "role": "developer",
+                    "tools": [{"type": "function", "name": "lookup"}]
+                },
+                {
+                    "type": "agent_message",
+                    "author": "agent",
+                    "recipient": "user",
+                    "content": [
+                        {"type": "input_text", "text": "done"},
+                        {"type": "encrypted_content", "encrypted_content": "opaque"}
+                    ]
+                },
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "summary"}],
+                    "content": [
+                        {"type": "reasoning_text", "text": "reasoning"},
+                        {"type": "text", "text": "legacy"}
+                    ]
+                },
+                {"type": "local_shell_call", "status": "completed", "action": {}},
+                {"type": "tool_search_call", "execution": "server", "arguments": {}},
+                {"type": "tool_search_output", "status": "completed", "execution": "server", "tools": []},
+                {"type": "web_search_call", "status": "completed"},
+                {"type": "image_generation_call", "status": "completed", "result": "opaque"},
+                {"type": "compaction", "encrypted_content": "opaque"},
+                {"type": "compaction_summary", "encrypted_content": "opaque"},
+                {"type": "compaction_trigger"},
+                {"type": "context_compaction", "encrypted_content": "opaque"}
+            ]
+        });
+        assert_eq!(openai_request_unknown_content_kind(&value), None);
+
+        let future = serde_json::json!({"input": [{"type": "future_block"}]});
+        assert_eq!(
+            openai_request_unknown_content_kind(&future),
+            Some("future_block")
+        );
+    }
+
+    #[test]
+    fn malformed_openai_json_obeys_unknown_format_policy() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let body = Bytes::from_static(b"{not-json");
+        let masker = Mutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
+        let files = HashMap::new();
+        assert!(protect_openai_request_body(&body, &masker, &plugins, &files, true).is_err());
+        let allowed = protect_openai_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
+        assert_eq!(allowed.body, body);
     }
 
     #[test]

--- a/crates/pentect-cli/tests/process_host.rs
+++ b/crates/pentect-cli/tests/process_host.rs
@@ -47,7 +47,8 @@ fn codex_dry_run_routes_through_the_http_gateway() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(rendered.contains("openai_base_url="), "{rendered}");
+    assert!(rendered.contains("pentect-openai-gateway"), "{rendered}");
+    assert!(rendered.contains("supports_websockets=false"), "{rendered}");
     assert!(rendered.contains("<pentect-gateway>"), "{rendered}");
     assert!(!rendered.contains("PENTECT_KEY_hash"), "{rendered}");
 }

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -317,6 +317,12 @@ pub(crate) enum UnscannedImagePolicy {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum UnknownFormatPolicy {
+    Ignore,
+    Error,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ImageRedactionStyle {
     Black,
     Blur,
@@ -412,6 +418,26 @@ pub(crate) fn activity_share_enabled() -> Result<bool, String> {
     let project = read_activity_share(project_config_path())?;
     let global = read_activity_share(global_config_path()?)?;
     Ok(project.or(global).unwrap_or(true))
+}
+
+pub(crate) fn unknown_formats_should_block() -> Result<bool, String> {
+    let project = read_unknown_format_policy(project_config_path())?;
+    let global = read_unknown_format_policy(global_config_path()?)?;
+    unknown_formats_should_block_effective(project, global)
+}
+
+fn unknown_formats_should_block_effective(
+    project: Option<UnknownFormatPolicy>,
+    global: Option<UnknownFormatPolicy>,
+) -> Result<bool, String> {
+    if project == Some(UnknownFormatPolicy::Ignore) {
+        return Err(
+            "compatibility.unknown_formats = \"ignore\" may only be set in the user config at ~/.pentect/config.toml"
+                .to_string(),
+        );
+    }
+    Ok(project == Some(UnknownFormatPolicy::Error)
+        || global.unwrap_or(UnknownFormatPolicy::Error) == UnknownFormatPolicy::Error)
 }
 
 fn require_pentect_agent_effective(project: Option<bool>, global: Option<bool>) -> bool {
@@ -593,6 +619,30 @@ fn files_remember_value(value: &toml::Value) -> Result<Option<bool>, String> {
 
 fn read_activity_share(path: PathBuf) -> Result<Option<bool>, String> {
     parse_config_file(&path)?.map_or(Ok(None), |value| activity_share_value(&value))
+}
+
+fn read_unknown_format_policy(path: PathBuf) -> Result<Option<UnknownFormatPolicy>, String> {
+    parse_config_file(&path)?.map_or(Ok(None), |value| unknown_format_policy_value(&value))
+}
+
+fn unknown_format_policy_value(value: &toml::Value) -> Result<Option<UnknownFormatPolicy>, String> {
+    let Some(raw) = value.get("compatibility") else {
+        return Ok(None);
+    };
+    let Some(table) = raw.as_table() else {
+        return Err("compatibility config must be a table".to_string());
+    };
+    let Some(raw) = table.get("unknown_formats") else {
+        return Ok(None);
+    };
+    let Some(raw) = raw.as_str() else {
+        return Err("compatibility.unknown_formats must be error or ignore".to_string());
+    };
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "ignore" => Ok(Some(UnknownFormatPolicy::Ignore)),
+        "error" => Ok(Some(UnknownFormatPolicy::Error)),
+        _ => Err("compatibility.unknown_formats must be error or ignore".to_string()),
+    }
 }
 
 fn activity_share_value(value: &toml::Value) -> Result<Option<bool>, String> {
@@ -966,6 +1016,36 @@ mod tests {
         assert!(!require_pentect_agent_effective(Some(false), None));
         assert!(!require_pentect_agent_effective(None, Some(false)));
         assert!(!require_pentect_agent_effective(None, None));
+    }
+
+    #[test]
+    fn unknown_formats_block_by_default_and_only_global_config_can_relax() {
+        assert!(unknown_formats_should_block_effective(None, None).unwrap());
+        assert!(
+            !unknown_formats_should_block_effective(None, Some(UnknownFormatPolicy::Ignore))
+                .unwrap()
+        );
+        assert!(unknown_formats_should_block_effective(
+            Some(UnknownFormatPolicy::Error),
+            Some(UnknownFormatPolicy::Ignore)
+        )
+        .unwrap());
+        assert!(
+            unknown_formats_should_block_effective(Some(UnknownFormatPolicy::Ignore), None)
+                .is_err()
+        );
+
+        let ignore = "[compatibility]\nunknown_formats = \"ignore\""
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(
+            unknown_format_policy_value(&ignore).unwrap(),
+            Some(UnknownFormatPolicy::Ignore)
+        );
+        let invalid = "[compatibility]\nunknown_formats = \"allow\""
+            .parse::<toml::Value>()
+            .unwrap();
+        assert!(unknown_format_policy_value(&invalid).is_err());
     }
 
     #[test]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -129,6 +129,10 @@ pub fn load_environment_variable_prefix() -> Result<String, String> {
     config::environment_variable_prefix()
 }
 
+pub fn unknown_formats_should_block() -> Result<bool, String> {
+    config::unknown_formats_should_block()
+}
+
 pub fn mask_input_into_active_memory_store(
     input: Input,
     profile: Profile,

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -4,7 +4,9 @@ Pentect needs no configuration for its default protection. Project settings
 live in `.pentect/config.toml`; global defaults live in
 `~/.pentect/config.toml`. Project values override global values.
 `agent.required` is the exception: a project cannot turn off a global
-requirement. The `plugins` list is project-only.
+requirement. `compatibility.unknown_formats = "ignore"` is also global-only,
+so a repository cannot silently weaken provider inspection. The `plugins` list
+is project-only.
 
 Start from [`templates/config.toml`](../templates/config.toml). The everyday
 settings are:
@@ -29,6 +31,7 @@ file so most users do not need to learn them.
 
 | Setting | Default | Meaning |
 | --- | ---: | --- |
+| `compatibility.unknown_formats` | `"error"` | Error on provider formats Pentect cannot safely inspect; `"ignore"` is a global-only escape hatch |
 | `image.max_edge` | `2048` | Largest OCR image edge in pixels |
 | `image.max_pixels` | `64000000` | Largest decoded image area |
 | `image.max_images` | `64` | Images inspected per request |


### PR DESCRIPTION
## What

- harden the Codex and Claude CLI HTTP gateways across current provider content types
- reject malformed or unknown provider formats by default, with a user-global compatibility escape hatch
- restore handles only at completed tool boundaries and keep visible model output masked
- fix Codex provider routing, Files API coverage, CLI help, and release metadata
- add focused provider-boundary tests and lightweight OSS contribution/security templates

## Why

The CLI proxy needed a single predictable security boundary before release. Previously, new or malformed provider payloads could be passed through partially, current Codex/Claude block variants were incomplete, and some tool/file paths were not consistently handled.

## Impact

Pentect now fails explicitly on unsupported provider request formats by default. Users who knowingly need pass-through compatibility can set `compatibility.unknown_formats = "ignore"` only in their global config; project repositories cannot weaken this policy. Codex WebSocket transport is disabled for Pentect-routed sessions so traffic stays on the inspected HTTP path.

## Root cause

The proxy format allowlists and stream/tool restoration paths had evolved independently from current provider schemas, while compatibility behavior had no explicit policy.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p pentect-cli --no-default-features --all-targets -- -D warnings`
- `cargo test --locked -p pentect-cli --no-default-features` (142 unit + integration suites)
- focused runtime unknown-format policy test
- real `pentect codex exec` round trip
- real `pentect claude -- -p` round trip
- `pentect --version`, help, doctor JSON, plugin list JSON, and update check smoke tests

Full OCR and release-platform builds are intentionally left to GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable handling for unknown or malformed provider request formats, with blocking enabled by default.
  - Improved Anthropic and OpenAI compatibility for newer content types, streaming responses, and custom tool calls.
  - Added safer Codex gateway routing with WebSockets disabled where required and improved process safeguards.
  - Updated CLI help to document `mask` and `read` commands.

- **Documentation**
  - Added contribution, security, issue-reporting, feature-request, and pull-request guidance.
  - Clarified compatibility configuration and precedence rules.

- **Release**
  - Updated the CLI version to 0.0.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->