### PR TITLE
chore: prepare v0.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.16"
+version = "0.0.17"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- bump the Pentect CLI version to 0.0.17
- prepare the next release containing the merged desktop gateway hardening

## Validation
- cargo metadata --no-deps --format-version 1
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Pentect CLI version to 0.0.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->