### PR TITLE
test: close release compatibility gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,21 @@ jobs:
           python tools/update_package_metadata.py --metadata-file packaging/release.json --check
           sh -n tools/install.sh tools/install-apt.sh tools/package_deb.sh tools/build_apt_repository.sh tools/propose_automation_pr.sh
           sh tools/test_propose_automation_pr.sh
+      - name: Validate PowerShell tools
+        shell: pwsh
+        run: |
+          foreach ($path in @('tools/install.ps1', 'tools/release_live_e2e.ps1')) {
+            $tokens = $null
+            $errors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile(
+              (Resolve-Path $path),
+              [ref]$tokens,
+              [ref]$errors
+            )
+            if ($errors.Count -ne 0) {
+              throw "$path`n$($errors | Out-String)"
+            }
+          }
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Check WebAssembly plugin SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,15 +48,17 @@ jobs:
       - name: Validate PowerShell installer
         shell: pwsh
         run: |
-          $tokens = $null
-          $errors = $null
-          [void][System.Management.Automation.Language.Parser]::ParseFile(
-            (Resolve-Path 'tools/install.ps1'),
-            [ref]$tokens,
-            [ref]$errors
-          )
-          if ($errors.Count -ne 0) {
-            throw ($errors | Out-String)
+          foreach ($path in @('tools/install.ps1', 'tools/release_live_e2e.ps1')) {
+            $tokens = $null
+            $errors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile(
+              (Resolve-Path $path),
+              [ref]$tokens,
+              [ref]$errors
+            )
+            if ($errors.Count -ne 0) {
+              throw "$path`n$($errors | Out-String)"
+            }
           }
       - name: Verify third-party licenses
         run: python tools/generate_licenses.py --check

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,21 +22,21 @@ version as verified until that automation exists.
 
 ## Manual live smoke tests
 
-The protected client behavior carried into v0.0.23 was exercised on Windows on
-2026-08-03 against the v0.0.17 release binary, using synthetic secrets only.
-The gateway code did not change between those releases:
+The v0.0.23 release binary was exercised on Windows on 2026-08-04 using
+synthetic secrets only. The reusable probe is `tools/release_live_e2e.ps1`:
 
 | Client | Version | Result |
 | --- | --- | --- |
-| Codex CLI | `0.145.0` | The provider received a handle; a completed shell tool call was restored locally to the exact synthetic value. |
-| Claude Code | `2.1.220` | A tool result reached the model as a handle; a later PowerShell tool call using that handle was restored locally to the exact synthetic value. |
-| ChatGPT desktop app (Codex mode) | `26.721.4979.0` | Installation, running-process detection, and protected Responses routing preflight passed. No signed-GUI message was sent. |
-| Claude Desktop | `1.24012.9` | The signed app launched through Pentect with the local proxy, certificate pin, and memory store attached. No signed-GUI message was sent. |
+| Codex CLI | `0.145.0` | A completed shell tool call was restored locally to the exact synthetic value. |
+| Claude Code | `2.1.220` | A later PowerShell tool call using the opaque value was restored locally to the exact synthetic value; final output did not contain it. |
+| ChatGPT desktop app (Codex mode) | `26.721.4979.0` | v0.0.23 installation, running-process detection, and protected Responses routing preflight passed. No signed-GUI message was sent. |
+| Claude Desktop | `1.24012.9` | The signed app launched through v0.0.23 with the local proxy, certificate pin, and memory store attached. No signed-GUI message was sent. |
 
-The CLI checks compare the final local file with the original synthetic value
-without printing the value. They cover a real provider round trip in addition
-to the deterministic mock protocol suite. Desktop message submission remains a
-manual release task until a dedicated signed-GUI runner is available.
+The CLI probe compares the final local file with the original synthetic value
+without printing the value and deletes its temporary files. It covers a real
+provider round trip in addition to the deterministic mock protocol suite.
+Desktop message submission remains a manual release task until a dedicated
+signed-GUI runner is available.
 
 The App rows do not imply protection for ChatGPT Chat or Work, remote Claude
 Cowork execution, Voice, experimental binary transports, or unknown future

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,8 +22,9 @@ version as verified until that automation exists.
 
 ## Manual live smoke tests
 
-The v0.0.23 release binary was exercised on Windows on 2026-08-04 using
-synthetic secrets only. The reusable probe is `tools/release_live_e2e.ps1`:
+The v0.0.23 release binary was exercised on Windows on 2026-08-03 UTC
+(2026-08-04 JST) using synthetic secrets only. The reusable probe is
+`tools/release_live_e2e.ps1`:
 
 | Client | Version | Result |
 | --- | --- | --- |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.23"
+version = "0.0.24"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2102,6 +2102,67 @@ mod tests {
         None
     }
 
+    fn first_openai_file_handle(body: &str) -> Option<String> {
+        fn visit(value: &Value) -> Option<String> {
+            match value {
+                Value::Array(values) => values.iter().find_map(visit),
+                Value::Object(object) => {
+                    if let Some(data) = object.get("file_data").and_then(Value::as_str) {
+                        let encoded = data.split_once(',').map_or(data, |(_, encoded)| encoded);
+                        let decoded = data_encoding::BASE64.decode(encoded.as_bytes()).ok()?;
+                        let decoded = std::str::from_utf8(&decoded).ok()?;
+                        if let Some(handle) = first_valid_handle(decoded) {
+                            return Some(handle.to_string());
+                        }
+                    }
+                    object.values().find_map(visit)
+                }
+                _ => None,
+            }
+        }
+
+        serde_json::from_str(body)
+            .ok()
+            .and_then(|value| visit(&value))
+    }
+
+    fn read_http_request(stream: &mut std::net::TcpStream) -> (String, Vec<u8>) {
+        use std::io::Read;
+
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(10)))
+            .unwrap();
+        let mut request = Vec::new();
+        let mut buffer = [0u8; 8192];
+        let header_end = loop {
+            let read = stream.read(&mut buffer).unwrap();
+            assert!(read > 0, "client closed before sending HTTP headers");
+            request.extend_from_slice(&buffer[..read]);
+            if let Some(at) = request.windows(4).position(|part| part == b"\r\n\r\n") {
+                break at + 4;
+            }
+        };
+        let headers = String::from_utf8(request[..header_end].to_vec()).unwrap();
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        while request.len() - header_end < content_length {
+            let read = stream.read(&mut buffer).unwrap();
+            assert!(read > 0, "client closed before sending HTTP body");
+            request.extend_from_slice(&buffer[..read]);
+        }
+        (
+            headers,
+            request[header_end..header_end + content_length].to_vec(),
+        )
+    }
+
     fn mock_upstream(
         provider: MockProvider,
     ) -> (
@@ -2109,43 +2170,15 @@ mod tests {
         std::sync::mpsc::Receiver<String>,
         std::thread::JoinHandle<()>,
     ) {
-        use std::io::{Read, Write};
+        use std::io::Write;
 
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let address = listener.local_addr().unwrap();
         let (body_tx, body_rx) = std::sync::mpsc::channel();
         let thread = std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
-            stream
-                .set_read_timeout(Some(std::time::Duration::from_secs(10)))
-                .unwrap();
-            let mut request = Vec::new();
-            let mut buffer = [0u8; 8192];
-            let header_end = loop {
-                let read = stream.read(&mut buffer).unwrap();
-                assert!(read > 0, "client closed before sending HTTP headers");
-                request.extend_from_slice(&buffer[..read]);
-                if let Some(at) = request.windows(4).position(|part| part == b"\r\n\r\n") {
-                    break at + 4;
-                }
-            };
-            let headers = String::from_utf8_lossy(&request[..header_end]);
-            let content_length = headers
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    name.eq_ignore_ascii_case("content-length")
-                        .then(|| value.trim().parse::<usize>().ok())
-                        .flatten()
-                })
-                .expect("proxy request must carry Content-Length");
-            while request.len() - header_end < content_length {
-                let read = stream.read(&mut buffer).unwrap();
-                assert!(read > 0, "client closed before sending HTTP body");
-                request.extend_from_slice(&buffer[..read]);
-            }
-            let body = String::from_utf8(request[header_end..header_end + content_length].to_vec())
-                .unwrap();
+            let (_, body) = read_http_request(&mut stream);
+            let body = String::from_utf8(body).unwrap();
             let handle = first_valid_handle(&body)
                 .expect("provider should receive a valid Pentect handle")
                 .to_string();
@@ -2197,6 +2230,59 @@ mod tests {
             .unwrap();
             stream.write_all(&response).unwrap();
             stream.flush().unwrap();
+        });
+        (format!("http://{address}"), body_rx, thread)
+    }
+
+    fn mock_openai_file_upstream(
+        file_body: String,
+    ) -> (
+        String,
+        std::sync::mpsc::Receiver<String>,
+        std::thread::JoinHandle<()>,
+    ) {
+        use std::io::Write;
+
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let (body_tx, body_rx) = std::sync::mpsc::channel();
+        let thread = std::thread::spawn(move || {
+            let (mut file_stream, _) = listener.accept().unwrap();
+            let (file_headers, file_request_body) = read_http_request(&mut file_stream);
+            assert!(file_headers.starts_with("GET /files/file-test/content "));
+            assert!(file_request_body.is_empty());
+            write!(
+                file_stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Disposition: attachment; filename=\"notes.txt\"\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                file_body.len()
+            )
+            .unwrap();
+            file_stream.write_all(file_body.as_bytes()).unwrap();
+            file_stream.flush().unwrap();
+
+            let (mut response_stream, _) = listener.accept().unwrap();
+            let (_, body) = read_http_request(&mut response_stream);
+            let body = String::from_utf8(body).unwrap();
+            let handle = first_openai_file_handle(&body)
+                .expect("provider should receive a handle for fetched file content");
+            body_tx.send(body).unwrap();
+            let event = serde_json::json!({
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "custom_tool_call",
+                    "name": "exec_command",
+                    "input": format!("python hash.py {handle}")
+                }
+            });
+            let response = format!("event: response.output_item.done\ndata: {event}\n\n");
+            write!(
+                response_stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response.len(),
+                response
+            )
+            .unwrap();
+            response_stream.flush().unwrap();
         });
         (format!("http://{address}"), body_rx, thread)
     }
@@ -2288,6 +2374,78 @@ mod tests {
         assert!(!openai_response.contains("<<PENTECT_E2E_TOKEN_"));
         drop(openai_proxy);
         openai_thread.join().unwrap();
+
+        for provider in [MockProvider::OpenAi, MockProvider::Anthropic] {
+            let (upload_upstream, upload_request, upload_thread) = mock_upstream(provider);
+            let (upload_url, guard): (String, Box<dyn std::any::Any>) = match provider {
+                MockProvider::OpenAi => {
+                    let guard =
+                        crate::openai_http_proxy::OpenAiHttpProxyGuard::start(upload_upstream)
+                            .unwrap();
+                    (format!("{}/v1/files", guard.base_url()), Box::new(guard))
+                }
+                MockProvider::Anthropic => {
+                    let guard = ClaudeHttpProxyGuard::start(upload_upstream).unwrap();
+                    (format!("{}/v1/files", guard.base_url()), Box::new(guard))
+                }
+            };
+            let boundary = "pentect-provider-boundary";
+            let upload_body = format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nuser_data\r\n--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"secrets.env\"\r\nContent-Type: text/plain\r\n\r\n{dotenv}\r\n--{boundary}--\r\n"
+            );
+            reqwest::blocking::Client::new()
+                .post(upload_url)
+                .header(
+                    reqwest::header::CONTENT_TYPE,
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(upload_body)
+                .send()
+                .unwrap()
+                .error_for_status()
+                .unwrap();
+            let provider_body = upload_request
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .unwrap();
+            assert!(!provider_body.contains(secret.as_str()));
+            assert!(first_valid_handle(&provider_body).is_some());
+            drop(guard);
+            upload_thread.join().unwrap();
+        }
+
+        let (file_upstream, file_request, file_thread) = mock_openai_file_upstream(dotenv.clone());
+        let file_proxy =
+            crate::openai_http_proxy::OpenAiHttpProxyGuard::start(file_upstream).unwrap();
+        let file_response = reqwest::blocking::Client::new()
+            .post(format!("{}/v1/responses", file_proxy.base_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(reqwest::header::AUTHORIZATION, "Bearer synthetic-test")
+            .body(
+                serde_json::to_vec(&serde_json::json!({
+                    "model": "test",
+                    "stream": true,
+                    "input": [{
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_file", "file_id": "file-test"}]
+                    }]
+                }))
+                .unwrap(),
+            )
+            .send()
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .text()
+            .unwrap();
+        let provider_body = file_request
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .unwrap();
+        assert!(!provider_body.contains(secret.as_str()));
+        assert!(first_openai_file_handle(&provider_body).is_some());
+        assert!(file_response.contains(&format!("python hash.py {secret}")));
+        drop(file_proxy);
+        file_thread.join().unwrap();
     }
 
     #[test]

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2102,17 +2102,22 @@ mod tests {
         None
     }
 
-    fn first_openai_file_handle(body: &str) -> Option<String> {
-        fn visit(value: &Value) -> Option<String> {
+    fn first_openai_file(body: &str) -> Option<(String, String, String)> {
+        fn visit(value: &Value) -> Option<(String, String, String)> {
             match value {
                 Value::Array(values) => values.iter().find_map(visit),
                 Value::Object(object) => {
                     if let Some(data) = object.get("file_data").and_then(Value::as_str) {
-                        let encoded = data.split_once(',').map_or(data, |(_, encoded)| encoded);
+                        let (metadata, encoded) = data.split_once(',')?;
+                        let media_type = metadata
+                            .strip_prefix("data:")?
+                            .strip_suffix(";base64")?
+                            .to_string();
                         let decoded = data_encoding::BASE64.decode(encoded.as_bytes()).ok()?;
                         let decoded = std::str::from_utf8(&decoded).ok()?;
                         if let Some(handle) = first_valid_handle(decoded) {
-                            return Some(handle.to_string());
+                            let filename = object.get("filename")?.as_str()?.to_string();
+                            return Some((handle.to_string(), media_type, filename));
                         }
                     }
                     object.values().find_map(visit)
@@ -2250,6 +2255,9 @@ mod tests {
             let (mut file_stream, _) = listener.accept().unwrap();
             let (file_headers, file_request_body) = read_http_request(&mut file_stream);
             assert!(file_headers.starts_with("GET /files/file-test/content "));
+            assert!(file_headers
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case("authorization: bearer synthetic-test")));
             assert!(file_request_body.is_empty());
             write!(
                 file_stream,
@@ -2263,8 +2271,9 @@ mod tests {
             let (mut response_stream, _) = listener.accept().unwrap();
             let (_, body) = read_http_request(&mut response_stream);
             let body = String::from_utf8(body).unwrap();
-            let handle = first_openai_file_handle(&body)
-                .expect("provider should receive a handle for fetched file content");
+            let handle = first_openai_file(&body)
+                .expect("provider should receive a handle for fetched file content")
+                .0;
             body_tx.send(body).unwrap();
             let event = serde_json::json!({
                 "type": "response.output_item.done",
@@ -2442,7 +2451,10 @@ mod tests {
             .recv_timeout(std::time::Duration::from_secs(10))
             .unwrap();
         assert!(!provider_body.contains(secret.as_str()));
-        assert!(first_openai_file_handle(&provider_body).is_some());
+        let (_, media_type, filename) = first_openai_file(&provider_body)
+            .expect("provider should receive the sanitized file and metadata");
+        assert_eq!(media_type, "text/plain");
+        assert_eq!(filename, "notes.txt");
         assert!(file_response.contains(&format!("python hash.py {secret}")));
         drop(file_proxy);
         file_thread.join().unwrap();

--- a/tools/release_live_e2e.ps1
+++ b/tools/release_live_e2e.ps1
@@ -61,6 +61,9 @@ with only DONE.
     if ([IO.File]::ReadAllText($resultPath) -cne $synthetic) {
         throw "$Name did not restore the exact synthetic value at the local tool boundary"
     }
+    # Codex intentionally renders local tool stdout to its user. Provider-side
+    # redaction is asserted directly by the Rust boundary suite; only Claude's
+    # final response is expected to omit the locally restored value here.
     if ($Name -eq 'claude' -and $output.IndexOf($synthetic, [StringComparison]::Ordinal) -ge 0) {
         throw 'Claude final output exposed the synthetic value'
     }

--- a/tools/release_live_e2e.ps1
+++ b/tools/release_live_e2e.ps1
@@ -1,0 +1,85 @@
+[CmdletBinding()]
+param(
+    [string]$Pentect,
+    [ValidateSet('all', 'codex', 'claude')]
+    [string]$Client = 'all'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Pentect) {
+    $command = Get-Command pentect -ErrorAction Stop
+    $Pentect = $command.Source
+}
+$Pentect = [IO.Path]::GetFullPath($Pentect)
+if (-not (Test-Path -LiteralPath $Pentect -PathType Leaf)) {
+    throw "Pentect executable not found: $Pentect"
+}
+
+$clients = if ($Client -eq 'all') { @('codex', 'claude') } else { @($Client) }
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ("pentect-live-e2e-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $testRoot | Out-Null
+$previousValue = [Environment]::GetEnvironmentVariable('PENTECT_E2E_VALUE', 'Process')
+$synthetic = @('rpa_', 'PENTECT_', 'SYNTHETIC_', 'ONLY_', '0123456789abcdef') -join ''
+
+function Invoke-ClientProbe {
+    param([Parameter(Mandatory)][string]$Name)
+
+    $resultPath = Join-Path $testRoot "$Name-result.txt"
+    $escapedResultPath = $resultPath.Replace("'", "''")
+    $prompt = @"
+Use the PowerShell tool twice. First output
+[Environment]::GetEnvironmentVariable('PENTECT_E2E_VALUE'). You should receive
+an opaque Pentect handle. Copy that handle byte-for-byte into a second
+PowerShell command that calls
+[IO.File]::WriteAllText('$escapedResultPath', '<HANDLE>'), replacing <HANDLE>
+with exactly the returned handle. Do not reveal or explain the value. Finish
+with only DONE.
+"@
+
+    # Windows PowerShell 5.1 wraps native stderr as ErrorRecord objects. Both
+    # clients write progress to stderr, so capture it without treating normal
+    # progress as a terminating PowerShell error.
+    $savedErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = if ($Name -eq 'codex') {
+            & $Pentect codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check $prompt 2>&1 | Out-String
+        } else {
+            & $Pentect claude --dangerously-skip-permissions -p $prompt 2>&1 | Out-String
+        }
+        $clientExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
+    if ($clientExitCode -ne 0) {
+        throw "$Name exited with code $clientExitCode"
+    }
+    if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
+        throw "$Name did not create its result file"
+    }
+    if ([IO.File]::ReadAllText($resultPath) -cne $synthetic) {
+        throw "$Name did not restore the exact synthetic value at the local tool boundary"
+    }
+    if ($Name -eq 'claude' -and $output.IndexOf($synthetic, [StringComparison]::Ordinal) -ge 0) {
+        throw 'Claude final output exposed the synthetic value'
+    }
+    [pscustomobject]@{
+        client = $Name
+        result = 'pass'
+        exact_local_restore = $true
+    }
+}
+
+try {
+    [Environment]::SetEnvironmentVariable('PENTECT_E2E_VALUE', $synthetic, 'Process')
+    $results = foreach ($name in $clients) {
+        Invoke-ClientProbe -Name $name
+    }
+    $results | Format-Table -AutoSize
+} finally {
+    [Environment]::SetEnvironmentVariable('PENTECT_E2E_VALUE', $previousValue, 'Process')
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary
- add repeatable real-provider Codex CLI and Claude Code synthetic-secret probes
- extend provider-boundary coverage to OpenAI/Anthropic multipart uploads and OpenAI file-ID retrieval
- validate PowerShell release tooling in CI and prepare the CLI crate as v0.0.24
- refresh the signed-client compatibility evidence

## Local verification
- cargo test -p pentect-cli provider_boundary_masks_plaintext_and_restores_only_tool_arguments -- --nocapture
- cargo clippy -p pentect-cli --all-targets -- -D warnings
- 	ools/release_live_e2e.ps1 against the v0.0.23 release binary with Codex CLI 0.145.0 and Claude Code 2.1.220
- pentect codex app --check and pentect claude app --check against installed signed apps

Closes the release-critical portion of #120 and advances #121. Remaining compatibility/scale enhancements stay tracked in those issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Windows live end-to-end verification tool for Codex and Claude workflows, including environment restoration, output redaction, and cleanup checks.
  - Added support verification for file uploads and remote file retrieval across supported AI providers.

- **Bug Fixes**
  - Improved validation of PowerShell scripts during testing and release checks, with clearer file-specific error reporting.

- **Documentation**
  - Updated Windows compatibility results for the latest release, including CLI and desktop-app checks.

- **Release**
  - Updated the CLI release version to 0.0.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->