### PR TITLE
docs: simplify homepage installation flow

### DIFF
--- a/website/src/components/InstallPicker.astro
+++ b/website/src/components/InstallPicker.astro
@@ -1,0 +1,298 @@
+---
+const installers = {
+  windows: [
+    {
+      id: 'powershell',
+      label: 'PowerShell',
+      command: 'irm https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.ps1 | iex',
+    },
+  ],
+  macos: [
+    {
+      id: 'homebrew',
+      label: 'Homebrew',
+      command: 'brew install EdamAme-x/pentect/pentect',
+    },
+    {
+      id: 'shell',
+      label: 'Shell',
+      command: 'curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.sh | sh',
+    },
+    {
+      id: 'nix',
+      label: 'Nix',
+      command: 'nix profile install github:EdamAme-x/pentect',
+    },
+  ],
+  linux: [
+    {
+      id: 'shell',
+      label: 'Shell',
+      command: 'curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.sh | sh',
+    },
+    {
+      id: 'apt',
+      label: 'APT',
+      command: 'curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install-apt.sh | sudo sh',
+    },
+    {
+      id: 'nix',
+      label: 'Nix',
+      command: 'nix profile install github:EdamAme-x/pentect',
+    },
+  ],
+};
+---
+
+<section class="install-picker" data-install-picker data-installers={JSON.stringify(installers)}>
+  <div class="install-heading">
+    <div>
+      <p class="install-kicker">Install Pentect</p>
+      <h2>Choose your setup</h2>
+    </div>
+    <a href="/start/install/">All install options →</a>
+  </div>
+
+  <div class="selector-row" aria-label="Operating system">
+    <span>OS</span>
+    <div class="selector-buttons">
+      <button type="button" data-os="windows" aria-pressed="true">Windows</button>
+      <button type="button" data-os="macos" aria-pressed="false">macOS</button>
+      <button type="button" data-os="linux" aria-pressed="false">Linux</button>
+    </div>
+  </div>
+
+  <div class="selector-row" aria-label="Installation method">
+    <span>Method</span>
+    <div class="selector-buttons">
+      {
+        Object.entries(installers).flatMap(([os, methods]) =>
+          methods.map((method, index) => (
+            <button
+              type="button"
+              data-method={method.id}
+              data-method-os={os}
+              aria-pressed={os === 'windows' && index === 0 ? 'true' : 'false'}
+              hidden={os !== 'windows'}
+            >
+              {method.label}
+            </button>
+          )),
+        )
+      }
+    </div>
+  </div>
+
+  <div class="install-command">
+    <code data-install-command>{installers.windows[0].command}</code>
+    <button type="button" data-copy-command aria-label="Copy install command">Copy</button>
+  </div>
+  <span class="copy-status" data-copy-status aria-live="polite"></span>
+</section>
+
+<script>
+  type Installer = { id: string; label: string; command: string };
+  type InstallerMap = Record<string, Installer[]>;
+
+  for (const picker of document.querySelectorAll<HTMLElement>('[data-install-picker]')) {
+    const installers = JSON.parse(
+      picker.getAttribute('data-installers') ?? '{}',
+    ) as InstallerMap;
+    const command = picker.querySelector<HTMLElement>('[data-install-command]');
+    const status = picker.querySelector<HTMLElement>('[data-copy-status]');
+    const osButtons = [...picker.querySelectorAll<HTMLButtonElement>('[data-os]')];
+    const methodButtons = [...picker.querySelectorAll<HTMLButtonElement>('[data-method]')];
+    let selectedOs = 'windows';
+
+    const chooseMethod = (methodButton: HTMLButtonElement) => {
+      const method = installers[selectedOs].find(
+        (item: Installer) => item.id === methodButton.dataset.method,
+      );
+      if (!method || !command) return;
+      for (const button of methodButtons) {
+        button.setAttribute('aria-pressed', String(button === methodButton));
+      }
+      command.textContent = method.command;
+      if (status) status.textContent = '';
+    };
+
+    const chooseOs = (os: string | undefined) => {
+      if (!os) return;
+      if (!installers[os]) return;
+      selectedOs = os;
+      for (const button of osButtons) {
+        button.setAttribute('aria-pressed', String(button.getAttribute('data-os') === os));
+      }
+      const availableMethods = methodButtons.filter((button) => {
+        const available = button.getAttribute('data-method-os') === os;
+        button.toggleAttribute('hidden', !available);
+        return available;
+      });
+      if (availableMethods[0]) chooseMethod(availableMethods[0]);
+    };
+
+    for (const button of osButtons) {
+      button.addEventListener('click', () => chooseOs(button.dataset.os));
+    }
+    for (const button of methodButtons) {
+      button.addEventListener('click', () => chooseMethod(button));
+    }
+
+    picker.querySelector('[data-copy-command]')?.addEventListener('click', async () => {
+      if (!command?.textContent) return;
+      try {
+        await navigator.clipboard.writeText(command.textContent);
+        if (status) status.textContent = 'Copied';
+      } catch {
+        if (status) status.textContent = 'Select the command and copy it manually';
+      }
+    });
+
+    const userAgent = navigator.userAgent.toLowerCase();
+    chooseOs(userAgent.includes('mac') ? 'macos' : userAgent.includes('win') ? 'windows' : 'linux');
+  }
+</script>
+
+<style>
+  .install-picker {
+    margin-block: 0 4rem;
+    padding: clamp(1rem, 3vw, 1.5rem);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 1rem;
+  }
+
+  .install-heading {
+    display: flex;
+    gap: 1rem;
+    align-items: end;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+  }
+
+  .install-heading h2,
+  .install-kicker {
+    margin: 0;
+  }
+
+  .install-heading h2 {
+    font-size: clamp(1.35rem, 3vw, 1.75rem);
+  }
+
+  .install-kicker {
+    color: var(--sl-color-gray-3);
+    font-size: 0.75rem;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .install-heading a {
+    color: var(--sl-color-gray-2);
+    font-size: 0.85rem;
+    text-decoration: none;
+  }
+
+  .selector-row {
+    display: grid;
+    grid-template-columns: 4.5rem 1fr;
+    gap: 0.75rem;
+    align-items: center;
+    margin-block: 0.65rem;
+  }
+
+  .selector-row > span {
+    color: var(--sl-color-gray-3);
+    font-size: 0.8rem;
+  }
+
+  .selector-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .selector-buttons button,
+  .install-command button {
+    border: 0;
+    border-radius: 0.45rem;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .selector-buttons button {
+    padding: 0.42rem 0.7rem;
+    color: var(--sl-color-gray-2);
+    background: transparent;
+    font-size: 0.82rem;
+  }
+
+  .selector-buttons button[aria-pressed='true'] {
+    color: var(--sl-color-white);
+    background: var(--sl-color-gray-6);
+    box-shadow: inset 0 0 0 1px var(--sl-color-gray-5);
+  }
+
+  .install-command {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 1.25rem;
+    padding: 0.9rem 1rem;
+    border-radius: 0.7rem;
+    background: var(--sl-color-black);
+  }
+
+  .install-command code {
+    overflow-x: auto;
+    color: var(--sl-color-white);
+    font-size: 0.8rem;
+    white-space: nowrap;
+  }
+
+  .install-command button {
+    flex: none;
+    padding: 0.4rem 0.65rem;
+    color: var(--sl-color-gray-2);
+    background: var(--sl-color-gray-6);
+    font-size: 0.75rem;
+  }
+
+  .copy-status {
+    display: block;
+    min-height: 1.2rem;
+    margin-top: 0.35rem;
+    color: var(--sl-color-gray-3);
+    font-size: 0.75rem;
+    text-align: right;
+  }
+
+  [hidden] {
+    display: none;
+  }
+
+  @media (max-width: 35rem) {
+    .install-heading {
+      align-items: start;
+      flex-direction: column;
+    }
+
+    .selector-row {
+      grid-template-columns: 1fr;
+    }
+
+    .install-command {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .install-command code {
+      white-space: normal;
+      word-break: break-word;
+    }
+
+    .install-command button {
+      align-self: end;
+    }
+  }
+</style>

--- a/website/src/components/SecretFlow.astro
+++ b/website/src/components/SecretFlow.astro
@@ -1,0 +1,75 @@
+<section class="secret-flow" aria-label="How Pentect protects a secret">
+  <div class="flow-step">
+    <span>Local input</span>
+    <code>API_KEY=live_value</code>
+  </div>
+  <span class="flow-arrow" aria-hidden="true">→</span>
+  <div class="flow-step flow-step-accent">
+    <span>Model receives</span>
+    <code>API_KEY=&lt;&lt;API_KEY_8f2a…&gt;&gt;</code>
+  </div>
+  <span class="flow-arrow" aria-hidden="true">→</span>
+  <div class="flow-step">
+    <span>Trusted tool</span>
+    <code>restored locally</code>
+  </div>
+</section>
+
+<style>
+  .secret-flow {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+    gap: 0.8rem;
+    align-items: center;
+    margin-block: 1rem 4rem;
+    padding: 1rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 1rem;
+    background: color-mix(in srgb, var(--sl-color-gray-6), transparent 58%);
+  }
+
+  .flow-step {
+    min-width: 0;
+    padding: 0.75rem;
+  }
+
+  .flow-step span {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--sl-color-gray-3);
+    font-size: 0.75rem;
+    font-weight: 650;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .flow-step code {
+    display: block;
+    overflow: hidden;
+    color: var(--sl-color-white);
+    font-size: 0.8rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .flow-step-accent code {
+    color: var(--sl-color-accent-high);
+  }
+
+  .flow-arrow {
+    color: var(--sl-color-gray-4);
+  }
+
+  @media (max-width: 45rem) {
+    .secret-flow {
+      grid-template-columns: 1fr;
+      gap: 0;
+    }
+
+    .flow-arrow {
+      padding-left: 0.75rem;
+      transform: rotate(90deg);
+      transform-origin: left center;
+    }
+  }
+</style>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -15,67 +15,26 @@ hero:
       variant: minimal
 ---
 
-import { Card, CardGrid, Steps, Aside } from '@astrojs/starlight/components';
+import SecretFlow from '../../components/SecretFlow.astro';
+import InstallPicker from '../../components/InstallPicker.astro';
 
-## The model gets context. Your secrets stay local.
+<SecretFlow>
+## How Pentect works
 
-```text
-RUNPOD_API_KEY=rpa_live_value
-         ↓ Pentect
-RUNPOD_API_KEY=<<RUNPOD_API_KEY_a53912f7228c6f9d>>
-         ↓ model tool call
-restored only at the trusted local boundary
-```
+Pentect replaces secrets with stable handles before content reaches an AI
+provider. The original value is restored only when a trusted local tool needs
+it.
+</SecretFlow>
 
-Pentect is not conventional redaction. The model retains a stable, meaningful
-handle, so it can compose commands and finish work without receiving the
-plaintext value.
+<InstallPicker>
+## Install Pentect
 
-<CardGrid>
-  <Card title="Local by design" icon="seti:lock">
-    Plaintext recovery stays in the local Pentect session. Providers receive
-    handles, not the protected values behind them.
-  </Card>
-  <Card title="Works with your tools" icon="terminal">
-    Launch Codex CLI, Claude Code, Codex App, or Claude Desktop through Pentect.
-    No replacement chat UI is required.
-  </Card>
-  <Card title="More than prompts" icon="document">
-    Protect structured configuration, tool results, supported uploads, images,
-    and completed tool-call arguments.
-  </Card>
-  <Card title="Extensible, constrained" icon="puzzle">
-    Add regex detectors or sandboxed WebAssembly middleware with explicit
-    permissions.
-  </Card>
-</CardGrid>
+Choose the installation method for your operating system. See the
+[installation guide](/start/install/) for every supported package manager.
+</InstallPicker>
 
-## Start in under a minute
-
-<Steps>
-1. Install Pentect.
-
-   ```powershell
-   irm https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.ps1 | iex
-   ```
-
-2. Check the installation.
-
-   ```text
-   pentect doctor
-   ```
-
-3. Launch an agent.
-
-   ```text
-   pentect codex
-   # or
-   pentect claude
-   ```
-</Steps>
-
-<Aside type="caution" title="Pre-1.0 security software">
-  Pentect blocks unknown provider formats by default, but no detector can
-  promise perfect detection. Keep provider and tool permissions narrow and
-  review the security model before production use.
-</Aside>
+<div class="home-links">
+  <a href="/start/how-it-works/">How it works <span>→</span></a>
+  <a href="/clients/codex/">Use with Codex <span>→</span></a>
+  <a href="/clients/claude/">Use with Claude <span>→</span></a>
+</div>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -38,14 +38,14 @@ body {
 }
 
 .hero {
-  padding-block: clamp(4rem, 10vw, 8rem);
+  padding-block: clamp(3rem, 8vw, 6rem);
 }
 
 .hero h1 {
-  max-width: 12ch;
-  font-size: clamp(3rem, 8vw, 6.4rem);
-  line-height: 0.95;
-  letter-spacing: -0.065em;
+  max-width: 13ch;
+  font-size: clamp(2.8rem, 7vw, 5.4rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
 }
 
 .hero .tagline {
@@ -56,8 +56,32 @@ body {
 }
 
 .hero .actions a {
-  border-radius: 999px;
+  border-radius: 0.55rem;
   box-shadow: none;
+}
+
+.home-links {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-block: 0 3rem;
+  border-block: 1px solid var(--sl-color-gray-5);
+}
+
+.home-links a {
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem 0.75rem;
+  color: var(--sl-color-gray-2);
+  font-size: 0.88rem;
+  text-decoration: none;
+}
+
+.home-links a + a {
+  border-left: 1px solid var(--sl-color-gray-5);
+}
+
+.home-links a:hover {
+  color: var(--sl-color-white);
 }
 
 .card {
@@ -87,5 +111,14 @@ body {
 @media (max-width: 50rem) {
   .hero {
     padding-block: 3rem;
+  }
+
+  .home-links {
+    grid-template-columns: 1fr;
+  }
+
+  .home-links a + a {
+    border-top: 1px solid var(--sl-color-gray-5);
+    border-left: 0;
   }
 }


### PR DESCRIPTION
## Summary
- reduce the homepage to the product flow, installer, and three next-step links
- add an OS-aware installer picker for Windows, macOS, and Linux
- remove the pre-1.0 warning from the homepage
- keep generated agent-readable Markdown concise

## Validation
- npm run build
- npm audit --audit-level=high
- desktop and narrow viewport screenshots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive installation picker with operating-system and installation-method options.
  * Added one-click command copying with success and failure feedback.
  * Added a visual explanation of how secrets are locally redacted, processed, and restored.
  * Added direct links to general usage, Codex, and Claude documentation.

* **Style**
  * Improved homepage layout, responsive behavior, spacing, typography, and navigation link styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->