### PR TITLE
ci: allow full Windows release link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
             asset: pentect-macos-aarch64
             binary: target/release/pentect
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,7 +22,7 @@ version as verified until that automation exists.
 
 ## Manual live smoke tests
 
-The protected client behavior carried into v0.0.19 was exercised on Windows on
+The protected client behavior carried into v0.0.20 was exercised on Windows on
 2026-08-03 against the v0.0.17 release binary, using synthetic secrets only.
 The gateway code did not change between those releases:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.19"
+version = "0.0.20"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Root cause

The v0.0.19 Windows release build was still compiling when the shared 30-minute build timeout canceled it at 30m11s. Linux x86_64/arm64 and macOS arm64/x86_64 all built and attested successfully. No compiler error occurred.

## Fix

- raise only the multi-platform release build job timeout from 30 to 60 minutes
- prepare v0.0.20 as the next immutable recovery release

All validation, lifecycle, and publishing job timeouts remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented Windows manual smoke-test release to v0.0.20.

* **Chores**
  * Extended the release build timeout to improve reliability for longer builds.
  * Bumped the command-line package version to v0.0.20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->