### PR TITLE
fix: make distribution automation self-starting

### DIFF
--- a/.github/workflows/distribution-health.yml
+++ b/.github/workflows/distribution-health.yml
@@ -28,9 +28,10 @@ jobs:
           test "$(jq -r .tag packaging/release.json)" = "$tag"
           version=${tag#v}
           test "$(jq -r .version packaging/release.json)" = "$version"
-          curl -fsSL --proto '=https' --tlsv1.2 \
-            https://raw.githubusercontent.com/EdamAme-x/homebrew-pentect/main/Formula/pentect.rb \
-            -o "$RUNNER_TEMP/pentect.rb"
+          gh api \
+            repos/EdamAme-x/homebrew-pentect/contents/Formula/pentect.rb \
+            -H 'Accept: application/vnd.github.raw' \
+            > "$RUNNER_TEMP/pentect.rb"
           grep -Fq "version \"$version\"" "$RUNNER_TEMP/pentect.rb"
       - name: Verify signed APT repository and key lifetime
         run: |

--- a/tools/propose_automation_pr.sh
+++ b/tools/propose_automation_pr.sh
@@ -39,6 +39,11 @@ if [ -z "$pull" ]; then
     --body "$body")
 fi
 
+# Pushes authenticated with GITHUB_TOKEN do not trigger other workflows. Start
+# the required branch checks explicitly so automation PRs can actually merge.
+gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
+gh workflow run nix.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
+
 gh pr merge "$pull" --repo "$GITHUB_REPOSITORY" --auto --merge --delete-branch \
   --match-head-commit "$(git rev-parse HEAD)" >&2
 printf '%s\n' "$pull"

--- a/tools/test_propose_automation_pr.sh
+++ b/tools/test_propose_automation_pr.sh
@@ -17,6 +17,7 @@ case "$1 $2" in
   "pr list") exit 0 ;;
   "pr create") printf '%s\n' https://github.com/example/project/pull/1 ;;
   "pr merge") printf '%s\n' 'merge scheduled' ;;
+  "workflow run") exit 0 ;;
   *) echo "unexpected gh invocation: $*" >&2; exit 1 ;;
 esac
 EOF


### PR DESCRIPTION
Fetch Homebrew metadata through the GitHub API to avoid stale CDN reads. Explicitly dispatch CI and Nix checks for automation branches pushed with GITHUB_TOKEN. Shell syntax, harness, and diff checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval of Homebrew distribution data for more reliable health checks.
  * Automation now explicitly starts required continuous integration checks before attempting to merge changes.

* **Tests**
  * Updated automation test coverage to support workflow dispatch commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->