### PR TITLE
fix: serialize Windows update and uninstall

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,7 +22,7 @@ version as verified until that automation exists.
 
 ## Manual live smoke tests
 
-The protected client behavior carried into v0.0.21 was exercised on Windows on
+The protected client behavior carried into v0.0.22 was exercised on Windows on
 2026-08-03 against the v0.0.17 release binary, using synthetic secrets only.
 The gateway code did not change between those releases:
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,7 +22,7 @@ version as verified until that automation exists.
 
 ## Manual live smoke tests
 
-The protected client behavior carried into v0.0.22 was exercised on Windows on
+The protected client behavior carried into v0.0.23 was exercised on Windows on
 2026-08-03 against the v0.0.17 release binary, using synthetic secrets only.
 The gateway code did not change between those releases:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.21"
+version = "0.0.22"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.22"
+version = "0.0.23"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/uninstall.rs
+++ b/crates/pentect-cli/src/uninstall.rs
@@ -108,7 +108,8 @@ for ($attempt = 0; $attempt -lt 3000; $attempt++) {
             catch { $false }
         } |
         Select-Object -First 1
-    if ($null -eq $updateRunning) { break }
+    $stagedUpdates = @(Get-ChildItem -LiteralPath $installDir -Filter 'pentect.update-*.exe' -File)
+    if (($null -eq $updateRunning) -and ($stagedUpdates.Count -eq 0)) { break }
     Start-Sleep -Milliseconds 100
 }
 $pathAdded = $false
@@ -117,7 +118,20 @@ if (Test-Path -LiteralPath $Marker) {
 }
 for ($attempt = 0; $attempt -lt 600; $attempt++) {
     Remove-Item -LiteralPath $Target -Force
-    if (-not (Test-Path -LiteralPath $Target)) { break }
+    if (-not (Test-Path -LiteralPath $Target)) {
+        # An update helper may have passed its process check but not completed
+        # the final copy yet. Require a short quiet period before declaring the
+        # target gone so a late replacement is removed as well.
+        $remainedAbsent = $true
+        for ($quiet = 0; $quiet -lt 20; $quiet++) {
+            Start-Sleep -Milliseconds 100
+            if (Test-Path -LiteralPath $Target) {
+                $remainedAbsent = $false
+                break
+            }
+        }
+        if ($remainedAbsent) { break }
+    }
     Start-Sleep -Milliseconds 100
 }
 if (Test-Path -LiteralPath $Target) { exit 1 }

--- a/crates/pentect-cli/src/uninstall.rs
+++ b/crates/pentect-cli/src/uninstall.rs
@@ -101,6 +101,7 @@ for ($attempt = 0; $attempt -lt 3000; $attempt++) {
     Start-Sleep -Milliseconds 100
 }
 $installDir = Split-Path -Parent $Target
+$updatesQuiesced = $false
 for ($attempt = 0; $attempt -lt 3000; $attempt++) {
     $updateRunning = Get-Process -Name 'pentect.update-*' -ErrorAction SilentlyContinue |
         Where-Object {
@@ -109,9 +110,13 @@ for ($attempt = 0; $attempt -lt 3000; $attempt++) {
         } |
         Select-Object -First 1
     $stagedUpdates = @(Get-ChildItem -LiteralPath $installDir -Filter 'pentect.update-*.exe' -File)
-    if (($null -eq $updateRunning) -and ($stagedUpdates.Count -eq 0)) { break }
+    if (($null -eq $updateRunning) -and ($stagedUpdates.Count -eq 0)) {
+        $updatesQuiesced = $true
+        break
+    }
     Start-Sleep -Milliseconds 100
 }
+if (-not $updatesQuiesced) { exit 1 }
 $pathAdded = $false
 if (Test-Path -LiteralPath $Marker) {
     try { $pathAdded = [bool]((Get-Content -Raw -LiteralPath $Marker | ConvertFrom-Json).path_added) } catch {}


### PR DESCRIPTION
## Summary
- wait for staged Windows updates to finish before uninstalling
- require a quiet period so late replacements cannot recreate the binary
- prepare v0.0.22 after the v0.0.21 lifecycle failure

## Verification
- cargo check -p pentect-cli --tests`n- full platform and lifecycle coverage runs in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows uninstall reliability by waiting for active updates and staged files to clear before completing removal.
  * Added verification that the application executable remains deleted after uninstall.

* **Documentation**
  * Updated the manual smoke-test reference for the latest release.

* **Chores**
  * Bumped the CLI version to 0.0.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->