### PR TITLE
feat: complete desktop app gateways

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       detector: ${{ steps.filter.outputs.detector }}
       ocr: ${{ steps.filter.outputs.ocr }}
       plugins: ${{ steps.filter.outputs.plugins }}
+      apps: ${{ steps.filter.outputs.apps }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -76,6 +77,25 @@ jobs:
               - 'plugins/**'
               - 'protocol/**'
               - 'sdk/rust/pentect-plugin/**'
+            apps:
+              - '.github/workflows/ci.yml'
+              - '.github/actions/rust-toolchain/**'
+              - '.cargo/**'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'crates/*/Cargo.toml'
+              - 'rust-toolchain*'
+              - 'crates/pentect-cli/src/claude_app_proxy.rs'
+              - 'crates/pentect-cli/src/claude_http_proxy.rs'
+              - 'crates/pentect-cli/src/codex_app.rs'
+              - 'crates/pentect-cli/src/http_files.rs'
+              - 'crates/pentect-cli/src/main.rs'
+              - 'crates/pentect-cli/src/openai_http_proxy.rs'
+              - 'crates/pentect-cli/src/remote_content.rs'
+              - 'crates/pentect-cli/src/upstream.rs'
+              - 'crates/pentect-runtime/**'
+              - 'guides/apps.md'
+              - 'COMPATIBILITY.md'
 
   native-ocr:
     name: Native OCR (${{ matrix.os }})
@@ -146,6 +166,39 @@ jobs:
       - name: No plugin changes
         if: needs.changes.outputs.plugins != 'true'
         run: echo "No plugin changes"
+
+  app-platform:
+    name: Desktop app boundaries (${{ matrix.os }})
+    needs: changes
+    if: always()
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - name: Require change detection
+        if: needs.changes.result != 'success'
+        run: exit 1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        if: needs.changes.outputs.apps == 'true'
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: ./.github/actions/rust-toolchain
+        if: needs.changes.outputs.apps == 'true'
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: needs.changes.outputs.apps == 'true'
+      - name: Test Codex App launcher and recovery
+        if: needs.changes.outputs.apps == 'true'
+        run: cargo test -p pentect-cli --no-default-features codex_app::tests --locked
+      - name: Test Claude Desktop gateway
+        if: needs.changes.outputs.apps == 'true'
+        run: cargo test -p pentect-cli --no-default-features claude_app_proxy::tests --locked
+      - name: No app changes
+        if: needs.changes.outputs.apps != 'true'
+        run: echo "No app changes"
 
   test:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,10 +192,10 @@ jobs:
         if: needs.changes.outputs.apps == 'true'
       - name: Test Codex App launcher and recovery
         if: needs.changes.outputs.apps == 'true'
-        run: cargo test -p pentect-cli --no-default-features codex_app::tests --locked
+        run: python tools/run_filtered_tests.py codex_app::tests
       - name: Test Claude Desktop gateway
         if: needs.changes.outputs.apps == 'true'
-        run: cargo test -p pentect-cli --no-default-features claude_app_proxy::tests --locked
+        run: python tools/run_filtered_tests.py claude_app_proxy::tests
       - name: No app changes
         if: needs.changes.outputs.apps != 'true'
         run: echo "No app changes"

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,8 +8,8 @@ through the release binary:
 | --- | --- | --- |
 | Codex CLI `0.146.0` | automated on Linux | `pentect codex` |
 | Claude Code `2.1.220` | automated on Linux | `pentect claude` |
-| Codex App | launcher and protocol tests | `pentect codex app` |
-| Claude App | launcher and protocol tests | `pentect claude app` |
+| ChatGPT desktop app (Codex mode) | launcher and Responses protocol tests | `pentect codex app` |
+| Claude Desktop (supported Chat, attachment, and Claude Code routes) | launcher and protocol tests | `pentect claude app` |
 
 The CLI gate proves that the vendor executable still starts under Pentect.
 Mock protocol tests cover text, streaming responses, completed tool calls,
@@ -19,6 +19,11 @@ path preservation without sending repository secrets to a model provider.
 Desktop vendor apps are not installed on ephemeral release runners, so their
 full signed-GUI flow is not yet a release gate. Pentect does not claim an App
 version as verified until that automation exists.
+
+The App rows do not imply protection for ChatGPT Chat or Work, remote Claude
+Cowork execution, Voice, experimental binary transports, or unknown future
+opaque routes. Current Claude multipart attachment flows are protected as
+described in [desktop apps](guides/apps.md).
 
 ## Upstreams
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ pentect codex app
 pentect claude app
 ```
 
+These commands protect Codex mode and supported Claude Desktop Chat, Code, and
+attachment traffic; they do not claim coverage for every Chat, Work, Cowork,
+Voice, or future opaque route.
+See the [desktop app guide](guides/apps.md) before using sensitive data.
+
 Mask text from stdin while preserving opaque handles:
 
 ```sh
@@ -121,6 +126,7 @@ global configuration, but project configuration cannot weaken this policy.
 
 See [configuration](guides/configuration.md) for policies and limits.
 See [compatibility](COMPATIBILITY.md) for the release-tested client matrix.
+See [desktop apps](guides/apps.md) for exact surface coverage and limitations.
 See [custom upstreams](guides/upstreams.md) for Bifrost, LiteLLM, local models,
 enterprise CA, mTLS, and proxy configuration.
 

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -55,6 +55,10 @@ pub(crate) fn cmd_claude_app(args: &[String]) -> i32 {
     }
 }
 
+pub(crate) fn check_mode(args: &[String]) -> Result<bool, String> {
+    ClaudeAppOptions::parse(args).map(|options| options.check)
+}
+
 fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     let options = ClaudeAppOptions::parse(args)?;
     let app = options.app.unwrap_or_else(default_claude_app_path);
@@ -155,7 +159,7 @@ fn configure_child_process(command: &mut Command) {
 
 #[cfg(windows)]
 fn terminate_child_process(pid: u32) {
-    let _ = Command::new("taskkill.exe")
+    let _ = Command::new(crate::windows_system_executable("taskkill.exe"))
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -357,7 +361,13 @@ struct ProxyState {
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
     block_unknown_formats: bool,
     files: Mutex<HashMap<String, crate::http_files::Coverage>>,
-    pending_files: Mutex<HashMap<String, Vec<String>>>,
+    pending_files: Mutex<PendingFiles>,
+}
+
+#[derive(Default)]
+struct PendingFiles {
+    entries: HashMap<String, Vec<String>>,
+    insertion_order: VecDeque<String>,
 }
 
 impl ProxyState {
@@ -411,7 +421,7 @@ async fn run_proxy(
         plugins: Arc::new(Mutex::new(plugins)),
         block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
         files: Mutex::new(HashMap::new()),
-        pending_files: Mutex::new(HashMap::new()),
+        pending_files: Mutex::new(PendingFiles::default()),
     });
     let _ = ready_tx.send(Ok(format!("http://{address}")));
 
@@ -427,9 +437,9 @@ async fn run_proxy(
                 };
                 let state = Arc::clone(&state);
                 tokio::spawn(async move {
-                    let _permit = permit;
+                    let permit = Arc::new(Mutex::new(Some(permit)));
                     let service = service_fn(move |request| {
-                        connect_request(request, Arc::clone(&state))
+                        connect_request(request, Arc::clone(&state), Arc::clone(&permit))
                     });
                     let io = hyper_util::rt::TokioIo::new(stream);
                     if let Err(error) = http1::Builder::new()
@@ -451,6 +461,7 @@ async fn run_proxy(
 async fn connect_request(
     mut request: Request<Incoming>,
     state: Arc<ProxyState>,
+    connection_permit: Arc<Mutex<Option<tokio::sync::OwnedSemaphorePermit>>>,
 ) -> Result<Response<ProxyBody>, Infallible> {
     if request.method() != Method::CONNECT {
         return Ok(empty_response(StatusCode::METHOD_NOT_ALLOWED));
@@ -463,9 +474,17 @@ async fn connect_request(
     if port != 443 {
         return Ok(empty_response(StatusCode::FORBIDDEN));
     }
+    let Some(permit) = connection_permit
+        .lock()
+        .ok()
+        .and_then(|mut permit| permit.take())
+    else {
+        return Ok(empty_response(StatusCode::SERVICE_UNAVAILABLE));
+    };
     let upgraded = hyper::upgrade::on(&mut request);
     if should_inspect(&host, port) {
         tokio::spawn(async move {
+            let _permit = permit;
             let result = async {
                 let upgraded = upgraded
                     .await
@@ -480,6 +499,7 @@ async fn connect_request(
         });
     } else {
         tokio::spawn(async move {
+            let _permit = permit;
             if let Err(error) = passthrough_tunnel(upgraded, &host, port).await {
                 eprintln!("[pentect] Claude App network tunnel failed: {error}");
             }
@@ -497,9 +517,13 @@ async fn passthrough_tunnel(
         .await
         .map_err(|error| format!("CONNECT upgrade failed: {error}"))?;
     let mut client = hyper_util::rt::TokioIo::new(upgraded);
-    let mut upstream = tokio::net::TcpStream::connect((host, port))
-        .await
-        .map_err(|error| format!("could not reach required app service: {error}"))?;
+    let mut upstream = tokio::time::timeout(
+        Duration::from_secs(15),
+        tokio::net::TcpStream::connect((host, port)),
+    )
+    .await
+    .map_err(|_| "could not reach required app service: connection timed out".to_string())?
+    .map_err(|error| format!("could not reach required app service: {error}"))?;
     if let Err(error) = tokio::io::copy_bidirectional(&mut client, &mut upstream).await {
         if !matches!(
             error.kind(),
@@ -609,6 +633,13 @@ async fn forward_inspected_inner(
     headers.remove(hyper::header::HOST);
     let mut upload_coverage = None;
     let mut upload_key = None;
+    let mut upload_filename = None;
+    if protect_chat || prepare_upload || request_kind == ClaudeAppRequest::Upload {
+        headers.insert(
+            hyper::header::ACCEPT_ENCODING,
+            hyper::header::HeaderValue::from_static("identity"),
+        );
+    }
     let body = if protect_chat {
         let body = read_request_capped(request.into_body(), "Chat").await?;
         let original = body.clone();
@@ -655,6 +686,7 @@ async fn forward_inspected_inner(
     } else if request_kind == ClaudeAppRequest::Upload {
         let body = read_request_capped(request.into_body(), "upload").await?;
         upload_key = claude_filestore_upload_key(&content_type, &body);
+        upload_filename = crate::http_files::multipart_file_name(&content_type, &body);
         let masker = Arc::clone(&state.masker);
         let plugins = Arc::clone(&state.plugins);
         let protected = tokio::task::spawn_blocking(move || {
@@ -706,17 +738,36 @@ async fn forward_inspected_inner(
         .unwrap_or("-");
     eprintln!("[pentect] claude-app < {status} {method} {host}{safe_path} {response_content_type}");
 
-    let mut builder = Response::builder().status(status);
-    for (name, value) in &response_headers {
-        builder = builder.header(name, value);
-    }
     let transform_chat = protect_chat
         && status.is_success()
         && response_content_type.eq_ignore_ascii_case("text/event-stream");
+    if (transform_chat || upload_coverage.is_some() || prepare_upload)
+        && response_headers
+            .get(hyper::header::CONTENT_ENCODING)
+            .is_some_and(|encoding| {
+                !encoding
+                    .to_str()
+                    .is_ok_and(|value| value.eq_ignore_ascii_case("identity"))
+            })
+    {
+        return Err(
+            "Claude App upstream returned compressed protected content despite requesting identity encoding"
+                .to_string(),
+        );
+    }
+
+    let mut builder = Response::builder().status(status);
+    for (name, value) in &response_headers {
+        if !transform_chat || name != hyper::header::CONTENT_LENGTH {
+            builder = builder.header(name, value);
+        }
+    }
     if let Some(coverage) = upload_coverage {
         let body = read_response_capped(upstream).await?;
         if status.is_success() {
-            remember_claude_file_ids(&body, coverage, &state.files)?;
+            if let Some(filename) = upload_filename.as_deref() {
+                remember_claude_file_ids(&body, filename, coverage, &state.files)?;
+            }
             if let Some(key) = upload_key.as_deref() {
                 promote_pending_claude_files(key, coverage, &state.pending_files, &state.files)?;
             }
@@ -835,7 +886,7 @@ fn is_chat_completion(host: &str, path: &str, content_type: &str) -> bool {
 }
 
 fn is_chat_completion_path(path: &str) -> bool {
-    let Some(segment) = path.rsplit('/').next() else {
+    let Some(segment) = path.trim_end_matches('/').rsplit('/').next() else {
         return false;
     };
     let completion = segment.strip_prefix("retry_").unwrap_or(segment);
@@ -894,14 +945,14 @@ fn is_claude_prepare_upload_path(path: &str) -> bool {
 
 fn remember_claude_file_ids(
     body: &[u8],
+    uploaded_filename: &str,
     coverage: crate::http_files::Coverage,
     files: &Mutex<HashMap<String, crate::http_files::Coverage>>,
 ) -> Result<(), String> {
     let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
         return Ok(());
     };
-    let mut ids = Vec::new();
-    collect_claude_file_ids(&value, &mut ids);
+    let ids = uploaded_file_ids(&value, uploaded_filename);
     let mut files = files
         .lock()
         .map_err(|_| "Claude App file registry lock was poisoned".to_string())?;
@@ -911,47 +962,54 @@ fn remember_claude_file_ids(
     Ok(())
 }
 
-fn collect_claude_file_ids(value: &serde_json::Value, ids: &mut Vec<String>) {
-    match value {
-        serde_json::Value::Array(values) => {
-            for value in values {
-                collect_claude_file_ids(value, ids);
-            }
-        }
-        serde_json::Value::Object(object) => {
-            for key in ["file_id", "file_uuid"] {
-                if let Some(id) = object.get(key).and_then(serde_json::Value::as_str) {
-                    if !id.is_empty() && id.len() <= 200 {
-                        ids.push(id.to_string());
-                    }
-                }
-            }
-            let file_shaped = object.contains_key("file_name")
-                || object.contains_key("filename")
-                || object.contains_key("mime_type")
-                || object.contains_key("content_type")
-                || object
-                    .get("type")
-                    .and_then(serde_json::Value::as_str)
-                    .is_some_and(|kind| {
-                        let kind = kind.to_ascii_lowercase();
-                        kind.contains("file") || kind.contains("document")
-                    });
-            if file_shaped {
-                for key in ["id", "uuid"] {
-                    if let Some(id) = object.get(key).and_then(serde_json::Value::as_str) {
-                        if !id.is_empty() && id.len() <= 200 {
-                            ids.push(id.to_string());
-                        }
-                    }
-                }
-            }
-            for value in object.values() {
-                collect_claude_file_ids(value, ids);
-            }
-        }
-        _ => {}
+fn uploaded_file_ids(value: &serde_json::Value, uploaded_filename: &str) -> Vec<String> {
+    let Some(root) = value.as_object() else {
+        return Vec::new();
+    };
+    let mut candidates = Vec::new();
+    if file_object_matches_name(root, uploaded_filename) {
+        candidates.push(root);
     }
+    for key in ["file", "data"] {
+        if let Some(object) = root.get(key).and_then(serde_json::Value::as_object) {
+            if file_object_matches_name(object, uploaded_filename) {
+                candidates.push(object);
+            }
+        }
+    }
+    for key in ["files", "uploads"] {
+        if let Some(values) = root.get(key).and_then(serde_json::Value::as_array) {
+            candidates.extend(
+                values
+                    .iter()
+                    .filter_map(serde_json::Value::as_object)
+                    .filter(|object| file_object_matches_name(object, uploaded_filename)),
+            );
+        }
+    }
+    candidates
+        .into_iter()
+        .flat_map(|object| ["file_id", "file_uuid", "id", "uuid"].map(move |key| (object, key)))
+        .filter_map(|(object, key)| object.get(key).and_then(serde_json::Value::as_str))
+        .filter(|id| !id.is_empty() && id.len() <= 200)
+        .map(str::to_string)
+        .collect()
+}
+
+fn file_object_matches_name(
+    object: &serde_json::Map<String, serde_json::Value>,
+    uploaded_filename: &str,
+) -> bool {
+    ["file_name", "filename", "name", "path"]
+        .into_iter()
+        .filter_map(|key| object.get(key).and_then(serde_json::Value::as_str))
+        .any(|candidate| {
+            candidate == uploaded_filename
+                || Path::new(candidate)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    == Some(uploaded_filename)
+        })
 }
 
 fn claude_filestore_upload_key(content_type: &str, body: &[u8]) -> Option<String> {
@@ -965,10 +1023,7 @@ fn claude_filestore_upload_key(content_type: &str, body: &[u8]) -> Option<String
     Some(format!("{filesystem}\0{path}"))
 }
 
-fn remember_pending_claude_files(
-    body: &[u8],
-    pending: &Mutex<HashMap<String, Vec<String>>>,
-) -> Result<(), String> {
+fn remember_pending_claude_files(body: &[u8], pending: &Mutex<PendingFiles>) -> Result<(), String> {
     let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
         return Ok(());
     };
@@ -1004,13 +1059,17 @@ fn remember_pending_claude_files(
         {
             continue;
         }
-        let ids = pending.entry(format!("{filesystem}\0{path}")).or_default();
+        let key = format!("{filesystem}\0{path}");
+        if !pending.entries.contains_key(&key) {
+            pending.insertion_order.push_back(key.clone());
+        }
+        let ids = pending.entries.entry(key).or_default();
         if ids.len() < MAX_IDS_PER_UPLOAD && !ids.iter().any(|known| known == file_id) {
             ids.push(file_id.to_string());
         }
-        if pending.len() > MAX_PENDING_UPLOADS {
-            if let Some(expired) = pending.keys().next().cloned() {
-                pending.remove(&expired);
+        while pending.entries.len() > MAX_PENDING_UPLOADS {
+            if let Some(expired) = pending.insertion_order.pop_front() {
+                pending.entries.remove(&expired);
             }
         }
     }
@@ -1020,14 +1079,16 @@ fn remember_pending_claude_files(
 fn promote_pending_claude_files(
     key: &str,
     coverage: crate::http_files::Coverage,
-    pending: &Mutex<HashMap<String, Vec<String>>>,
+    pending: &Mutex<PendingFiles>,
     files: &Mutex<HashMap<String, crate::http_files::Coverage>>,
 ) -> Result<(), String> {
-    let ids = pending
-        .lock()
-        .map_err(|_| "Claude App pending file registry lock was poisoned".to_string())?
-        .remove(key)
-        .unwrap_or_default();
+    let ids = {
+        let mut pending = pending
+            .lock()
+            .map_err(|_| "Claude App pending file registry lock was poisoned".to_string())?;
+        pending.insertion_order.retain(|known| known != key);
+        pending.entries.remove(key).unwrap_or_default()
+    };
     if ids.is_empty() {
         return Ok(());
     }
@@ -1139,6 +1200,11 @@ fn protect_chat_request(
         if error.starts_with("image blocked:") || error.starts_with("document blocked:") {
             return Err(error);
         }
+        if block_unknown_formats {
+            return Err(format!(
+                "Claude App Chat request blocked: content inspection is unavailable ({error})"
+            ));
+        }
         eprintln!("[pentect] Claude App Chat protection skipped: {error}");
         return Ok(ProtectedChatRequest {
             body: body.clone(),
@@ -1185,6 +1251,11 @@ fn protect_generic_json_request(
         .lock()
         .map_err(|_| "Claude App JSON masker lock was poisoned".to_string())?;
     if let Err(error) = mask_generic_json_value(&mut value, &mut masker) {
+        if block_unknown_formats {
+            return Err(format!(
+                "Claude App JSON request blocked: content inspection is unavailable ({error})"
+            ));
+        }
         eprintln!("[pentect] Claude App JSON protection skipped: {error}");
         return Ok(body.clone());
     }
@@ -1275,14 +1346,11 @@ fn mask_chat_value(
                 if matches!(
                     key.as_str(),
                     "signature" | "thinking_signature" | "attestation"
-                ) {
+                ) || (!nested_tool_result && is_chat_protocol_metadata_field(key))
+                {
                     continue;
                 }
-                if is_chat_content_field(key)
-                    || (nested_tool_result && !is_chat_protocol_metadata_field(key))
-                {
-                    mask_chat_value(nested, nested_tool_result, masker, files)?;
-                }
+                mask_chat_value(nested, nested_tool_result, masker, files)?;
             }
             Ok(())
         }
@@ -1405,29 +1473,6 @@ fn inspect_chat_document(
     crate::claude_http_proxy::inspect_base64_document(&source, tool_result, masker)
 }
 
-fn is_chat_content_field(key: &str) -> bool {
-    matches!(
-        key,
-        "system"
-            | "prompt"
-            | "custom_system_prompt"
-            | "messages"
-            | "message"
-            | "content"
-            | "text"
-            | "parts"
-            | "attachments"
-            | "files"
-            | "input"
-            | "output"
-            | "result"
-            | "tool_result"
-            | "tool_output"
-            | "function_output"
-            | "extracted_content"
-    )
-}
-
 fn is_chat_protocol_metadata_field(key: &str) -> bool {
     matches!(
         key,
@@ -1442,6 +1487,8 @@ fn is_chat_protocol_metadata_field(key: &str) -> bool {
             | "signature"
             | "thinking_signature"
             | "attestation"
+            | "authorization"
+            | "token"
     )
 }
 
@@ -1469,6 +1516,7 @@ fn unscanned_chat_image() -> Result<(), String> {
 
 type ChatFrameStream =
     Pin<Box<dyn futures_util::Stream<Item = Result<Frame<Bytes>, ProxyBodyError>> + Send>>;
+type ChatResolver = Box<dyn FnMut(&str) -> Result<String, String> + Send>;
 
 struct ChatStreamState {
     upstream: ChatFrameStream,
@@ -1477,6 +1525,7 @@ struct ChatStreamState {
     passthrough: bool,
     finished: bool,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
+    resolve: ChatResolver,
 }
 
 fn chat_sse_body<S>(stream: S, plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>) -> ProxyBody
@@ -1490,6 +1539,7 @@ where
         passthrough: false,
         finished: false,
         plugins,
+        resolve: Box::new(crate::claude_http_proxy::request_scoped_resolver()),
     };
     let stream = futures_util::stream::unfold(state, |mut state| async move {
         loop {
@@ -1520,7 +1570,7 @@ where
                     state.pending.extend_from_slice(&chunk);
                     while let Some(end) = first_sse_block_end(&state.pending) {
                         let block = state.pending.drain(..end).collect::<Vec<_>>();
-                        match rewrite_chat_sse_block(&block, &state.plugins) {
+                        match rewrite_chat_sse_block(&block, &state.plugins, &mut state.resolve) {
                             Ok(block) => state.ready.push_back(Ok(Frame::data(block))),
                             Err(error) => {
                                 state.finished = true;
@@ -1552,10 +1602,14 @@ where
     StreamBody::new(stream).boxed_unsync()
 }
 
-fn rewrite_chat_sse_block(
+fn rewrite_chat_sse_block<R>(
     block: &[u8],
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
-) -> Result<Bytes, String> {
+    resolve: &mut R,
+) -> Result<Bytes, String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
     let Ok(text) = std::str::from_utf8(block) else {
         return Ok(Bytes::copy_from_slice(block));
     };
@@ -1565,12 +1619,13 @@ fn rewrite_chat_sse_block(
     let Ok(mut value) = serde_json::from_str::<serde_json::Value>(data.trim_start()) else {
         return Ok(Bytes::copy_from_slice(block));
     };
-    let plugins = plugins
-        .lock()
-        .map_err(|_| "Claude App plugin lock was poisoned".to_string())?;
-    run_chat_tool_plugins(&mut value, &plugins)?;
-    let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
-    if let Err(error) = resolve_chat_tool_calls(&mut value, &mut resolve) {
+    if contains_chat_tool_call(&value) {
+        let plugins = plugins
+            .lock()
+            .map_err(|_| "Claude App plugin lock was poisoned".to_string())?;
+        run_chat_tool_plugins(&mut value, &plugins)?;
+    }
+    if let Err(error) = resolve_chat_tool_calls(&mut value, resolve) {
         eprintln!("[pentect] Claude App Chat tool restoration skipped: {error}");
         return Ok(Bytes::copy_from_slice(block));
     }
@@ -1594,6 +1649,27 @@ fn rewrite_chat_sse_block(
         }
     }
     Ok(Bytes::from(output))
+}
+
+fn contains_chat_tool_call(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Array(values) => values.iter().any(contains_chat_tool_call),
+        serde_json::Value::Object(object) => {
+            let kind = object
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            ((kind.contains("tool_use")
+                || kind.contains("tool_call")
+                || kind.contains("function_call"))
+                && ["arguments", "input"]
+                    .into_iter()
+                    .any(|key| object.contains_key(key)))
+                || object.values().any(contains_chat_tool_call)
+        }
+        _ => false,
+    }
 }
 
 fn run_chat_tool_plugins(
@@ -1884,7 +1960,8 @@ fn find_windows_claude_app() -> Option<PathBuf> {
     // WindowsApps intentionally denies ordinary directory enumeration. The
     // per-user AppModel repository is the supported local index for package
     // roots and does not require elevation.
-    let output = Command::new("reg.exe")
+    let reg = crate::windows_system_executable("reg.exe");
+    let output = Command::new(&reg)
         .args(["query", PACKAGES_KEY])
         .creation_flags(CREATE_NO_WINDOW)
         .output()
@@ -1903,7 +1980,7 @@ fn find_windows_claude_app() -> Option<PathBuf> {
         })
         .filter_map(|key| {
             let package_name = key.rsplit('\\').next()?.to_string();
-            let output = Command::new("reg.exe")
+            let output = Command::new(&reg)
                 .args(["query", key, "/v", "PackageRootFolder"])
                 .creation_flags(CREATE_NO_WINDOW)
                 .output()
@@ -2084,6 +2161,18 @@ mod tests {
     }
 
     #[test]
+    fn check_mode_does_not_treat_an_option_value_as_a_flag() {
+        let args = vec![
+            "pentect".to_string(),
+            "claude".to_string(),
+            "app".to_string(),
+            "--app".to_string(),
+            "--check".to_string(),
+        ];
+        assert!(!check_mode(&args).unwrap());
+    }
+
+    #[test]
     fn inspection_scope_is_exact_domain_suffix() {
         assert!(should_inspect("claude.ai", 443));
         assert!(should_inspect("assets.claude.ai", 443));
@@ -2112,6 +2201,11 @@ mod tests {
         assert!(is_chat_completion(
             "claude.ai",
             "/api/organizations/example/chat_conversations/example/retry_completion2",
+            "application/json"
+        ));
+        assert!(is_chat_completion(
+            "claude.ai",
+            "/api/organizations/example/chat_conversations/example/completion/",
             "application/json"
         ));
         assert!(!is_chat_completion(
@@ -2241,6 +2335,7 @@ mod tests {
                 "model": "claude-test-model",
                 "organization_uuid": "11111111-2222-3333-4444-555555555555",
                 "prompt": format!("Use this value:\nRUNPOD_API_KEY={secret}\n"),
+                "future_instructions": format!("A future field contains {secret}"),
                 "messages": [{"content": [{
                     "type": "tool_result",
                     "tool_use_id": "tool-stable-id",
@@ -2259,6 +2354,10 @@ mod tests {
         assert!(!prompt.contains(&secret));
         assert!(prompt.contains("<<"));
         assert!(prompt.contains(HANDLE_CONTRACT));
+        assert!(!value["future_instructions"]
+            .as_str()
+            .unwrap()
+            .contains(&secret));
         assert_eq!(value["model"], "claude-test-model");
         assert_eq!(
             value["organization_uuid"],
@@ -2289,17 +2388,15 @@ mod tests {
     fn uploaded_file_ids_are_registered_without_trusting_unrelated_ids() {
         let files = Mutex::new(HashMap::new());
         remember_claude_file_ids(
-            br#"{"id":"organization-id","nested":{"file_uuid":"file-123"},"file":{"id":"file-456","type":"file"}}"#,
+            br#"{"id":"organization-id","nested":{"file_uuid":"file-123","filename":"other.txt"},"file":{"id":"file-456","type":"file","filename":"a.txt"}}"#,
+            "a.txt",
             crate::http_files::Coverage::Full,
             &files,
         )
         .unwrap();
         let files = files.lock().unwrap();
         assert!(!files.contains_key("organization-id"));
-        assert_eq!(
-            files.get("file-123"),
-            Some(&crate::http_files::Coverage::Full)
-        );
+        assert!(!files.contains_key("file-123"));
         assert_eq!(
             files.get("file-456"),
             Some(&crate::http_files::Coverage::Full)
@@ -2321,7 +2418,7 @@ mod tests {
             "--pentect-test--\r\n"
         );
         let key = claude_filestore_upload_key(content_type, body.as_bytes()).unwrap();
-        let pending = Mutex::new(HashMap::new());
+        let pending = Mutex::new(PendingFiles::default());
         let files = Mutex::new(HashMap::new());
         remember_pending_claude_files(
             br#"{"uploads":[{"filesystem_id":"fs-1","path":"/uploads/a.txt","file_uuid":"file-1"}]}"#,
@@ -2335,6 +2432,28 @@ mod tests {
             files.lock().unwrap().get("file-1"),
             Some(&crate::http_files::Coverage::Full)
         );
+    }
+
+    #[test]
+    fn pending_upload_eviction_keeps_the_newest_correlations() {
+        let pending = Mutex::new(PendingFiles::default());
+        for index in 0..=MAX_PENDING_UPLOADS {
+            let body = serde_json::to_vec(&serde_json::json!({
+                "uploads": [{
+                    "filesystem_id": "fs",
+                    "path": format!("/{index}.txt"),
+                    "file_uuid": format!("file-{index}")
+                }]
+            }))
+            .unwrap();
+            remember_pending_claude_files(&body, &pending).unwrap();
+        }
+        let pending = pending.lock().unwrap();
+        assert_eq!(pending.entries.len(), MAX_PENDING_UPLOADS);
+        assert!(!pending.entries.contains_key("fs\0/0.txt"));
+        assert!(pending
+            .entries
+            .contains_key(&format!("fs\0/{MAX_PENDING_UPLOADS}.txt")));
     }
 
     #[test]

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -39,6 +39,7 @@ type ProxyBody = UnsyncBoxBody<Bytes, ProxyBodyError>;
 
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_CONNECTIONS: usize = 128;
+const MAX_CERTIFICATE_CACHE_ENTRIES: usize = 64;
 const MAX_CHAT_BODY_BYTES: usize = 32 * 1024 * 1024;
 const MAX_PENDING_UPLOADS: usize = 256;
 const MAX_IDS_PER_UPLOAD: usize = 16;
@@ -331,6 +332,11 @@ impl ProxyState {
             return Ok(Arc::clone(config));
         }
         let config = self.authority.server_config(host)?;
+        if configs.len() >= MAX_CERTIFICATE_CACHE_ENTRIES {
+            if let Some(expired) = configs.keys().next().cloned() {
+                configs.remove(&expired);
+            }
+        }
         configs.insert(host.to_string(), Arc::clone(&config));
         Ok(config)
     }
@@ -508,7 +514,8 @@ async fn forward_inspected(
     match forward_inspected_inner(request, &host, &state).await {
         Ok(response) => Ok(response),
         Err(error) => {
-            eprintln!("[pentect] Claude App request failed: {error}");
+            let category = error.split(':').next().unwrap_or("gateway request failed");
+            eprintln!("[pentect] Claude App request failed: {category}");
             Ok(
                 if error.starts_with("unknown format blocked:")
                     || error.starts_with("image blocked:")
@@ -518,6 +525,8 @@ async fn forward_inspected(
                     || error.starts_with("plugin blocked:")
                 {
                     text_response(StatusCode::UNPROCESSABLE_ENTITY, &error)
+                } else if error.starts_with("payload too large:") {
+                    text_response(StatusCode::PAYLOAD_TOO_LARGE, &error)
                 } else {
                     text_response(StatusCode::BAD_GATEWAY, "Pentect Claude App gateway failed")
                 },
@@ -563,11 +572,7 @@ async fn forward_inspected_inner(
     let mut upload_coverage = None;
     let mut upload_key = None;
     let body = if protect_chat {
-        let body = Limited::new(request.into_body(), MAX_CHAT_BODY_BYTES)
-            .collect()
-            .await
-            .map_err(|error| format!("could not read Claude App Chat request: {error}"))?
-            .to_bytes();
+        let body = read_request_capped(request.into_body(), "Chat").await?;
         let original = body.clone();
         let masker = Arc::clone(&state.masker);
         let plugins = Arc::clone(&state.plugins);
@@ -599,11 +604,7 @@ async fn forward_inspected_inner(
         request_kind,
         ClaudeAppRequest::JsonScan | ClaudeAppRequest::PrepareUploadJson
     ) {
-        let body = Limited::new(request.into_body(), MAX_CHAT_BODY_BYTES)
-            .collect()
-            .await
-            .map_err(|error| format!("could not read Claude App JSON request: {error}"))?
-            .to_bytes();
+        let body = read_request_capped(request.into_body(), "JSON").await?;
         let masker = Arc::clone(&state.masker);
         let block_unknown_formats = state.block_unknown_formats;
         let protected = tokio::task::spawn_blocking(move || {
@@ -614,11 +615,7 @@ async fn forward_inspected_inner(
         headers.remove(hyper::header::CONTENT_LENGTH);
         reqwest::Body::from(protected)
     } else if request_kind == ClaudeAppRequest::Upload {
-        let body = Limited::new(request.into_body(), MAX_CHAT_BODY_BYTES)
-            .collect()
-            .await
-            .map_err(|error| format!("could not read Claude App upload: {error}"))?
-            .to_bytes();
+        let body = read_request_capped(request.into_body(), "upload").await?;
         upload_key = claude_filestore_upload_key(&content_type, &body);
         let masker = Arc::clone(&state.masker);
         let plugins = Arc::clone(&state.plugins);
@@ -1021,6 +1018,16 @@ async fn read_response_capped(response: reqwest::Response) -> Result<Bytes, Stri
         body.extend_from_slice(&chunk);
     }
     Ok(Bytes::from(body))
+}
+
+async fn read_request_capped(body: Incoming, label: &str) -> Result<Bytes, String> {
+    match Limited::new(body, MAX_CHAT_BODY_BYTES).collect().await {
+        Ok(body) => Ok(body.to_bytes()),
+        Err(error) if error.is::<http_body_util::LengthLimitError>() => Err(format!(
+            "payload too large: Claude App {label} request exceeds {MAX_CHAT_BODY_BYTES} bytes"
+        )),
+        Err(_) => Err(format!("could not read Claude App {label} request")),
+    }
 }
 
 fn reqwest_error_summary(error: &reqwest::Error) -> &'static str {

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -1,4 +1,4 @@
-//! Explicit HTTPS proxy PoC for the unmodified Claude Desktop application.
+//! Explicit HTTPS gateway for the unmodified Claude Desktop application.
 //!
 //! The root CA and its signing key exist only in memory. Claude Desktop is
 //! launched with Chromium's SPKI allow-list, so this does not modify the OS
@@ -7,7 +7,7 @@
 
 use futures_util::StreamExt;
 use http_body_util::combinators::UnsyncBoxBody;
-use http_body_util::{BodyExt, Empty, Limited, StreamBody};
+use http_body_util::{BodyExt, Empty, Full, Limited, StreamBody};
 use hyper::body::{Bytes, Frame, Incoming};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
@@ -17,8 +17,6 @@ use rcgen::{
     KeyUsagePurpose, PublicKeyData,
 };
 use sha2::{Digest, Sha256};
-#[cfg(debug_assertions)]
-use std::collections::HashSet;
 use std::collections::{HashMap, VecDeque};
 use std::convert::Infallible;
 use std::error::Error;
@@ -42,6 +40,8 @@ type ProxyBody = UnsyncBoxBody<Bytes, ProxyBodyError>;
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_CONNECTIONS: usize = 128;
 const MAX_CHAT_BODY_BYTES: usize = 32 * 1024 * 1024;
+const MAX_PENDING_UPLOADS: usize = 256;
+const MAX_IDS_PER_UPLOAD: usize = 16;
 const HANDLE_CONTRACT: &str = "Values formatted as <<LABEL_HASH>> are opaque local secret handles. Copy a handle byte-for-byte into a client tool call when the tool needs the represented value. Do not alter, expand, guess, or expose it.";
 
 pub(crate) fn cmd_claude_app(args: &[String]) -> i32 {
@@ -57,8 +57,27 @@ pub(crate) fn cmd_claude_app(args: &[String]) -> i32 {
 fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     let options = ClaudeAppOptions::parse(args)?;
     let app = options.app.unwrap_or_else(default_claude_app_path);
-    if options.dry_run {
-        println!("{}", app.display());
+    if options.check {
+        let installed = app.is_file();
+        println!("App: {}", app.display());
+        println!("Installed: {}", if installed { "yes" } else { "no" });
+        println!(
+            "Running: {}",
+            if claude_desktop_is_running(&app) {
+                "yes"
+            } else {
+                "no"
+            }
+        );
+        println!("Protection: Claude Chat, attachments, and Anthropic Messages APIs");
+        let upstream = options
+            .upstream
+            .as_deref()
+            .unwrap_or("https://api.anthropic.com");
+        crate::upstream::parse_base(upstream, "Anthropic Messages")?;
+        if !installed {
+            return Err("Claude Desktop was not found; pass --app PATH".to_string());
+        }
         return Ok(success_status());
     }
     if !app.is_file() {
@@ -85,7 +104,9 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         "[pentect] Claude App gateway ready at {}",
         proxy.proxy_url()
     );
-    eprintln!("[pentect] Chat and Claude Code model traffic is protected; bodies are not logged");
+    eprintln!(
+        "[pentect] Chat, supported attachments, and Claude Code model traffic are protected; bodies are not logged"
+    );
 
     let mut command = Command::new(&app);
     command
@@ -114,14 +135,14 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
 struct ClaudeAppOptions {
     app: Option<PathBuf>,
     upstream: Option<String>,
-    dry_run: bool,
+    check: bool,
 }
 
 impl ClaudeAppOptions {
     fn parse(args: &[String]) -> Result<Self, String> {
         let mut app = None;
         let mut upstream = None;
-        let mut dry_run = false;
+        let mut check = false;
         let mut index = if args.get(1).is_some_and(|arg| arg == "claude")
             && args.get(2).is_some_and(|arg| arg == "app")
         {
@@ -138,8 +159,8 @@ impl ClaudeAppOptions {
                     app = Some(PathBuf::from(value));
                     index += 2;
                 }
-                "--dry-run" => {
-                    dry_run = true;
+                "--check" | "--dry-run" => {
+                    check = true;
                     index += 1;
                 }
                 "--upstream" => {
@@ -164,7 +185,7 @@ impl ClaudeAppOptions {
         Ok(Self {
             app,
             upstream,
-            dry_run,
+            check,
         })
     }
 }
@@ -294,6 +315,10 @@ struct ProxyState {
     server_configs: Mutex<HashMap<String, Arc<ServerConfig>>>,
     client: reqwest::Client,
     masker: Arc<Mutex<pentect_agent::ActiveToolOutputMasker>>,
+    plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
+    block_unknown_formats: bool,
+    files: Mutex<HashMap<String, crate::http_files::Coverage>>,
+    pending_files: Mutex<HashMap<String, Vec<String>>>,
 }
 
 impl ProxyState {
@@ -331,11 +356,18 @@ async fn run_proxy(
         .tcp_nodelay(true)
         .build()
         .map_err(|error| format!("could not build Claude App upstream client: {error}"))?;
+    let plugins = pentect_agent::PluginMiddleware::from_env()?;
     let state = Arc::new(ProxyState {
         authority,
         server_configs: Mutex::new(HashMap::new()),
         client,
-        masker: Arc::new(Mutex::new(pentect_agent::ActiveToolOutputMasker::new()?)),
+        masker: Arc::new(Mutex::new(
+            pentect_agent::ActiveToolOutputMasker::new_with_plugins(plugins.clone())?,
+        )),
+        plugins: Arc::new(Mutex::new(plugins)),
+        block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
+        files: Mutex::new(HashMap::new()),
+        pending_files: Mutex::new(HashMap::new()),
     });
     let _ = ready_tx.send(Ok(format!("http://{address}")));
 
@@ -384,32 +416,69 @@ async fn connect_request(
     };
     let host = authority.host().to_ascii_lowercase();
     let port = authority.port_u16().unwrap_or(443);
-    if !should_inspect(&host, port) {
+    if port != 443 {
         return Ok(empty_response(StatusCode::FORBIDDEN));
     }
     let upgraded = hyper::upgrade::on(&mut request);
-    tokio::spawn(async move {
-        let result = async {
-            let upgraded = upgraded
-                .await
-                .map_err(|error| format!("CONNECT upgrade failed: {error}"))?;
-            let stream = hyper_util::rt::TokioIo::new(upgraded);
-            serve_inspected(stream, host, state).await
-        }
-        .await;
-        if let Err(error) = result {
-            eprintln!("[pentect] Claude App tunnel failed: {error}");
-        }
-    });
+    if should_inspect(&host, port) {
+        tokio::spawn(async move {
+            let result = async {
+                let upgraded = upgraded
+                    .await
+                    .map_err(|error| format!("CONNECT upgrade failed: {error}"))?;
+                let stream = hyper_util::rt::TokioIo::new(upgraded);
+                serve_inspected(stream, host, state).await
+            }
+            .await;
+            if let Err(error) = result {
+                eprintln!("[pentect] Claude App inspected tunnel failed: {error}");
+            }
+        });
+    } else {
+        tokio::spawn(async move {
+            if let Err(error) = passthrough_tunnel(upgraded, &host, port).await {
+                eprintln!("[pentect] Claude App network tunnel failed: {error}");
+            }
+        });
+    }
     Ok(empty_response(StatusCode::OK))
 }
 
+async fn passthrough_tunnel(
+    upgraded: hyper::upgrade::OnUpgrade,
+    host: &str,
+    port: u16,
+) -> Result<(), String> {
+    let upgraded = upgraded
+        .await
+        .map_err(|error| format!("CONNECT upgrade failed: {error}"))?;
+    let mut client = hyper_util::rt::TokioIo::new(upgraded);
+    let mut upstream = tokio::net::TcpStream::connect((host, port))
+        .await
+        .map_err(|error| format!("could not reach required app service: {error}"))?;
+    if let Err(error) = tokio::io::copy_bidirectional(&mut client, &mut upstream).await {
+        if !matches!(
+            error.kind(),
+            io::ErrorKind::ConnectionReset
+                | io::ErrorKind::ConnectionAborted
+                | io::ErrorKind::BrokenPipe
+                | io::ErrorKind::UnexpectedEof
+        ) {
+            return Err(format!("network tunnel failed: {error}"));
+        }
+    }
+    Ok(())
+}
+
 fn should_inspect(host: &str, port: u16) -> bool {
-    port == 443
-        && (host == "claude.ai"
-            || host.ends_with(".claude.ai")
-            || host == "claude.com"
-            || host.ends_with(".claude.com"))
+    port == 443 && is_claude_host(host)
+}
+
+fn is_claude_host(host: &str) -> bool {
+    host == "claude.ai"
+        || host.ends_with(".claude.ai")
+        || host == "claude.com"
+        || host.ends_with(".claude.com")
 }
 
 async fn serve_inspected<T>(stream: T, host: String, state: Arc<ProxyState>) -> Result<(), String>
@@ -440,7 +509,19 @@ async fn forward_inspected(
         Ok(response) => Ok(response),
         Err(error) => {
             eprintln!("[pentect] Claude App request failed: {error}");
-            Ok(empty_response(StatusCode::BAD_GATEWAY))
+            Ok(
+                if error.starts_with("unknown format blocked:")
+                    || error.starts_with("image blocked:")
+                    || error.starts_with("document blocked:")
+                    || error.starts_with("file upload blocked:")
+                    || error.starts_with("Files API upload")
+                    || error.starts_with("plugin blocked:")
+                {
+                    text_response(StatusCode::UNPROCESSABLE_ENTITY, &error)
+                } else {
+                    text_response(StatusCode::BAD_GATEWAY, "Pentect Claude App gateway failed")
+                },
+            )
         }
     }
 }
@@ -462,14 +543,25 @@ async fn forward_inspected_inner(
         .headers()
         .get(hyper::header::CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
-        .unwrap_or("-");
-    let protect_chat = is_chat_completion(host, &path, content_type);
+        .unwrap_or("-")
+        .to_string();
+    let request_kind = classify_claude_app_request(&method, host, &path, &content_type);
+    let protect_chat = request_kind == ClaudeAppRequest::ChatJson;
+    let prepare_upload = request_kind == ClaudeAppRequest::PrepareUploadJson;
+    if request_kind == ClaudeAppRequest::UnsupportedModel && state.block_unknown_formats {
+        return Err(
+            "unknown format blocked: Claude App selected a model transport Pentect cannot inspect; set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
+                .to_string(),
+        );
+    }
     eprintln!("[pentect] claude-app > {method} {host}{safe_path} {content_type}");
 
     let url = format!("https://{host}{path_and_query}");
     let mut headers = request.headers().clone();
     remove_hop_by_hop_headers(&mut headers);
     headers.remove(hyper::header::HOST);
+    let mut upload_coverage = None;
+    let mut upload_key = None;
     let body = if protect_chat {
         let body = Limited::new(request.into_body(), MAX_CHAT_BODY_BYTES)
             .collect()
@@ -478,11 +570,77 @@ async fn forward_inspected_inner(
             .to_bytes();
         let original = body.clone();
         let masker = Arc::clone(&state.masker);
-        let protected =
-            tokio::task::spawn_blocking(move || protect_chat_request(&original, &masker))
-                .await
-                .map_err(|_| "Claude App Chat protection task failed".to_string())??;
+        let plugins = Arc::clone(&state.plugins);
+        let files = state
+            .files
+            .lock()
+            .map_err(|_| "Claude App file registry lock was poisoned".to_string())?
+            .clone();
+        let block_unknown_formats = state.block_unknown_formats;
+        let protected = tokio::task::spawn_blocking(move || {
+            protect_chat_request(&original, &masker, &plugins, &files, block_unknown_formats)
+        })
+        .await
+        .map_err(|_| "Claude App Chat protection task failed".to_string())??;
+        if let Some(response) = protected.local_response {
+            return Response::builder()
+                .status(StatusCode::OK)
+                .header(hyper::header::CONTENT_TYPE, "application/json")
+                .body(
+                    Full::new(response)
+                        .map_err(|never| match never {})
+                        .boxed_unsync(),
+                )
+                .map_err(|error| format!("could not build Claude App plugin response: {error}"));
+        }
+        headers.remove(hyper::header::CONTENT_LENGTH);
+        reqwest::Body::from(protected.body)
+    } else if matches!(
+        request_kind,
+        ClaudeAppRequest::JsonScan | ClaudeAppRequest::PrepareUploadJson
+    ) {
+        let body = Limited::new(request.into_body(), MAX_CHAT_BODY_BYTES)
+            .collect()
+            .await
+            .map_err(|error| format!("could not read Claude App JSON request: {error}"))?
+            .to_bytes();
+        let masker = Arc::clone(&state.masker);
+        let block_unknown_formats = state.block_unknown_formats;
+        let protected = tokio::task::spawn_blocking(move || {
+            protect_generic_json_request(&body, &masker, block_unknown_formats)
+        })
+        .await
+        .map_err(|_| "Claude App JSON protection task failed".to_string())??;
+        headers.remove(hyper::header::CONTENT_LENGTH);
         reqwest::Body::from(protected)
+    } else if request_kind == ClaudeAppRequest::Upload {
+        let body = Limited::new(request.into_body(), MAX_CHAT_BODY_BYTES)
+            .collect()
+            .await
+            .map_err(|error| format!("could not read Claude App upload: {error}"))?
+            .to_bytes();
+        upload_key = claude_filestore_upload_key(&content_type, &body);
+        let masker = Arc::clone(&state.masker);
+        let plugins = Arc::clone(&state.plugins);
+        let protected = tokio::task::spawn_blocking(move || {
+            let mut masker = masker
+                .lock()
+                .map_err(|_| "Claude App upload masker lock was poisoned".to_string())?;
+            let plugins = plugins
+                .lock()
+                .map_err(|_| "Claude App plugin lock was poisoned".to_string())?;
+            crate::http_files::protect_multipart_upload_with_plugins(
+                &content_type,
+                &body,
+                &mut masker,
+                &plugins,
+            )
+        })
+        .await
+        .map_err(|_| "Claude App upload protection task failed".to_string())??;
+        upload_coverage = Some(protected.coverage);
+        headers.remove(hyper::header::CONTENT_LENGTH);
+        reqwest::Body::from(protected.body)
     } else {
         let stream = request
             .into_body()
@@ -497,10 +655,16 @@ async fn forward_inspected_inner(
         .body(body)
         .send()
         .await
-        .map_err(|error| format!("upstream request failed for {method} {host}{path}: {error}"))?;
+        .map_err(|error| {
+            format!(
+                "upstream request failed for {method} {host}{safe_path}: {}",
+                reqwest_error_summary(&error)
+            )
+        })?;
     let status = upstream.status();
-    let response_content_type = upstream
-        .headers()
+    let mut response_headers = upstream.headers().clone();
+    remove_hop_by_hop_headers(&mut response_headers);
+    let response_content_type = response_headers
         .get(hyper::header::CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.split(';').next())
@@ -508,32 +672,62 @@ async fn forward_inspected_inner(
     eprintln!("[pentect] claude-app < {status} {method} {host}{safe_path} {response_content_type}");
 
     let mut builder = Response::builder().status(status);
-    for (name, value) in upstream.headers() {
-        if !is_hop_by_hop_header(name) {
-            builder = builder.header(name, value);
-        }
+    for (name, value) in &response_headers {
+        builder = builder.header(name, value);
     }
-    #[cfg(debug_assertions)]
-    let schema_trace = (std::env::var_os("PENTECT_CLAUDE_APP_TRACE_SCHEMA").is_some()
-        && path.ends_with("/completion")
-        && response_content_type.eq_ignore_ascii_case("text/event-stream"))
-    .then(|| Arc::new(Mutex::new(SseSchemaTracer::default())));
     let transform_chat = protect_chat
         && status.is_success()
         && response_content_type.eq_ignore_ascii_case("text/event-stream");
-    let stream = upstream.bytes_stream().map(move |result| {
-        #[cfg(debug_assertions)]
-        if let (Ok(chunk), Some(trace)) = (&result, &schema_trace) {
-            if let Ok(mut trace) = trace.lock() {
-                trace.observe(chunk);
+    if let Some(coverage) = upload_coverage {
+        let body = read_response_capped(upstream).await?;
+        if status.is_success() {
+            remember_claude_file_ids(&body, coverage, &state.files)?;
+            if let Some(key) = upload_key.as_deref() {
+                promote_pending_claude_files(key, coverage, &state.pending_files, &state.files)?;
             }
         }
+        let mut response = Response::builder().status(status);
+        for (name, value) in &response_headers {
+            if name != hyper::header::CONTENT_LENGTH {
+                response = response.header(name, value);
+            }
+        }
+        return response
+            .header("x-pentect-coverage", coverage.as_header())
+            .body(
+                Full::new(body)
+                    .map_err(|never| match never {})
+                    .boxed_unsync(),
+            )
+            .map_err(|error| format!("could not build Claude App upload response: {error}"));
+    }
+    if prepare_upload {
+        let body = read_response_capped(upstream).await?;
+        if status.is_success() {
+            remember_pending_claude_files(&body, &state.pending_files)?;
+        }
+        let mut response = Response::builder().status(status);
+        for (name, value) in &response_headers {
+            if name != hyper::header::CONTENT_LENGTH {
+                response = response.header(name, value);
+            }
+        }
+        return response
+            .body(
+                Full::new(body)
+                    .map_err(|never| match never {})
+                    .boxed_unsync(),
+            )
+            .map_err(|error| format!("could not build Claude App prepare response: {error}"));
+    }
+
+    let stream = upstream.bytes_stream().map(move |result| {
         result
             .map(Frame::data)
             .map_err(|error| Box::new(error) as ProxyBodyError)
     });
     let body = if transform_chat {
-        chat_sse_body(Box::pin(stream))
+        chat_sse_body(Box::pin(stream), Arc::clone(&state.plugins))
     } else {
         BodyExt::boxed_unsync(StreamBody::new(stream))
     };
@@ -542,47 +736,453 @@ async fn forward_inspected_inner(
         .map_err(|error| format!("could not build Claude App response: {error}"))
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ClaudeAppRequest {
+    Other,
+    ChatJson,
+    PrepareUploadJson,
+    JsonScan,
+    Upload,
+    UnsupportedModel,
+}
+
+fn classify_claude_app_request(
+    method: &Method,
+    host: &str,
+    path: &str,
+    content_type: &str,
+) -> ClaudeAppRequest {
+    if !is_claude_host(host) {
+        return ClaudeAppRequest::Other;
+    }
+    if is_claude_voice_path(path) {
+        return ClaudeAppRequest::UnsupportedModel;
+    }
+    if *method != Method::POST {
+        return ClaudeAppRequest::Other;
+    }
+    let media_type = content_type
+        .split(';')
+        .next()
+        .map(str::trim)
+        .unwrap_or_default();
+    if is_chat_completion_path(path) {
+        return if media_type.eq_ignore_ascii_case("application/json") {
+            ClaudeAppRequest::ChatJson
+        } else {
+            ClaudeAppRequest::UnsupportedModel
+        };
+    }
+    if is_claude_binary_model_path(path) {
+        return ClaudeAppRequest::UnsupportedModel;
+    }
+    if is_claude_prepare_upload_path(path)
+        && (media_type.eq_ignore_ascii_case("application/json")
+            || media_type.to_ascii_lowercase().ends_with("+json"))
+    {
+        return ClaudeAppRequest::PrepareUploadJson;
+    }
+    if media_type.eq_ignore_ascii_case("multipart/form-data") && is_claude_upload_path(path) {
+        return ClaudeAppRequest::Upload;
+    }
+    if media_type.eq_ignore_ascii_case("application/json")
+        || media_type.to_ascii_lowercase().ends_with("+json")
+    {
+        return ClaudeAppRequest::JsonScan;
+    }
+    ClaudeAppRequest::Other
+}
+
+#[cfg(test)]
 fn is_chat_completion(host: &str, path: &str, content_type: &str) -> bool {
-    (host == "claude.ai" || host.ends_with(".claude.ai"))
-        && path.ends_with("/completion")
-        && content_type
-            .split(';')
-            .next()
-            .is_some_and(|value| value.trim().eq_ignore_ascii_case("application/json"))
+    classify_claude_app_request(&Method::POST, host, path, content_type)
+        == ClaudeAppRequest::ChatJson
+}
+
+fn is_chat_completion_path(path: &str) -> bool {
+    let Some(segment) = path.rsplit('/').next() else {
+        return false;
+    };
+    let completion = segment.strip_prefix("retry_").unwrap_or(segment);
+    completion == "completion"
+        || completion.strip_prefix("completion").is_some_and(|suffix| {
+            !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit())
+        })
+}
+
+fn is_claude_binary_model_path(path: &str) -> bool {
+    matches!(
+        path.rsplit('/').next(),
+        Some("appendMessage" | "retryMessage")
+    ) && path.starts_with("/v1/mobile/")
+}
+
+fn is_claude_voice_path(path: &str) -> bool {
+    path.starts_with("/api/ws/voice/") && path.contains("/chat_conversations/")
+}
+
+fn is_claude_upload_path(path: &str) -> bool {
+    let segments = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    matches!(segments.as_slice(), ["api", _, "upload"])
+        || matches!(
+            segments.as_slice(),
+            ["api", "organizations", _, "projects", _, "upload"]
+        )
+        || matches!(
+            segments.as_slice(),
+            ["api", "organizations", _, "cowork", "attachments"]
+        )
+        || matches!(segments.as_slice(), ["v1", "filestore", "fs", "createFile"])
+}
+
+fn is_claude_prepare_upload_path(path: &str) -> bool {
+    let segments = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    matches!(
+        segments.as_slice(),
+        [
+            "api",
+            "organizations",
+            _,
+            "conversations",
+            _,
+            "files",
+            "prepare-upload"
+        ]
+    )
+}
+
+fn remember_claude_file_ids(
+    body: &[u8],
+    coverage: crate::http_files::Coverage,
+    files: &Mutex<HashMap<String, crate::http_files::Coverage>>,
+) -> Result<(), String> {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return Ok(());
+    };
+    let mut ids = Vec::new();
+    collect_claude_file_ids(&value, &mut ids);
+    let mut files = files
+        .lock()
+        .map_err(|_| "Claude App file registry lock was poisoned".to_string())?;
+    for id in ids {
+        crate::http_files::remember_file_coverage(&mut files, id, coverage);
+    }
+    Ok(())
+}
+
+fn collect_claude_file_ids(value: &serde_json::Value, ids: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_claude_file_ids(value, ids);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            for key in ["file_id", "file_uuid"] {
+                if let Some(id) = object.get(key).and_then(serde_json::Value::as_str) {
+                    if !id.is_empty() && id.len() <= 200 {
+                        ids.push(id.to_string());
+                    }
+                }
+            }
+            let file_shaped = object.contains_key("file_name")
+                || object.contains_key("filename")
+                || object.contains_key("mime_type")
+                || object.contains_key("content_type")
+                || object
+                    .get("type")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|kind| {
+                        let kind = kind.to_ascii_lowercase();
+                        kind.contains("file") || kind.contains("document")
+                    });
+            if file_shaped {
+                for key in ["id", "uuid"] {
+                    if let Some(id) = object.get(key).and_then(serde_json::Value::as_str) {
+                        if !id.is_empty() && id.len() <= 200 {
+                            ids.push(id.to_string());
+                        }
+                    }
+                }
+            }
+            for value in object.values() {
+                collect_claude_file_ids(value, ids);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn claude_filestore_upload_key(content_type: &str, body: &[u8]) -> Option<String> {
+    let params = crate::http_files::multipart_text_field(content_type, body, "params")?;
+    let value: serde_json::Value = serde_json::from_str(&params).ok()?;
+    let filesystem = value.get("filesystem_id")?.as_str()?;
+    let path = value.get("path")?.as_str()?;
+    if filesystem.is_empty() || path.is_empty() || filesystem.len() > 500 || path.len() > 4096 {
+        return None;
+    }
+    Some(format!("{filesystem}\0{path}"))
+}
+
+fn remember_pending_claude_files(
+    body: &[u8],
+    pending: &Mutex<HashMap<String, Vec<String>>>,
+) -> Result<(), String> {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return Ok(());
+    };
+    let Some(uploads) = value.get("uploads").and_then(serde_json::Value::as_array) else {
+        return Ok(());
+    };
+    let mut pending = pending
+        .lock()
+        .map_err(|_| "Claude App pending file registry lock was poisoned".to_string())?;
+    for upload in uploads {
+        let Some(filesystem) = upload
+            .get("filesystem_id")
+            .and_then(serde_json::Value::as_str)
+        else {
+            continue;
+        };
+        let Some(path) = upload.get("path").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let Some(file_id) = upload
+            .get("file_uuid")
+            .or_else(|| upload.get("file_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            continue;
+        };
+        if filesystem.is_empty()
+            || path.is_empty()
+            || file_id.is_empty()
+            || filesystem.len() > 500
+            || path.len() > 4096
+            || file_id.len() > 200
+        {
+            continue;
+        }
+        let ids = pending.entry(format!("{filesystem}\0{path}")).or_default();
+        if ids.len() < MAX_IDS_PER_UPLOAD && !ids.iter().any(|known| known == file_id) {
+            ids.push(file_id.to_string());
+        }
+        if pending.len() > MAX_PENDING_UPLOADS {
+            if let Some(expired) = pending.keys().next().cloned() {
+                pending.remove(&expired);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn promote_pending_claude_files(
+    key: &str,
+    coverage: crate::http_files::Coverage,
+    pending: &Mutex<HashMap<String, Vec<String>>>,
+    files: &Mutex<HashMap<String, crate::http_files::Coverage>>,
+) -> Result<(), String> {
+    let ids = pending
+        .lock()
+        .map_err(|_| "Claude App pending file registry lock was poisoned".to_string())?
+        .remove(key)
+        .unwrap_or_default();
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let mut files = files
+        .lock()
+        .map_err(|_| "Claude App file registry lock was poisoned".to_string())?;
+    for id in ids {
+        crate::http_files::remember_file_coverage(&mut files, id, coverage);
+    }
+    Ok(())
+}
+
+async fn read_response_capped(response: reqwest::Response) -> Result<Bytes, String> {
+    let mut stream = response.bytes_stream();
+    let mut body = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| {
+            format!(
+                "could not read Claude App upstream response: {}",
+                reqwest_error_summary(&error)
+            )
+        })?;
+        if body.len().saturating_add(chunk.len()) > MAX_CHAT_BODY_BYTES {
+            return Err("Claude App upload response exceeded the size limit".to_string());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(Bytes::from(body))
+}
+
+fn reqwest_error_summary(error: &reqwest::Error) -> &'static str {
+    if error.is_timeout() {
+        "request timed out"
+    } else if error.is_connect() {
+        "connection failed"
+    } else if error.is_body() || error.is_decode() {
+        "response body failed"
+    } else {
+        "request failed"
+    }
+}
+
+struct ProtectedChatRequest {
+    body: Bytes,
+    local_response: Option<Bytes>,
 }
 
 fn protect_chat_request(
     body: &Bytes,
     masker: &Mutex<pentect_agent::ActiveToolOutputMasker>,
-) -> Result<Bytes, String> {
-    let mut value: serde_json::Value = match serde_json::from_slice(body) {
-        Ok(value) => value,
-        Err(error) => {
-            eprintln!("[pentect] Claude App Chat protection skipped: invalid JSON: {error}");
-            return Ok(body.clone());
+    plugins: &Mutex<pentect_agent::PluginMiddleware>,
+    files: &HashMap<String, crate::http_files::Coverage>,
+    block_unknown_formats: bool,
+) -> Result<ProtectedChatRequest, String> {
+    let mut value = match parse_chat_json(body, block_unknown_formats)? {
+        Some(value) => value,
+        None => {
+            return Ok(ProtectedChatRequest {
+                body: body.clone(),
+                local_response: None,
+            });
         }
     };
+    let run = plugins
+        .lock()
+        .map_err(|_| "Claude App plugin lock was poisoned".to_string())?
+        .run(
+            pentect_agent::MiddlewareStage::Request,
+            value,
+            Some(serde_json::json!({"provider": "claude", "transport": "desktop-http"})),
+        )?;
+    if block_unknown_formats && run.coverage == pentect_agent::MiddlewareCoverage::Partial {
+        return Err(
+            "unknown format blocked: a Claude App plugin reported partial request coverage; set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to allow it"
+                .to_string(),
+        );
+    }
+    value = run.payload;
+    if let Some(outcome) = run.stopped {
+        if outcome == pentect_agent::StopOutcome::Block {
+            return Err(format!(
+                "plugin blocked: {}",
+                run.message.unwrap_or_else(|| "request blocked".to_string())
+            ));
+        }
+        let body = serde_json::to_vec(&value)
+            .map(Bytes::from)
+            .map_err(|error| format!("could not encode Claude App plugin response: {error}"))?;
+        return Ok(ProtectedChatRequest {
+            body: Bytes::new(),
+            local_response: Some(body),
+        });
+    }
     inject_chat_contract(&mut value);
     let mut masker = masker
         .lock()
         .map_err(|_| "Claude App Chat masker lock was poisoned".to_string())?;
-    if let Err(error) = mask_chat_value(&mut value, false, &mut masker) {
+    if let Err(error) = mask_chat_value(&mut value, false, &mut masker, files) {
         if error.starts_with("image blocked:") || error.starts_with("document blocked:") {
             return Err(error);
         }
         eprintln!("[pentect] Claude App Chat protection skipped: {error}");
+        return Ok(ProtectedChatRequest {
+            body: body.clone(),
+            local_response: None,
+        });
+    }
+    let protected = serde_json::to_vec(&value)
+        .map(Bytes::from)
+        .map_err(|error| format!("could not encode protected Claude App Chat request: {error}"))?;
+    Ok(ProtectedChatRequest {
+        body: protected,
+        local_response: None,
+    })
+}
+
+fn parse_chat_json(
+    body: &Bytes,
+    block_unknown_formats: bool,
+) -> Result<Option<serde_json::Value>, String> {
+    match serde_json::from_slice(body) {
+        Ok(value) => Ok(Some(value)),
+        Err(error) => {
+            if block_unknown_formats {
+                return Err(format!(
+                    "unknown format blocked: Claude App Chat request is not valid JSON ({error}); set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
+                ));
+            }
+            eprintln!("[pentect] Claude App Chat protection skipped: invalid JSON: {error}");
+            Ok(None)
+        }
+    }
+}
+
+fn protect_generic_json_request(
+    body: &Bytes,
+    masker: &Mutex<pentect_agent::ActiveToolOutputMasker>,
+    block_unknown_formats: bool,
+) -> Result<Bytes, String> {
+    let mut value = match parse_chat_json(body, block_unknown_formats)? {
+        Some(value) => value,
+        None => return Ok(body.clone()),
+    };
+    let mut masker = masker
+        .lock()
+        .map_err(|_| "Claude App JSON masker lock was poisoned".to_string())?;
+    if let Err(error) = mask_generic_json_value(&mut value, &mut masker) {
+        eprintln!("[pentect] Claude App JSON protection skipped: {error}");
         return Ok(body.clone());
     }
     serde_json::to_vec(&value)
         .map(Bytes::from)
-        .map_err(|error| format!("could not encode protected Claude App Chat request: {error}"))
+        .map_err(|error| format!("could not encode protected Claude App JSON request: {error}"))
+}
+
+fn mask_generic_json_value(
+    value: &mut serde_json::Value,
+    masker: &mut pentect_agent::ActiveToolOutputMasker,
+) -> Result<(), String> {
+    match value {
+        serde_json::Value::String(text) => {
+            crate::claude_http_proxy::mask_string(text, false, masker)
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                mask_generic_json_value(value, masker)?;
+            }
+            Ok(())
+        }
+        serde_json::Value::Object(object) => {
+            for (key, value) in object {
+                if matches!(
+                    key.as_str(),
+                    "signature" | "thinking_signature" | "attestation" | "authorization" | "token"
+                ) {
+                    continue;
+                }
+                mask_generic_json_value(value, masker)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
 }
 
 fn inject_chat_contract(value: &mut serde_json::Value) {
     let Some(object) = value.as_object_mut() else {
         return;
     };
-    for key in ["system", "prompt"] {
+    for key in ["system", "prompt", "custom_system_prompt"] {
         if let Some(serde_json::Value::String(text)) = object.get_mut(key) {
             if !text.contains(HANDLE_CONTRACT) {
                 let existing = std::mem::take(text);
@@ -597,6 +1197,7 @@ fn mask_chat_value(
     value: &mut serde_json::Value,
     tool_result: bool,
     masker: &mut pentect_agent::ActiveToolOutputMasker,
+    files: &HashMap<String, crate::http_files::Coverage>,
 ) -> Result<(), String> {
     match value {
         serde_json::Value::String(text) => {
@@ -604,7 +1205,7 @@ fn mask_chat_value(
         }
         serde_json::Value::Array(values) => {
             for value in values {
-                mask_chat_value(value, tool_result, masker)?;
+                mask_chat_value(value, tool_result, masker, files)?;
             }
             Ok(())
         }
@@ -615,12 +1216,11 @@ fn mask_chat_value(
                 .unwrap_or_default()
                 .to_ascii_lowercase();
             if kind.contains("image") {
-                inspect_chat_image(object)?;
+                inspect_chat_image(object, files)?;
                 return Ok(());
             }
-            if kind.contains("file") || kind.contains("document") {
-                inspect_chat_document(object, tool_result, masker)?;
-                return Ok(());
+            if kind.contains("file") || kind.contains("document") || looks_like_chat_file(object) {
+                inspect_chat_document(object, tool_result, masker, files)?;
             }
             let nested_tool_result = tool_result
                 || kind.contains("tool_result")
@@ -629,11 +1229,15 @@ fn mask_chat_value(
             for (key, nested) in object {
                 if matches!(
                     key.as_str(),
-                    "signature" | "thinking_signature" | "attestation" | "authorization" | "token"
+                    "signature" | "thinking_signature" | "attestation"
                 ) {
                     continue;
                 }
-                mask_chat_value(nested, nested_tool_result, masker)?;
+                if is_chat_content_field(key)
+                    || (nested_tool_result && !is_chat_protocol_metadata_field(key))
+                {
+                    mask_chat_value(nested, nested_tool_result, masker, files)?;
+                }
             }
             Ok(())
         }
@@ -643,7 +1247,39 @@ fn mask_chat_value(
 
 fn inspect_chat_image(
     object: &mut serde_json::Map<String, serde_json::Value>,
+    files: &HashMap<String, crate::http_files::Coverage>,
 ) -> Result<(), String> {
+    if chat_file_reference(object)
+        .and_then(|id| files.get(id))
+        .copied()
+        == Some(crate::http_files::Coverage::Full)
+    {
+        return Ok(());
+    }
+    if let Some(source) = object
+        .get_mut("source")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        if source.get("type").and_then(serde_json::Value::as_str) == Some("base64")
+            && source
+                .get("media_type")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|media_type| media_type.starts_with("image/"))
+        {
+            let Some(serde_json::Value::String(encoded)) = source.get_mut("data") else {
+                return unscanned_chat_image();
+            };
+            if let Some(protected) = crate::claude_http_proxy::redact_inline_image_data(encoded)? {
+                *encoded = protected;
+                source.insert(
+                    "media_type".to_string(),
+                    serde_json::Value::String("image/png".to_string()),
+                );
+            }
+            return Ok(());
+        }
+        return unscanned_chat_image();
+    }
     let key = ["image_url", "url", "data"]
         .into_iter()
         .find(|key| object.contains_key(*key));
@@ -666,8 +1302,38 @@ fn inspect_chat_document(
     object: &mut serde_json::Map<String, serde_json::Value>,
     tool_result: bool,
     masker: &mut pentect_agent::ActiveToolOutputMasker,
+    files: &HashMap<String, crate::http_files::Coverage>,
 ) -> Result<(), String> {
-    if object.get("file_id").is_some() || object.get("url").is_some() {
+    if chat_file_reference(object)
+        .and_then(|id| files.get(id))
+        .copied()
+        == Some(crate::http_files::Coverage::Full)
+    {
+        return Ok(());
+    }
+    if let Some(source) = object.get_mut("source") {
+        if let Some(id) = ["file_id", "id"]
+            .into_iter()
+            .find_map(|key| source.get(key).and_then(serde_json::Value::as_str))
+        {
+            if files.get(id) == Some(&crate::http_files::Coverage::Full) {
+                return Ok(());
+            }
+        }
+        if source.get("type").and_then(serde_json::Value::as_str) == Some("text") {
+            if let Some(serde_json::Value::String(text)) = source.get_mut("data") {
+                return crate::claude_http_proxy::mask_string(text, tool_result, masker);
+            }
+        }
+        if source.get("type").and_then(serde_json::Value::as_str) == Some("base64") {
+            return crate::claude_http_proxy::inspect_base64_document(source, tool_result, masker);
+        }
+        return crate::claude_http_proxy::enforce_unscanned_document_policy();
+    }
+    if object.get("file_id").is_some()
+        || object.get("file_uuid").is_some()
+        || object.get("url").is_some()
+    {
         return crate::claude_http_proxy::enforce_unscanned_document_policy();
     }
     let data = object
@@ -694,6 +1360,60 @@ fn inspect_chat_document(
     crate::claude_http_proxy::inspect_base64_document(&source, tool_result, masker)
 }
 
+fn is_chat_content_field(key: &str) -> bool {
+    matches!(
+        key,
+        "system"
+            | "prompt"
+            | "custom_system_prompt"
+            | "messages"
+            | "message"
+            | "content"
+            | "text"
+            | "parts"
+            | "attachments"
+            | "files"
+            | "input"
+            | "output"
+            | "result"
+            | "tool_result"
+            | "tool_output"
+            | "function_output"
+            | "extracted_content"
+    )
+}
+
+fn is_chat_protocol_metadata_field(key: &str) -> bool {
+    matches!(
+        key,
+        "type"
+            | "id"
+            | "uuid"
+            | "tool_use_id"
+            | "role"
+            | "name"
+            | "index"
+            | "stop_reason"
+            | "signature"
+            | "thinking_signature"
+            | "attestation"
+    )
+}
+
+fn looks_like_chat_file(object: &serde_json::Map<String, serde_json::Value>) -> bool {
+    (object.contains_key("file_id") || object.contains_key("file_uuid"))
+        && (object.contains_key("file_name")
+            || object.contains_key("filename")
+            || object.contains_key("mime_type")
+            || object.contains_key("content_type"))
+}
+
+fn chat_file_reference(object: &serde_json::Map<String, serde_json::Value>) -> Option<&str> {
+    ["file_id", "file_uuid"]
+        .into_iter()
+        .find_map(|key| object.get(key).and_then(serde_json::Value::as_str))
+}
+
 fn unscanned_chat_image() -> Result<(), String> {
     if pentect_agent::unscanned_images_should_block()? {
         Err("image blocked: image source could not be scanned".to_string())
@@ -711,9 +1431,10 @@ struct ChatStreamState {
     ready: VecDeque<Result<Frame<Bytes>, ProxyBodyError>>,
     passthrough: bool,
     finished: bool,
+    plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
 }
 
-fn chat_sse_body<S>(stream: S) -> ProxyBody
+fn chat_sse_body<S>(stream: S, plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>) -> ProxyBody
 where
     S: futures_util::Stream<Item = Result<Frame<Bytes>, ProxyBodyError>> + Send + 'static,
 {
@@ -723,6 +1444,7 @@ where
         ready: VecDeque::new(),
         passthrough: false,
         finished: false,
+        plugins,
     };
     let stream = futures_util::stream::unfold(state, |mut state| async move {
         loop {
@@ -753,9 +1475,16 @@ where
                     state.pending.extend_from_slice(&chunk);
                     while let Some(end) = first_sse_block_end(&state.pending) {
                         let block = state.pending.drain(..end).collect::<Vec<_>>();
-                        state
-                            .ready
-                            .push_back(Ok(Frame::data(rewrite_chat_sse_block(&block))));
+                        match rewrite_chat_sse_block(&block, &state.plugins) {
+                            Ok(block) => state.ready.push_back(Ok(Frame::data(block))),
+                            Err(error) => {
+                                state.finished = true;
+                                state
+                                    .ready
+                                    .push_back(Err(Box::new(io::Error::other(error))));
+                                break;
+                            }
+                        }
                     }
                 }
                 Some(Err(error)) => {
@@ -778,23 +1507,30 @@ where
     StreamBody::new(stream).boxed_unsync()
 }
 
-fn rewrite_chat_sse_block(block: &[u8]) -> Bytes {
+fn rewrite_chat_sse_block(
+    block: &[u8],
+    plugins: &Mutex<pentect_agent::PluginMiddleware>,
+) -> Result<Bytes, String> {
     let Ok(text) = std::str::from_utf8(block) else {
-        return Bytes::copy_from_slice(block);
+        return Ok(Bytes::copy_from_slice(block));
     };
     let Some(data) = text.lines().find_map(|line| line.strip_prefix("data:")) else {
-        return Bytes::copy_from_slice(block);
+        return Ok(Bytes::copy_from_slice(block));
     };
     let Ok(mut value) = serde_json::from_str::<serde_json::Value>(data.trim_start()) else {
-        return Bytes::copy_from_slice(block);
+        return Ok(Bytes::copy_from_slice(block));
     };
+    let plugins = plugins
+        .lock()
+        .map_err(|_| "Claude App plugin lock was poisoned".to_string())?;
+    run_chat_tool_plugins(&mut value, &plugins)?;
     let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
     if let Err(error) = resolve_chat_tool_calls(&mut value, &mut resolve) {
         eprintln!("[pentect] Claude App Chat tool restoration skipped: {error}");
-        return Bytes::copy_from_slice(block);
+        return Ok(Bytes::copy_from_slice(block));
     }
     let Ok(encoded) = serde_json::to_string(&value) else {
-        return Bytes::copy_from_slice(block);
+        return Ok(Bytes::copy_from_slice(block));
     };
     let mut replaced = false;
     let mut output = String::with_capacity(text.len());
@@ -812,7 +1548,57 @@ fn rewrite_chat_sse_block(block: &[u8]) -> Bytes {
             output.push_str(line);
         }
     }
-    Bytes::from(output)
+    Ok(Bytes::from(output))
+}
+
+fn run_chat_tool_plugins(
+    value: &mut serde_json::Value,
+    plugins: &pentect_agent::PluginMiddleware,
+) -> Result<(), String> {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                run_chat_tool_plugins(value, plugins)?;
+            }
+        }
+        serde_json::Value::Object(object) => {
+            let kind = object
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            let is_call = (kind.contains("tool_use")
+                || kind.contains("tool_call")
+                || kind.contains("function_call"))
+                && ["arguments", "input"]
+                    .into_iter()
+                    .any(|key| object.contains_key(key));
+            if is_call {
+                let run = plugins.run(
+                    pentect_agent::MiddlewareStage::ToolCall,
+                    serde_json::Value::Object(object.clone()),
+                    Some(serde_json::json!({"provider": "claude", "transport": "desktop-http"})),
+                )?;
+                if run.stopped == Some(pentect_agent::StopOutcome::Block) {
+                    return Err(format!(
+                        "plugin blocked: {}",
+                        run.message
+                            .unwrap_or_else(|| "tool call blocked".to_string())
+                    ));
+                }
+                *object = run
+                    .payload
+                    .as_object()
+                    .cloned()
+                    .ok_or_else(|| "tool_call plugin payload must be an object".to_string())?;
+            }
+            for child in object.values_mut() {
+                run_chat_tool_plugins(child, plugins)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 fn resolve_chat_tool_calls<R>(value: &mut serde_json::Value, resolve: &mut R) -> Result<(), String>
@@ -840,12 +1626,28 @@ where
                     .and_then(serde_json::Value::as_str)
                     .map(str::to_owned);
                 for key in ["arguments", "input"] {
-                    if let Some(serde_json::Value::String(arguments)) = object.get_mut(key) {
-                        *arguments = crate::claude_http_proxy::resolve_tool_input_json(
-                            arguments,
+                    if let Some(arguments) = object.get_mut(key) {
+                        let (encoded, was_string) = match &*arguments {
+                            serde_json::Value::String(text) => (text.clone(), true),
+                            value => (
+                                serde_json::to_string(value).map_err(|error| {
+                                    format!("could not encode Claude App tool input: {error}")
+                                })?,
+                                false,
+                            ),
+                        };
+                        let resolved = crate::claude_http_proxy::resolve_tool_input_json(
+                            &encoded,
                             name.as_deref(),
                             resolve,
                         )?;
+                        *arguments = if was_string {
+                            serde_json::Value::String(resolved)
+                        } else {
+                            serde_json::from_str(&resolved).map_err(|error| {
+                                format!("could not decode Claude App tool input: {error}")
+                            })?
+                        };
                     }
                 }
             }
@@ -872,120 +1674,6 @@ fn first_sse_block_end(bytes: &[u8]) -> Option<usize> {
         (Some(end), None) | (None, Some(end)) => Some(end),
         (None, None) => None,
     }
-}
-
-#[cfg(debug_assertions)]
-#[derive(Default)]
-struct SseSchemaTracer {
-    pending: Vec<u8>,
-    seen: HashSet<String>,
-    event_name: Option<String>,
-}
-
-#[cfg(debug_assertions)]
-impl SseSchemaTracer {
-    fn observe(&mut self, chunk: &[u8]) {
-        const MAX_PENDING: usize = 1024 * 1024;
-        if self.pending.len().saturating_add(chunk.len()) > MAX_PENDING {
-            self.pending.clear();
-            return;
-        }
-        self.pending.extend_from_slice(chunk);
-        while let Some(end) = self.pending.iter().position(|byte| *byte == b'\n') {
-            let line = self.pending.drain(..=end).collect::<Vec<_>>();
-            self.observe_line(&line);
-        }
-    }
-
-    fn observe_line(&mut self, bytes: &[u8]) {
-        let Ok(text) = std::str::from_utf8(bytes) else {
-            return;
-        };
-        let line = text.trim_end_matches(['\r', '\n']);
-        if let Some(event_name) = line
-            .strip_prefix("event:")
-            .map(str::trim)
-            .filter(|value| protocol_name(value))
-        {
-            self.event_name = Some(event_name.to_string());
-            return;
-        }
-        let Some(data) = line.strip_prefix("data:").map(str::trim) else {
-            return;
-        };
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(data) else {
-            return;
-        };
-        let shape = safe_json_shape(&value, 0);
-        let event_name = self.event_name.as_deref().unwrap_or("message");
-        let summary = format!("{event_name} {shape}");
-        if self.seen.insert(summary.clone()) {
-            eprintln!("[pentect] claude-app SSE schema: {summary}");
-        }
-    }
-}
-
-#[cfg(debug_assertions)]
-fn safe_json_shape(value: &serde_json::Value, depth: usize) -> String {
-    use serde_json::Value;
-    match value {
-        Value::Null => "null".to_string(),
-        Value::Bool(_) => "bool".to_string(),
-        Value::Number(_) => "number".to_string(),
-        Value::String(_) => "string".to_string(),
-        Value::Array(values) => {
-            let nested = values
-                .first()
-                .map(|value| safe_json_shape(value, depth + 1))
-                .unwrap_or_else(|| "empty".to_string());
-            format!("array<{nested}>")
-        }
-        Value::Object(object) => {
-            let mut fields = object
-                .iter()
-                .map(|(key, value)| {
-                    let shape = if matches!(key.as_str(), "type" | "subtype" | "event" | "status")
-                        && value.as_str().is_some_and(protocol_name)
-                    {
-                        format!("string({})", value.as_str().unwrap_or_default())
-                    } else if depth >= 2
-                        || matches!(
-                            key.as_str(),
-                            "input" | "arguments" | "content" | "text" | "prompt"
-                        )
-                    {
-                        json_kind(value).to_string()
-                    } else {
-                        safe_json_shape(value, depth + 1)
-                    };
-                    format!("{key}:{shape}")
-                })
-                .collect::<Vec<_>>();
-            fields.sort_unstable();
-            format!("{{{}}}", fields.join(","))
-        }
-    }
-}
-
-#[cfg(debug_assertions)]
-fn json_kind(value: &serde_json::Value) -> &'static str {
-    match value {
-        serde_json::Value::Null => "null",
-        serde_json::Value::Bool(_) => "bool",
-        serde_json::Value::Number(_) => "number",
-        serde_json::Value::String(_) => "string",
-        serde_json::Value::Array(_) => "array",
-        serde_json::Value::Object(_) => "object",
-    }
-}
-
-#[cfg(debug_assertions)]
-fn protocol_name(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
 
 fn metadata_path(path: &str) -> String {
@@ -1036,6 +1724,19 @@ fn looks_like_uuid(segment: &str) -> bool {
 }
 
 fn remove_hop_by_hop_headers(headers: &mut hyper::HeaderMap) {
+    let connection_headers = headers
+        .get(hyper::header::CONNECTION)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(|name| name.trim().parse::<hyper::header::HeaderName>().ok())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    for name in connection_headers {
+        headers.remove(name);
+    }
     for name in [
         hyper::header::CONNECTION,
         hyper::header::PROXY_AUTHENTICATE,
@@ -1047,19 +1748,7 @@ fn remove_hop_by_hop_headers(headers: &mut hyper::HeaderMap) {
     ] {
         headers.remove(name);
     }
-}
-
-fn is_hop_by_hop_header(name: &hyper::header::HeaderName) -> bool {
-    matches!(
-        name.as_str(),
-        "connection"
-            | "proxy-authenticate"
-            | "proxy-authorization"
-            | "te"
-            | "trailer"
-            | "transfer-encoding"
-            | "upgrade"
-    )
+    headers.remove("proxy-connection");
 }
 
 fn empty_response(status: StatusCode) -> Response<ProxyBody> {
@@ -1071,6 +1760,18 @@ fn empty_response(status: StatusCode) -> Response<ProxyBody> {
                 .boxed_unsync(),
         )
         .expect("static empty response")
+}
+
+fn text_response(status: StatusCode, message: &str) -> Response<ProxyBody> {
+    Response::builder()
+        .status(status)
+        .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(
+            Full::new(Bytes::copy_from_slice(message.as_bytes()))
+                .map_err(|never| match never {})
+                .boxed_unsync(),
+        )
+        .expect("static text response")
 }
 
 fn default_claude_app_path() -> PathBuf {
@@ -1151,9 +1852,9 @@ fn find_windows_claude_app() -> Option<PathBuf> {
         .lines()
         .map(str::trim)
         .filter(|line| {
-            line.rsplit('\\')
-                .next()
-                .is_some_and(|name| name.starts_with("Claude_") && name.contains("_x64__"))
+            line.rsplit('\\').next().is_some_and(|name| {
+                name.starts_with("Claude_") && windows_package_matches_arch(name)
+            })
         })
         .filter_map(|key| {
             let package_name = key.rsplit('\\').next()?.to_string();
@@ -1192,6 +1893,16 @@ fn windows_package_version(name: &str) -> Vec<u64> {
         .collect()
 }
 
+#[cfg(windows)]
+fn windows_package_matches_arch(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    if cfg!(target_arch = "aarch64") {
+        name.contains("_arm64__")
+    } else {
+        name.contains("_x64__")
+    }
+}
+
 fn claude_desktop_is_running(app: &Path) -> bool {
     let expected = app
         .canonicalize()
@@ -1224,6 +1935,68 @@ fn success_status() -> std::process::ExitStatus {
 mod tests {
     use super::*;
 
+    struct MaskingTestEnv {
+        _guard: crate::EnvVarGuard,
+        home: PathBuf,
+        process_host_candidate: Option<PathBuf>,
+    }
+
+    impl MaskingTestEnv {
+        fn install(store: &pentect_agent::InProcessMemoryStore) -> Self {
+            let home = std::env::temp_dir().join(format!(
+                "pentect-claude-app-test-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&home).unwrap();
+            let guard = crate::EnvVarGuard::set_optional([
+                (
+                    "PENTECT_MEMORY_STORE_ADDR",
+                    Some(store.addr().to_string().into()),
+                ),
+                (
+                    "PENTECT_MEMORY_STORE_TOKEN",
+                    Some(store.token().to_string().into()),
+                ),
+                (
+                    "PENTECT_AGENT_LAUNCHED",
+                    Some(store.token().to_string().into()),
+                ),
+                ("PENTECT_HOME", Some(home.as_os_str().to_owned())),
+                (crate::plugins::CONFIGS_ENV, None),
+                (crate::plugins::BINARIES_ENV, None),
+            ]);
+            let process_host_candidate = Some(
+                pentect_agent::register_process_host_candidate(
+                    &pentect_agent::process_host_root().unwrap(),
+                    store.addr(),
+                    store.token(),
+                    store.process_host_read_token(),
+                    store.process_host_write_token(),
+                    std::process::id(),
+                )
+                .unwrap(),
+            );
+            Self {
+                _guard: guard,
+                home,
+                process_host_candidate,
+            }
+        }
+    }
+
+    impl Drop for MaskingTestEnv {
+        fn drop(&mut self) {
+            if let Some(path) = self.process_host_candidate.take() {
+                let _ = std::fs::remove_file(path);
+            }
+            let _ = std::fs::remove_dir_all(&self.home);
+        }
+    }
+
     #[test]
     fn options_accept_an_explicit_app_path() {
         let args = vec![
@@ -1250,7 +2023,7 @@ mod tests {
         ];
         let options = ClaudeAppOptions::parse(&args).unwrap();
         assert_eq!(options.app, Some(PathBuf::from("Claude.exe")));
-        assert!(options.dry_run);
+        assert!(options.check);
     }
 
     #[test]
@@ -1281,6 +2054,21 @@ mod tests {
             "/api/organizations/example/chat_conversations/example/completion",
             "application/json; charset=utf-8"
         ));
+        assert!(is_chat_completion(
+            "api.claude.com",
+            "/api/chat_conversations/example/completion",
+            "application/json"
+        ));
+        assert!(is_chat_completion(
+            "claude.ai",
+            "/api/organizations/example/chat_conversations/example/completion2",
+            "application/json"
+        ));
+        assert!(is_chat_completion(
+            "claude.ai",
+            "/api/organizations/example/chat_conversations/example/retry_completion2",
+            "application/json"
+        ));
         assert!(!is_chat_completion(
             "claude.ai.example.test",
             "/completion",
@@ -1291,6 +2079,239 @@ mod tests {
             "/completion",
             "multipart/form-data"
         ));
+        assert!(!is_chat_completion(
+            "claude.ai",
+            "/completion_status",
+            "application/json"
+        ));
+    }
+
+    #[test]
+    fn unsupported_model_transports_are_classified_without_matching_unrelated_routes() {
+        assert_eq!(
+            classify_claude_app_request(
+                &Method::POST,
+                "claude.ai",
+                "/v1/mobile/appendMessage",
+                "application/proto"
+            ),
+            ClaudeAppRequest::UnsupportedModel
+        );
+        assert_eq!(
+            classify_claude_app_request(
+                &Method::GET,
+                "claude.ai",
+                "/api/ws/voice/organizations/o/chat_conversations/c",
+                "-"
+            ),
+            ClaudeAppRequest::UnsupportedModel
+        );
+        assert_eq!(
+            classify_claude_app_request(
+                &Method::POST,
+                "claude.ai",
+                "/v1/mobile/unrelated",
+                "application/proto"
+            ),
+            ClaudeAppRequest::Other
+        );
+        assert_eq!(
+            classify_claude_app_request(
+                &Method::POST,
+                "claude.ai",
+                "/api/event_logging/v2/batch",
+                "application/json"
+            ),
+            ClaudeAppRequest::JsonScan
+        );
+    }
+
+    #[test]
+    fn only_known_claude_upload_routes_are_rewritten() {
+        for path in [
+            "/api/org/upload",
+            "/api/organizations/org/projects/project/upload",
+            "/api/organizations/org/cowork/attachments",
+            "/v1/filestore/fs/createFile",
+        ] {
+            assert_eq!(
+                classify_claude_app_request(
+                    &Method::POST,
+                    "claude.ai",
+                    path,
+                    "multipart/form-data; boundary=test"
+                ),
+                ClaudeAppRequest::Upload,
+                "{path}"
+            );
+        }
+        for path in ["/upload", "/api/organizations/org/dxt/upload"] {
+            assert_eq!(
+                classify_claude_app_request(
+                    &Method::POST,
+                    "claude.ai",
+                    path,
+                    "multipart/form-data; boundary=test"
+                ),
+                ClaudeAppRequest::Other,
+                "{path}"
+            );
+        }
+        assert_eq!(
+            classify_claude_app_request(
+                &Method::POST,
+                "claude.ai",
+                "/api/organizations/org/conversations/conversation/files/prepare-upload",
+                "application/json"
+            ),
+            ClaudeAppRequest::PrepareUploadJson
+        );
+    }
+
+    #[test]
+    fn malformed_chat_json_obeys_the_unknown_format_policy() {
+        let body = Bytes::from_static(b"{not-json");
+        assert!(parse_chat_json(&body, true)
+            .unwrap_err()
+            .starts_with("unknown format blocked:"));
+        assert!(parse_chat_json(&body, false).unwrap().is_none());
+    }
+
+    #[test]
+    fn chat_request_masks_content_without_rewriting_protocol_metadata() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = MaskingTestEnv::install(&store);
+        let secret = [
+            "rpa_",
+            "ZYXWVUTS",
+            "RQPONMLK",
+            "JIHGFEDC",
+            "BA098765",
+            "4321fedcba",
+        ]
+        .concat();
+        let body = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "claude-test-model",
+                "organization_uuid": "11111111-2222-3333-4444-555555555555",
+                "prompt": format!("Use this value:\nRUNPOD_API_KEY={secret}\n"),
+                "messages": [{"content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "tool-stable-id",
+                    "content": {"token": secret, "status": "ok"}
+                }]}],
+                "client_context": {"locale": "ja-JP", "revision": 7}
+            }))
+            .unwrap(),
+        );
+        let masker = Mutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let protected =
+            protect_chat_request(&body, &masker, &plugins, &HashMap::new(), true).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&protected.body).unwrap();
+        let prompt = value["prompt"].as_str().unwrap();
+        assert!(!prompt.contains(&secret));
+        assert!(prompt.contains("<<"));
+        assert!(prompt.contains(HANDLE_CONTRACT));
+        assert_eq!(value["model"], "claude-test-model");
+        assert_eq!(
+            value["organization_uuid"],
+            "11111111-2222-3333-4444-555555555555"
+        );
+        assert_eq!(value["client_context"]["revision"], 7);
+        assert_eq!(
+            value["messages"][0]["content"][0]["tool_use_id"],
+            "tool-stable-id"
+        );
+        assert_ne!(
+            value["messages"][0]["content"][0]["content"]["token"],
+            secret
+        );
+
+        let telemetry = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "event": "client-error",
+                "detail": format!("accidentally captured:\nRUNPOD_API_KEY={secret}\n")
+            }))
+            .unwrap(),
+        );
+        let protected = protect_generic_json_request(&telemetry, &masker, true).unwrap();
+        assert!(!String::from_utf8_lossy(&protected).contains(&secret));
+    }
+
+    #[test]
+    fn uploaded_file_ids_are_registered_without_trusting_unrelated_ids() {
+        let files = Mutex::new(HashMap::new());
+        remember_claude_file_ids(
+            br#"{"id":"organization-id","nested":{"file_uuid":"file-123"},"file":{"id":"file-456","type":"file"}}"#,
+            crate::http_files::Coverage::Full,
+            &files,
+        )
+        .unwrap();
+        let files = files.lock().unwrap();
+        assert!(!files.contains_key("organization-id"));
+        assert_eq!(
+            files.get("file-123"),
+            Some(&crate::http_files::Coverage::Full)
+        );
+        assert_eq!(
+            files.get("file-456"),
+            Some(&crate::http_files::Coverage::Full)
+        );
+    }
+
+    #[test]
+    fn direct_upload_preparation_is_promoted_only_after_the_file_is_protected() {
+        let content_type = "multipart/form-data; boundary=pentect-test";
+        let body = concat!(
+            "--pentect-test\r\n",
+            "Content-Disposition: form-data; name=\"params\"\r\n",
+            "Content-Type: application/json\r\n\r\n",
+            "{\"filesystem_id\":\"fs-1\",\"path\":\"/uploads/a.txt\"}\r\n",
+            "--pentect-test\r\n",
+            "Content-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\n",
+            "Content-Type: text/plain\r\n\r\n",
+            "hello\r\n",
+            "--pentect-test--\r\n"
+        );
+        let key = claude_filestore_upload_key(content_type, body.as_bytes()).unwrap();
+        let pending = Mutex::new(HashMap::new());
+        let files = Mutex::new(HashMap::new());
+        remember_pending_claude_files(
+            br#"{"uploads":[{"filesystem_id":"fs-1","path":"/uploads/a.txt","file_uuid":"file-1"}]}"#,
+            &pending,
+        )
+        .unwrap();
+        assert!(!files.lock().unwrap().contains_key("file-1"));
+        promote_pending_claude_files(&key, crate::http_files::Coverage::Full, &pending, &files)
+            .unwrap();
+        assert_eq!(
+            files.lock().unwrap().get("file-1"),
+            Some(&crate::http_files::Coverage::Full)
+        );
+    }
+
+    #[test]
+    fn completed_tool_calls_restore_nested_inputs_but_normal_text_stays_opaque() {
+        let handle = "<<SECRET_0011223344556677>>";
+        let mut value = serde_json::json!({
+            "content": [
+                {"type": "text", "text": format!("show {handle}")},
+                {"type": "tool_use", "name": "http", "input": {
+                    "headers": {"x-token": handle},
+                    "body": [handle]
+                }}
+            ]
+        });
+        let mut resolve = |text: &str| Ok(text.replace(handle, "local-value"));
+        resolve_chat_tool_calls(&mut value, &mut resolve).unwrap();
+        assert_eq!(value["content"][0]["text"], format!("show {handle}"));
+        assert_eq!(
+            value["content"][1]["input"]["headers"]["x-token"],
+            "local-value"
+        );
+        assert_eq!(value["content"][1]["input"]["body"][0], "local-value");
     }
 
     #[test]
@@ -1312,6 +2333,27 @@ mod tests {
     }
 
     #[test]
+    fn proxy_removes_standard_and_connection_named_hop_headers() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(
+            hyper::header::CONNECTION,
+            hyper::header::HeaderValue::from_static("keep-alive, x-private-hop"),
+        );
+        headers.insert(
+            hyper::header::HeaderName::from_static("x-private-hop"),
+            hyper::header::HeaderValue::from_static("remove"),
+        );
+        headers.insert(
+            hyper::header::HeaderName::from_static("x-end-to-end"),
+            hyper::header::HeaderValue::from_static("keep"),
+        );
+        remove_hop_by_hop_headers(&mut headers);
+        assert!(!headers.contains_key(hyper::header::CONNECTION));
+        assert!(!headers.contains_key("x-private-hop"));
+        assert_eq!(headers["x-end-to-end"], "keep");
+    }
+
+    #[test]
     fn ephemeral_ca_builds_host_certificate() {
         let authority = CertificateAuthority::new().unwrap();
         assert!(!authority.spki_hash.is_empty());
@@ -1325,5 +2367,12 @@ mod tests {
             windows_package_version("Claude_1.10.0.0_x64__id")
                 > windows_package_version("Claude_1.9.99.0_x64__id")
         );
+        assert!(windows_package_matches_arch(
+            if cfg!(target_arch = "aarch64") {
+                "Claude_1.10.0.0_arm64__id"
+            } else {
+                "Claude_1.10.0.0_x64__id"
+            }
+        ));
     }
 }

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -1068,9 +1068,10 @@ fn remember_pending_claude_files(body: &[u8], pending: &Mutex<PendingFiles>) -> 
             ids.push(file_id.to_string());
         }
         while pending.entries.len() > MAX_PENDING_UPLOADS {
-            if let Some(expired) = pending.insertion_order.pop_front() {
-                pending.entries.remove(&expired);
-            }
+            let Some(expired) = pending.insertion_order.pop_front() else {
+                break;
+            };
+            pending.entries.remove(&expired);
         }
     }
     Ok(())
@@ -1525,7 +1526,7 @@ struct ChatStreamState {
     passthrough: bool,
     finished: bool,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
-    resolve: ChatResolver,
+    resolve: Option<ChatResolver>,
 }
 
 fn chat_sse_body<S>(stream: S, plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>) -> ProxyBody
@@ -1539,7 +1540,7 @@ where
         passthrough: false,
         finished: false,
         plugins,
-        resolve: Box::new(crate::claude_http_proxy::request_scoped_resolver()),
+        resolve: Some(Box::new(crate::claude_http_proxy::request_scoped_resolver())),
     };
     let stream = futures_util::stream::unfold(state, |mut state| async move {
         loop {
@@ -1570,7 +1571,35 @@ where
                     state.pending.extend_from_slice(&chunk);
                     while let Some(end) = first_sse_block_end(&state.pending) {
                         let block = state.pending.drain(..end).collect::<Vec<_>>();
-                        match rewrite_chat_sse_block(&block, &state.plugins, &mut state.resolve) {
+                        if !chat_sse_block_contains_tool_call(&block) {
+                            state.ready.push_back(Ok(Frame::data(Bytes::from(block))));
+                            continue;
+                        }
+                        let Some(mut resolve) = state.resolve.take() else {
+                            state.finished = true;
+                            state.ready.push_back(Err(Box::new(io::Error::other(
+                                "Claude App Chat resolver is unavailable",
+                            ))));
+                            break;
+                        };
+                        let plugins = Arc::clone(&state.plugins);
+                        let rewritten = tokio::task::spawn_blocking(move || {
+                            let result = rewrite_chat_sse_block(&block, &plugins, &mut resolve);
+                            (result, resolve)
+                        })
+                        .await;
+                        let (result, resolve) = match rewritten {
+                            Ok(result) => result,
+                            Err(_) => {
+                                state.finished = true;
+                                state.ready.push_back(Err(Box::new(io::Error::other(
+                                    "Claude App Chat restoration task failed",
+                                ))));
+                                break;
+                            }
+                        };
+                        state.resolve = Some(resolve);
+                        match result {
                             Ok(block) => state.ready.push_back(Ok(Frame::data(block))),
                             Err(error) => {
                                 state.finished = true;
@@ -1602,6 +1631,14 @@ where
     StreamBody::new(stream).boxed_unsync()
 }
 
+fn chat_sse_block_contains_tool_call(block: &[u8]) -> bool {
+    std::str::from_utf8(block)
+        .ok()
+        .and_then(|text| text.lines().find_map(|line| line.strip_prefix("data:")))
+        .and_then(|data| serde_json::from_str::<serde_json::Value>(data.trim_start()).ok())
+        .is_some_and(|value| contains_chat_tool_call(&value))
+}
+
 fn rewrite_chat_sse_block<R>(
     block: &[u8],
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
@@ -1620,9 +1657,12 @@ where
         return Ok(Bytes::copy_from_slice(block));
     };
     if contains_chat_tool_call(&value) {
-        let plugins = plugins
-            .lock()
-            .map_err(|_| "Claude App plugin lock was poisoned".to_string())?;
+        let plugins = {
+            plugins
+                .lock()
+                .map_err(|_| "Claude App plugin lock was poisoned".to_string())?
+                .clone()
+        };
         run_chat_tool_plugins(&mut value, &plugins)?;
     }
     if let Err(error) = resolve_chat_tool_calls(&mut value, resolve) {

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -121,15 +121,53 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    configure_child_process(&mut command);
     let mut child = command
         .spawn()
         .map_err(|error| format!("could not start Claude Desktop: {error}"))?;
+    let child_id = child.id();
+    if let Err(error) = ctrlc::set_handler(move || {
+        terminate_child_process(child_id);
+        std::process::exit(130);
+    }) {
+        terminate_child_process(child_id);
+        let _ = child.wait();
+        return Err(format!(
+            "could not install Claude Desktop shutdown handler: {error}"
+        ));
+    }
     let status = child
         .wait()
         .map_err(|error| format!("could not wait for Claude Desktop: {error}"))?;
     drop(proxy);
     drop(anthropic);
     Ok(status)
+}
+
+#[cfg(windows)]
+fn configure_child_process(_command: &mut Command) {}
+
+#[cfg(unix)]
+fn configure_child_process(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    command.process_group(0);
+}
+
+#[cfg(windows)]
+fn terminate_child_process(pid: u32) {
+    let _ = Command::new("taskkill.exe")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+#[cfg(unix)]
+fn terminate_child_process(pid: u32) {
+    unsafe {
+        libc::kill(-(pid as i32), libc::SIGTERM);
+    }
 }
 
 #[derive(Debug)]

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1459,9 +1459,7 @@ pub(crate) fn mask_string(
     } else {
         masker.mask_prompt_text(text)?
     };
-    if let Some(masked) = masked {
-        *text = masked;
-    }
+    *text = masked.ok_or_else(|| "content inspection is unavailable".to_string())?;
     Ok(())
 }
 

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -653,6 +653,11 @@ fn protect_anthropic_request_body(
         if is_media_policy_rejection(&error) {
             return Err(error);
         }
+        if block_unknown_formats {
+            return Err(format!(
+                "Anthropic request blocked: content inspection is unavailable ({error})"
+            ));
+        }
         eprintln!("[pentect] Claude request protection skipped: {error}");
         return Ok(ProtectedJsonBody {
             body: body.clone(),

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -58,7 +58,7 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
 
     let routing = crate::codex_app_routing(options.upstream)?;
     let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start(routing.upstream)?;
-    let config_lock = CodexConfigLock::acquire()?;
+    let config_lock = Arc::new(Mutex::new(Some(CodexConfigLock::acquire()?)));
     let config_override = Some(CodexConfigOverride::install(
         &routing.provider,
         proxy.base_url(),
@@ -84,11 +84,15 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         .map_err(|error| format!("could not start Codex App: {error}"))?;
     let config_cleanup = Arc::new(Mutex::new(config_override));
     let signal_cleanup = Arc::clone(&config_cleanup);
+    let signal_lock = Arc::clone(&config_lock);
     let child_id = child.id();
     if let Err(error) = ctrlc::set_handler(move || {
         terminate_child_process(child_id);
         if let Ok(mut cleanup) = signal_cleanup.lock() {
             cleanup.take();
+        }
+        if let Ok(mut lock) = signal_lock.lock() {
+            lock.take();
         }
         std::process::exit(130);
     }) {
@@ -96,6 +100,9 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         let _ = child.wait();
         if let Ok(mut cleanup) = config_cleanup.lock() {
             cleanup.take();
+        }
+        if let Ok(mut lock) = config_lock.lock() {
+            lock.take();
         }
         return Err(format!(
             "could not install Codex App config recovery handler: {error}"
@@ -108,14 +115,21 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         .lock()
         .map_err(|_| "Codex App config recovery lock is unavailable".to_string())?
         .take();
-    drop(config_lock);
+    config_lock
+        .lock()
+        .map_err(|_| "Codex App session lock is unavailable".to_string())?
+        .take();
     drop(proxy);
     Ok(status)
 }
 
+pub(crate) fn check_mode(args: &[String]) -> Result<bool, String> {
+    CodexAppOptions::parse(args).map(|options| options.check)
+}
+
 #[cfg(windows)]
 fn terminate_child_process(pid: u32) {
-    let _ = Command::new("taskkill.exe")
+    let _ = Command::new(crate::windows_system_executable("taskkill.exe"))
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -145,8 +159,10 @@ struct CodexConfigOverride {
     no_original_marker: PathBuf,
 }
 
+#[derive(Debug)]
 struct CodexConfigLock {
     path: PathBuf,
+    file: std::fs::File,
 }
 
 impl CodexConfigLock {
@@ -159,75 +175,48 @@ impl CodexConfigLock {
             .map_err(|error| format!("could not create '{}': {error}", home.display()))?;
         let path = home.join("pentect-codex-app.lock");
         reject_symlink(&path, "Codex App lock")?;
-        for attempt in 0..2 {
-            match std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&path)
-            {
-                Ok(mut file) => {
-                    writeln!(file, "{}", std::process::id()).map_err(|error| {
-                        format!("could not initialize '{}': {error}", path.display())
-                    })?;
-                    file.sync_all().map_err(|error| {
-                        format!("could not persist '{}': {error}", path.display())
-                    })?;
-                    return Ok(Self { path });
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists && attempt == 0 => {
-                    if lock_owner_is_running(&path) {
-                        return Err(
-                            "another `pentect codex app` session is already active".to_string()
-                        );
-                    }
-                    std::fs::remove_file(&path).map_err(|remove_error| {
-                        format!(
-                            "could not clear stale Codex App lock '{}': {remove_error}",
-                            path.display()
-                        )
-                    })?;
-                }
-                Err(error) => {
-                    return Err(format!(
-                        "could not lock Codex App configuration '{}': {error}",
-                        path.display()
-                    ));
-                }
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&path).map_err(|error| {
+            format!(
+                "could not open Codex App lock '{}': {error}",
+                path.display()
+            )
+        })?;
+        match file.try_lock() {
+            Ok(()) => {}
+            Err(std::fs::TryLockError::WouldBlock) => {
+                return Err("another `pentect codex app` session is already active".to_string());
+            }
+            Err(std::fs::TryLockError::Error(error)) => {
+                return Err(format!(
+                    "could not lock Codex App configuration '{}': {error}",
+                    path.display()
+                ));
             }
         }
-        Err("could not acquire Codex App configuration lock".to_string())
+        file.set_len(0)
+            .and_then(|_| writeln!(file, "{}", std::process::id()))
+            .and_then(|_| file.sync_all())
+            .map_err(|error| format!("could not initialize '{}': {error}", path.display()))?;
+        Ok(Self { path, file })
     }
 }
 
 impl Drop for CodexConfigLock {
     fn drop(&mut self) {
-        if let Err(error) = std::fs::remove_file(&self.path) {
-            if error.kind() != std::io::ErrorKind::NotFound {
-                eprintln!(
-                    "[pentect] could not remove Codex App lock '{}': {error}",
-                    self.path.display()
-                );
-            }
+        if let Err(error) = self.file.unlock() {
+            eprintln!(
+                "[pentect] could not release Codex App lock '{}': {error}",
+                self.path.display()
+            );
         }
     }
-}
-
-fn lock_owner_is_running(path: &Path) -> bool {
-    let Ok(value) = std::fs::read_to_string(path) else {
-        return false;
-    };
-    let Ok(pid) = value.trim().parse::<sysinfo::Pid>() else {
-        return false;
-    };
-    let mut system = sysinfo::System::new();
-    system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
-    system.process(pid).is_some_and(|process| {
-        process
-            .name()
-            .to_string_lossy()
-            .to_ascii_lowercase()
-            .starts_with("pentect")
-    })
 }
 
 impl CodexConfigOverride {
@@ -561,7 +550,8 @@ fn find_windows_store_chatgpt() -> Option<PathBuf> {
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     const PACKAGES_KEY: &str = r"HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\Repository\Packages";
 
-    let output = Command::new("reg.exe")
+    let reg = crate::windows_system_executable("reg.exe");
+    let output = Command::new(&reg)
         .args(["query", PACKAGES_KEY])
         .creation_flags(CREATE_NO_WINDOW)
         .output()
@@ -582,7 +572,7 @@ fn find_windows_store_chatgpt() -> Option<PathBuf> {
         })
         .filter_map(|key| {
             let package_name = key.rsplit('\\').next()?.to_string();
-            let output = Command::new("reg.exe")
+            let output = Command::new(&reg)
                 .args(["query", key, "/v", "PackageRootFolder"])
                 .creation_flags(CREATE_NO_WINDOW)
                 .output()
@@ -742,6 +732,18 @@ mod tests {
             "--dry-run".to_string(),
         ];
         assert!(CodexAppOptions::parse(&args).is_err());
+    }
+
+    #[test]
+    fn check_mode_does_not_treat_an_option_value_as_a_flag() {
+        let args = vec![
+            "pentect".to_string(),
+            "codex".to_string(),
+            "app".to_string(),
+            "--app".to_string(),
+            "--check".to_string(),
+        ];
+        assert!(!check_mode(&args).unwrap());
     }
 
     #[cfg(windows)]
@@ -976,7 +978,7 @@ base_url = "https://other.example/v1"
     }
 
     #[test]
-    fn config_lock_rejects_a_second_session_and_clears_on_drop() {
+    fn config_lock_rejects_a_second_session_and_releases_on_drop() {
         let home = std::env::temp_dir().join(format!(
             "pentect-codex-app-lock-{}-{}",
             std::process::id(),
@@ -986,7 +988,8 @@ base_url = "https://other.example/v1"
                 .as_nanos()
         ));
         let first = CodexConfigLock::acquire_in(&home).unwrap();
-        assert!(CodexConfigLock::acquire_in(&home).is_err());
+        let error = CodexConfigLock::acquire_in(&home).unwrap_err();
+        assert!(error.contains("another `pentect codex app` session is already active"));
         drop(first);
         let second = CodexConfigLock::acquire_in(&home).unwrap();
         drop(second);
@@ -994,7 +997,7 @@ base_url = "https://other.example/v1"
     }
 
     #[test]
-    fn config_lock_recovers_a_stale_owner() {
+    fn config_lock_ignores_stale_diagnostic_pid() {
         let home = std::env::temp_dir().join(format!(
             "pentect-codex-app-stale-lock-{}-{}",
             std::process::id(),

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -8,6 +8,7 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
+use std::{fs::OpenOptions, io::Write};
 
 pub(crate) fn cmd_codex_app(args: &[String]) -> i32 {
     match run_codex_app(args) {
@@ -22,8 +23,24 @@ pub(crate) fn cmd_codex_app(args: &[String]) -> i32 {
 fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     let options = CodexAppOptions::parse(args)?;
     let app = options.app.unwrap_or_else(default_codex_app_path);
-    if options.dry_run {
-        println!("{}", app.display());
+    if options.check {
+        let installed = app.is_file();
+        println!("App: {}", app.display());
+        println!("Installed: {}", if installed { "yes" } else { "no" });
+        println!(
+            "Running: {}",
+            if codex_app_is_running(&app) {
+                "yes"
+            } else {
+                "no"
+            }
+        );
+        let routing = crate::codex_app_routing(options.upstream)?;
+        println!("Provider: {}", routing.provider);
+        println!("Protection: OpenAI Responses API (HTTP)");
+        if !installed {
+            return Err("Codex mode was not found; pass --app PATH".to_string());
+        }
         return Ok(success_status());
     }
     if !app.is_file() {
@@ -41,6 +58,7 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
 
     let routing = crate::codex_app_routing(options.upstream)?;
     let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start(routing.upstream)?;
+    let config_lock = CodexConfigLock::acquire()?;
     let config_override = Some(CodexConfigOverride::install(
         &routing.provider,
         proxy.base_url(),
@@ -87,6 +105,7 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         .lock()
         .map_err(|_| "Codex App config recovery lock is unavailable".to_string())?
         .take();
+    drop(config_lock);
     drop(proxy);
     Ok(status)
 }
@@ -114,6 +133,91 @@ struct CodexConfigOverride {
     no_original_marker: PathBuf,
 }
 
+struct CodexConfigLock {
+    path: PathBuf,
+}
+
+impl CodexConfigLock {
+    fn acquire() -> Result<Self, String> {
+        Self::acquire_in(&crate::codex_home_dir()?)
+    }
+
+    fn acquire_in(home: &Path) -> Result<Self, String> {
+        std::fs::create_dir_all(home)
+            .map_err(|error| format!("could not create '{}': {error}", home.display()))?;
+        let path = home.join("pentect-codex-app.lock");
+        reject_symlink(&path, "Codex App lock")?;
+        for attempt in 0..2 {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(mut file) => {
+                    writeln!(file, "{}", std::process::id()).map_err(|error| {
+                        format!("could not initialize '{}': {error}", path.display())
+                    })?;
+                    file.sync_all().map_err(|error| {
+                        format!("could not persist '{}': {error}", path.display())
+                    })?;
+                    return Ok(Self { path });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists && attempt == 0 => {
+                    if lock_owner_is_running(&path) {
+                        return Err(
+                            "another `pentect codex app` session is already active".to_string()
+                        );
+                    }
+                    std::fs::remove_file(&path).map_err(|remove_error| {
+                        format!(
+                            "could not clear stale Codex App lock '{}': {remove_error}",
+                            path.display()
+                        )
+                    })?;
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "could not lock Codex App configuration '{}': {error}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+        Err("could not acquire Codex App configuration lock".to_string())
+    }
+}
+
+impl Drop for CodexConfigLock {
+    fn drop(&mut self) {
+        if let Err(error) = std::fs::remove_file(&self.path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                eprintln!(
+                    "[pentect] could not remove Codex App lock '{}': {error}",
+                    self.path.display()
+                );
+            }
+        }
+    }
+}
+
+fn lock_owner_is_running(path: &Path) -> bool {
+    let Ok(value) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(pid) = value.trim().parse::<sysinfo::Pid>() else {
+        return false;
+    };
+    let mut system = sysinfo::System::new();
+    system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
+    system.process(pid).is_some_and(|process| {
+        process
+            .name()
+            .to_string_lossy()
+            .to_ascii_lowercase()
+            .starts_with("pentect")
+    })
+}
+
 impl CodexConfigOverride {
     fn install(provider: &str, gateway: &str) -> Result<Self, String> {
         let home = crate::codex_home_dir()?;
@@ -126,6 +230,9 @@ impl CodexConfigOverride {
         let config = home.join("config.toml");
         let backup = home.join("config.toml.pentect-backup");
         let no_original_marker = home.join("config.toml.pentect-no-original");
+        reject_symlink(&config, "Codex config")?;
+        reject_symlink(&backup, "Codex recovery backup")?;
+        reject_symlink(&no_original_marker, "Codex recovery marker")?;
         if backup.is_file() {
             if config.is_file() {
                 std::fs::remove_file(&config).map_err(|error| {
@@ -167,14 +274,15 @@ impl CodexConfigOverride {
         };
         set_provider_gateway(&mut parsed, provider, gateway)?;
 
-        std::fs::write(&backup, original.as_bytes())
+        write_new_private_file(&backup, original.as_bytes())
             .map_err(|error| format!("could not back up '{}': {error}", config.display()))?;
         if !had_original {
-            std::fs::write(&no_original_marker, b"")
+            write_new_private_file(&no_original_marker, b"")
                 .map_err(|error| format!("could not create Codex recovery marker: {error}"))?;
         }
         let temporary = home.join(format!("config.toml.pentect-{}.tmp", std::process::id()));
-        std::fs::write(&temporary, parsed.to_string())
+        reject_symlink(&temporary, "Codex temporary config")?;
+        write_new_private_file(&temporary, parsed.to_string().as_bytes())
             .map_err(|error| format!("could not write '{}': {error}", temporary.display()))?;
         if config.is_file() {
             std::fs::remove_file(&config)
@@ -200,6 +308,9 @@ impl CodexConfigOverride {
     }
 
     fn restore(&self) -> Result<(), String> {
+        reject_symlink(&self.config, "Codex config")?;
+        reject_symlink(&self.backup, "Codex recovery backup")?;
+        reject_symlink(&self.no_original_marker, "Codex recovery marker")?;
         if !self.backup.is_file() {
             return Ok(());
         }
@@ -225,6 +336,29 @@ impl CodexConfigOverride {
             })
         }
     }
+}
+
+fn reject_symlink(path: &Path, label: &str) -> Result<(), String> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(format!(
+            "{label} '{}' is a symbolic link; Pentect will not replace it",
+            path.display()
+        )),
+        Ok(_) | Err(_) => Ok(()),
+    }
+}
+
+fn write_new_private_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()
 }
 
 impl Drop for CodexConfigOverride {
@@ -278,14 +412,14 @@ fn set_provider_gateway(
 struct CodexAppOptions {
     app: Option<PathBuf>,
     upstream: Option<String>,
-    dry_run: bool,
+    check: bool,
 }
 
 impl CodexAppOptions {
     fn parse(args: &[String]) -> Result<Self, String> {
         let mut app = None;
         let mut upstream = None;
-        let mut dry_run = false;
+        let mut check = false;
         let mut index = if args.get(1).is_some_and(|arg| arg == "codex")
             && args.get(2).is_some_and(|arg| arg == "app")
         {
@@ -309,8 +443,8 @@ impl CodexAppOptions {
                     upstream = Some(value.clone());
                     index += 2;
                 }
-                "--dry-run" => {
-                    dry_run = true;
+                "--check" | "--dry-run" => {
+                    check = true;
                     index += 1;
                 }
                 "--plugins" => {
@@ -328,7 +462,7 @@ impl CodexAppOptions {
         Ok(Self {
             app,
             upstream,
-            dry_run,
+            check,
         })
     }
 }
@@ -342,7 +476,15 @@ fn default_codex_app_path() -> PathBuf {
     }
     #[cfg(target_os = "macos")]
     {
-        return PathBuf::from("/Applications/Codex.app/Contents/MacOS/Codex");
+        for candidate in [
+            "/Applications/ChatGPT.app/Contents/MacOS/ChatGPT",
+            "/Applications/Codex.app/Contents/MacOS/Codex",
+        ] {
+            let candidate = PathBuf::from(candidate);
+            if candidate.is_file() {
+                return candidate;
+            }
+        }
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
@@ -366,11 +508,18 @@ fn default_codex_app_path() -> PathBuf {
 
 #[cfg(windows)]
 fn find_windows_codex_app() -> Option<PathBuf> {
-    let root = std::env::var_os("LOCALAPPDATA")
-        .map(PathBuf::from)?
-        .join(Path::new("Programs").join("OpenAI Codex Standalone"));
-    let mut candidates = std::fs::read_dir(root)
-        .ok()?
+    let local_app_data = std::env::var_os("LOCALAPPDATA").map(PathBuf::from)?;
+    let roots = [
+        local_app_data
+            .join("Programs")
+            .join("OpenAI Codex Standalone"),
+        local_app_data.join("Programs").join("OpenAI ChatGPT"),
+        local_app_data.join("Programs").join("ChatGPT"),
+    ];
+    let mut candidates = roots
+        .into_iter()
+        .filter_map(|root| std::fs::read_dir(root).ok())
+        .flatten()
         .filter_map(Result::ok)
         .filter_map(|entry| {
             // Codex.exe is an updater/launcher stub in current standalone
@@ -388,7 +537,84 @@ fn find_windows_codex_app() -> Option<PathBuf> {
         })
         .collect::<Vec<_>>();
     candidates.sort_by(|left, right| left.0.cmp(&right.0));
+    if let Some((_, executable)) = candidates.pop() {
+        return Some(executable);
+    }
+    find_windows_store_chatgpt()
+}
+
+#[cfg(windows)]
+fn find_windows_store_chatgpt() -> Option<PathBuf> {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    const PACKAGES_KEY: &str = r"HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\Repository\Packages";
+
+    let output = Command::new("reg.exe")
+        .args(["query", PACKAGES_KEY])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let keys = String::from_utf8_lossy(&output.stdout);
+    let mut candidates = keys
+        .lines()
+        .map(str::trim)
+        .filter(|key| {
+            key.rsplit('\\').next().is_some_and(|name| {
+                let name = name.to_ascii_lowercase();
+                (name.starts_with("chatgpt_") || name.starts_with("openai.chatgpt"))
+                    && windows_package_matches_arch(&name)
+            })
+        })
+        .filter_map(|key| {
+            let package_name = key.rsplit('\\').next()?.to_string();
+            let output = Command::new("reg.exe")
+                .args(["query", key, "/v", "PackageRootFolder"])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+                .ok()?;
+            if !output.status.success() {
+                return None;
+            }
+            let root = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .find_map(|line| line.split_once("REG_SZ").map(|(_, value)| value.trim()))?
+                .to_string();
+            ["ChatGPT.exe", "app\\ChatGPT.exe", "Codex.exe"]
+                .into_iter()
+                .map(|relative| PathBuf::from(&root).join(relative))
+                .find(|path| path.is_file())
+                .map(|path| (windows_package_version(&package_name), path))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| left.0.cmp(&right.0));
     candidates.pop().map(|(_, executable)| executable)
+}
+
+#[cfg(windows)]
+fn windows_package_matches_arch(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    if cfg!(target_arch = "aarch64") {
+        name.contains("_arm64__")
+    } else {
+        name.contains("_x64__")
+    }
+}
+
+#[cfg(windows)]
+fn windows_package_version(name: &str) -> Vec<u64> {
+    name.split('_')
+        .find(|part| {
+            part.chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_digit())
+        })
+        .unwrap_or_default()
+        .split('.')
+        .map(|part| part.parse().unwrap_or(0))
+        .collect()
 }
 
 #[cfg(windows)]
@@ -469,7 +695,7 @@ mod tests {
             CodexAppOptions {
                 app: Some(PathBuf::from("Codex.exe")),
                 upstream: Some("https://example.test/v1".to_string()),
-                dry_run: true,
+                check: true,
             }
         );
     }
@@ -489,7 +715,7 @@ mod tests {
             CodexAppOptions {
                 app: None,
                 upstream: None,
-                dry_run: true,
+                check: true,
             }
         );
     }
@@ -510,6 +736,17 @@ mod tests {
     #[test]
     fn version_sort_is_numeric() {
         assert!(version_components("26.10.0") > version_components("26.9.99"));
+        assert!(
+            windows_package_version("ChatGPT_26.10.0.0_x64__id")
+                > windows_package_version("ChatGPT_26.9.99.0_x64__id")
+        );
+        assert!(windows_package_matches_arch(
+            if cfg!(target_arch = "aarch64") {
+                "ChatGPT_1.0.0.0_arm64__id"
+            } else {
+                "ChatGPT_1.0.0.0_x64__id"
+            }
+        ));
     }
 
     #[test]
@@ -595,5 +832,169 @@ base_url = "https://other.example/v1"
         );
         assert!(!root.join("config.toml.pentect-backup").exists());
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn interrupted_config_override_is_recovered_before_reinstall() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-codex-recovery-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let original = "model = \"original\"\n";
+        std::fs::write(root.join("config.toml"), "model = \"interrupted\"\n").unwrap();
+        std::fs::write(root.join("config.toml.pentect-backup"), original).unwrap();
+        let guard =
+            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").unwrap();
+        drop(guard);
+        assert_eq!(
+            std::fs::read_to_string(root.join("config.toml")).unwrap(),
+            original
+        );
+        assert!(!root.join("config.toml.pentect-backup").exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn interrupted_override_without_an_original_remains_absent_after_recovery() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-codex-no-original-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("config.toml"), "model = \"interrupted\"\n").unwrap();
+        std::fs::write(root.join("config.toml.pentect-backup"), b"").unwrap();
+        std::fs::write(root.join("config.toml.pentect-no-original"), b"").unwrap();
+        let guard =
+            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").unwrap();
+        drop(guard);
+        assert!(!root.join("config.toml").exists());
+        assert!(!root.join("config.toml.pentect-backup").exists());
+        assert!(!root.join("config.toml.pentect-no-original").exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn malformed_config_does_not_create_recovery_artifacts() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-codex-malformed-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let malformed = "[not valid";
+        std::fs::write(root.join("config.toml"), malformed).unwrap();
+        assert!(
+            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").is_err()
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("config.toml")).unwrap(),
+            malformed
+        );
+        assert!(!root.join("config.toml.pentect-backup").exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_symlinks_are_rejected_without_touching_the_target() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "pentect-codex-symlink-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let target = root.join("outside.toml");
+        std::fs::write(&target, "model = \"untouched\"\n").unwrap();
+        symlink(&target, root.join("config.toml")).unwrap();
+        assert!(
+            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").is_err()
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "model = \"untouched\"\n"
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn active_config_and_recovery_files_are_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "pentect-codex-permissions-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("config.toml"), "model = \"original\"\n").unwrap();
+        let guard =
+            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").unwrap();
+        for path in [
+            root.join("config.toml"),
+            root.join("config.toml.pentect-backup"),
+        ] {
+            assert_eq!(
+                std::fs::metadata(path).unwrap().permissions().mode() & 0o077,
+                0
+            );
+        }
+        drop(guard);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_lock_rejects_a_second_session_and_clears_on_drop() {
+        let home = std::env::temp_dir().join(format!(
+            "pentect-codex-app-lock-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let first = CodexConfigLock::acquire_in(&home).unwrap();
+        assert!(CodexConfigLock::acquire_in(&home).is_err());
+        drop(first);
+        let second = CodexConfigLock::acquire_in(&home).unwrap();
+        drop(second);
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn config_lock_recovers_a_stale_owner() {
+        let home = std::env::temp_dir().join(format!(
+            "pentect-codex-app-stale-lock-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(home.join("pentect-codex-app.lock"), "4294967295\n").unwrap();
+        let lock = CodexConfigLock::acquire_in(&home).unwrap();
+        drop(lock);
+        std::fs::remove_dir_all(home).unwrap();
     }
 }

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -72,11 +72,14 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     }
     eprintln!("[pentect] Responses API prompts, files, and completed tool calls are protected");
 
-    let mut child = Command::new(&app)
+    let mut command = Command::new(&app);
+    command
         .env("OPENAI_BASE_URL", proxy.base_url())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    configure_child_process(&mut command);
+    let mut child = command
         .spawn()
         .map_err(|error| format!("could not start Codex App: {error}"))?;
     let config_cleanup = Arc::new(Mutex::new(config_override));
@@ -89,7 +92,7 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         }
         std::process::exit(130);
     }) {
-        let _ = child.kill();
+        terminate_child_process(child_id);
         let _ = child.wait();
         if let Ok(mut cleanup) = config_cleanup.lock() {
             cleanup.take();
@@ -123,8 +126,17 @@ fn terminate_child_process(pid: u32) {
 #[cfg(unix)]
 fn terminate_child_process(pid: u32) {
     unsafe {
-        libc::kill(pid as i32, libc::SIGTERM);
+        libc::kill(-(pid as i32), libc::SIGTERM);
     }
+}
+
+#[cfg(windows)]
+fn configure_child_process(_command: &mut Command) {}
+
+#[cfg(unix)]
+fn configure_child_process(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    command.process_group(0);
 }
 
 struct CodexConfigOverride {

--- a/crates/pentect-cli/src/http_files.rs
+++ b/crates/pentect-cli/src/http_files.rs
@@ -232,6 +232,19 @@ fn multipart_field(
     None
 }
 
+pub(crate) fn multipart_text_field(
+    content_type: &str,
+    body: &[u8],
+    expected: &str,
+) -> Option<String> {
+    let boundary = multipart_boundary(content_type)?;
+    let delimiter = format!("--{boundary}").into_bytes();
+    let mut next_part_prefix = Vec::with_capacity(delimiter.len() + 2);
+    next_part_prefix.extend_from_slice(b"\r\n");
+    next_part_prefix.extend_from_slice(&delimiter);
+    multipart_field(body, &delimiter, &next_part_prefix, expected)
+}
+
 fn multipart_boundary(content_type: &str) -> Option<String> {
     if !content_type
         .split(';')

--- a/crates/pentect-cli/src/http_files.rs
+++ b/crates/pentect-cli/src/http_files.rs
@@ -245,6 +245,29 @@ pub(crate) fn multipart_text_field(
     multipart_field(body, &delimiter, &next_part_prefix, expected)
 }
 
+pub(crate) fn multipart_file_name(content_type: &str, body: &[u8]) -> Option<String> {
+    let boundary = multipart_boundary(content_type)?;
+    let delimiter = format!("--{boundary}").into_bytes();
+    let mut cursor = 0;
+    while let Some(relative_start) = memmem::find(&body[cursor..], &delimiter) {
+        let after_delimiter = cursor + relative_start + delimiter.len();
+        if body.get(after_delimiter..after_delimiter + 2) == Some(b"--") {
+            break;
+        }
+        let headers_start = after_delimiter.checked_add(2)?;
+        if body.get(after_delimiter..headers_start) != Some(b"\r\n") {
+            return None;
+        }
+        let headers_relative_end = memmem::find(&body[headers_start..], b"\r\n\r\n")?;
+        let headers_end = headers_start + headers_relative_end;
+        if let Some(file) = file_part(&body[headers_start..headers_end]) {
+            return Some(file.filename);
+        }
+        cursor = headers_end + 4;
+    }
+    None
+}
+
 fn multipart_boundary(content_type: &str) -> Option<String> {
     if !content_type
         .split(';')

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -180,10 +180,8 @@ fn help_text() -> &'static str {
         "Use:\n",
         "  pentect\n",
         "  pentect codex|claude [--plugins NAME|PATH.toml]\n",
-        "  pentect codex app [--app PATH] [--upstream URL] [--plugins SOURCE] [--dry-run]\n",
-        "  pentect codex-app [--app PATH] [--upstream URL] [--dry-run]  (alias)\n",
-        "  pentect claude app [--app PATH] [--upstream URL] [--plugins SOURCE] [--dry-run]\n",
-        "  pentect claude-app [--app PATH] [--upstream URL] [--dry-run]  (alias)\n",
+        "  pentect codex app [--app PATH] [--upstream URL] [--plugins SOURCE] [--check]\n",
+        "  pentect claude app [--app PATH] [--upstream URL] [--plugins SOURCE] [--check]\n",
         "  pentect exec \"<command>\"\n\n",
         "  pentect doctor [--json | --fix [--yes]]\n",
         "  pentect update [VERSION] [--check | --force]\n",
@@ -211,7 +209,7 @@ fn help_text() -> &'static str {
         "update: verified GitHub Release binary\n",
         "uninstall: remove the binary; keep project data\n",
         "plugins: add, remove, list, search, inspect, test, config, setup, update\n",
-        "codex-app: launch Codex App through the Responses API gateway\n",
+        "codex app: launch Codex App through the Responses API gateway\n",
         "claude app: launch Claude Desktop through the Chat and Anthropic gateways\n",
     )
 }
@@ -343,7 +341,10 @@ fn cmd_agent_tool(tool: AgentTool, args: &[String]) -> i32 {
 }
 
 fn cmd_claude_app(args: &[String]) -> i32 {
-    if args.iter().any(|arg| arg == "--dry-run") {
+    if args
+        .iter()
+        .any(|arg| arg == "--check" || arg == "--dry-run")
+    {
         return claude_app_proxy::cmd_claude_app(args);
     }
     let _plugin_env = app_plugin_env_guard(args).unwrap_or_else(|error| die(error));
@@ -360,7 +361,10 @@ fn cmd_claude_app(args: &[String]) -> i32 {
 }
 
 fn cmd_codex_app(args: &[String]) -> i32 {
-    if args.iter().any(|arg| arg == "--dry-run") {
+    if args
+        .iter()
+        .any(|arg| arg == "--check" || arg == "--dry-run")
+    {
         return codex_app::cmd_codex_app(args);
     }
     let _plugin_env = app_plugin_env_guard(args).unwrap_or_else(|error| die(error));

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -32,6 +32,13 @@ use zeroize::Zeroize;
 
 pub(crate) type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 
+#[cfg(windows)]
+pub(crate) fn windows_system_executable(name: &str) -> PathBuf {
+    PathBuf::from(std::env::var_os("SystemRoot").unwrap_or_else(|| OsString::from(r"C:\Windows")))
+        .join("System32")
+        .join(name)
+}
+
 #[cfg(test)]
 pub(crate) static TEST_PROCESS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -341,10 +348,7 @@ fn cmd_agent_tool(tool: AgentTool, args: &[String]) -> i32 {
 }
 
 fn cmd_claude_app(args: &[String]) -> i32 {
-    if args
-        .iter()
-        .any(|arg| arg == "--check" || arg == "--dry-run")
-    {
+    if claude_app_proxy::check_mode(args).unwrap_or_else(|error| die(error)) {
         return claude_app_proxy::cmd_claude_app(args);
     }
     let _plugin_env = app_plugin_env_guard(args).unwrap_or_else(|error| die(error));
@@ -361,10 +365,7 @@ fn cmd_claude_app(args: &[String]) -> i32 {
 }
 
 fn cmd_codex_app(args: &[String]) -> i32 {
-    if args
-        .iter()
-        .any(|arg| arg == "--check" || arg == "--dry-run")
-    {
+    if codex_app::check_mode(args).unwrap_or_else(|error| die(error)) {
         return codex_app::cmd_codex_app(args);
     }
     let _plugin_env = app_plugin_env_guard(args).unwrap_or_else(|error| die(error));

--- a/guides/apps.md
+++ b/guides/apps.md
@@ -1,0 +1,117 @@
+# Desktop apps
+
+Pentect launches an installed desktop app only when you ask it to. Normal app
+launches are unchanged.
+
+```text
+pentect codex app
+pentect claude app
+```
+
+Quit the target app completely before launching it through Pentect. Background
+processes must also exit so every child process inherits the local gateway.
+
+Check what Pentect would use without launching anything:
+
+```text
+pentect codex app --check
+pentect claude app --check
+```
+
+## Coverage
+
+| Command | Protected surface | Not covered by this command |
+| --- | --- | --- |
+| `pentect codex app` | Codex mode in the ChatGPT desktop app, over the OpenAI Responses API | ChatGPT Chat and Work |
+| `pentect claude app` | Claude Chat completion, supported attachment uploads, outbound JSON safety scanning, and Claude Code model traffic started by the app | Remote Cowork execution, Voice, experimental binary model transports, and unrecognized future opaque routes |
+
+The local app UI is not rewritten. Text you type remains visible locally;
+Pentect replaces detected values at the outbound model boundary. Model tool-call
+arguments are resolved only at the trusted local tool boundary.
+
+Malformed or recognized-but-unsupported model formats are rejected by default.
+Other outbound Claude JSON is scanned generically so telemetry and newly added
+JSON routes do not become an easy plaintext bypass. The global compatibility
+escape hatch is documented in [configuration](configuration.md).
+
+## Codex mode
+
+`pentect codex app` starts the unmodified app and inserts a loopback-only
+Responses API gateway. It temporarily routes the selected Codex provider
+through that gateway and restores the exact previous Codex configuration when
+the app exits. An interrupted override is recovered on the next launch.
+
+The current ChatGPT desktop app and the earlier standalone Codex app are both
+auto-detected on Windows and macOS. Use `--app PATH` for another installation:
+
+```text
+pentect codex app --app "C:\path\to\ChatGPT.exe"
+```
+
+Do not run a separate Codex CLI process while this App session is open: Codex
+surfaces share `~/.codex/config.toml`, so that CLI may also see the temporary
+provider route.
+
+For a Responses-compatible custom provider or local gateway:
+
+```text
+pentect codex app --upstream http://127.0.0.1:8080/openai/v1
+```
+
+## Claude Desktop
+
+`pentect claude app` starts the unmodified app with an explicit local HTTPS
+proxy. Pentect creates an ephemeral certificate authority in memory and passes
+only its public-key fingerprint to Chromium for this process. It does not add a
+certificate to the operating-system trust store.
+
+Claude Chat request bodies on the current `completion`, numbered completion,
+and retry routes are masked before they leave the device. Completed tool-call
+inputs are restored at the local app boundary; ordinary assistant text keeps
+handles opaque. Claude Code sessions started by the app inherit the local
+Anthropic Messages gateway. `--upstream` changes the Anthropic endpoint used by
+Claude Code; it does not redirect Claude's proprietary Chat service.
+
+```text
+pentect claude app --upstream http://127.0.0.1:8080/anthropic
+```
+
+Current direct, project, Cowork-attachment, and filestore multipart upload
+routes pass through Pentect's file protection before upload. Prepared direct
+uploads are correlated with the later filestore write, so a file reference is
+trusted only after that write was protected successfully. Supported text is
+rewritten; media and partial inspection follow the configured image/document
+policy. Unknown upload routes are not claimed as protected.
+
+Claude's optional binary mobile transport and Voice WebSocket cannot currently
+be rewritten and are rejected when Pentect recognizes them. Remote Cowork work
+may execute beyond this local process boundary and is not covered.
+
+## Plugins
+
+App sessions can enable the same sandboxed plugins as the CLI. Claude Chat runs
+request middleware before masking and completed-tool-call middleware before
+local restoration:
+
+```text
+pentect codex app --plugins company-policy
+pentect claude app --plugins company-policy
+```
+
+## Troubleshooting
+
+- Run the matching `--check` command first.
+- If it reports `Running: yes`, quit the app from its menu or system tray and
+  retry. Pentect will not attach to an already-running process.
+- If auto-detection fails, pass the actual executable with `--app PATH`.
+- Run `pentect doctor` for configuration and installation checks.
+- Provider errors are shown by the app; Pentect writes only gateway metadata
+  and safe error summaries to stderr, never request bodies.
+
+Linux desktop app launchers are not release-gated. Use `--app PATH` only for an
+experimental installation and verify the exact flow before relying on it.
+
+The Windows startup smoke test used while developing this boundary verified
+ChatGPT desktop `26.721.4979.0` detection and Claude Desktop `1.24012.9.0`
+startup/API loading. Signed GUI versions still change independently of Pentect,
+so protocol tests remain the release gate.

--- a/tools/run_filtered_tests.py
+++ b/tools/run_filtered_tests.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Run a Rust test filter and fail if it selects no unit tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or not sys.argv[1].endswith("::tests"):
+        print("usage: run_filtered_tests.py MODULE::tests", file=sys.stderr)
+        return 2
+
+    test_filter = sys.argv[1]
+    command = [
+        "cargo",
+        "test",
+        "-p",
+        "pentect-cli",
+        "--no-default-features",
+        test_filter,
+        "--locked",
+    ]
+    listed = subprocess.run(
+        [*command, "--", "--list"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    print(listed.stdout, end="")
+    prefix = f"{test_filter}::"
+    if not any(line.startswith(prefix) and ": test" in line for line in listed.stdout.splitlines()):
+        print(f"no tests selected by {test_filter!r}", file=sys.stderr)
+        return 1
+    return subprocess.run(command, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- make pentect codex app detect current ChatGPT/Codex installations and safely lock, recover, and restore temporary provider routing
- protect current Claude Desktop completion/retry routes, nested tool inputs, outbound JSON, supported multipart/direct filestore uploads, and Claude Code traffic
- pass non-Claude HTTPS dependencies through without inspection while keeping Claude traffic on the ephemeral in-memory CA boundary
- add focused Windows/macOS CI plus an exact desktop app coverage guide

## Safety and compatibility
- recognized unsupported binary model transports and Voice are rejected under the default unknown-format policy
- remote Cowork execution and unrecognized future opaque routes remain explicitly out of scope
- Codex config recovery files use create-new/private writes and reject symlinks

## Verification
- cargo test -p pentect-cli --no-default-features --locked (120 unit + 12 integration tests)
- cargo clippy -p pentect-cli --no-default-features --all-targets -- -D warnings
- cargo fmt --all -- --check
- real Claude Desktop 1.24012.9.0 startup/API-loading smoke test on Windows, with no prompt submitted
- current ChatGPT/Codex 26.721.4979.0 and Claude Desktop install detection via --check

Heavy OCR/all-feature compilation is intentionally left to GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop app protection for Codex and Claude Desktop on macOS and Windows.
  * Added app status checks covering installation, configuration, running state, provider, and protection coverage.
  * Added support for chat, attachments, uploads, tool calls, streaming traffic, and plugin processing.
  * Added safer configuration recovery, session locking, and stale-lock cleanup.

* **Bug Fixes**
  * Improved app discovery, architecture selection, symlink protection, multipart handling, and non-target HTTPS routing.

* **Documentation**
  * Added a desktop app guide and updated compatibility and README documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->