### PR TITLE
release: prepare v0.0.18

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -20,6 +20,23 @@ Desktop vendor apps are not installed on ephemeral release runners, so their
 full signed-GUI flow is not yet a release gate. Pentect does not claim an App
 version as verified until that automation exists.
 
+## Manual live smoke tests
+
+The v0.0.18 release candidate was exercised on Windows on 2026-08-03 with
+synthetic secrets only:
+
+| Client | Version | Result |
+| --- | --- | --- |
+| Codex CLI | `0.145.0` | The provider received a handle; a completed shell tool call was restored locally to the exact synthetic value. |
+| Claude Code | `2.1.220` | A tool result reached the model as a handle; a later PowerShell tool call using that handle was restored locally to the exact synthetic value. |
+| ChatGPT desktop app (Codex mode) | `26.721.4979.0` | Installation, running-process detection, and protected Responses routing preflight passed. No signed-GUI message was sent. |
+| Claude Desktop | `1.24012.9` | The signed app launched through Pentect with the local proxy, certificate pin, and memory store attached. No signed-GUI message was sent. |
+
+The CLI checks compare the final local file with the original synthetic value
+without printing the value. They cover a real provider round trip in addition
+to the deterministic mock protocol suite. Desktop message submission remains a
+manual release task until a dedicated signed-GUI runner is available.
+
 The App rows do not imply protection for ChatGPT Chat or Work, remote Claude
 Cowork execution, Voice, experimental binary transports, or unknown future
 opaque routes. Current Claude multipart attachment flows are protected as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.17"
+version = "0.0.18"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- bump the CLI to v0.0.18
- document real-provider Codex CLI and Claude Code round-trip smoke results using synthetic secrets
- document signed desktop app launcher/preflight coverage precisely
- include the merged CredSweeper 1.17.2 update in the next release

## Local verification

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `python tools/update_package_metadata.py --metadata-file packaging/release.json --check`
- `git diff --check`
- downloaded v0.0.17 Windows asset and verified its published SHA-256
- Codex CLI 0.145.0: real provider saw a handle; completed shell tool call restored to the exact synthetic value
- Claude Code 2.1.220: tool output was masked to a handle; a later PowerShell call restored the exact synthetic value
- Codex App 26.721.4979.0: protected routing preflight passed
- Claude Desktop 1.24012.9: launched with Pentect proxy, certificate pin, and memory store attached

Full repository and release builds are delegated to GitHub Actions because native OCR compilation is intentionally not repeated on the workstation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added manual live smoke-test results for the v0.0.18 release candidate across supported Windows integrations.
  * Documented tested versions, outcomes, synthetic-secret handling, and the distinction between completed CLI tests and desktop preflight checks.

* **Release**
  * Updated the application version to 0.0.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->