### PR TITLE
fix: invoke Debian packaging scripts portably

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -54,7 +54,7 @@ jobs:
             if gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
               --pattern "$asset" --dir binaries; then
               chmod +x "binaries/$asset"
-              tools/package_deb.sh "$version" "$architecture" "binaries/$asset" debs
+              bash tools/package_deb.sh "$version" "$architecture" "binaries/$asset" debs
             fi
           done <<'EOF'
           pentect-linux-x86_64 amd64
@@ -83,7 +83,7 @@ jobs:
           printf '%s' "$APT_SIGNING_KEY" | gpg --batch --import
           fingerprint=$(gpg --batch --with-colons --list-secret-keys | awk -F: '$1 == "fpr" { print $10; exit }')
           test "$fingerprint" = "$(cat packaging/apt/KEY_FINGERPRINT)"
-          tools/build_apt_repository.sh debs site \
+          bash tools/build_apt_repository.sh debs site \
             packaging/apt/pentect-archive-keyring.asc "$fingerprint"
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Build Debian package
         run: |
           chmod +x "binary/${{ matrix.artifact }}"
-          tools/package_deb.sh "${GITHUB_REF_NAME#v}" "${{ matrix.arch }}" \
+          bash tools/package_deb.sh "${GITHUB_REF_NAME#v}" "${{ matrix.arch }}" \
             "binary/${{ matrix.artifact }}" dist
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -365,7 +365,7 @@ jobs:
           test "$fingerprint" = "$expected"
           echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
       - name: Build signed repository
-        run: tools/build_apt_repository.sh debs site packaging/apt/pentect-archive-keyring.asc "${{ steps.signing.outputs.fingerprint }}"
+        run: bash tools/build_apt_repository.sh debs site packaging/apt/pentect-archive-keyring.asc "${{ steps.signing.outputs.fingerprint }}"
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:


### PR DESCRIPTION
Fixes v0.0.15 release packaging failure by invoking repository shell scripts through bash, independent of executable-bit preservation. Applies to release and recovery package workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release and package automation by explicitly running Debian packaging and APT repository scripts through Bash.
  * Increased reliability of automated package and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->