### PR TITLE
fix: relaunch renamed release binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/instal
 
 The installers detect the platform, download a GitHub Release asset, and verify
 its SHA-256 checksum. Run `pentect doctor` after installation. Version-specific
-installation is supported with `-Version 0.0.12` in PowerShell or
-`--version 0.0.12` for `install.sh`.
+installation is supported with `-Version 0.0.13` in PowerShell or
+`--version 0.0.13` for `install.sh`.
 
 ## Use
 

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.12"
+version = "0.0.13"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -2180,18 +2180,29 @@ fn apply_plugin_env(cmd: &mut Command, active: &plugins::ActivePlugins) -> Resul
 }
 
 fn default_pentect_path() -> PathBuf {
-    let exe_name = if cfg!(windows) {
-        "pentect.exe"
-    } else {
-        "pentect"
-    };
-    let mut candidates = Vec::new();
-    if let Ok(current) = std::env::current_exe() {
-        if let Some(dir) = current.parent() {
-            candidates.push(dir.join(exe_name));
-        }
+    default_pentect_path_from(
+        std::env::current_exe().ok(),
+        std::env::current_dir().ok(),
+        cfg!(windows),
+    )
+}
+
+fn default_pentect_path_from(
+    current_exe: Option<PathBuf>,
+    current_dir: Option<PathBuf>,
+    windows: bool,
+) -> PathBuf {
+    // The release asset may be executed before installation, under a
+    // platform-qualified filename such as `pentect-linux-x86_64`.  Child
+    // services must relaunch that exact executable instead of assuming a
+    // sibling file named `pentect` exists.
+    if let Some(current) = current_exe {
+        return current;
     }
-    if let Ok(cwd) = std::env::current_dir() {
+
+    let exe_name = if windows { "pentect.exe" } else { "pentect" };
+    let mut candidates = Vec::new();
+    if let Some(cwd) = current_dir {
         candidates.push(cwd.join("target").join("debug").join(exe_name));
         candidates.push(cwd.join("target").join("release").join(exe_name));
     }
@@ -2516,5 +2527,18 @@ mod tests {
             let args = vec!["pentect".to_string(), command.to_string()];
             assert!(!supports_process_host(&args));
         }
+    }
+
+    #[test]
+    fn child_services_relaunch_the_exact_current_executable() {
+        let release_asset = PathBuf::from("/tmp/pentect-linux-x86_64");
+        assert_eq!(
+            default_pentect_path_from(
+                Some(release_asset.clone()),
+                Some(PathBuf::from("/workspace")),
+                false,
+            ),
+            release_asset
+        );
     }
 }


### PR DESCRIPTION
## Summary
- relaunch the exact current Pentect executable for child services
- support platform-qualified release asset filenames before installation
- add a regression test for renamed binaries
- prepare v0.0.13 without moving the failed v0.0.12 tag

## Verification
- cargo fmt --check
- cargo test -p pentect-cli child_services_relaunch_the_exact_current_executable

Fixes the release CLI compatibility failure.