### PR TITLE
Improve doctor repairs and structured stdin masking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.10"
+version = "0.0.11"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -46,7 +46,7 @@ struct Check {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Repair {
     AddToPath(PathBuf),
-    MigrateConfig { path: PathBuf, content: String },
+    MigrateConfig { path: PathBuf },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -174,9 +174,11 @@ fn check_configs() -> Vec<Check> {
 }
 
 fn home_dir() -> Option<PathBuf> {
-    std::env::var_os("USERPROFILE")
-        .or_else(|| std::env::var_os("HOME"))
-        .map(PathBuf::from)
+    #[cfg(windows)]
+    let variable = "USERPROFILE";
+    #[cfg(not(windows))]
+    let variable = "HOME";
+    std::env::var_os(variable).map(PathBuf::from)
 }
 
 fn check_config(name: &'static str, path: PathBuf) -> Check {
@@ -188,10 +190,10 @@ fn check_config(name: &'static str, path: PathBuf) -> Check {
         Err(error) => return Check::fail(name, format!("{}: {error}", path.display())),
     };
     match migrate_removed_config_keys(&source) {
-        Ok(Some(content)) => Check::repairable_warn(
+        Ok(Some(_)) => Check::repairable_warn(
             name,
             format!("{} uses removed settings", path.display()),
-            Repair::MigrateConfig { path, content },
+            Repair::MigrateConfig { path },
         ),
         Ok(None) => Check::ok(name, "ready"),
         Err(error) => Check::fail(name, format!("{}: {error}", path.display())),
@@ -263,7 +265,7 @@ fn migrate_removed_config_keys(source: &str) -> Result<Option<String>, String> {
 
     if document.contains_key("file_pointer_manager") {
         let legacy = document["file_pointer_manager"]
-            .as_table()
+            .as_table_like()
             .ok_or_else(|| "file_pointer_manager must be a table".to_string())?;
         if legacy.len() != 1 || !legacy.contains_key("save") {
             return Err("file_pointer_manager cannot be migrated automatically".to_string());
@@ -279,7 +281,7 @@ fn migrate_removed_config_keys(source: &str) -> Result<Option<String>, String> {
     }
     if document.contains_key("log") {
         let legacy = document["log"]
-            .as_table()
+            .as_table_like()
             .ok_or_else(|| "log must be a table".to_string())?;
         if legacy.len() != 1 || !legacy.contains_key("share") {
             return Err("log cannot be migrated automatically".to_string());
@@ -300,7 +302,7 @@ fn migrate_removed_config_keys(source: &str) -> Result<Option<String>, String> {
 fn table_string(document: &toml_edit::DocumentMut, table: &str, key: &str) -> Option<String> {
     document
         .get(table)?
-        .as_table()?
+        .as_table_like()?
         .get(key)?
         .as_str()
         .map(str::to_string)
@@ -309,23 +311,23 @@ fn table_string(document: &toml_edit::DocumentMut, table: &str, key: &str) -> Op
 fn table_has(document: &toml_edit::DocumentMut, table: &str, key: &str) -> bool {
     document
         .get(table)
-        .and_then(toml_edit::Item::as_table)
+        .and_then(toml_edit::Item::as_table_like)
         .is_some_and(|table| table.contains_key(key))
 }
 
 fn table_bool(document: &toml_edit::DocumentMut, table: &str, key: &str) -> Option<bool> {
-    document.get(table)?.as_table()?.get(key)?.as_bool()
+    document.get(table)?.as_table_like()?.get(key)?.as_bool()
 }
 
 fn ensure_table<'a>(
     document: &'a mut toml_edit::DocumentMut,
     name: &str,
-) -> Result<&'a mut toml_edit::Table, String> {
+) -> Result<&'a mut dyn toml_edit::TableLike, String> {
     if !document.contains_key(name) {
         document[name] = toml_edit::Item::Table(toml_edit::Table::new());
     }
     document[name]
-        .as_table_mut()
+        .as_table_like_mut()
         .ok_or_else(|| format!("{name} config must be a table"))
 }
 
@@ -468,7 +470,7 @@ impl Repair {
             Self::AddToPath(directory) => {
                 format!("add '{}' to your user PATH", directory.display())
             }
-            Self::MigrateConfig { path, .. } => format!(
+            Self::MigrateConfig { path } => format!(
                 "back up '{}' and migrate its removed setting names",
                 path.display()
             ),
@@ -478,12 +480,17 @@ impl Repair {
     fn apply(&self) -> Result<String, String> {
         match self {
             Self::AddToPath(directory) => add_to_user_path(directory),
-            Self::MigrateConfig { path, content } => migrate_config_file(path, content),
+            Self::MigrateConfig { path } => migrate_config_file(path),
         }
     }
 }
 
-fn migrate_config_file(path: &Path, content: &str) -> Result<String, String> {
+fn migrate_config_file(path: &Path) -> Result<String, String> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|error| format!("could not read '{}': {error}", path.display()))?;
+    let Some(content) = migrate_removed_config_keys(&source)? else {
+        return Ok("(already migrated)".to_string());
+    };
     let nonce = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -491,7 +498,7 @@ fn migrate_config_file(path: &Path, content: &str) -> Result<String, String> {
     let backup = path.with_extension(format!("toml.pentect-backup-{nonce}"));
     std::fs::copy(path, &backup)
         .map_err(|error| format!("could not back up '{}': {error}", path.display()))?;
-    if let Err(error) = std::fs::write(path, content) {
+    if let Err(error) = std::fs::write(path, &content) {
         let _ = std::fs::copy(&backup, path);
         return Err(format!("could not update '{}': {error}", path.display()));
     }
@@ -500,13 +507,21 @@ fn migrate_config_file(path: &Path, content: &str) -> Result<String, String> {
 
 #[cfg(windows)]
 fn add_to_user_path(directory: &Path) -> Result<String, String> {
-    const SCRIPT: &str = r#"$dir=$env:PENTECT_DOCTOR_PATH_DIR
-$user=[Environment]::GetEnvironmentVariable('Path','User')
-$parts=@($user -split ';' | Where-Object { $_ })
+    const SCRIPT: &str = r#"$ErrorActionPreference='Stop'
+$dir=$env:PENTECT_DOCTOR_PATH_DIR
+$key=[Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment',$true)
+if ($null -eq $key) { throw 'could not open HKCU\Environment' }
+try {
+  try { $kind=$key.GetValueKind('Path') } catch { $kind=[Microsoft.Win32.RegistryValueKind]::ExpandString }
+  $user=$key.GetValue('Path','',[Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+  $parts=if ($user -is [string[]]) { @($user) } else { @(([string]$user) -split ';' | Where-Object { $_ }) }
 if (-not ($parts | Where-Object { $_.TrimEnd('\') -ieq $dir.TrimEnd('\') })) {
-  [Environment]::SetEnvironmentVariable('Path',((@($parts)+$dir)-join ';'),'User')
-}"#;
-    let status = Command::new("powershell.exe")
+    $parts=@($parts)+$dir
+    $value=if ($kind -eq [Microsoft.Win32.RegistryValueKind]::MultiString) { [string[]]$parts } else { $parts -join ';' }
+    $key.SetValue('Path',$value,$kind)
+  }
+} finally { $key.Dispose() }"#;
+    let output = Command::new("powershell.exe")
         .args([
             "-NoLogo",
             "-NoProfile",
@@ -518,10 +533,15 @@ if (-not ($parts | Where-Object { $_.TrimEnd('\') -ieq $dir.TrimEnd('\') })) {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
-        .status()
+        .output()
         .map_err(|error| format!("could not update the user PATH: {error}"))?;
-    if !status.success() {
-        return Err("PowerShell could not update the user PATH".to_string());
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if detail.is_empty() {
+            "PowerShell could not update the user PATH".to_string()
+        } else {
+            format!("PowerShell could not update the user PATH: {detail}")
+        });
     }
     update_process_path(directory)?;
     Ok("restart open terminals to inherit the updated PATH".to_string())
@@ -537,37 +557,59 @@ fn add_to_user_path(directory: &Path) -> Result<String, String> {
     if shell == "fish" {
         return Err("fish PATH changes require a manual `fish_add_path`".to_string());
     }
-    let profile = if shell == "zsh" {
-        home.join(".zprofile")
-    } else {
-        home.join(".profile")
+    let profiles = match shell.as_str() {
+        "zsh" => vec![home.join(".zprofile"), home.join(".zshrc")],
+        "bash" => vec![
+            if home.join(".bash_profile").exists() {
+                home.join(".bash_profile")
+            } else {
+                home.join(".profile")
+            },
+            home.join(".bashrc"),
+        ],
+        _ => vec![home.join(".profile")],
     };
-    if std::fs::symlink_metadata(&profile).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+    let marker = "# Added by `pentect doctor --fix`";
+    for profile in &profiles {
+        append_path_profile(profile, directory, marker)?;
+    }
+    update_process_path(directory)?;
+    let names = profiles
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Ok(format!(
+        "restart login and interactive shells to load {names}"
+    ))
+}
+
+#[cfg(not(windows))]
+fn append_path_profile(profile: &Path, directory: &Path, marker: &str) -> Result<(), String> {
+    if std::fs::symlink_metadata(profile).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
         return Err(format!(
             "refusing to modify symlink '{}'",
             profile.display()
         ));
     }
-    let marker = "# Added by `pentect doctor --fix`";
-    let existing = std::fs::read_to_string(&profile).unwrap_or_default();
-    if !existing.contains(marker) {
-        let line = format!(
-            "{marker}\nexport PATH={}:\"$PATH\"\n",
-            shell_single_quote(&directory.to_string_lossy())
-        );
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&profile)
-            .map_err(|error| format!("could not open '{}': {error}", profile.display()))?;
-        if !existing.is_empty() && !existing.ends_with('\n') {
-            writeln!(file).map_err(|error| error.to_string())?;
-        }
-        file.write_all(line.as_bytes())
-            .map_err(|error| format!("could not update '{}': {error}", profile.display()))?;
+    let existing = std::fs::read_to_string(profile).unwrap_or_default();
+    if existing.contains(marker) {
+        return Ok(());
     }
-    update_process_path(directory)?;
-    Ok(format!("restart the shell to load {}", profile.display()))
+    let line = format!(
+        "{marker}\nexport PATH={}:\"$PATH\"\n",
+        shell_single_quote(&directory.to_string_lossy())
+    );
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(profile)
+        .map_err(|error| format!("could not open '{}': {error}", profile.display()))?;
+    if !existing.is_empty() && !existing.ends_with('\n') {
+        writeln!(file).map_err(|error| error.to_string())?;
+    }
+    file.write_all(line.as_bytes())
+        .map_err(|error| format!("could not update '{}': {error}", profile.display()))
 }
 
 #[cfg(not(windows))]
@@ -698,6 +740,30 @@ mod tests {
             "--fix".into(),
         ];
         assert!(parse_args(&invalid).is_err());
+        let yes_only = vec!["pentect".into(), "doctor".into(), "--yes".into()];
+        assert!(parse_args(&yes_only).is_err());
+    }
+
+    #[test]
+    fn ambiguous_removed_settings_are_reported() {
+        assert!(migrate_removed_config_keys("[handles]\nhash_scope = \"team\"\n").is_err());
+        assert!(migrate_removed_config_keys("[handles]\nhash_scope = 1\n").is_err());
+        assert!(migrate_removed_config_keys("not = = toml").is_err());
+    }
+
+    #[test]
+    fn inline_removed_config_tables_migrate() {
+        let source = concat!(
+            "file_pointer_manager = { save = false }\n",
+            "log = { share = true }\n",
+            "agent = { require_pentect = true }\n",
+            "handles = { hash_scope = \"machine\" }\n",
+        );
+        let migrated = migrate_removed_config_keys(source).unwrap().unwrap();
+        assert!(migrated.contains("remember = false"), "{migrated}");
+        assert!(migrated.contains("share = true"), "{migrated}");
+        assert!(migrated.contains("required = true"), "{migrated}");
+        assert!(migrated.contains("scope = \"device\""), "{migrated}");
     }
 
     #[test]
@@ -756,7 +822,7 @@ share = true
         let original = "[handles]\nhash_scope = \"machine\"\n";
         std::fs::write(&path, original).unwrap();
         let migrated = migrate_removed_config_keys(original).unwrap().unwrap();
-        let detail = migrate_config_file(&path, &migrated).unwrap();
+        let detail = migrate_config_file(&path).unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), migrated);
         let backup = detail
             .strip_prefix("(backup: ")

--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -1,22 +1,26 @@
 use crate::plugins;
 use serde_json::json;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
 
 pub(crate) fn cmd_doctor(args: &[String]) {
-    let json_output = match parse_args(args) {
+    let options = match parse_args(args) {
         Ok(value) => value,
         Err(e) => crate::die(e),
     };
-    let checks = run_checks();
-    if json_output {
+    let mut checks = run_checks();
+    if options.json {
         println!("{}", checks_json(&checks));
     } else {
-        for check in &checks {
-            println!("{}: {} {}", check.name, check.status.as_str(), check.detail);
+        print_checks(&checks);
+        if options.fix {
+            apply_repairs(&checks, options.yes);
+            checks = run_checks();
+            println!("\nRechecking...");
+            print_checks(&checks);
         }
     }
     if checks.iter().any(|check| check.status == Status::Fail) {
@@ -24,11 +28,25 @@ pub(crate) fn cmd_doctor(args: &[String]) {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct DoctorOptions {
+    json: bool,
+    fix: bool,
+    yes: bool,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct Check {
     name: &'static str,
     status: Status,
     detail: String,
+    repair: Option<Repair>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Repair {
+    AddToPath(PathBuf),
+    MigrateConfig { path: PathBuf, content: String },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -48,27 +66,37 @@ impl Status {
     }
 }
 
-fn parse_args(args: &[String]) -> Result<bool, String> {
-    let mut json_output = false;
+fn parse_args(args: &[String]) -> Result<DoctorOptions, String> {
+    let mut options = DoctorOptions::default();
     for arg in &args[2..] {
         match arg.as_str() {
-            "--json" => json_output = true,
+            "--json" => options.json = true,
+            "--fix" => options.fix = true,
+            "--yes" => options.yes = true,
             flag if flag.starts_with("--") => return Err(format!("unknown option: {flag}")),
             value => return Err(format!("unexpected argument for doctor: {value}")),
         }
     }
-    Ok(json_output)
+    if options.yes && !options.fix {
+        return Err("doctor --yes requires --fix".to_string());
+    }
+    if options.json && options.fix {
+        return Err("doctor --json is read-only and cannot be combined with --fix".to_string());
+    }
+    Ok(options)
 }
 
 fn run_checks() -> Vec<Check> {
-    vec![
-        check_pentect_binary(),
+    let mut checks = vec![check_pentect_binary(), check_path()];
+    checks.extend(check_configs());
+    checks.extend([
         check_memory_store(),
         check_config_plugins(),
         check_ocr(),
         check_command("codex"),
         check_command("claude"),
-    ]
+    ]);
+    checks
 }
 
 fn check_pentect_binary() -> Check {
@@ -77,6 +105,228 @@ fn check_pentect_binary() -> Check {
         Ok(path) => Check::fail("pentect", format!("not a file: {}", compact_path(&path))),
         Err(e) => Check::fail("pentect", e.to_string()),
     }
+}
+
+fn check_path() -> Check {
+    let Ok(executable) = std::env::current_exe() else {
+        return Check::warn("path", "could not locate the current executable");
+    };
+    let Some(directory) = executable.parent() else {
+        return Check::warn("path", "the executable has no parent directory");
+    };
+    if path_contains(directory) {
+        return Check::ok("path", "ready");
+    }
+    #[cfg(not(windows))]
+    if std::env::var_os("SHELL")
+        .and_then(|path| PathBuf::from(path).file_name().map(|name| name.to_owned()))
+        .is_some_and(|name| name == "fish")
+    {
+        return Check::warn(
+            "path",
+            format!(
+                "{} is not on PATH; run `fish_add_path {}`",
+                directory.display(),
+                directory.display()
+            ),
+        );
+    }
+    Check::repairable_warn(
+        "path",
+        format!("{} is not on PATH", directory.display()),
+        Repair::AddToPath(directory.to_path_buf()),
+    )
+}
+
+fn path_contains(directory: &Path) -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).any(|path| same_path(&path, directory)))
+        .unwrap_or(false)
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    if let (Ok(left), Ok(right)) = (left.canonicalize(), right.canonicalize()) {
+        #[cfg(windows)]
+        return left
+            .to_string_lossy()
+            .eq_ignore_ascii_case(&right.to_string_lossy());
+        #[cfg(not(windows))]
+        return left == right;
+    }
+    #[cfg(windows)]
+    return left
+        .to_string_lossy()
+        .eq_ignore_ascii_case(&right.to_string_lossy());
+    #[cfg(not(windows))]
+    return left == right;
+}
+
+fn check_configs() -> Vec<Check> {
+    let project = PathBuf::from(".pentect").join("config.toml");
+    let global = home_dir().map(|home| home.join(".pentect").join("config.toml"));
+    vec![
+        check_config("config-project", project),
+        global.map_or_else(
+            || Check::warn("config-user", "home directory unavailable"),
+            |path| check_config("config-user", path),
+        ),
+    ]
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
+}
+
+fn check_config(name: &'static str, path: PathBuf) -> Check {
+    if !path.exists() {
+        return Check::ok(name, "defaults");
+    }
+    let source = match std::fs::read_to_string(&path) {
+        Ok(source) => source,
+        Err(error) => return Check::fail(name, format!("{}: {error}", path.display())),
+    };
+    match migrate_removed_config_keys(&source) {
+        Ok(Some(content)) => Check::repairable_warn(
+            name,
+            format!("{} uses removed settings", path.display()),
+            Repair::MigrateConfig { path, content },
+        ),
+        Ok(None) => Check::ok(name, "ready"),
+        Err(error) => Check::fail(name, format!("{}: {error}", path.display())),
+    }
+}
+
+fn migrate_removed_config_keys(source: &str) -> Result<Option<String>, String> {
+    if source.trim().is_empty() {
+        return Ok(None);
+    }
+    let mut document = source
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|error| format!("invalid TOML: {error}"))?;
+    let mut changed = false;
+
+    if table_has(&document, "handles", "hash_scope") {
+        let scope = table_string(&document, "handles", "hash_scope")
+            .ok_or_else(|| "handles.hash_scope must be a string".to_string())?;
+        let scope = match scope.as_str() {
+            "machine" | "device" => "device",
+            "project" => "project",
+            "session" => "session",
+            _ => return Err("handles.hash_scope cannot be migrated automatically".to_string()),
+        };
+        let handles = ensure_table(&mut document, "handles")?;
+        if !handles.contains_key("scope") {
+            handles.insert("scope", toml_edit::value(scope));
+        }
+        handles.remove("hash_scope");
+        changed = true;
+    }
+
+    if document.contains_key("require_pentect") {
+        let value = document
+            .get("require_pentect")
+            .and_then(toml_edit::Item::as_bool)
+            .ok_or_else(|| "require_pentect must be a boolean".to_string())?;
+        let agent = ensure_table(&mut document, "agent")?;
+        if !agent.contains_key("required") {
+            agent.insert("required", toml_edit::value(value));
+        }
+        document.remove("require_pentect");
+        changed = true;
+    }
+    if table_has(&document, "agent", "require_pentect") {
+        let value = table_bool(&document, "agent", "require_pentect")
+            .ok_or_else(|| "agent.require_pentect must be a boolean".to_string())?;
+        let agent = ensure_table(&mut document, "agent")?;
+        if !agent.contains_key("required") {
+            agent.insert("required", toml_edit::value(value));
+        }
+        agent.remove("require_pentect");
+        changed = true;
+    }
+
+    if table_has(&document, "image", "unscanned_images") {
+        let value = table_string(&document, "image", "unscanned_images")
+            .ok_or_else(|| "image.unscanned_images must be a string".to_string())?;
+        if !matches!(value.as_str(), "allow" | "block") {
+            return Err("image.unscanned_images cannot be migrated automatically".to_string());
+        }
+        let image = ensure_table(&mut document, "image")?;
+        if !image.contains_key("unscanned") {
+            image.insert("unscanned", toml_edit::value(value));
+        }
+        image.remove("unscanned_images");
+        changed = true;
+    }
+
+    if document.contains_key("file_pointer_manager") {
+        let legacy = document["file_pointer_manager"]
+            .as_table()
+            .ok_or_else(|| "file_pointer_manager must be a table".to_string())?;
+        if legacy.len() != 1 || !legacy.contains_key("save") {
+            return Err("file_pointer_manager cannot be migrated automatically".to_string());
+        }
+        let value = table_bool(&document, "file_pointer_manager", "save")
+            .ok_or_else(|| "file_pointer_manager.save must be a boolean".to_string())?;
+        let files = ensure_table(&mut document, "files")?;
+        if !files.contains_key("remember") {
+            files.insert("remember", toml_edit::value(value));
+        }
+        document.remove("file_pointer_manager");
+        changed = true;
+    }
+    if document.contains_key("log") {
+        let legacy = document["log"]
+            .as_table()
+            .ok_or_else(|| "log must be a table".to_string())?;
+        if legacy.len() != 1 || !legacy.contains_key("share") {
+            return Err("log cannot be migrated automatically".to_string());
+        }
+        let value = table_bool(&document, "log", "share")
+            .ok_or_else(|| "log.share must be a boolean".to_string())?;
+        let activity = ensure_table(&mut document, "activity")?;
+        if !activity.contains_key("share") {
+            activity.insert("share", toml_edit::value(value));
+        }
+        document.remove("log");
+        changed = true;
+    }
+
+    Ok(changed.then(|| document.to_string()))
+}
+
+fn table_string(document: &toml_edit::DocumentMut, table: &str, key: &str) -> Option<String> {
+    document
+        .get(table)?
+        .as_table()?
+        .get(key)?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn table_has(document: &toml_edit::DocumentMut, table: &str, key: &str) -> bool {
+    document
+        .get(table)
+        .and_then(toml_edit::Item::as_table)
+        .is_some_and(|table| table.contains_key(key))
+}
+
+fn table_bool(document: &toml_edit::DocumentMut, table: &str, key: &str) -> Option<bool> {
+    document.get(table)?.as_table()?.get(key)?.as_bool()
+}
+
+fn ensure_table<'a>(
+    document: &'a mut toml_edit::DocumentMut,
+    name: &str,
+) -> Result<&'a mut toml_edit::Table, String> {
+    if !document.contains_key(name) {
+        document[name] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    document[name]
+        .as_table_mut()
+        .ok_or_else(|| format!("{name} config must be a table"))
 }
 
 fn check_memory_store() -> Check {
@@ -171,6 +421,168 @@ fn find_command(name: &str) -> Option<PathBuf> {
     None
 }
 
+fn print_checks(checks: &[Check]) {
+    for check in checks {
+        println!("{}: {} {}", check.name, check.status.as_str(), check.detail);
+    }
+}
+
+fn apply_repairs(checks: &[Check], assume_yes: bool) {
+    let repairs = checks
+        .iter()
+        .filter_map(|check| check.repair.as_ref().map(|repair| (check.name, repair)))
+        .collect::<Vec<_>>();
+    if repairs.is_empty() {
+        println!("\nNo safe automatic fixes are available.");
+        return;
+    }
+    if !assume_yes && !std::io::stdin().is_terminal() {
+        println!("\nInput is not interactive. Rerun with `pentect doctor --fix --yes` to apply safe fixes.");
+        return;
+    }
+    for (name, repair) in repairs {
+        let apply = assume_yes || confirm(&format!("I can {}. Fix it?", repair.description()));
+        if !apply {
+            println!("{name}: skipped");
+            continue;
+        }
+        match repair.apply() {
+            Ok(detail) => println!("{name}: fixed {detail}"),
+            Err(error) => println!("{name}: fix failed {error}"),
+        }
+    }
+}
+
+fn confirm(prompt: &str) -> bool {
+    print!("\n{prompt} [y/N] ");
+    let _ = std::io::stdout().flush();
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .is_ok_and(|_| matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
+}
+
+impl Repair {
+    fn description(&self) -> String {
+        match self {
+            Self::AddToPath(directory) => {
+                format!("add '{}' to your user PATH", directory.display())
+            }
+            Self::MigrateConfig { path, .. } => format!(
+                "back up '{}' and migrate its removed setting names",
+                path.display()
+            ),
+        }
+    }
+
+    fn apply(&self) -> Result<String, String> {
+        match self {
+            Self::AddToPath(directory) => add_to_user_path(directory),
+            Self::MigrateConfig { path, content } => migrate_config_file(path, content),
+        }
+    }
+}
+
+fn migrate_config_file(path: &Path, content: &str) -> Result<String, String> {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let backup = path.with_extension(format!("toml.pentect-backup-{nonce}"));
+    std::fs::copy(path, &backup)
+        .map_err(|error| format!("could not back up '{}': {error}", path.display()))?;
+    if let Err(error) = std::fs::write(path, content) {
+        let _ = std::fs::copy(&backup, path);
+        return Err(format!("could not update '{}': {error}", path.display()));
+    }
+    Ok(format!("(backup: {})", backup.display()))
+}
+
+#[cfg(windows)]
+fn add_to_user_path(directory: &Path) -> Result<String, String> {
+    const SCRIPT: &str = r#"$dir=$env:PENTECT_DOCTOR_PATH_DIR
+$user=[Environment]::GetEnvironmentVariable('Path','User')
+$parts=@($user -split ';' | Where-Object { $_ })
+if (-not ($parts | Where-Object { $_.TrimEnd('\') -ieq $dir.TrimEnd('\') })) {
+  [Environment]::SetEnvironmentVariable('Path',((@($parts)+$dir)-join ';'),'User')
+}"#;
+    let status = Command::new("powershell.exe")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            SCRIPT,
+        ])
+        .env("PENTECT_DOCTOR_PATH_DIR", directory)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .status()
+        .map_err(|error| format!("could not update the user PATH: {error}"))?;
+    if !status.success() {
+        return Err("PowerShell could not update the user PATH".to_string());
+    }
+    update_process_path(directory)?;
+    Ok("restart open terminals to inherit the updated PATH".to_string())
+}
+
+#[cfg(not(windows))]
+fn add_to_user_path(directory: &Path) -> Result<String, String> {
+    let home = home_dir().ok_or_else(|| "home directory unavailable".to_string())?;
+    let shell = std::env::var_os("SHELL")
+        .and_then(|path| PathBuf::from(path).file_name().map(|name| name.to_owned()))
+        .and_then(|name| name.to_str().map(str::to_string))
+        .unwrap_or_else(|| "sh".to_string());
+    if shell == "fish" {
+        return Err("fish PATH changes require a manual `fish_add_path`".to_string());
+    }
+    let profile = if shell == "zsh" {
+        home.join(".zprofile")
+    } else {
+        home.join(".profile")
+    };
+    if std::fs::symlink_metadata(&profile).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return Err(format!(
+            "refusing to modify symlink '{}'",
+            profile.display()
+        ));
+    }
+    let marker = "# Added by `pentect doctor --fix`";
+    let existing = std::fs::read_to_string(&profile).unwrap_or_default();
+    if !existing.contains(marker) {
+        let line = format!(
+            "{marker}\nexport PATH={}:\"$PATH\"\n",
+            shell_single_quote(&directory.to_string_lossy())
+        );
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&profile)
+            .map_err(|error| format!("could not open '{}': {error}", profile.display()))?;
+        if !existing.is_empty() && !existing.ends_with('\n') {
+            writeln!(file).map_err(|error| error.to_string())?;
+        }
+        file.write_all(line.as_bytes())
+            .map_err(|error| format!("could not update '{}': {error}", profile.display()))?;
+    }
+    update_process_path(directory)?;
+    Ok(format!("restart the shell to load {}", profile.display()))
+}
+
+#[cfg(not(windows))]
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn update_process_path(directory: &Path) -> Result<(), String> {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let paths = std::iter::once(directory.to_path_buf()).chain(std::env::split_paths(&current));
+    let joined = std::env::join_paths(paths).map_err(|error| error.to_string())?;
+    std::env::set_var("PATH", joined);
+    Ok(())
+}
+
 #[cfg(windows)]
 fn command_names(name: &str) -> Vec<String> {
     let has_ext = Path::new(name).extension().is_some();
@@ -196,6 +608,7 @@ fn checks_json(checks: &[Check]) -> String {
             "name": check.name,
             "status": check.status.as_str(),
             "detail": check.detail,
+            "fixable": check.repair.is_some(),
         })).collect::<Vec<_>>()
     })
     .to_string()
@@ -214,6 +627,7 @@ impl Check {
             name,
             status: Status::Ok,
             detail: detail.into(),
+            repair: None,
         }
     }
 
@@ -222,6 +636,7 @@ impl Check {
             name,
             status: Status::Warn,
             detail: detail.into(),
+            repair: None,
         }
     }
 
@@ -230,6 +645,16 @@ impl Check {
             name,
             status: Status::Fail,
             detail: detail.into(),
+            repair: None,
+        }
+    }
+
+    fn repairable_warn(name: &'static str, detail: impl Into<String>, repair: Repair) -> Self {
+        Self {
+            name,
+            status: Status::Warn,
+            detail: detail.into(),
+            repair: Some(repair),
         }
     }
 }
@@ -247,7 +672,99 @@ mod tests {
     #[test]
     fn doctor_accepts_json() {
         let args = vec!["pentect".into(), "doctor".into(), "--json".into()];
-        assert!(parse_args(&args).unwrap());
+        assert!(parse_args(&args).unwrap().json);
+    }
+
+    #[test]
+    fn doctor_fix_flags_are_explicit() {
+        let args = vec![
+            "pentect".into(),
+            "doctor".into(),
+            "--fix".into(),
+            "--yes".into(),
+        ];
+        assert_eq!(
+            parse_args(&args).unwrap(),
+            DoctorOptions {
+                fix: true,
+                yes: true,
+                json: false,
+            }
+        );
+        let invalid = vec![
+            "pentect".into(),
+            "doctor".into(),
+            "--json".into(),
+            "--fix".into(),
+        ];
+        assert!(parse_args(&invalid).is_err());
+    }
+
+    #[test]
+    fn removed_config_keys_migrate_without_losing_unrelated_settings() {
+        let source = r#"# keep this comment
+plugins = ["jp-pii"]
+require_pentect = true
+
+[handles]
+hash_scope = "machine"
+
+[image]
+unscanned_images = "block"
+
+[file_pointer_manager]
+save = false
+
+[log]
+share = true
+"#;
+        let migrated = migrate_removed_config_keys(source).unwrap().unwrap();
+        assert!(migrated.contains("# keep this comment"));
+        assert!(migrated.contains("plugins = [\"jp-pii\"]"));
+        assert!(migrated.contains("scope = \"device\""));
+        assert!(migrated.contains("unscanned = \"block\""));
+        assert!(migrated.contains("[agent]"));
+        assert!(migrated.contains("required = true"));
+        assert!(migrated.contains("[files]"));
+        assert!(migrated.contains("remember = false"));
+        assert!(migrated.contains("[activity]"));
+        assert!(migrated.contains("share = true"));
+        for removed in [
+            "require_pentect",
+            "hash_scope",
+            "unscanned_images",
+            "file_pointer_manager",
+            "[log]",
+        ] {
+            assert!(!migrated.contains(removed), "{removed}: {migrated}");
+        }
+        assert!(migrate_removed_config_keys(&migrated).unwrap().is_none());
+    }
+
+    #[test]
+    fn config_repair_keeps_a_recoverable_backup() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-doctor-repair-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("config.toml");
+        let original = "[handles]\nhash_scope = \"machine\"\n";
+        std::fs::write(&path, original).unwrap();
+        let migrated = migrate_removed_config_keys(original).unwrap().unwrap();
+        let detail = migrate_config_file(&path, &migrated).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), migrated);
+        let backup = detail
+            .strip_prefix("(backup: ")
+            .and_then(|value| value.strip_suffix(')'))
+            .map(PathBuf::from)
+            .unwrap();
+        assert_eq!(std::fs::read_to_string(backup).unwrap(), original);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -424,12 +424,12 @@ fn cmd_mask(args: &[String]) {
     if let Err(e) = validate_mask_args(args) {
         die(&e);
     }
-    let kind = match arg_value(args, "--kind").as_deref() {
+    let explicit_kind = match arg_value(args, "--kind").as_deref() {
         Some(name) => match parse_kind(name) {
-            Ok(k) => k,
+            Ok(kind) => Some(kind),
             Err(e) => die(&e),
         },
-        None => Kind::Text,
+        None => None,
     };
     let profile: Profile = match arg_value(args, "--profile").as_deref() {
         Some(name) => match name.parse() {
@@ -473,6 +473,8 @@ fn cmd_mask(args: &[String]) {
         Ok(s) => s,
         Err(e) => die(&e),
     };
+    let kind =
+        explicit_kind.unwrap_or_else(|| infer_kind_with_content(Path::new("stdin"), data.as_str()));
 
     // Fresh per-run key: mask-only, so the recovery map is not retained and a
     // reproducible key isn't needed (resolve/restore is unavailable by design).

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -149,7 +149,7 @@ fn usage() {
          pentect codex app\n\
          pentect claude app\n\
          pentect exec \"<command>\"\n\
-         pentect doctor\n\
+         pentect doctor [--fix [--yes]]\n\
          pentect update [VERSION] [--check]\n\
          pentect uninstall\n\
          pentect plugins add|remove|list|search|inspect|test|config|setup|update [NAME]\n\
@@ -185,7 +185,7 @@ fn help_text() -> &'static str {
         "  pentect claude app [--app PATH] [--upstream URL] [--plugins SOURCE] [--dry-run]\n",
         "  pentect claude-app [--app PATH] [--upstream URL] [--dry-run]  (alias)\n",
         "  pentect exec \"<command>\"\n\n",
-        "  pentect doctor [--json]\n",
+        "  pentect doctor [--json | --fix [--yes]]\n",
         "  pentect update [VERSION] [--check | --force]\n",
         "  pentect uninstall\n",
         "  pentect plugins add SOURCE [--yes]\n",
@@ -208,7 +208,7 @@ fn help_text() -> &'static str {
         "resolve: write handles\n",
         "scan: secrets; gitignore on; --no-gitignore broadens\n",
         "groups: ~vcs ~deps ~build ~cache ~pentect ~heavy ~all; ! restores\n",
-        "doctor: readiness\n",
+        "doctor: readiness; --fix offers safe repairs\n",
         "update: verified GitHub Release binary\n",
         "uninstall: remove the binary; keep project data\n",
         "plugins: add, remove, list, search, inspect, test, config, setup, update\n",

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -149,7 +149,7 @@ fn usage() {
          pentect codex app\n\
          pentect claude app\n\
          pentect exec \"<command>\"\n\
-         pentect doctor [--fix [--yes]]\n\
+         pentect doctor [--json | --fix [--yes]]\n\
          pentect update [VERSION] [--check]\n\
          pentect uninstall\n\
          pentect plugins add|remove|list|search|inspect|test|config|setup|update [NAME]\n\
@@ -473,6 +473,7 @@ fn cmd_mask(args: &[String]) {
         Ok(s) => s,
         Err(e) => die(&e),
     };
+    let inferred_kind = explicit_kind.is_none();
     let kind =
         explicit_kind.unwrap_or_else(|| infer_kind_with_content(Path::new("stdin"), data.as_str()));
 
@@ -501,7 +502,12 @@ fn cmd_mask(args: &[String]) {
         result.summary.residual.len()
     );
     if result.summary.parser_fallback {
-        eprintln!("[pentect] note: --kind {kind_label} failed to parse; masked as plaintext (key context lost, structure not guaranteed).");
+        let source = if inferred_kind {
+            "inferred kind"
+        } else {
+            "--kind"
+        };
+        eprintln!("[pentect] note: {source} {kind_label} failed to parse; masked as plaintext (key context lost, structure not guaranteed).");
     }
     if !result.summary.collisions.is_empty() {
         eprintln!(

--- a/crates/pentect-cli/tests/structured_sources.rs
+++ b/crates/pentect-cli/tests/structured_sources.rs
@@ -37,6 +37,29 @@ fn read_as(kind: &str, path: &std::path::Path) -> String {
     ])
 }
 
+fn mask_stdin(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_pentect"))
+        .arg("mask")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
 #[test]
 fn read_cloudflare_dev_vars_masks_every_value_with_key_labels() {
     let root = temp_dir("dev-vars");
@@ -100,28 +123,40 @@ fn explicit_kinds_cover_arbitrary_dotenv_structured_and_one_secret_files() {
 
 #[test]
 fn mask_stdin_infers_dotenv_without_a_kind_flag() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_pentect"))
-        .arg("mask")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(b"API_TOKEN=x\nMODE=dev\n")
-        .unwrap();
-    let output = child.wait_with_output().unwrap();
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let masked = String::from_utf8(output.stdout).unwrap();
+    let masked = mask_stdin("API_TOKEN=x\nMODE=dev\n");
     assert!(masked.contains("API_TOKEN=<<API_TOKEN_"), "{masked}");
     assert!(masked.contains("MODE=<<MODE_"), "{masked}");
     assert!(!masked.contains("API_TOKEN=x"), "{masked}");
     assert!(!masked.contains("MODE=dev"), "{masked}");
+}
+
+#[test]
+fn mask_stdin_infers_terraform_without_a_kind_flag() {
+    let masked = mask_stdin("region = \"us-east-1\"\ndb_password = \"x\"\n");
+    assert!(masked.contains("region = \"us-east-1\""), "{masked}");
+    assert!(
+        masked.contains("db_password = \"<<DB_PASSWORD_"),
+        "{masked}"
+    );
+    assert!(!masked.contains("db_password = \"x\""), "{masked}");
+}
+
+#[test]
+fn mask_stdin_infers_kubernetes_yaml_without_a_kind_flag() {
+    let masked = mask_stdin(
+        "apiVersion: v1\nkind: Secret\nmetadata:\n  name: app\nstringData:\n  password: x\n",
+    );
+    assert!(masked.contains("name: app"), "{masked}");
+    assert!(masked.contains("password: <<PASSWORD_"), "{masked}");
+    assert!(!masked.contains("password: x"), "{masked}");
+}
+
+#[test]
+fn mask_stdin_infers_kubernetes_json_without_a_kind_flag() {
+    let masked = mask_stdin(
+        r#"{"apiVersion":"v1","kind":"Secret","metadata":{"name":"app"},"stringData":{"password":"x"}}"#,
+    );
+    assert!(masked.contains(r#""name":"app""#), "{masked}");
+    assert!(masked.contains("<<PASSWORD_"), "{masked}");
+    assert!(!masked.contains(r#""password":"x""#), "{masked}");
 }

--- a/crates/pentect-cli/tests/structured_sources.rs
+++ b/crates/pentect-cli/tests/structured_sources.rs
@@ -1,5 +1,6 @@
+use std::io::Write;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn temp_dir(name: &str) -> PathBuf {
@@ -95,4 +96,32 @@ fn explicit_kinds_cover_arbitrary_dotenv_structured_and_one_secret_files() {
     assert_eq!(output.matches("<<").count(), 1, "{output}");
 
     std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn mask_stdin_infers_dotenv_without_a_kind_flag() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_pentect"))
+        .arg("mask")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"API_TOKEN=x\nMODE=dev\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let masked = String::from_utf8(output.stdout).unwrap();
+    assert!(masked.contains("API_TOKEN=<<API_TOKEN_"), "{masked}");
+    assert!(masked.contains("MODE=<<MODE_"), "{masked}");
+    assert!(!masked.contains("API_TOKEN=x"), "{masked}");
+    assert!(!masked.contains("MODE=dev"), "{masked}");
 }

--- a/crates/pentect-core/src/lib.rs
+++ b/crates/pentect-core/src/lib.rs
@@ -232,8 +232,8 @@ fn looks_like_structured_document(raw: &str) -> bool {
                 continue;
             }
         }
-        if let Some((key, _)) = body.split_once(':') {
-            if structured_key(key.trim()) {
+        if let Some((key, value)) = body.split_once(':') {
+            if structured_yaml_key(key.trim()) && !value.trim().is_empty() {
                 yaml_entries += 1;
                 continue;
             }
@@ -249,6 +249,13 @@ fn structured_key(key: &str) -> bool {
         && key
             .chars()
             .all(|character| character.is_ascii_alphanumeric() || "_.-/".contains(character))
+}
+
+fn structured_yaml_key(key: &str) -> bool {
+    let key = key.trim_matches(['"', '\'']);
+    structured_key(key)
+        && key.starts_with(|character: char| character.is_ascii_lowercase())
+        && !matches!(key, "http" | "https")
 }
 
 fn is_dotenv_name(name: &str) -> bool {
@@ -451,6 +458,20 @@ mod tests {
         );
         assert_eq!(
             infer_kind_with_content(Path::new("stdin"), "This is ordinary prose.\nSecond line."),
+            Kind::Text
+        );
+        assert_eq!(
+            infer_kind_with_content(
+                Path::new("stdin"),
+                "Contact: support@example.com\nWebsite: https://example.com\n"
+            ),
+            Kind::Text
+        );
+        assert_eq!(
+            infer_kind_with_content(
+                Path::new("stdin"),
+                "http://example.com\nhttps://example.org\n"
+            ),
             Kind::Text
         );
     }

--- a/crates/pentect-core/src/lib.rs
+++ b/crates/pentect-core/src/lib.rs
@@ -103,11 +103,152 @@ pub fn infer_kind(path: &std::path::Path) -> Kind {
 /// an all-values secret boundary.
 pub fn infer_kind_with_content(path: &std::path::Path, raw: &str) -> Kind {
     let inferred = infer_kind(path);
-    if inferred == Kind::Text && parse::looks_like_dotenv_document(raw) {
-        Kind::Env
-    } else {
-        inferred
+    if inferred != Kind::Text {
+        return inferred;
     }
+    if parse::looks_like_dotenv_document(raw) {
+        return Kind::Env;
+    }
+    let trimmed = raw.trim_start_matches('\u{feff}').trim_start();
+    if matches!(trimmed.as_bytes().first(), Some(b'{') | Some(b'['))
+        && serde_json::from_str::<serde_json::Value>(trimmed).is_ok()
+    {
+        return Kind::Json;
+    }
+    if looks_like_kubeconfig(raw) {
+        return Kind::Other("structured:kubeconfig".to_string());
+    }
+    if looks_like_kubernetes_yaml(raw) {
+        return Kind::Other("structured".to_string());
+    }
+    if looks_like_aws_config(raw) {
+        return Kind::Other("structured:aws".to_string());
+    }
+    if looks_like_npm_config(raw) {
+        return Kind::Other("structured:npm".to_string());
+    }
+    if looks_like_pypi_config(raw) {
+        return Kind::Other("structured:pypi".to_string());
+    }
+    if looks_like_structured_document(raw) {
+        return Kind::Other("structured".to_string());
+    }
+    Kind::Text
+}
+
+fn looks_like_kubernetes_yaml(raw: &str) -> bool {
+    has_yaml_key_value(raw, "apiVersion", None) && has_yaml_key_value(raw, "kind", Some("Secret"))
+}
+
+fn looks_like_kubeconfig(raw: &str) -> bool {
+    has_yaml_key_value(raw, "apiVersion", None)
+        && ["clusters", "contexts", "users"]
+            .iter()
+            .filter(|key| has_yaml_key_value(raw, key, None))
+            .count()
+            >= 2
+}
+
+fn has_yaml_key_value(raw: &str, expected_key: &str, expected_value: Option<&str>) -> bool {
+    raw.lines().any(|line| {
+        let line = line.trim().trim_start_matches("- ");
+        let Some((key, value)) = line.split_once(':') else {
+            return false;
+        };
+        key.trim() == expected_key
+            && expected_value.is_none_or(|expected| value.trim().eq_ignore_ascii_case(expected))
+    })
+}
+
+fn looks_like_aws_config(raw: &str) -> bool {
+    has_ini_section(raw)
+        && raw.lines().any(|line| {
+            line.split_once('=').is_some_and(|(key, _)| {
+                matches!(
+                    key.trim().to_ascii_lowercase().as_str(),
+                    "aws_access_key_id" | "aws_secret_access_key" | "aws_session_token"
+                )
+            })
+        })
+}
+
+fn looks_like_npm_config(raw: &str) -> bool {
+    raw.lines().any(|line| {
+        let key = line.split_once('=').map(|(key, _)| key.trim());
+        key.is_some_and(|key| {
+            matches!(key, "_auth" | "_authToken" | "_password")
+                || (key.starts_with("//")
+                    && matches!(
+                        key.rsplit(':').next().unwrap_or_default(),
+                        "_auth" | "_authToken" | "_password"
+                    ))
+        })
+    })
+}
+
+fn looks_like_pypi_config(raw: &str) -> bool {
+    raw.lines().any(|line| {
+        matches!(
+            line.trim().to_ascii_lowercase().as_str(),
+            "[pypi]" | "[testpypi]" | "[distutils]"
+        )
+    }) && raw.lines().any(|line| {
+        line.split_once('=').is_some_and(|(key, _)| {
+            matches!(
+                key.trim().to_ascii_lowercase().as_str(),
+                "repository" | "username" | "password"
+            )
+        })
+    })
+}
+
+fn has_ini_section(raw: &str) -> bool {
+    raw.lines().any(|line| {
+        let line = line.trim();
+        line.starts_with('[') && line.ends_with(']') && line.len() > 2
+    })
+}
+
+fn looks_like_structured_document(raw: &str) -> bool {
+    let mut assignments = 0usize;
+    let mut yaml_entries = 0usize;
+    let mut sections = 0usize;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with(['#', ';']) {
+            continue;
+        }
+        if trimmed.starts_with('[') && trimmed.ends_with(']') && trimmed.len() > 2 {
+            sections += 1;
+            continue;
+        }
+        if matches!(trimmed, "{" | "}" | "[" | "]") {
+            continue;
+        }
+        let body = trimmed.trim_start_matches("- ");
+        if let Some((key, value)) = body.split_once('=') {
+            if structured_key(key.trim()) && !value.trim().is_empty() {
+                assignments += 1;
+                continue;
+            }
+        }
+        if let Some((key, _)) = body.split_once(':') {
+            if structured_key(key.trim()) {
+                yaml_entries += 1;
+                continue;
+            }
+        }
+        return false;
+    }
+    assignments >= 2 || yaml_entries >= 2 || (sections > 0 && yaml_entries + assignments > 0)
+}
+
+fn structured_key(key: &str) -> bool {
+    let key = key.trim_matches(['"', '\'']);
+    !key.is_empty()
+        && key
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "_.-/".contains(character))
 }
 
 fn is_dotenv_name(name: &str) -> bool {
@@ -256,6 +397,60 @@ mod tests {
         );
         assert_eq!(
             infer_kind_with_content(Path::new("notes"), "example=value"),
+            Kind::Text
+        );
+    }
+
+    #[test]
+    fn content_sniffing_recognizes_structured_stdin_formats() {
+        assert_eq!(
+            infer_kind_with_content(Path::new("stdin"), r#"{"token":"x"}"#),
+            Kind::Json
+        );
+        assert_eq!(
+            infer_kind_with_content(
+                Path::new("stdin"),
+                "apiVersion: v1\nkind: Secret\nmetadata:\n  name: app\nstringData:\n  password: x\n"
+            ),
+            Kind::Other("structured".into())
+        );
+        assert_eq!(
+            infer_kind_with_content(
+                Path::new("stdin"),
+                "apiVersion: v1\nclusters: []\ncontexts: []\nusers: []\n"
+            ),
+            Kind::Other("structured:kubeconfig".into())
+        );
+        assert_eq!(
+            infer_kind_with_content(
+                Path::new("stdin"),
+                "[default]\naws_access_key_id=x\naws_secret_access_key=y\n"
+            ),
+            Kind::Other("structured:aws".into())
+        );
+        assert_eq!(
+            infer_kind_with_content(
+                Path::new("stdin"),
+                "_authToken=x\nregistry=https://example.com\n"
+            ),
+            Kind::Other("structured:npm".into())
+        );
+        assert_eq!(
+            infer_kind_with_content(
+                Path::new("stdin"),
+                "[pypi]\nrepository = https://upload.pypi.org/legacy/\npassword = x\n"
+            ),
+            Kind::Other("structured:pypi".into())
+        );
+        assert_eq!(
+            infer_kind_with_content(
+                Path::new("stdin"),
+                "region = \"us-east-1\"\ndb_password = \"x\"\n"
+            ),
+            Kind::Other("structured".into())
+        );
+        assert_eq!(
+            infer_kind_with_content(Path::new("stdin"), "This is ordinary prose.\nSecond line."),
             Kind::Text
         );
     }

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -53,3 +53,15 @@ TOML booleans (`true` or `false`).
 
 Pentect v0.0.x intentionally does not preserve old configuration names.
 Errors name the replacement setting directly.
+
+## Repair
+
+`pentect doctor` checks the executable, PATH, configuration, memory store,
+plugins, OCR support, and supported agent commands. Run `pentect doctor --fix`
+to receive an English confirmation prompt for each safe repair Pentect can
+perform. It currently adds the installed binary directory to the user PATH and
+migrates known removed configuration names after writing a backup.
+
+Use `pentect doctor --fix --yes` only in automation where those repairs are
+already approved. `--json` is always read-only and cannot be combined with
+`--fix`.

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -61,6 +61,8 @@ plugins, OCR support, and supported agent commands. Run `pentect doctor --fix`
 to receive an English confirmation prompt for each safe repair Pentect can
 perform. It currently adds the installed binary directory to the user PATH and
 migrates known removed configuration names after writing a backup.
+On fish, Pentect reports the required `fish_add_path` command instead of
+changing PATH automatically.
 
 Use `pentect doctor --fix --yes` only in automation where those repairs are
 already approved. `--json` is always read-only and cannot be combined with


### PR DESCRIPTION
## Summary
- add `pentect doctor --fix` with an English `y/N` prompt for each safe repair
- add `--yes` for explicitly approved automation while keeping `--json` read-only
- diagnose PATH readiness and safely migrate known removed configuration names with backup files
- infer high-confidence structured stdin for `pentect mask` without requiring `--kind`
- cover dotenv, JSON, Kubernetes Secret YAML/JSON, kubeconfig, AWS, npm, PyPI, and Terraform-style configuration
- prepare v0.0.11

## Safety
- no doctor repair runs without confirmation unless `--yes` is supplied
- malformed or ambiguous legacy settings are reported but not rewritten
- configuration writes create a recoverable backup first
- stdin inference is conservative; ordinary prose and a single ambiguous assignment remain text

## Validation
- `cargo test -p pentect-core --locked` (360 passed)
- `cargo test -p pentect-cli --no-default-features --test structured_sources --locked` (7 passed)
- real PowerShell pipes verified Terraform and Kubernetes YAML/JSON produce handles with no plaintext secret remaining
- `cargo clippy --locked -p pentect-cli --no-default-features --all-targets -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic input-format detection for dotenv, Terraform, Kubernetes, JSON, AWS, npm, PyPI, and other structured content.
  * Enhanced `doctor` with JSON diagnostics, automatic repairs, confirmation controls, PATH fixes, and configuration migration.
  * Added safe configuration backups and rollback protection during repairs.
* **Bug Fixes**
  * Improved masking behavior when no input type is specified.
* **Documentation**
  * Documented diagnostics, repairs, confirmations, automation, and read-only JSON mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->