### PR TITLE
docs: use the Pentect tagline as the homepage title

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Pentect
+title: Protect what you pen.
 description: Let agents use secrets without seeing them.
 template: splash
 hero:


### PR DESCRIPTION
Avoids the duplicate Pentect page title and makes the product promise the first heading. Validated with the production docs build.