### PR TITLE
Support structured secret sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.9"
+version = "0.0.10"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -16,7 +16,8 @@ mod update;
 
 use input::{decode_utf8_text, ImageOcrInput, InputAdapter, TextInput};
 use pentect_core::{
-    infer_kind, load_pack, parse_placeholder, Config, Engine, Input, Kind, Pack, Profile,
+    infer_kind_with_content, load_pack, parse_placeholder, Config, Engine, Input, Kind, Pack,
+    Profile,
 };
 use serde_json::Value;
 use std::ffi::OsString;
@@ -553,7 +554,9 @@ fn cmd_read(args: &[String]) {
         Ok(s) => s,
         Err(e) => die(&e),
     };
-    let kind = opts.kind.unwrap_or_else(|| infer_kind(&opts.path));
+    let kind = opts
+        .kind
+        .unwrap_or_else(|| infer_kind_with_content(&opts.path, &data));
     let active_plugins = match plugins::active_from_specs(opts.plugins.clone(), true) {
         Ok(active) => active,
         Err(e) => die(&e),
@@ -2287,6 +2290,8 @@ fn parse_kind(value: &str) -> Result<Kind, String> {
         "ndjson" | "jsonl" => Ok(Kind::Ndjson),
         "env" => Ok(Kind::Env),
         "har" => Ok(Kind::Har),
+        "structured" | "config" => Ok(Kind::Other("structured".to_string())),
+        "secret" | "secret-file" => Ok(Kind::Other("secret-file:SECRET".to_string())),
         other => Err(format!("unknown kind: {other}")),
     }
 }

--- a/crates/pentect-cli/src/scan/engine.rs
+++ b/crates/pentect-cli/src/scan/engine.rs
@@ -5,8 +5,8 @@ use super::report::{FileFinding, ScanScope, SkippedFile};
 use super::walk::ignored_file_reason;
 use memchr::memchr;
 use pentect_core::{
-    infer_kind, ByteRange, Category, Context, DecodeConfig, Engine, Input, Kind, Profile,
-    RegionKind, Span,
+    infer_kind_with_content, ByteRange, Category, Context, DecodeConfig, Engine, Input, Kind,
+    Profile, RegionKind, Span,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -470,7 +470,7 @@ fn scan_file_with_limits(
     // Detectors can temporarily expand text several times. Keep small files
     // fully parallel while bounding the peak created by large inputs.
     let _large_file_permit = large_files.acquire(data.len());
-    let kind = infer_kind(path);
+    let kind = infer_kind_with_content(path, &data);
     let line_index = LineIndex::new(&data);
     let plugin_spans = if plugins.is_empty() {
         Vec::new()

--- a/crates/pentect-cli/tests/structured_sources.rs
+++ b/crates/pentect-cli/tests/structured_sources.rs
@@ -11,9 +11,13 @@ fn temp_dir(name: &str) -> PathBuf {
 }
 
 fn read(path: &std::path::Path) -> String {
+    read_with_args(&[path.as_os_str()])
+}
+
+fn read_with_args(args: &[&std::ffi::OsStr]) -> String {
     let output = Command::new(env!("CARGO_BIN_EXE_pentect"))
         .arg("read")
-        .arg(path)
+        .args(args)
         .output()
         .unwrap();
     assert!(
@@ -22,6 +26,14 @@ fn read(path: &std::path::Path) -> String {
         String::from_utf8_lossy(&output.stderr)
     );
     String::from_utf8(output.stdout).unwrap()
+}
+
+fn read_as(kind: &str, path: &std::path::Path) -> String {
+    read_with_args(&[
+        std::ffi::OsStr::new("--kind"),
+        std::ffi::OsStr::new(kind),
+        path.as_os_str(),
+    ])
 }
 
 #[test]
@@ -56,5 +68,31 @@ fn read_npmrc_masks_auth_but_keeps_public_registry() {
     );
     assert!(output.contains("_authToken=<<AUTH_TOKEN_"), "{output}");
     assert!(!output.contains("_authToken=x"), "{output}");
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn explicit_kinds_cover_arbitrary_dotenv_structured_and_one_secret_files() {
+    let root = temp_dir("explicit-kinds");
+    std::fs::create_dir_all(&root).unwrap();
+
+    let dotenv = root.join("credentials.custom");
+    std::fs::write(&dotenv, "TOKEN=x\nMODE=dev\n").unwrap();
+    let output = read_as("env", &dotenv);
+    assert!(output.contains("TOKEN=<<TOKEN_"), "{output}");
+    assert!(output.contains("MODE=<<MODE_"), "{output}");
+
+    let structured = root.join("settings.custom");
+    std::fs::write(&structured, "region: us-east-1\npassword: x\n").unwrap();
+    let output = read_as("structured", &structured);
+    assert!(output.contains("region: us-east-1"), "{output}");
+    assert!(output.contains("password: <<PASSWORD_"), "{output}");
+
+    let secret = root.join("opaque.custom");
+    std::fs::write(&secret, "short value with spaces\nand another line").unwrap();
+    let output = read_as("secret", &secret);
+    assert!(output.trim().starts_with("<<SECRET_"), "{output}");
+    assert_eq!(output.matches("<<").count(), 1, "{output}");
+
     std::fs::remove_dir_all(root).unwrap();
 }

--- a/crates/pentect-cli/tests/structured_sources.rs
+++ b/crates/pentect-cli/tests/structured_sources.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_dir(name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("pentect-{name}-{}-{nonce}", std::process::id()))
+}
+
+fn read(path: &std::path::Path) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_pentect"))
+        .arg("read")
+        .arg(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn read_cloudflare_dev_vars_masks_every_value_with_key_labels() {
+    let root = temp_dir("dev-vars");
+    std::fs::create_dir_all(&root).unwrap();
+    let path = root.join(".dev.vars");
+    std::fs::write(&path, "API_TOKEN=x\nMODE=dev\n").unwrap();
+
+    let output = read(&path);
+    assert!(output.contains("API_TOKEN=<<API_TOKEN_"), "{output}");
+    assert!(output.contains("MODE=<<MODE_"), "{output}");
+    assert!(!output.contains("API_TOKEN=x"), "{output}");
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn read_npmrc_masks_auth_but_keeps_public_registry() {
+    let root = temp_dir("npmrc");
+    std::fs::create_dir_all(&root).unwrap();
+    let path = root.join(".npmrc");
+    std::fs::write(
+        &path,
+        "registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=x\n",
+    )
+    .unwrap();
+
+    let output = read(&path);
+    assert!(
+        output.contains("registry=https://registry.npmjs.org/"),
+        "{output}"
+    );
+    assert!(output.contains("_authToken=<<AUTH_TOKEN_"), "{output}");
+    assert!(!output.contains("_authToken=x"), "{output}");
+    std::fs::remove_dir_all(root).unwrap();
+}

--- a/crates/pentect-core/src/detect/mod.rs
+++ b/crates/pentect-core/src/detect/mod.rs
@@ -41,6 +41,7 @@ pub use pattern::{PatternMatchDetector, PatternSpec};
 pub use pem::PemDetector;
 pub use phone::PhoneDetector;
 pub use rule::{RuleDetector, RuleSpec};
+pub(crate) use structural::SECRET_VALUE_HINT;
 pub use structural::{EnvValueDetector, SensitiveKeyDetector, StructuralDetector};
 pub use url::UrlDetector;
 pub use uuid::UuidDetector;

--- a/crates/pentect-core/src/detect/structural.rs
+++ b/crates/pentect-core/src/detect/structural.rs
@@ -11,6 +11,9 @@ use std::sync::LazyLock;
 static SENSITIVE_HEADERS: LazyLock<Vec<String>> =
     LazyLock::new(|| parse_sensitive_headers(include_str!("sensitive_header_names.txt")));
 
+/// Marks a region whose value is secret by schema rather than by shape.
+pub(crate) const SECRET_VALUE_HINT: &str = "pentect:secret-value";
+
 /// Masks values that are sensitive by protocol-defined structural position: a
 /// cookie value or a credential-bearing HTTP header. Bounded and protocol-
 /// grounded, so it is separate from key-name based structured value masking.
@@ -78,7 +81,7 @@ impl Detector for EnvValueDetector {
                 .ctx
                 .hints
                 .iter()
-                .any(|hint| hint == "pentect:secret-value");
+                .any(|hint| hint == SECRET_VALUE_HINT);
         if region.span.is_empty() || !explicit_secret || is_rendered_placeholder(view.text()) {
             return vec![];
         }

--- a/crates/pentect-core/src/detect/structural.rs
+++ b/crates/pentect-core/src/detect/structural.rs
@@ -16,9 +16,9 @@ static SENSITIVE_HEADERS: LazyLock<Vec<String>> =
 /// grounded, so it is separate from key-name based structured value masking.
 pub struct StructuralDetector;
 
-/// `.env` value regions are masked wholesale. The parser already strips the
-/// structural shell, so the core can treat every non-placeholder value as
-/// secret without key-name guessing.
+/// Values in an explicit secret-bearing source are masked wholesale. This
+/// includes dotenv boundaries and parser-verified schema slots or mounted
+/// one-secret files.
 pub struct EnvValueDetector;
 
 /// Masks values under explicit structured key/path context supplied by a parser.
@@ -73,10 +73,13 @@ fn is_sensitive_header_name(header: &str) -> bool {
 impl Detector for EnvValueDetector {
     fn detect(&self, view: &NormalizedView) -> Vec<Span> {
         let region = view.region;
-        if region.span.is_empty()
-            || region.ctx.format != Kind::Env
-            || is_rendered_placeholder(view.text())
-        {
+        let explicit_secret = region.ctx.format == Kind::Env
+            || region
+                .ctx
+                .hints
+                .iter()
+                .any(|hint| hint == "pentect:secret-value");
+        if region.span.is_empty() || !explicit_secret || is_rendered_placeholder(view.text()) {
             return vec![];
         }
         vec![Span {

--- a/crates/pentect-core/src/lib.rs
+++ b/crates/pentect-core/src/lib.rs
@@ -42,7 +42,9 @@ pub use model::{
     ByteRange, Category, Confidence, Context, DetectorId, Input, Kind, Region, RegionKind, Span,
 };
 pub use pack::{load_pack, load_plugin_pack, Pack};
-pub use parse::{EnvParser, JsonParser, NdjsonParser, Parser, TextParser, ToolResultParser};
+pub use parse::{
+    EnvParser, JsonParser, NdjsonParser, Parser, StructuredParser, TextParser, ToolResultParser,
+};
 pub use pipeline::{
     Config, Engine, EngineBuilder, MaskResult, MaskedItem, RenderSegment, ResidualNote,
     SpanAnalysisResult, Summary,
@@ -64,15 +66,19 @@ pub fn explain(result: &MaskResult) -> Summary {
 
 /// Infer the parser kind from a path without reading the file.
 pub fn infer_kind(path: &std::path::Path) -> Kind {
-    if path
+    let name = path
         .file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| {
-            let lower = name.to_ascii_lowercase();
-            lower == ".env" || lower.starts_with(".env.")
-        })
-    {
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if is_dotenv_name(&name) || is_aws_credentials_path(path) || is_github_env_path(path) {
         return Kind::Env;
+    }
+    if let Some(label) = mounted_secret_label(path) {
+        return Kind::Other(format!("secret-file:{label}"));
+    }
+    if let Some(kind) = structured_config_kind(path, &name) {
+        return Kind::Other(kind.to_string());
     }
     match path
         .extension()
@@ -84,8 +90,101 @@ pub fn infer_kind(path: &std::path::Path) -> Kind {
         Some("jsonl" | "ndjson") => Kind::Ndjson,
         Some("env") => Kind::Env,
         Some("har") => Kind::Har,
+        Some("yaml" | "yml" | "toml" | "ini" | "conf" | "properties" | "tfvars") => {
+            Kind::Other("structured".to_string())
+        }
         _ => Kind::Text,
     }
+}
+
+/// Infer a parser from both provenance and content. Content sniffing is used
+/// only for a high-confidence dotenv document; an arbitrary one-line
+/// assignment remains ordinary text to avoid turning prose or source code into
+/// an all-values secret boundary.
+pub fn infer_kind_with_content(path: &std::path::Path, raw: &str) -> Kind {
+    let inferred = infer_kind(path);
+    if inferred == Kind::Text && parse::looks_like_dotenv_document(raw) {
+        Kind::Env
+    } else {
+        inferred
+    }
+}
+
+fn is_dotenv_name(name: &str) -> bool {
+    name == ".env"
+        || name.starts_with(".env.")
+        || name == ".dev.vars"
+        || name.starts_with(".dev.vars.")
+        || name == ".secret.local"
+        || name.ends_with(".secret.local")
+}
+
+fn structured_config_kind(path: &std::path::Path, name: &str) -> Option<&'static str> {
+    if name == ".npmrc" {
+        return Some("structured:npm");
+    }
+    if name == ".pypirc" {
+        return Some("structured:pypi");
+    }
+    if name == "kubeconfig"
+        || (name == "config"
+            && path
+                .parent()
+                .and_then(std::path::Path::file_name)
+                .is_some_and(|parent| parent.to_string_lossy().eq_ignore_ascii_case(".kube")))
+    {
+        return Some("structured:kubeconfig");
+    }
+    if name == "config"
+        && path
+            .parent()
+            .and_then(std::path::Path::file_name)
+            .is_some_and(|parent| parent.to_string_lossy().eq_ignore_ascii_case(".aws"))
+    {
+        return Some("structured:aws");
+    }
+    name.ends_with(".auto.tfvars").then_some("structured")
+}
+
+fn is_aws_credentials_path(path: &std::path::Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("credentials"))
+        && path
+            .parent()
+            .and_then(std::path::Path::file_name)
+            .is_some_and(|parent| parent.to_string_lossy().eq_ignore_ascii_case(".aws"))
+}
+
+fn is_github_env_path(path: &std::path::Path) -> bool {
+    path.to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase()
+        .contains("/_runner_file_commands/set_env_")
+}
+
+fn mounted_secret_label(path: &std::path::Path) -> Option<String> {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    let lower = normalized.to_ascii_lowercase();
+    let in_named_secret_dir = path
+        .parent()
+        .and_then(std::path::Path::file_name)
+        .is_some_and(|parent| parent.to_string_lossy().eq_ignore_ascii_case("secrets"));
+    let has_secret_extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("secret"));
+    let in_secret_mount = lower.contains("/run/secrets/")
+        || lower.contains("/var/run/secrets/kubernetes.io/serviceaccount/")
+        || in_named_secret_dir
+        || has_secret_extension;
+    if !in_secret_mount {
+        return None;
+    }
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -97,5 +196,58 @@ mod tests {
     fn infer_kind_recognizes_json_lines_files() {
         assert_eq!(infer_kind(Path::new("events.jsonl")), Kind::Ndjson);
         assert_eq!(infer_kind(Path::new("events.ndjson")), Kind::Ndjson);
+    }
+
+    #[test]
+    fn infer_kind_recognizes_official_dotenv_families() {
+        for path in [
+            ".env.local",
+            ".dev.vars",
+            ".dev.vars.staging",
+            ".secret.local",
+            "extensions/image-resizer.secret.local",
+            "service.env",
+        ] {
+            assert_eq!(infer_kind(Path::new(path)), Kind::Env, "{path}");
+        }
+    }
+
+    #[test]
+    fn infer_kind_recognizes_structured_and_mounted_sources() {
+        assert_eq!(
+            infer_kind(Path::new(".npmrc")),
+            Kind::Other("structured:npm".into())
+        );
+        assert_eq!(infer_kind(Path::new(".aws/credentials")), Kind::Env);
+        assert_eq!(
+            infer_kind(Path::new(".kube/config")),
+            Kind::Other("structured:kubeconfig".into())
+        );
+        assert_eq!(
+            infer_kind(Path::new(
+                "/home/runner/work/_temp/_runner_file_commands/set_env_1234"
+            )),
+            Kind::Env
+        );
+        assert_eq!(
+            infer_kind(Path::new("/run/secrets/database-password")),
+            Kind::Other("secret-file:database-password".into())
+        );
+        assert_eq!(
+            infer_kind(Path::new("deploy/secrets/api-token")),
+            Kind::Other("secret-file:api-token".into())
+        );
+    }
+
+    #[test]
+    fn content_sniffing_requires_a_dotenv_document() {
+        assert_eq!(
+            infer_kind_with_content(Path::new("settings"), "API_KEY=abc\nMODE=dev\n"),
+            Kind::Env
+        );
+        assert_eq!(
+            infer_kind_with_content(Path::new("notes"), "example=value"),
+            Kind::Text
+        );
     }
 }

--- a/crates/pentect-core/src/lib.rs
+++ b/crates/pentect-core/src/lib.rs
@@ -143,7 +143,7 @@ fn structured_config_kind(path: &std::path::Path, name: &str) -> Option<&'static
     {
         return Some("structured:aws");
     }
-    name.ends_with(".auto.tfvars").then_some("structured")
+    None
 }
 
 fn is_aws_credentials_path(path: &std::path::Path) -> bool {
@@ -169,7 +169,8 @@ fn mounted_secret_label(path: &std::path::Path) -> Option<String> {
     let in_named_secret_dir = path
         .parent()
         .and_then(std::path::Path::file_name)
-        .is_some_and(|parent| parent.to_string_lossy().eq_ignore_ascii_case("secrets"));
+        .is_some_and(|parent| parent.to_string_lossy().eq_ignore_ascii_case("secrets"))
+        && path.extension().is_none();
     let has_secret_extension = path
         .extension()
         .and_then(|extension| extension.to_str())
@@ -236,6 +237,14 @@ mod tests {
         assert_eq!(
             infer_kind(Path::new("deploy/secrets/api-token")),
             Kind::Other("secret-file:api-token".into())
+        );
+        assert_eq!(
+            infer_kind(Path::new("deploy/secrets/app-secret.yaml")),
+            Kind::Other("structured".into())
+        );
+        assert_eq!(
+            infer_kind(Path::new("deploy/secrets/values.json")),
+            Kind::Json
         );
     }
 

--- a/crates/pentect-core/src/model.rs
+++ b/crates/pentect-core/src/model.rs
@@ -14,6 +14,14 @@ pub mod labels {
     pub const OPAQUE_BLOB: &str = "OPAQUE_BLOB";
     /// Value masked because its key name looks sensitive.
     pub const SECRET: &str = "SECRET";
+    /// Ambiguous personally identifying information.
+    pub const PII: &str = "PII";
+    /// Ambiguous identifier.
+    pub const IDENTIFIER: &str = "IDENTIFIER";
+    /// Ambiguous endpoint.
+    pub const ENDPOINT: &str = "ENDPOINT";
+    /// Sensitive value whose category could not be narrowed further.
+    pub const SENSITIVE: &str = "SENSITIVE";
     /// Value masked because a plaintext key/value structure carries a sensitive key.
     pub const KEYED_SECRET: &str = "KEYED_SECRET";
     /// One-time password or verification code.

--- a/crates/pentect-core/src/parse/mod.rs
+++ b/crates/pentect-core/src/parse/mod.rs
@@ -29,7 +29,86 @@ pub struct JsonParser;
 
 impl Parser for JsonParser {
     fn parse(&self, raw: &str) -> Option<Vec<Region>> {
-        json::parse_json_regions(raw)
+        let mut regions = json::parse_json_regions(raw)?;
+        mark_json_secret_schema(raw, &mut regions);
+        Some(regions)
+    }
+}
+
+fn mark_json_secret_schema(raw: &str, regions: &mut [Region]) {
+    let Ok(document) = serde_json::from_str::<serde_json::Value>(raw) else {
+        return;
+    };
+    let mut secret_keys = std::collections::HashSet::new();
+    if document
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|kind| kind.eq_ignore_ascii_case("secret"))
+    {
+        for container in ["data", "stringData"] {
+            if let Some(values) = document
+                .get(container)
+                .and_then(serde_json::Value::as_object)
+            {
+                secret_keys.extend(values.keys().cloned());
+            }
+        }
+    }
+    collect_terraform_sensitive_keys(&document, &mut secret_keys);
+    if secret_keys.is_empty() {
+        return;
+    }
+    for region in regions {
+        if region
+            .ctx
+            .key
+            .as_ref()
+            .is_some_and(|key| secret_keys.contains(key))
+        {
+            region.ctx.hints.push("pentect:secret-value".to_string());
+        }
+    }
+}
+
+fn collect_terraform_sensitive_keys(
+    value: &serde_json::Value,
+    out: &mut std::collections::HashSet<String>,
+) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(sensitive) = map.get("sensitive_values") {
+                collect_true_leaf_keys(sensitive, out);
+            }
+            for child in map.values() {
+                collect_terraform_sensitive_keys(child, out);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                collect_terraform_sensitive_keys(child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_true_leaf_keys(value: &serde_json::Value, out: &mut std::collections::HashSet<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, child) in map {
+                if child == &serde_json::Value::Bool(true) {
+                    out.insert(key.clone());
+                } else {
+                    collect_true_leaf_keys(child, out);
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                collect_true_leaf_keys(child, out);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -69,6 +148,20 @@ impl Parser for EnvParser {
         let mut pos = 0;
         while pos < raw.len() {
             let line_end = raw[pos..].find('\n').map_or(raw.len(), |i| pos + i);
+            if let Some((key, span, next)) = parse_env_multiline(raw, pos, line_end) {
+                regions.push(Region {
+                    span,
+                    ctx: Context {
+                        path: None,
+                        key: Some(key),
+                        hints: Vec::new(),
+                        kind: RegionKind::Body,
+                        format: Kind::Env,
+                    },
+                });
+                pos = next;
+                continue;
+            }
             if let Some((key, span)) = parse_env_line(raw, pos, line_end) {
                 regions.push(Region {
                     span,
@@ -85,6 +178,357 @@ impl Parser for EnvParser {
         }
         Some(regions)
     }
+}
+
+fn parse_env_multiline(
+    raw: &str,
+    start: usize,
+    line_end: usize,
+) -> Option<(String, ByteRange, usize)> {
+    let header = raw[start..line_end].trim().trim_start_matches('\u{feff}');
+    let (key, delimiter) = header.split_once("<<")?;
+    let key = key.trim();
+    let delimiter = delimiter.trim();
+    if key.is_empty()
+        || delimiter.is_empty()
+        || delimiter.chars().any(char::is_whitespace)
+        || !key.chars().all(is_key_char)
+    {
+        return None;
+    }
+    let value_start = line_end.checked_add(1)?;
+    let mut pos = value_start;
+    while pos <= raw.len() {
+        let end = raw[pos..].find('\n').map_or(raw.len(), |i| pos + i);
+        if raw[pos..end].trim_end_matches('\r') == delimiter {
+            let mut value_end = pos;
+            if raw[..value_end].ends_with("\r\n") {
+                value_end -= 2;
+            } else if raw[..value_end].ends_with('\n') {
+                value_end -= 1;
+            }
+            if value_end <= value_start {
+                return None;
+            }
+            return Some((
+                key.to_string(),
+                ByteRange::new(value_start, value_end),
+                end.saturating_add(1),
+            ));
+        }
+        if end == raw.len() {
+            break;
+        }
+        pos = end + 1;
+    }
+    None
+}
+
+/// Parses line-oriented structured configuration without declaring every value
+/// sensitive. Detectors decide which values to mask from their key/path. The
+/// one exception is a Kubernetes `kind: Secret` document, where values directly
+/// below `data` and `stringData` are secret by schema.
+pub struct StructuredParser {
+    schema: StructuredSchema,
+}
+
+#[derive(Clone, Copy)]
+enum StructuredSchema {
+    Generic,
+    Aws,
+    Kubeconfig,
+    Npm,
+    Pypi,
+}
+
+impl StructuredParser {
+    pub fn generic() -> Self {
+        Self {
+            schema: StructuredSchema::Generic,
+        }
+    }
+
+    pub fn aws() -> Self {
+        Self {
+            schema: StructuredSchema::Aws,
+        }
+    }
+
+    pub fn kubeconfig() -> Self {
+        Self {
+            schema: StructuredSchema::Kubeconfig,
+        }
+    }
+
+    pub fn npm() -> Self {
+        Self {
+            schema: StructuredSchema::Npm,
+        }
+    }
+
+    pub fn pypi() -> Self {
+        Self {
+            schema: StructuredSchema::Pypi,
+        }
+    }
+
+    fn is_schema_secret_key(&self, key: &str) -> bool {
+        match self.schema {
+            StructuredSchema::Generic => false,
+            StructuredSchema::Aws => matches!(
+                key.to_ascii_lowercase().as_str(),
+                "aws_access_key_id" | "aws_secret_access_key" | "aws_session_token"
+            ),
+            StructuredSchema::Kubeconfig => matches!(
+                key.to_ascii_lowercase().as_str(),
+                "token" | "password" | "client-key-data"
+            ),
+            StructuredSchema::Npm => matches!(key, "AUTH_TOKEN" | "PASSWORD" | "AUTH"),
+            StructuredSchema::Pypi => key.eq_ignore_ascii_case("password"),
+        }
+    }
+
+    fn format(&self) -> Kind {
+        let name = match self.schema {
+            StructuredSchema::Generic => "structured",
+            StructuredSchema::Aws => "structured:aws",
+            StructuredSchema::Kubeconfig => "structured:kubeconfig",
+            StructuredSchema::Npm => "structured:npm",
+            StructuredSchema::Pypi => "structured:pypi",
+        };
+        Kind::Other(name.to_string())
+    }
+}
+
+impl Parser for StructuredParser {
+    fn parse(&self, raw: &str) -> Option<Vec<Region>> {
+        let kubernetes_secret = raw.lines().any(|line| {
+            let line = line.trim();
+            line.strip_prefix("kind:")
+                .is_some_and(|value| value.trim().eq_ignore_ascii_case("secret"))
+        });
+        let mut regions = Vec::new();
+        let mut yaml_stack: Vec<(usize, String)> = Vec::new();
+        let mut ini_section: Option<String> = None;
+        let mut pos = 0usize;
+
+        while pos < raw.len() {
+            let line_end = raw[pos..].find('\n').map_or(raw.len(), |i| pos + i);
+            let line = raw[pos..line_end].trim_end_matches('\r');
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                pos = line_end.saturating_add(1);
+                continue;
+            }
+            if trimmed.starts_with(['#', ';']) {
+                push_plain_structured_line(&mut regions, pos, line, self.format());
+                pos = line_end.saturating_add(1);
+                continue;
+            }
+            if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                ini_section = Some(trimmed[1..trimmed.len() - 1].trim().to_string());
+                yaml_stack.clear();
+                pos = line_end.saturating_add(1);
+                continue;
+            }
+
+            let indent = line.len() - line.trim_start_matches([' ', '\t']).len();
+            let body_offset = indent + usize::from(line[indent..].starts_with("- ")) * 2;
+            let body = &line[body_offset..];
+            let Some((separator, separator_len)) = structured_separator(body) else {
+                push_plain_structured_line(&mut regions, pos, line, self.format());
+                pos = line_end.saturating_add(1);
+                continue;
+            };
+            let raw_key = body[..separator].trim().trim_matches(['"', '\'']);
+            if raw_key.is_empty() {
+                push_plain_structured_line(&mut regions, pos, line, self.format());
+                pos = line_end.saturating_add(1);
+                continue;
+            }
+            let key = semantic_structured_key(raw_key);
+            let value_offset = body_offset + separator + separator_len;
+            let value_part = &line[value_offset..];
+            let leading = value_part.len() - value_part.trim_start_matches([' ', '\t']).len();
+            let value = &value_part[leading..];
+
+            while yaml_stack.last().is_some_and(|(level, _)| *level >= indent) {
+                yaml_stack.pop();
+            }
+            let mut path = yaml_stack
+                .iter()
+                .map(|(_, key)| key.as_str())
+                .collect::<Vec<_>>();
+            if let Some(section) = ini_section.as_deref() {
+                path.insert(0, section);
+            }
+            path.push(&key);
+            let path_string = path.join(".");
+
+            if value.is_empty() {
+                yaml_stack.push((indent, key));
+                pos = line_end.saturating_add(1);
+                continue;
+            }
+
+            let parent_is_kubernetes_secret_data = kubernetes_secret
+                && yaml_stack
+                    .last()
+                    .is_some_and(|(_, parent)| matches!(parent.as_str(), "data" | "stringData"));
+            let mut hints = Vec::new();
+            if parent_is_kubernetes_secret_data {
+                hints.push("pentect:secret-value".to_string());
+            }
+            if self.is_schema_secret_key(&key) {
+                hints.push("pentect:secret-value".to_string());
+            }
+
+            let scalar_start = pos + value_offset + leading;
+            let scalar_span = if is_yaml_block_indicator(value) {
+                let Some(span) = yaml_block_span(raw, line_end.saturating_add(1), indent) else {
+                    pos = line_end.saturating_add(1);
+                    continue;
+                };
+                span
+            } else {
+                structured_scalar_span(raw, scalar_start, scalar_start + value.len())
+            };
+            if !scalar_span.is_empty() {
+                regions.push(Region {
+                    span: scalar_span,
+                    ctx: Context {
+                        path: Some(path_string),
+                        key: Some(key),
+                        hints,
+                        kind: RegionKind::JsonValue,
+                        format: self.format(),
+                    },
+                });
+            }
+            pos = line_end.saturating_add(1);
+        }
+        Some(regions)
+    }
+}
+
+fn push_plain_structured_line(regions: &mut Vec<Region>, start: usize, line: &str, format: Kind) {
+    if line.is_empty() {
+        return;
+    }
+    regions.push(Region {
+        span: ByteRange::new(start, start + line.len()),
+        ctx: Context {
+            path: None,
+            key: None,
+            hints: Vec::new(),
+            kind: RegionKind::PlainText,
+            format,
+        },
+    });
+}
+
+pub(crate) fn looks_like_dotenv_document(raw: &str) -> bool {
+    let mut assignments = 0usize;
+    let mut meaningful = 0usize;
+    let mut pos = 0usize;
+    while pos < raw.len() {
+        let line_end = raw[pos..].find('\n').map_or(raw.len(), |i| pos + i);
+        let trimmed = raw[pos..line_end].trim();
+        if !trimmed.is_empty() && !trimmed.starts_with('#') {
+            meaningful += 1;
+            if let Some((key, _)) = parse_env_line(raw, pos, line_end) {
+                let mut chars = key.chars();
+                let strict_env_key = chars
+                    .next()
+                    .is_some_and(|ch| ch.is_ascii_uppercase() || ch == '_')
+                    && chars.all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_');
+                if strict_env_key {
+                    assignments += 1;
+                }
+            }
+        }
+        pos = line_end.saturating_add(1);
+    }
+    assignments >= 2 && assignments == meaningful
+}
+
+fn structured_separator(value: &str) -> Option<(usize, usize)> {
+    let equals = value.find('=').map(|index| (index, 1));
+    let colon = value.char_indices().find_map(|(index, ch)| {
+        (ch == ':'
+            && value[index + 1..]
+                .chars()
+                .next()
+                .is_none_or(char::is_whitespace))
+        .then_some((index, 1))
+    });
+    match (equals, colon) {
+        (Some(a), Some(b)) => Some(if a.0 < b.0 { a } else { b }),
+        (Some(found), None) | (None, Some(found)) => Some(found),
+        (None, None) => None,
+    }
+}
+
+fn semantic_structured_key(key: &str) -> String {
+    if key.starts_with("//") {
+        if let Some((_, auth_key)) = key.rsplit_once(':') {
+            return match auth_key.trim_start_matches('_') {
+                "authToken" => "AUTH_TOKEN".to_string(),
+                "password" => "PASSWORD".to_string(),
+                "auth" => "AUTH".to_string(),
+                other => other.to_string(),
+            };
+        }
+    }
+    key.to_string()
+}
+
+fn structured_scalar_span(raw: &str, start: usize, end: usize) -> ByteRange {
+    let value = &raw[start..end];
+    let (mut inner_start, mut inner_end) = (start, end);
+    if let Some(quote @ ('"' | '\'')) = value.chars().next() {
+        inner_start += quote.len_utf8();
+        let after = &value[quote.len_utf8()..];
+        let closing = if quote == '"' {
+            closing_double_quote(after)
+        } else {
+            after.find('\'')
+        };
+        inner_end = closing.map_or(end, |index| inner_start + index);
+    } else if let Some(comment) = value.char_indices().find_map(|(index, ch)| {
+        (ch == '#'
+            && index > 0
+            && value[..index]
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace))
+        .then_some(index)
+    }) {
+        inner_end = start + value[..comment].trim_end().len();
+    }
+    ByteRange::new(inner_start, inner_end)
+}
+
+fn is_yaml_block_indicator(value: &str) -> bool {
+    matches!(value.trim(), "|" | "|-" | "|+" | ">" | ">-" | ">+")
+}
+
+fn yaml_block_span(raw: &str, mut pos: usize, parent_indent: usize) -> Option<ByteRange> {
+    let start = pos;
+    let mut end = pos;
+    while pos < raw.len() {
+        let line_end = raw[pos..].find('\n').map_or(raw.len(), |i| pos + i);
+        let line = raw[pos..line_end].trim_end_matches('\r');
+        if !line.trim().is_empty() {
+            let indent = line.len() - line.trim_start_matches([' ', '\t']).len();
+            if indent <= parent_indent {
+                break;
+            }
+            end = line_end;
+        }
+        pos = line_end.saturating_add(1);
+    }
+    (end > start).then_some(ByteRange::new(start, end))
 }
 
 /// Returns (key, value byte range) for a `KEY=VALUE` line, or None for blank,
@@ -281,5 +725,134 @@ mod tests {
             parsed(raw),
             [(Some("DB_PASSWORD".into()), "abc\\\"def".into())]
         );
+    }
+
+    #[test]
+    fn github_environment_multiline_value_is_one_region() {
+        let raw = "JSON_RESPONSE<<EOF\n{\"token\":\"abc\"}\nsecond line\nEOF\nMODE=dev\n";
+        assert_eq!(
+            parsed(raw),
+            [
+                (
+                    Some("JSON_RESPONSE".into()),
+                    "{\"token\":\"abc\"}\nsecond line".into()
+                ),
+                (Some("MODE".into()), "dev".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn dotenv_content_sniff_is_strict_and_order_independent() {
+        assert!(looks_like_dotenv_document("API_KEY=abc\nMODE=dev\n"));
+        assert!(looks_like_dotenv_document(
+            "# comment\nMODE=dev\nAPI_KEY=abc\n"
+        ));
+        assert!(!looks_like_dotenv_document("example=value\n"));
+        assert!(!looks_like_dotenv_document(
+            "API_KEY=abc\nthis is ordinary prose\n"
+        ));
+        assert!(!looks_like_dotenv_document("lower=value\nOTHER=value\n"));
+    }
+
+    #[test]
+    fn structured_parser_preserves_keys_paths_quotes_and_comments() {
+        let raw = concat!(
+            "[pypi]\n",
+            "repository = https://upload.pypi.org/legacy/\n",
+            "password = \"pypi-token\" # keep\n",
+            "//registry.npmjs.org/:_authToken=npm-token\n",
+        );
+        let regions = StructuredParser::generic().parse(raw).unwrap();
+        let values = regions
+            .iter()
+            .map(|region| {
+                (
+                    region.ctx.path.clone().unwrap(),
+                    region.ctx.key.clone().unwrap(),
+                    raw[region.span.start..region.span.end].to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            values,
+            [
+                (
+                    "pypi.repository".into(),
+                    "repository".into(),
+                    "https://upload.pypi.org/legacy/".into()
+                ),
+                (
+                    "pypi.password".into(),
+                    "password".into(),
+                    "pypi-token".into()
+                ),
+                (
+                    "pypi.AUTH_TOKEN".into(),
+                    "AUTH_TOKEN".into(),
+                    "npm-token".into()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn kubernetes_secret_data_is_schema_marked() {
+        let raw = concat!(
+            "apiVersion: v1\n",
+            "kind: Secret\n",
+            "metadata:\n  name: app\n",
+            "stringData:\n  DB_PASSWORD: plain\n",
+            "data:\n  API_TOKEN: YWJj\n",
+        );
+        let regions = StructuredParser::generic().parse(raw).unwrap();
+        let marked = regions
+            .iter()
+            .filter(|region| {
+                region
+                    .ctx
+                    .hints
+                    .iter()
+                    .any(|hint| hint == "pentect:secret-value")
+            })
+            .map(|region| region.ctx.key.as_deref().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(marked, ["DB_PASSWORD", "API_TOKEN"]);
+    }
+
+    #[test]
+    fn yaml_block_scalar_is_kept_as_one_value() {
+        let raw = "client-key-data: |\n  line-one\n  line-two\nnext: public\n";
+        let regions = StructuredParser::generic().parse(raw).unwrap();
+        assert_eq!(
+            &raw[regions[0].span.start..regions[0].span.end],
+            "  line-one\n  line-two"
+        );
+    }
+
+    #[test]
+    fn structured_comments_and_unknown_lines_still_reach_normal_detectors() {
+        let raw = "# api_token: abcdefghijklmnopqrstuvwxyz\nunknown directive value\n";
+        let regions = StructuredParser::generic().parse(raw).unwrap();
+        assert_eq!(regions.len(), 2);
+        assert!(regions
+            .iter()
+            .all(|region| region.ctx.kind == RegionKind::PlainText));
+        assert_eq!(
+            &raw[regions[0].span.start..regions[0].span.end],
+            "# api_token: abcdefghijklmnopqrstuvwxyz"
+        );
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn structured_parse_never_panics_and_spans_are_valid(raw in proptest::prelude::any::<String>()) {
+            for region in StructuredParser::generic().parse(&raw).unwrap_or_default() {
+                proptest::prop_assert!(region.span.start <= region.span.end);
+                proptest::prop_assert!(region.span.end <= raw.len());
+                proptest::prop_assert!(raw.is_char_boundary(region.span.start));
+                proptest::prop_assert!(raw.is_char_boundary(region.span.end));
+            }
+        }
     }
 }

--- a/crates/pentect-core/src/parse/mod.rs
+++ b/crates/pentect-core/src/parse/mod.rs
@@ -1,3 +1,4 @@
+use crate::detect::SECRET_VALUE_HINT;
 use crate::model::*;
 
 mod json;
@@ -36,6 +37,9 @@ impl Parser for JsonParser {
 }
 
 fn mark_json_secret_schema(raw: &str, regions: &mut [Region]) {
+    if !raw.contains("sensitive_values") && !raw.contains("\"kind\"") {
+        return;
+    }
     let Ok(document) = serde_json::from_str::<serde_json::Value>(raw) else {
         return;
     };
@@ -65,7 +69,7 @@ fn mark_json_secret_schema(raw: &str, regions: &mut [Region]) {
             .as_ref()
             .is_some_and(|key| secret_keys.contains(key))
         {
-            region.ctx.hints.push("pentect:secret-value".to_string());
+            region.ctx.hints.push(SECRET_VALUE_HINT.to_string());
         }
     }
 }
@@ -186,9 +190,15 @@ fn parse_env_multiline(
     line_end: usize,
 ) -> Option<(String, ByteRange, usize)> {
     let header = raw[start..line_end].trim().trim_start_matches('\u{feff}');
-    let (key, delimiter) = header.split_once("<<")?;
+    let (key, raw_delimiter) = header.split_once("<<")?;
     let key = key.trim();
-    let delimiter = delimiter.trim();
+    let raw_delimiter = raw_delimiter.trim();
+    let strip_tabs = raw_delimiter.starts_with('-');
+    let delimiter = raw_delimiter
+        .strip_prefix('-')
+        .unwrap_or(raw_delimiter)
+        .trim();
+    let delimiter = matching_quote_contents(delimiter)?;
     if key.is_empty()
         || delimiter.is_empty()
         || delimiter.chars().any(char::is_whitespace)
@@ -200,7 +210,13 @@ fn parse_env_multiline(
     let mut pos = value_start;
     while pos <= raw.len() {
         let end = raw[pos..].find('\n').map_or(raw.len(), |i| pos + i);
-        if raw[pos..end].trim_end_matches('\r') == delimiter {
+        let terminator = raw[pos..end].trim_end_matches('\r');
+        let terminator = if strip_tabs {
+            terminator.trim_start_matches('\t')
+        } else {
+            terminator
+        };
+        if terminator == delimiter {
             let mut value_end = pos;
             if raw[..value_end].ends_with("\r\n") {
                 value_end -= 2;
@@ -222,6 +238,17 @@ fn parse_env_multiline(
         pos = end + 1;
     }
     None
+}
+
+fn matching_quote_contents(value: &str) -> Option<&str> {
+    for quote in ['\'', '"'] {
+        if value.starts_with(quote) || value.ends_with(quote) {
+            return value
+                .strip_prefix(quote)
+                .and_then(|inner| inner.strip_suffix(quote));
+        }
+    }
+    Some(value)
 }
 
 /// Parses line-oriented structured configuration without declaring every value
@@ -281,9 +308,12 @@ impl StructuredParser {
             ),
             StructuredSchema::Kubeconfig => matches!(
                 key.to_ascii_lowercase().as_str(),
-                "token" | "password" | "client-key-data"
+                "token" | "password" | "client-key-data" | "id-token" | "refresh-token"
             ),
-            StructuredSchema::Npm => matches!(key, "AUTH_TOKEN" | "PASSWORD" | "AUTH"),
+            StructuredSchema::Npm => matches!(
+                key.trim_start_matches('_').to_ascii_lowercase().as_str(),
+                "auth_token" | "authtoken" | "password" | "auth"
+            ),
             StructuredSchema::Pypi => key.eq_ignore_ascii_case("password"),
         }
     }
@@ -377,18 +407,20 @@ impl Parser for StructuredParser {
                     .is_some_and(|(_, parent)| matches!(parent.as_str(), "data" | "stringData"));
             let mut hints = Vec::new();
             if parent_is_kubernetes_secret_data {
-                hints.push("pentect:secret-value".to_string());
+                hints.push(SECRET_VALUE_HINT.to_string());
             }
             if self.is_schema_secret_key(&key) {
-                hints.push("pentect:secret-value".to_string());
+                hints.push(SECRET_VALUE_HINT.to_string());
             }
 
             let scalar_start = pos + value_offset + leading;
+            let mut next_pos = line_end.saturating_add(1);
             let scalar_span = if is_yaml_block_indicator(value) {
                 let Some(span) = yaml_block_span(raw, line_end.saturating_add(1), indent) else {
                     pos = line_end.saturating_add(1);
                     continue;
                 };
+                next_pos = span.end.saturating_add(1).min(raw.len());
                 span
             } else {
                 structured_scalar_span(raw, scalar_start, scalar_start + value.len())
@@ -405,7 +437,7 @@ impl Parser for StructuredParser {
                     },
                 });
             }
-            pos = line_end.saturating_add(1);
+            pos = next_pos;
         }
         Some(regions)
     }
@@ -743,6 +775,19 @@ mod tests {
     }
 
     #[test]
+    fn quoted_and_tab_stripping_heredocs_are_parsed_as_values() {
+        for raw in [
+            "TOKEN<<'EOF'\nfirst\nsecond\nEOF\n",
+            "TOKEN<<-\"EOF\"\nfirst\nsecond\n\tEOF\n",
+        ] {
+            assert_eq!(
+                parsed(raw),
+                [(Some("TOKEN".into()), "first\nsecond".into())]
+            );
+        }
+    }
+
+    #[test]
     fn dotenv_content_sniff_is_strict_and_order_independent() {
         assert!(looks_like_dotenv_document("API_KEY=abc\nMODE=dev\n"));
         assert!(looks_like_dotenv_document(
@@ -813,7 +858,7 @@ mod tests {
                     .ctx
                     .hints
                     .iter()
-                    .any(|hint| hint == "pentect:secret-value")
+                    .any(|hint| hint == SECRET_VALUE_HINT)
             })
             .map(|region| region.ctx.key.as_deref().unwrap())
             .collect::<Vec<_>>();
@@ -822,12 +867,26 @@ mod tests {
 
     #[test]
     fn yaml_block_scalar_is_kept_as_one_value() {
-        let raw = "client-key-data: |\n  line-one\n  line-two\nnext: public\n";
+        let raw = "client-key-data: |\n  line-one\n  nested: text\nnext: public\n";
         let regions = StructuredParser::generic().parse(raw).unwrap();
         assert_eq!(
             &raw[regions[0].span.start..regions[0].span.end],
-            "  line-one\n  line-two"
+            "  line-one\n  nested: text"
         );
+        assert_eq!(regions.len(), 2);
+        assert_eq!(regions[1].ctx.path.as_deref(), Some("next"));
+    }
+
+    #[test]
+    fn official_schema_keys_include_top_level_npm_and_auth_provider_tokens() {
+        let npm = StructuredParser::npm();
+        for key in ["_auth", "_authToken", "_password", "AUTH_TOKEN"] {
+            assert!(npm.is_schema_secret_key(key), "{key}");
+        }
+        let kubeconfig = StructuredParser::kubeconfig();
+        for key in ["token", "id-token", "refresh-token", "client-key-data"] {
+            assert!(kubeconfig.is_schema_secret_key(key), "{key}");
+        }
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/interval.rs
+++ b/crates/pentect-core/src/pipeline/interval.rs
@@ -36,24 +36,6 @@ impl RangeIndex {
         let idx = self.ranges.partition_point(|r| r.start < range.start);
         self.ranges.insert(idx, range);
     }
-
-    pub(super) fn overlapping(&self, range: &ByteRange) -> Vec<ByteRange> {
-        if range.is_empty() {
-            return Vec::new();
-        }
-        let mut idx = self.ranges.partition_point(|r| r.end <= range.start);
-        let mut out = Vec::new();
-        while let Some(r) = self.ranges.get(idx) {
-            if r.start >= range.end {
-                break;
-            }
-            if r.overlaps(range) {
-                out.push(*r);
-            }
-            idx += 1;
-        }
-        out
-    }
 }
 
 #[cfg(test)]
@@ -76,22 +58,5 @@ mod tests {
         assert!(!idx.contains(&ByteRange::new(1, 3)));
         assert!(!idx.contains(&ByteRange::new(4, 9)));
         assert!(!idx.contains(&ByteRange::new(12, 12)));
-    }
-
-    #[test]
-    fn overlapping_returns_sorted_intersections() {
-        let idx = RangeIndex::new(vec![
-            ByteRange::new(0, 2),
-            ByteRange::new(4, 6),
-            ByteRange::new(8, 10),
-        ]);
-        assert_eq!(
-            idx.overlapping(&ByteRange::new(1, 9)),
-            vec![
-                ByteRange::new(0, 2),
-                ByteRange::new(4, 6),
-                ByteRange::new(8, 10)
-            ]
-        );
     }
 }

--- a/crates/pentect-core/src/pipeline/merge.rs
+++ b/crates/pentect-core/src/pipeline/merge.rs
@@ -27,53 +27,51 @@ pub fn merge(mut spans: Vec<Span>, protected: &[ByteRange]) -> Vec<Span> {
                 || can_touch_protected(s))
     });
 
-    // Strongest first (Span::cmp_strength is the one canonical ordering).
-    spans.sort_by(|a, b| b.cmp_strength(a));
-
-    let mut accepted: Vec<Span> = Vec::new();
-    let mut accepted_index = RangeIndex::default();
-    for s in spans {
-        if !accepted_index.overlaps(&s.range) {
-            accepted_index.insert(s.range);
-            accepted.push(s);
-            continue;
-        }
-        // A context-free span ("this whole run is opaque") keeps the part not
-        // already claimed by a stronger span, so the uncovered remainder is still
-        // masked. Without this, masking the overlap leaves a maskable tail in
-        // plaintext (a leak, and a break of idempotency: a second pass would mask
-        // it). Anchored weaker spans still drop whole, so a vendor token is never
-        // split into fragments.
-        if is_context_free(&s) {
-            let mut pieces = vec![s.range];
-            for a in accepted_index.overlapping(&s.range) {
-                pieces = pieces.into_iter().flat_map(|p| subtract(p, &a)).collect();
-            }
-            for range in pieces {
-                if !range.is_empty() && !accepted_index.overlaps(&range) {
-                    accepted_index.insert(range);
-                    accepted.push(Span { range, ..s.clone() });
+    // Every connected overlap describes one underlying byte sequence. Mask its
+    // full union so a weaker candidate cannot leave a prefix or suffix visible.
+    // Ranges that merely touch at an edge remain independent.
+    spans.sort_by_key(|s| (s.range.start, s.range.end));
+    let mut merged: Vec<Span> = Vec::new();
+    let mut component: Option<(ByteRange, Span)> = None;
+    for span in spans {
+        match component.take() {
+            None => component = Some((span.range, span)),
+            Some((union, mut strongest)) if union.overlaps(&span.range) => {
+                let union = ByteRange::new(
+                    union.start.min(span.range.start),
+                    union.end.max(span.range.end),
+                );
+                match span.cmp_strength(&strongest) {
+                    core::cmp::Ordering::Greater => strongest = span,
+                    core::cmp::Ordering::Equal if span.label != strongest.label => {
+                        strongest.label = canonical_category_label(strongest.category).into();
+                    }
+                    core::cmp::Ordering::Equal | core::cmp::Ordering::Less => {}
                 }
+                component = Some((union, strongest));
+            }
+            Some((union, mut strongest)) => {
+                strongest.range = union;
+                merged.push(strongest);
+                component = Some((span.range, span));
             }
         }
     }
-    accepted.sort_by_key(|s| s.range.start);
-    accepted
+    if let Some((union, mut strongest)) = component {
+        strongest.range = union;
+        merged.push(strongest);
+    }
+    merged
 }
 
-/// `p` minus `a`: the 0–2 sub-ranges of `p` that `a` does not cover.
-fn subtract(p: ByteRange, a: &ByteRange) -> Vec<ByteRange> {
-    if !p.overlaps(a) {
-        return vec![p];
+fn canonical_category_label(category: Category) -> &'static str {
+    match category {
+        Category::Secret => "SECRET",
+        Category::Pii => "PII",
+        Category::Identifier => "IDENTIFIER",
+        Category::Endpoint => "ENDPOINT",
+        Category::Other => "SENSITIVE",
     }
-    let mut out = Vec::new();
-    if p.start < a.start {
-        out.push(ByteRange::new(p.start, a.start));
-    }
-    if a.end < p.end {
-        out.push(ByteRange::new(a.end, p.end));
-    }
-    out
 }
 
 fn touches_protected(range: &ByteRange, protected_edges: &HashSet<usize>) -> bool {
@@ -101,13 +99,14 @@ mod tests {
     }
 
     #[test]
-    fn higher_confidence_wins_overlap() {
+    fn higher_confidence_selects_metadata_and_union_masks_the_range() {
         let out = merge(
             vec![span(0, 10, Confidence::Low), span(2, 8, Confidence::High)],
             &[],
         );
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].confidence, Confidence::High);
+        assert_eq!(out[0].range, ByteRange::new(0, 10));
     }
 
     #[test]
@@ -189,23 +188,59 @@ mod tests {
     }
 
     #[test]
-    fn context_free_span_keeps_uncovered_remainder() {
-        // A strong anchored hit claims [0,6); the entropy run [4,30) keeps [6,30)
-        // so the tail is still masked (no leak, and idempotent).
+    fn overlapping_spans_become_one_handle_for_the_full_union() {
         let out = merge(vec![span(0, 6, Confidence::High), entropy_span(4, 30)], &[]);
-        assert_eq!(out.len(), 2);
-        assert_eq!(out[0].range, ByteRange::new(0, 6));
-        assert_eq!(out[1].range, ByteRange::new(6, 30));
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].range, ByteRange::new(0, 30));
+        assert_eq!(out[0].confidence, Confidence::High);
     }
 
     #[test]
-    fn anchored_weaker_span_still_drops_whole() {
-        // A non-context-free (Rule) span is not fragmented around a stronger hit.
+    fn weaker_anchored_tail_is_not_left_in_plaintext() {
         let out = merge(
             vec![span(2, 8, Confidence::High), span(0, 10, Confidence::Low)],
             &[],
         );
         assert_eq!(out.len(), 1);
-        assert_eq!(out[0].range, ByteRange::new(2, 8));
+        assert_eq!(out[0].range, ByteRange::new(0, 10));
+    }
+
+    #[test]
+    fn same_range_conflicting_labels_fall_back_to_category() {
+        let mut alpha = span(0, 10, Confidence::High);
+        alpha.label = "ALPHA".into();
+        let mut beta = alpha.clone();
+        beta.label = "BETA".into();
+
+        let forward = merge(vec![beta.clone(), alpha.clone()], &[]);
+        let reverse = merge(vec![alpha, beta], &[]);
+        assert_eq!(forward[0].label, "SECRET");
+        assert_eq!(forward[0].label, reverse[0].label);
+    }
+
+    #[test]
+    fn unambiguous_stronger_finding_keeps_specific_label() {
+        let mut weak = span(0, 10, Confidence::Medium);
+        weak.label = "LIKELY_SECRET".into();
+        let mut strong = span(0, 10, Confidence::High);
+        strong.label = "API_KEY".into();
+        let out = merge(vec![weak, strong], &[]);
+        assert_eq!(out[0].label, "API_KEY");
+    }
+
+    #[test]
+    fn transitive_overlaps_union_but_adjacent_ranges_stay_separate() {
+        let out = merge(
+            vec![
+                span(0, 4, Confidence::Medium),
+                span(3, 7, Confidence::Medium),
+                span(6, 9, Confidence::Medium),
+                span(9, 12, Confidence::Medium),
+            ],
+            &[],
+        );
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].range, ByteRange::new(0, 9));
+        assert_eq!(out[1].range, ByteRange::new(9, 12));
     }
 }

--- a/crates/pentect-core/src/pipeline/merge.rs
+++ b/crates/pentect-core/src/pipeline/merge.rs
@@ -66,11 +66,11 @@ pub fn merge(mut spans: Vec<Span>, protected: &[ByteRange]) -> Vec<Span> {
 
 fn canonical_category_label(category: Category) -> &'static str {
     match category {
-        Category::Secret => "SECRET",
-        Category::Pii => "PII",
-        Category::Identifier => "IDENTIFIER",
-        Category::Endpoint => "ENDPOINT",
-        Category::Other => "SENSITIVE",
+        Category::Secret => labels::SECRET,
+        Category::Pii => labels::PII,
+        Category::Identifier => labels::IDENTIFIER,
+        Category::Endpoint => labels::ENDPOINT,
+        Category::Other => labels::SENSITIVE,
     }
 }
 

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -11,7 +11,7 @@ use crate::detect::{
 };
 use crate::model::*;
 use crate::normalize::NormalizedView;
-use crate::parse::{EnvParser, JsonParser, NdjsonParser, Parser, TextParser};
+use crate::parse::{EnvParser, JsonParser, NdjsonParser, Parser, StructuredParser, TextParser};
 use crate::policy::guard::{NoGuard, OverMaskGuard, ShapeGuard};
 use crate::policy::{
     is_context_free, Action, MaskAll, Policy, Profile, ProfileKnobs, ProfilePolicy,
@@ -545,6 +545,31 @@ impl Engine {
         raw: String,
         protected: Vec<ByteRange>,
     ) -> (Ir, bool) {
+        if let Kind::Other(name) = &kind {
+            if let Some(label) = name.strip_prefix("secret-file:") {
+                let regions = (!raw.is_empty())
+                    .then(|| Region {
+                        span: ByteRange::new(0, raw.len()),
+                        ctx: Context {
+                            path: None,
+                            key: Some(label.to_string()),
+                            hints: vec!["pentect:secret-value".to_string()],
+                            kind: RegionKind::Body,
+                            format: kind.clone(),
+                        },
+                    })
+                    .into_iter()
+                    .collect();
+                return (
+                    Ir {
+                        raw,
+                        regions,
+                        protected,
+                    },
+                    false,
+                );
+            }
+        }
         let (regions, fell_back) = match self.parsers.iter().find(|(k, _)| *k == kind) {
             Some((_, p)) => match p.parse(&raw) {
                 Some(regions) => (regions, false),
@@ -566,9 +591,16 @@ impl Engine {
 fn relabel_env_spans(spans: &mut [Span], regions: &[Region]) {
     for span in spans {
         let Some(key) = regions.iter().find_map(|region| {
-            (region.ctx.format == Kind::Env && region.span.contains(&span.range))
-                .then_some(region.ctx.key.as_deref())
-                .flatten()
+            ((region.ctx.format == Kind::Env
+                || matches!(&region.ctx.format, Kind::Other(name) if name.starts_with("structured"))
+                || region
+                    .ctx
+                    .hints
+                    .iter()
+                    .any(|hint| hint == "pentect:secret-value"))
+                && region.span.contains(&span.range))
+            .then_some(region.ctx.key.as_deref())
+            .flatten()
         }) else {
             continue;
         };
@@ -647,6 +679,26 @@ impl EngineBuilder {
         self.parser(Kind::Json, Box::new(JsonParser))
             .parser(Kind::Ndjson, Box::new(NdjsonParser))
             .parser(Kind::Env, Box::new(EnvParser))
+            .parser(
+                Kind::Other("structured".to_string()),
+                Box::new(StructuredParser::generic()),
+            )
+            .parser(
+                Kind::Other("structured:aws".to_string()),
+                Box::new(StructuredParser::aws()),
+            )
+            .parser(
+                Kind::Other("structured:kubeconfig".to_string()),
+                Box::new(StructuredParser::kubeconfig()),
+            )
+            .parser(
+                Kind::Other("structured:npm".to_string()),
+                Box::new(StructuredParser::npm()),
+            )
+            .parser(
+                Kind::Other("structured:pypi".to_string()),
+                Box::new(StructuredParser::pypi()),
+            )
             .parser(Kind::Har, Box::new(JsonParser))
             .detector(Box::new(UrlDetector))
             .detector(Box::new(CliCredentialDetector))
@@ -676,6 +728,26 @@ impl EngineBuilder {
         self.parser(Kind::Json, Box::new(JsonParser))
             .parser(Kind::Ndjson, Box::new(NdjsonParser))
             .parser(Kind::Env, Box::new(EnvParser))
+            .parser(
+                Kind::Other("structured".to_string()),
+                Box::new(StructuredParser::generic()),
+            )
+            .parser(
+                Kind::Other("structured:aws".to_string()),
+                Box::new(StructuredParser::aws()),
+            )
+            .parser(
+                Kind::Other("structured:kubeconfig".to_string()),
+                Box::new(StructuredParser::kubeconfig()),
+            )
+            .parser(
+                Kind::Other("structured:npm".to_string()),
+                Box::new(StructuredParser::npm()),
+            )
+            .parser(
+                Kind::Other("structured:pypi".to_string()),
+                Box::new(StructuredParser::pypi()),
+            )
             .parser(Kind::Har, Box::new(JsonParser))
             .detector(Box::new(CredSweeperNativeDetector::builtin()))
             .detector(Box::new(KeyValueDetector))
@@ -1387,11 +1459,10 @@ mod tests {
         let input = "open http://user:pass@local.jira.corp:8080/api/issues/ABC-123?token=s3cr3t&project=OPS#comment-456.";
         let r = m(input);
         assert!(
-            r.masked.starts_with("open http://<<URL_CREDENTIAL_"),
+            r.masked.starts_with("open http://<<INTERNAL_ENDPOINT_"),
             "{}",
             r.masked
         );
-        assert!(r.masked.contains("@<<INTERNAL_ENDPOINT_"), "{}", r.masked);
         assert!(
             r.masked.contains("/api/issues/<<RESOURCE_ID_"),
             "{}",
@@ -2469,6 +2540,246 @@ mod tests {
             r.masked
         );
         assert!(r.masked.contains("9PATCH=<<ENV_9PATCH_"), "{}", r.masked);
+    }
+
+    #[test]
+    fn structured_credentials_mask_only_credential_fields() {
+        let raw = concat!(
+            "[pypi]\n",
+            "repository = https://upload.pypi.org/legacy/\n",
+            "username = __token__\n",
+            "password = pypi-example-token\n",
+            "//registry.npmjs.org/:_authToken=npm-example-token\n",
+        );
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Other("structured".into()),
+                data: raw.into(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert!(
+            result
+                .masked
+                .contains("repository = https://upload.pypi.org/legacy/"),
+            "{}",
+            result.masked
+        );
+        assert!(
+            result.masked.contains("password = <<PASSWORD_"),
+            "{}",
+            result.masked
+        );
+        assert!(
+            result.masked.contains("_authToken=<<AUTH_TOKEN_"),
+            "{}",
+            result.masked
+        );
+        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+    }
+
+    #[test]
+    fn kubernetes_secret_schema_masks_low_entropy_values_by_key() {
+        let raw = concat!(
+            "apiVersion: v1\n",
+            "kind: Secret\n",
+            "metadata:\n  name: app\n",
+            "stringData:\n  DB_PASSWORD: plain\n",
+            "data:\n  API_TOKEN: YWJj\n",
+        );
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Other("structured".into()),
+                data: raw.into(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert!(result.masked.contains("name: app"), "{}", result.masked);
+        assert!(
+            result.masked.contains("DB_PASSWORD: <<DB_PASSWORD_"),
+            "{}",
+            result.masked
+        );
+        assert!(
+            result.masked.contains("API_TOKEN: <<API_TOKEN_"),
+            "{}",
+            result.masked
+        );
+        assert!(!result.masked.contains(": plain"), "{}", result.masked);
+        assert!(!result.masked.contains(": YWJj"), "{}", result.masked);
+        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+    }
+
+    #[test]
+    fn generic_structured_config_does_not_mask_benign_values() {
+        let raw = "mode: development\nregion: us-east-1\nretries = 3\n";
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Other("structured".into()),
+                data: raw.into(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert_eq!(result.masked, raw);
+    }
+
+    #[test]
+    fn mounted_secret_file_masks_the_entire_payload_with_filename_label() {
+        let raw = "short value with spaces\nand another line";
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Other("secret-file:database-password".into()),
+                data: raw.into(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert!(
+            result.masked.starts_with("<<DATABASE_PASSWORD_"),
+            "{}",
+            result.masked
+        );
+        assert!(!result.masked.contains("short value"), "{}", result.masked);
+        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+    }
+
+    #[test]
+    fn kubernetes_secret_json_uses_data_keys_as_labels() {
+        let raw = r#"{"apiVersion":"v1","kind":"Secret","metadata":{"name":"app"},"stringData":{"DB_PASSWORD":"plain"},"data":{"API_TOKEN":"YWJj"}}"#;
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Json,
+                data: raw.into(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert!(
+            result.masked.contains("\"name\":\"app\""),
+            "{}",
+            result.masked
+        );
+        assert!(
+            result.masked.contains("\"DB_PASSWORD\":\"<<DB_PASSWORD_"),
+            "{}",
+            result.masked
+        );
+        assert!(
+            result.masked.contains("\"API_TOKEN\":\"<<API_TOKEN_"),
+            "{}",
+            result.masked
+        );
+        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+    }
+
+    #[test]
+    fn terraform_sensitive_values_metadata_forces_masking() {
+        let raw = r#"{"version":4,"resources":[{"instances":[{"attributes":{"password":"short","region":"us-east-1"},"sensitive_values":{"password":true}}]}]}"#;
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Json,
+                data: raw.into(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert!(
+            !result.masked.contains("\"password\":\"short\""),
+            "{}",
+            result.masked
+        );
+        assert!(
+            result.masked.contains("\"region\":\"us-east-1\""),
+            "{}",
+            result.masked
+        );
+        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+    }
+
+    #[test]
+    fn kubeconfig_and_tfvars_keep_structural_credential_labels() {
+        for (raw, key, value, kind) in [
+            (
+                "users:\n  - name: admin\n    user:\n      token: kube-token-example\n",
+                "token",
+                "kube-token-example",
+                "structured:kubeconfig",
+            ),
+            (
+                "region = \"us-east-1\"\ndb_password = \"terraform-password\"\n",
+                "db_password",
+                "terraform-password",
+                "structured",
+            ),
+        ] {
+            let result = Engine::with_profile(Profile::Strict).mask(
+                Input {
+                    kind: Kind::Other(kind.into()),
+                    data: raw.into(),
+                },
+                &Config::insecure_testing(),
+            );
+            assert!(!result.masked.contains(value), "{}", result.masked);
+            assert!(
+                result
+                    .masked
+                    .contains(&format!("<<{}_", env_placeholder_label(key))),
+                "{}",
+                result.masked
+            );
+            assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+        }
+    }
+
+    #[test]
+    fn official_credential_schemas_mask_short_values_but_keep_public_config() {
+        for (kind, raw, visible, label) in [
+            (
+                "structured:aws",
+                "region = us-east-1\naws_session_token = x\n",
+                "region = us-east-1",
+                "AWS_SESSION_TOKEN",
+            ),
+            (
+                "structured:npm",
+                "registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=x\n",
+                "registry=https://registry.npmjs.org/",
+                "AUTH_TOKEN",
+            ),
+            (
+                "structured:pypi",
+                "[pypi]\nrepository = https://upload.pypi.org/legacy/\npassword = x\n",
+                "repository = https://upload.pypi.org/legacy/",
+                "PASSWORD",
+            ),
+        ] {
+            let result = Engine::with_profile(Profile::Strict).mask(
+                Input {
+                    kind: Kind::Other(kind.into()),
+                    data: raw.into(),
+                },
+                &Config::insecure_testing(),
+            );
+            assert!(result.masked.contains(visible), "{}", result.masked);
+            assert!(
+                result.masked.contains(&format!("<<{label}_")),
+                "{}",
+                result.masked
+            );
+            assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+        }
+    }
+
+    #[test]
+    fn duplicate_env_keys_keep_distinct_values_reversible() {
+        let raw = "TOKEN=first\nTOKEN=second\n";
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Env,
+                data: raw.into(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert_eq!(result.summary.masked_count, 2);
+        assert_eq!(result.masked.matches("<<TOKEN_").count(), 2);
+        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -7,7 +7,7 @@ use crate::detect::{
     AuthCodeDetector, Bip39Detector, CardDetector, CliCredentialDetector,
     CredSweeperNativeDetector, DecodeConfig, DecodeDetector, Detector, EntropyDetector,
     EnvValueDetector, KeyValueDetector, PemDetector, PhoneDetector, RuleDetector,
-    SensitiveKeyDetector, StructuralDetector, UrlDetector, UuidDetector,
+    SensitiveKeyDetector, StructuralDetector, UrlDetector, UuidDetector, SECRET_VALUE_HINT,
 };
 use crate::model::*;
 use crate::normalize::NormalizedView;
@@ -553,7 +553,7 @@ impl Engine {
                         ctx: Context {
                             path: None,
                             key: Some(label.to_string()),
-                            hints: vec!["pentect:secret-value".to_string()],
+                            hints: vec![SECRET_VALUE_HINT.to_string()],
                             kind: RegionKind::Body,
                             format: kind.clone(),
                         },
@@ -597,7 +597,7 @@ fn relabel_env_spans(spans: &mut [Span], regions: &[Region]) {
                     .ctx
                     .hints
                     .iter()
-                    .any(|hint| hint == "pentect:secret-value"))
+                    .any(|hint| hint == SECRET_VALUE_HINT))
                 && region.span.contains(&span.range))
             .then_some(region.ctx.key.as_deref())
             .flatten()
@@ -675,30 +675,35 @@ impl EngineBuilder {
         self.standard_stack_with_decode(knobs, profile_decode_config(knobs))
     }
 
+    /// Register every structured configuration schema from one canonical list.
+    pub fn structured_parsers(self) -> Self {
+        self.parser(
+            Kind::Other("structured".to_string()),
+            Box::new(StructuredParser::generic()),
+        )
+        .parser(
+            Kind::Other("structured:aws".to_string()),
+            Box::new(StructuredParser::aws()),
+        )
+        .parser(
+            Kind::Other("structured:kubeconfig".to_string()),
+            Box::new(StructuredParser::kubeconfig()),
+        )
+        .parser(
+            Kind::Other("structured:npm".to_string()),
+            Box::new(StructuredParser::npm()),
+        )
+        .parser(
+            Kind::Other("structured:pypi".to_string()),
+            Box::new(StructuredParser::pypi()),
+        )
+    }
+
     pub fn standard_stack_with_decode(self, knobs: ProfileKnobs, decode: DecodeConfig) -> Self {
         self.parser(Kind::Json, Box::new(JsonParser))
             .parser(Kind::Ndjson, Box::new(NdjsonParser))
             .parser(Kind::Env, Box::new(EnvParser))
-            .parser(
-                Kind::Other("structured".to_string()),
-                Box::new(StructuredParser::generic()),
-            )
-            .parser(
-                Kind::Other("structured:aws".to_string()),
-                Box::new(StructuredParser::aws()),
-            )
-            .parser(
-                Kind::Other("structured:kubeconfig".to_string()),
-                Box::new(StructuredParser::kubeconfig()),
-            )
-            .parser(
-                Kind::Other("structured:npm".to_string()),
-                Box::new(StructuredParser::npm()),
-            )
-            .parser(
-                Kind::Other("structured:pypi".to_string()),
-                Box::new(StructuredParser::pypi()),
-            )
+            .structured_parsers()
             .parser(Kind::Har, Box::new(JsonParser))
             .detector(Box::new(UrlDetector))
             .detector(Box::new(CliCredentialDetector))
@@ -728,26 +733,7 @@ impl EngineBuilder {
         self.parser(Kind::Json, Box::new(JsonParser))
             .parser(Kind::Ndjson, Box::new(NdjsonParser))
             .parser(Kind::Env, Box::new(EnvParser))
-            .parser(
-                Kind::Other("structured".to_string()),
-                Box::new(StructuredParser::generic()),
-            )
-            .parser(
-                Kind::Other("structured:aws".to_string()),
-                Box::new(StructuredParser::aws()),
-            )
-            .parser(
-                Kind::Other("structured:kubeconfig".to_string()),
-                Box::new(StructuredParser::kubeconfig()),
-            )
-            .parser(
-                Kind::Other("structured:npm".to_string()),
-                Box::new(StructuredParser::npm()),
-            )
-            .parser(
-                Kind::Other("structured:pypi".to_string()),
-                Box::new(StructuredParser::pypi()),
-            )
+            .structured_parsers()
             .parser(Kind::Har, Box::new(JsonParser))
             .detector(Box::new(CredSweeperNativeDetector::builtin()))
             .detector(Box::new(KeyValueDetector))

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -50,9 +50,11 @@ pub use memory_store::{
 };
 use memory_store::{MemoryStore, MemoryStoreClient, ENV_ADDR, ENV_TOKEN};
 pub use output_remask::ActiveTerminalOutputRemasker;
+#[cfg(test)]
+use pentect_core::infer_kind;
 use pentect_core::{
-    infer_kind, parse_placeholder, Config, Engine, Input, Kind, MaskResult, Pack, Profile,
-    RegionKind,
+    infer_kind_with_content, parse_placeholder, Config, Engine, Input, Kind, MaskResult, Pack,
+    Profile, RegionKind,
 };
 use serde_json::{json, Value};
 use session::{checked_session_name, session_root, Session};
@@ -592,7 +594,9 @@ fn cmd_read(args: &[String]) -> i32 {
         Ok(s) => s,
         Err(e) => return die(&e),
     };
-    let kind = opts.kind.unwrap_or_else(|| infer_kind(&opts.path));
+    let kind = opts
+        .kind
+        .unwrap_or_else(|| infer_kind_with_content(&opts.path, &data));
     let source = data.clone();
     let input = Input { kind, data };
     match mask_input_into_active_memory_store(input.clone(), Profile::Strict, Vec::new()) {
@@ -1532,7 +1536,7 @@ fn register_local_file_inputs(store: &MemoryStore, script: &str) -> Result<(), S
         let Ok(input) = read_input(&path, InputFormat::Text) else {
             continue;
         };
-        let kind = infer_kind(&path);
+        let kind = infer_kind_with_content(&path, &input);
         if kind == Kind::Text {
             let _ = masker.mask_tool_output(&input)?;
         } else {
@@ -2695,7 +2699,7 @@ fn masked_read_copy(session: &Session, path_text: &str) -> Result<Option<PathBuf
         session.key,
         session.identity_key,
         data.clone(),
-        infer_kind(path),
+        infer_kind_with_content(path, &data),
     )?;
     if result.summary.masked_count == 0 {
         return Ok(None);
@@ -4174,6 +4178,8 @@ fn parse_kind(value: &str) -> Result<Kind, String> {
         "ndjson" | "jsonl" => Ok(Kind::Ndjson),
         "env" => Ok(Kind::Env),
         "har" => Ok(Kind::Har),
+        "structured" | "config" => Ok(Kind::Other("structured".to_string())),
+        "secret" | "secret-file" => Ok(Kind::Other("secret-file:SECRET".to_string())),
         other => Err(format!("unknown kind: {other}")),
     }
 }

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -8,7 +8,7 @@ use pentect_core::{
     load_pack, ByteRange, Category, Config, Context, CredSweeperNativeDetector, Engine,
     EntropyDetector, EnvParser, EnvValueDetector, Input, JsonParser, Kind, MaskResult,
     NdjsonParser, PemDetector, Profile, ProfilePolicy, Recovery, Region, RegionKind,
-    SensitiveKeyDetector, ShapeGuard, ToolResultParser,
+    SensitiveKeyDetector, ShapeGuard, StructuredParser, ToolResultParser,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::sync::OnceLock;
@@ -964,6 +964,26 @@ fn build_pentect_engine() -> Result<Engine, String> {
         .parser(Kind::Json, Box::new(JsonParser))
         .parser(Kind::Ndjson, Box::new(NdjsonParser))
         .parser(Kind::Env, Box::new(EnvParser))
+        .parser(
+            Kind::Other("structured".to_string()),
+            Box::new(StructuredParser::generic()),
+        )
+        .parser(
+            Kind::Other("structured:aws".to_string()),
+            Box::new(StructuredParser::aws()),
+        )
+        .parser(
+            Kind::Other("structured:kubeconfig".to_string()),
+            Box::new(StructuredParser::kubeconfig()),
+        )
+        .parser(
+            Kind::Other("structured:npm".to_string()),
+            Box::new(StructuredParser::npm()),
+        )
+        .parser(
+            Kind::Other("structured:pypi".to_string()),
+            Box::new(StructuredParser::pypi()),
+        )
         .parser(Kind::Har, Box::new(JsonParser))
         .parser(Kind::ToolResult, Box::new(ToolResultParser))
         .detector(Box::new(CredSweeperNativeDetector::builtin()))

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -8,7 +8,7 @@ use pentect_core::{
     load_pack, ByteRange, Category, Config, Context, CredSweeperNativeDetector, Engine,
     EntropyDetector, EnvParser, EnvValueDetector, Input, JsonParser, Kind, MaskResult,
     NdjsonParser, PemDetector, Profile, ProfilePolicy, Recovery, Region, RegionKind,
-    SensitiveKeyDetector, ShapeGuard, StructuredParser, ToolResultParser,
+    SensitiveKeyDetector, ShapeGuard, ToolResultParser,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::sync::OnceLock;
@@ -964,26 +964,7 @@ fn build_pentect_engine() -> Result<Engine, String> {
         .parser(Kind::Json, Box::new(JsonParser))
         .parser(Kind::Ndjson, Box::new(NdjsonParser))
         .parser(Kind::Env, Box::new(EnvParser))
-        .parser(
-            Kind::Other("structured".to_string()),
-            Box::new(StructuredParser::generic()),
-        )
-        .parser(
-            Kind::Other("structured:aws".to_string()),
-            Box::new(StructuredParser::aws()),
-        )
-        .parser(
-            Kind::Other("structured:kubeconfig".to_string()),
-            Box::new(StructuredParser::kubeconfig()),
-        )
-        .parser(
-            Kind::Other("structured:npm".to_string()),
-            Box::new(StructuredParser::npm()),
-        )
-        .parser(
-            Kind::Other("structured:pypi".to_string()),
-            Box::new(StructuredParser::pypi()),
-        )
+        .structured_parsers()
         .parser(Kind::Har, Box::new(JsonParser))
         .parser(Kind::ToolResult, Box::new(ToolResultParser))
         .detector(Box::new(CredSweeperNativeDetector::builtin()))

--- a/guides/structured-secrets.md
+++ b/guides/structured-secrets.md
@@ -1,0 +1,42 @@
+# Structured secret sources
+
+Pentect uses source structure only when it can identify the format with high
+confidence. A structural key becomes the handle label; it never changes the
+handle's underlying value or recovery behavior.
+
+## Supported sources
+
+| Source | Recognition | Masking rule |
+| --- | --- | --- |
+| dotenv | `.env*`, `*.env`, high-confidence dotenv content | every parsed value |
+| Cloudflare | `.dev.vars*` | every parsed value |
+| Firebase | `.secret.local`, `*.secret.local` | every parsed value |
+| GitHub Actions | runner `set_env_*` files, including delimiter-based multiline values | every parsed value |
+| AWS | `.aws/credentials`, sensitive fields in `.aws/config` | credential values only |
+| npm | `.npmrc` | scoped auth values only |
+| Python packaging | `.pypirc` | passwords/tokens only |
+| Kubernetes Secret | YAML or JSON `kind: Secret`, `data` and `stringData` | every schema-defined secret value |
+| kubeconfig | `kubeconfig` or `.kube/config` | token, password, and client private-key data |
+| Docker/Kubernetes secret files | standard runtime mounts, `secrets/` directories, `*.secret` | complete file as one value |
+| Git credential store | plaintext credential URLs | credential portion of each URL |
+| Terraform | `*.tfvars`, `*.auto.tfvars`, JSON state `sensitive_values` | detected or explicitly sensitive values |
+| generic config | YAML, TOML, INI, properties, and conf files | detected sensitive values only |
+
+The parser preserves assignment keys, separators, quotes, comments, and UTF-8
+boundaries. YAML block scalars and GitHub environment-file multiline values are
+treated as one reversible value.
+
+## Detection order
+
+1. An explicit source schema or standard secret mount.
+2. An official filename convention.
+3. A high-confidence content signature.
+4. Normal CredSweeper and Pentect detection.
+
+An unknown or malformed format remains ordinary text. Pentect does not infer
+that every value in an arbitrary configuration file is secret.
+
+Tools may use arbitrary dotenv paths. `pentect read --kind env PATH` is the
+explicit override when neither provenance nor content is sufficient;
+`--kind structured` selects the conservative structured-config parser, and
+`--kind secret` treats an explicitly supplied one-secret file as one value.


### PR DESCRIPTION
Closes #117

## Summary
- recognize dotenv families, official credential files, Kubernetes/Terraform schemas, and standard mounted secret files
- preserve source syntax while using structural keys as stable handle labels
- keep generic structured configuration conservative and send comments/unknown lines through normal CredSweeper detection
- merge overlapping findings deterministically so conflicting labels cannot expose a prefix or suffix
- add CLI integration coverage and a structured-source guide
- bump the CLI to v0.0.10

## Local verification
- `cargo test -p pentect-core --locked` (356 passed before the final parser fallback test; targeted structured suite then 8 passed)
- `cargo test -p pentect-runtime --lib --locked -- --test-threads=1` (252 passed)
- `cargo test -p pentect-cli --no-default-features --test structured_sources --locked` (2 passed)
- `cargo clippy --locked -p pentect-cli --no-default-features --all-targets -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added masking support for structured configuration, dotenv, Kubernetes, Terraform, npm, PyPI, AWS, and mounted secret files.
  * Improved automatic source detection using file content and path information.
  * Added aliases for structured configuration and secret-file input types.
  * Added support for multiline environment values and schema-specific secret identification.
* **Bug Fixes**
  * Improved overlapping-secret masking and label selection.
  * Preserved public configuration values while masking embedded credentials.
* **Documentation**
  * Added guidance for supported structured secret sources and masking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->