### PR TITLE
ci: scope unmaintained dependency alerts

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -37,6 +37,11 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Pentect owns maintenance decisions for direct dependencies. These
+          # informational advisories only affect transitive crates; actionable
+          # vulnerability and unsoundness advisories remain enforced at every
+          # dependency depth.
+          ignore: RUSTSEC-2023-0089,RUSTSEC-2026-0173,RUSTSEC-2026-0192
 
   rustsec-report:
     name: RustSec scheduled report
@@ -54,3 +59,5 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Keep the scheduled report aligned with the pull-request gate.
+          ignore: RUSTSEC-2023-0089,RUSTSEC-2026-0173,RUSTSEC-2026-0192


### PR DESCRIPTION
## Summary

- keep RustSec vulnerability and unsoundness enforcement across the full dependency graph
- ignore three informational unmaintained advisories that only affect transitive dependencies
- apply the same policy to pull-request and scheduled audits

## Policy

Pentect owns maintenance decisions for direct dependencies. Transitive unmaintained notices do not trigger replacement work unless they become an actionable vulnerability or unsoundness advisory.

Closes #139.
Closes #140.
Closes #141.

## Validation

- git diff --check`n- GitHub Actions validates the pinned audit action inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Security audit checks now exclude select informational advisories that do not directly affect the application.
  * Vulnerability and unsoundness advisories continue to be reported and enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->