### PR TITLE
fix: authenticate GitHub release update checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,8 @@ jobs:
       - name: Install, update, and uninstall (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           $version = $env:GITHUB_REF_NAME.TrimStart('v')
           $env:PENTECT_INSTALL_DIR = Join-Path $env:RUNNER_TEMP 'pentect-lifecycle\bin'
@@ -348,6 +350,8 @@ jobs:
       - name: Install, update, and uninstall (POSIX)
         if: runner.os != 'Windows'
         shell: sh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
           version=${GITHUB_REF_NAME#v}

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,8 +22,9 @@ version as verified until that automation exists.
 
 ## Manual live smoke tests
 
-The v0.0.18 release candidate was exercised on Windows on 2026-08-03 with
-synthetic secrets only:
+The protected client behavior carried into v0.0.19 was exercised on Windows on
+2026-08-03 against the v0.0.17 release binary, using synthetic secrets only.
+The gateway code did not change between those releases:
 
 | Client | Version | Result |
 | --- | --- | --- |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.18"
+version = "0.0.19"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -242,8 +242,11 @@ fn get_response<T: for<'de> Deserialize<'de>>(
     url: &str,
     max_bytes: u64,
 ) -> Result<T, String> {
-    let response = client
-        .get(url)
+    let mut request = client.get(url);
+    if let Some(token) = github_token() {
+        request = request.bearer_auth(token);
+    }
+    let response = request
         .send()
         .map_err(|e| format!("could not fetch GitHub release: {e}"))?;
     if !response.status().is_success() {
@@ -267,6 +270,19 @@ fn get_response<T: for<'de> Deserialize<'de>>(
         return Err("GitHub release response is too large".to_string());
     }
     serde_json::from_slice(&bytes).map_err(|e| format!("invalid GitHub release response: {e}"))
+}
+
+fn github_token() -> Option<String> {
+    github_token_from(|name| std::env::var(name).ok())
+}
+
+fn github_token_from(mut read: impl FnMut(&str) -> Option<String>) -> Option<String> {
+    ["GH_TOKEN", "GITHUB_TOKEN"].into_iter().find_map(|name| {
+        read(name).and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_string())
+        })
+    })
 }
 
 fn release_version(tag: &str) -> Result<Version, String> {
@@ -534,5 +550,22 @@ mod tests {
         assert!(validate_repository("EdamAme-x/pentect").is_ok());
         assert!(validate_repository("owner/repo/extra").is_err());
         assert!(validate_repository("owner/../repo").is_err());
+    }
+
+    #[test]
+    fn selects_a_non_empty_github_token_without_exposing_it() {
+        let token = github_token_from(|name| match name {
+            "GH_TOKEN" => Some("  ".to_string()),
+            "GITHUB_TOKEN" => Some(" test-token ".to_string()),
+            _ => None,
+        });
+        assert_eq!(token.as_deref(), Some("test-token"));
+
+        let token = github_token_from(|name| match name {
+            "GH_TOKEN" => Some("preferred".to_string()),
+            "GITHUB_TOKEN" => Some("fallback".to_string()),
+            _ => None,
+        });
+        assert_eq!(token.as_deref(), Some("preferred"));
     }
 }


### PR DESCRIPTION
## Root cause

The v0.0.18 release lifecycle gate installed the signed macOS asset successfully, then `pentect update 0.0.18 --force` hit GitHub's anonymous Releases API rate limit (`HTTP 403`). Windows and Linux lifecycle jobs passed; stable promotion correctly stopped.

## Fix

- use `GH_TOKEN`, falling back to `GITHUB_TOKEN`, for GitHub Releases API requests when either is available
- keep release asset downloads and checksum verification unchanged
- pass the workflow's read-only token to all lifecycle update tests
- add a unit test for token precedence/empty-value handling
- bump the recovery release to v0.0.19

The token is attached only to GitHub API requests and is never logged.

## Local verification

- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1`
- `python tools/update_package_metadata.py --metadata-file packaging/release.json --check`
- `git diff --check`

The focused Rust test was intentionally stopped after dependency compilation exceeded 40 seconds; full tests run on GitHub Actions to avoid local OCR build load.