### PR TITLE
docs: configure pentect.dev

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,8 +1,8 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
-const site = process.env.PENTECT_DOCS_SITE ?? 'https://edamame-x.github.io';
-const base = process.env.PENTECT_DOCS_BASE ?? '/pentect';
+const site = process.env.PENTECT_DOCS_SITE ?? 'https://pentect.dev';
+const base = process.env.PENTECT_DOCS_BASE ?? '/';
 
 export default defineConfig({
   site,

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+pentect.dev


### PR DESCRIPTION
## Summary
- serve the documentation from the new pentect.dev custom domain
- build Astro with root-relative routes
- include the Pages CNAME in the deployment artifact

## Validation
- npm run build (website)