### PR TITLE
fix: serialize Windows update cleanup

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,7 +22,7 @@ version as verified until that automation exists.
 
 ## Manual live smoke tests
 
-The protected client behavior carried into v0.0.20 was exercised on Windows on
+The protected client behavior carried into v0.0.21 was exercised on Windows on
 2026-08-03 against the v0.0.17 release binary, using synthetic secrets only.
 The gateway code did not change between those releases:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.20"
+version = "0.0.21"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/uninstall.rs
+++ b/crates/pentect-cli/src/uninstall.rs
@@ -101,14 +101,29 @@ for ($attempt = 0; $attempt -lt 3000; $attempt++) {
     Start-Sleep -Milliseconds 100
 }
 $installDir = Split-Path -Parent $Target
+for ($attempt = 0; $attempt -lt 3000; $attempt++) {
+    $updateRunning = Get-Process -Name 'pentect.update-*' -ErrorAction SilentlyContinue |
+        Where-Object {
+            try { [string]::Equals((Split-Path -Parent $_.Path), $installDir, [StringComparison]::OrdinalIgnoreCase) }
+            catch { $false }
+        } |
+        Select-Object -First 1
+    if ($null -eq $updateRunning) { break }
+    Start-Sleep -Milliseconds 100
+}
 $pathAdded = $false
 if (Test-Path -LiteralPath $Marker) {
     try { $pathAdded = [bool]((Get-Content -Raw -LiteralPath $Marker | ConvertFrom-Json).path_added) } catch {}
 }
-Remove-Item -LiteralPath $Target -Force
+for ($attempt = 0; $attempt -lt 600; $attempt++) {
+    Remove-Item -LiteralPath $Target -Force
+    if (-not (Test-Path -LiteralPath $Target)) { break }
+    Start-Sleep -Milliseconds 100
+}
 if (Test-Path -LiteralPath $Target) { exit 1 }
 $name = Split-Path -Leaf $Target
 Get-ChildItem -LiteralPath $installDir -Filter "$name.previous-*" -File | Remove-Item -Force
+Get-ChildItem -LiteralPath $installDir -Filter 'pentect.update-*.exe' -File | Remove-Item -Force
 Remove-Item -LiteralPath $Marker -Force
 if ($pathAdded) {
     $pathKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)

--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -493,7 +493,10 @@ fn apply_update(args: &[String]) -> Result<(), String> {
     let backup = Path::new(backup);
     for _ in 0..600 {
         match std::fs::copy(&source, destination) {
-            Ok(_) if sha256_file(destination)? == expected.to_ascii_lowercase() => return Ok(()),
+            Ok(_) if sha256_file(destination)? == expected.to_ascii_lowercase() => {
+                let _ = spawn_windows_staged_cleanup(&source);
+                return Ok(());
+            }
             Ok(_) => {
                 let _ = std::fs::copy(backup, destination);
                 return Err("installed update checksum mismatch".to_string());
@@ -502,6 +505,56 @@ fn apply_update(args: &[String]) -> Result<(), String> {
         }
     }
     Err("timed out waiting to replace the executable".to_string())
+}
+
+#[cfg(windows)]
+fn spawn_windows_staged_cleanup(staged: &Path) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    const SCRIPT: &str = r#"param(
+    [Parameter(Mandatory=$true)][int]$ParentPid,
+    [Parameter(Mandatory=$true)][string]$Target
+)
+$ErrorActionPreference = 'SilentlyContinue'
+for ($attempt = 0; $attempt -lt 600; $attempt++) {
+    if (-not (Get-Process -Id $ParentPid -ErrorAction SilentlyContinue)) { break }
+    Start-Sleep -Milliseconds 100
+}
+for ($attempt = 0; $attempt -lt 600; $attempt++) {
+    Remove-Item -LiteralPath $Target -Force
+    if (-not (Test-Path -LiteralPath $Target)) { break }
+    Start-Sleep -Milliseconds 100
+}
+Remove-Item -LiteralPath $PSCommandPath -Force
+"#;
+
+    let helper = std::env::temp_dir().join(format!(
+        "pentect-update-cleanup-{}-{}.ps1",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos())
+    ));
+    std::fs::write(&helper, SCRIPT)
+        .map_err(|error| format!("could not create update cleanup helper: {error}"))?;
+    Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-WindowStyle",
+            "Hidden",
+            "-File",
+        ])
+        .arg(&helper)
+        .arg("-ParentPid")
+        .arg(std::process::id().to_string())
+        .arg("-Target")
+        .arg(staged)
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| format!("could not start update cleanup helper: {error}"))
 }
 
 #[cfg(test)]

--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -494,6 +494,7 @@ fn apply_update(args: &[String]) -> Result<(), String> {
     for _ in 0..600 {
         match std::fs::copy(&source, destination) {
             Ok(_) if sha256_file(destination)? == expected.to_ascii_lowercase() => {
+                #[cfg(windows)]
                 let _ = spawn_windows_staged_cleanup(&source);
                 return Ok(());
             }


### PR DESCRIPTION
## Root cause

The v0.0.20 Windows lifecycle installed and force-updated successfully, then invoked uninstall about 300ms later. The asynchronous update helper was still active, racing the asynchronous uninstall helper; the destination executable remained after the 10-second check.

Inspection also found that successful Windows updates left the staged `pentect.update-*.exe` behind. A real 50 MB residue from an earlier update was reproduced locally.

## Fix

- schedule deletion of the staged Windows update executable after its helper exits
- make Windows uninstall wait for update helpers in the same install directory
- retry target deletion to tolerate transient Windows file locks
- remove old update staging files together with update backups during uninstall
- prepare v0.0.21 as the next immutable recovery release

Paths are passed as PowerShell arguments, not interpolated into scripts. Cleanup remains scoped to Pentect's exact install directory and generated filename patterns.

## Verification

- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1`
- `python tools/update_package_metadata.py --metadata-file packaging/release.json --check`
- `git diff --check`
- full Windows lifecycle runs in the release workflow