### PR TITLE
docs: rebuild documentation hub

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -5,12 +5,13 @@ const site = process.env.PENTECT_DOCS_SITE ?? 'https://pentect.dev';
 const base = process.env.PENTECT_DOCS_BASE ?? '/';
 
 const sidebar = [
+  { text: 'Home', link: '/' },
+  { text: 'Quick start', link: '/start/quick-start/' },
   {
-    text: 'Start here',
+    text: 'Get started',
     items: [
       { text: 'What is Pentect?', link: '/start/what-is-pentect/' },
       { text: 'Install', link: '/start/install/' },
-      { text: 'Quick start', link: '/start/quick-start/' },
       { text: 'How it works', link: '/start/how-it-works/' },
     ],
   },
@@ -40,6 +41,7 @@ const sidebar = [
   {
     text: 'Reference',
     items: [
+      { text: 'Capabilities', link: '/reference/capabilities/' },
       { text: 'CLI', link: '/reference/cli/' },
       { text: 'Configuration', link: '/reference/configuration/' },
       { text: 'Compatibility', link: '/reference/compatibility/' },
@@ -100,11 +102,7 @@ export default defineConfig({
       dark: '/pentect-logo-dark.png',
       alt: 'Pentect',
     },
-    nav: [
-      { text: 'Guide', link: '/start/what-is-pentect/' },
-      { text: 'Reference', link: '/reference/cli/' },
-      { text: 'Plugins', link: '/plugins/overview/' },
-    ],
+    nav: [],
     sidebar,
     outline: { level: [2, 3], label: 'On this page' },
     search: { provider: 'local' },
@@ -117,7 +115,7 @@ export default defineConfig({
     ],
     footer: {
       message: 'Pentect is open source.',
-      copyright: 'Released under the Apache-2.0 license.',
+      copyright: 'Released under the MIT license.',
     },
     lastUpdated: { text: 'Updated' },
     docFooter: { prev: 'Previous', next: 'Next' },

--- a/website/.vitepress/theme/DocsGrid.vue
+++ b/website/.vitepress/theme/DocsGrid.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="docs-grid">
+    <slot />
+  </div>
+</template>

--- a/website/.vitepress/theme/Layout.vue
+++ b/website/.vitepress/theme/Layout.vue
@@ -7,6 +7,12 @@ const { frontmatter } = useData();
 
 <template>
   <DefaultTheme.Layout>
+    <template #nav-bar-title-after>
+      <span class="docs-wordmark">Docs</span>
+    </template>
+    <template #nav-bar-content-after>
+      <a class="docs-nav-cta" href="/start/quick-start/">Get started</a>
+    </template>
     <template #doc-before>
       <header v-if="frontmatter.title" class="doc-heading">
         <h1>{{ frontmatter.title }}</h1>

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -1,4 +1,5 @@
 import DefaultTheme from 'vitepress/theme';
+import DocsGrid from './DocsGrid.vue';
 import HomeInstall from './HomeInstall.vue';
 import Layout from './Layout.vue';
 import './style.css';
@@ -7,6 +8,7 @@ export default {
   extends: DefaultTheme,
   Layout,
   enhanceApp({ app }) {
+    app.component('DocsGrid', DocsGrid);
     app.component('HomeInstall', HomeInstall);
   },
 };

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -14,7 +14,8 @@
   --vp-c-gutter: #e7e6df;
   --vp-font-family-base: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --vp-font-family-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  --vp-nav-height: 64px;
+  --vp-nav-height: 72px;
+  --vp-sidebar-width: 280px;
 }
 
 .dark {
@@ -36,6 +37,100 @@ body {
 .VPNavBar {
   background: color-mix(in srgb, var(--vp-c-bg) 88%, transparent) !important;
   backdrop-filter: blur(14px);
+}
+
+.VPNav {
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.VPNavBar.has-sidebar .title {
+  border-bottom: 0 !important;
+}
+
+.VPNavBar .content-body {
+  gap: 12px;
+}
+
+.docs-wordmark {
+  margin-left: 22px;
+  color: var(--vp-c-text-1);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.docs-nav-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 38px;
+  margin-left: 8px;
+  padding: 0 16px;
+  border-radius: 8px;
+  color: #fff !important;
+  background: var(--vp-c-brand-1);
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none !important;
+}
+
+.VPNavBarSearch {
+  max-width: 410px;
+}
+
+.VPNavBarSearch #local-search,
+.VPNavBarSearch .DocSearch-Button {
+  width: 100%;
+}
+
+.VPNavBarSearch .DocSearch-Button {
+  height: 40px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+}
+
+.VPSidebar {
+  border-right: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg) !important;
+}
+
+.VPSidebar .nav {
+  padding-top: 22px;
+}
+
+.VPSidebar {
+  scrollbar-width: none;
+}
+
+.VPSidebar::-webkit-scrollbar {
+  display: none;
+}
+
+.VPSidebarItem.level-0 {
+  padding-bottom: 22px;
+}
+
+.VPSidebarItem.level-0.is-link {
+  padding-bottom: 2px;
+}
+
+.VPSidebarItem.level-0.is-link > .item > .link {
+  margin: 0 -10px;
+  padding: 3px 10px;
+  border-radius: 7px;
+}
+
+.VPSidebarItem.level-0.is-link > .item > .link:hover,
+.VPSidebarItem.level-0.is-link.is-active > .item > .link {
+  background: var(--vp-c-bg-soft);
+}
+
+.VPSidebarItem.level-0:not(.is-link) > .item > .text {
+  color: var(--vp-c-text-3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .VPNavBarTitle .logo {
@@ -257,6 +352,51 @@ body {
   border-bottom: 1px solid var(--vp-c-divider);
 }
 
+.docs-hub .VPDoc {
+  background:
+    radial-gradient(circle at 72% 8%, rgba(221, 72, 45, 0.10), transparent 32rem),
+    var(--vp-c-bg);
+}
+
+.docs-hub .VPDoc .container {
+  max-width: 1060px;
+}
+
+.docs-hub .doc-heading {
+  max-width: 720px;
+  margin-bottom: 26px;
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.docs-hub .doc-heading h1 {
+  font-size: clamp(52px, 7vw, 72px);
+}
+
+.docs-hub .doc-heading h1::first-letter {
+  color: inherit;
+}
+
+.docs-hub .doc-heading p {
+  max-width: 630px;
+  font-size: 20px;
+}
+
+.docs-hub .vp-doc > p:first-of-type {
+  max-width: 680px;
+  margin-bottom: 34px;
+  color: var(--vp-c-text-2);
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.docs-hub .vp-doc > h2 {
+  margin-top: 64px;
+  border-top: 0;
+  padding-top: 0;
+  font-size: clamp(28px, 4vw, 38px);
+}
+
 .doc-heading h1 {
   margin: 0;
   color: var(--vp-c-text-1);
@@ -290,7 +430,104 @@ body {
   border-radius: 10px;
 }
 
+.docs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 20px 0 40px !important;
+  padding: 0 !important;
+}
+
+.docs-grid.is-compact {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.docs-grid.is-compact .docs-grid__item {
+  min-height: 170px;
+}
+
+.docs-grid__item {
+  position: relative;
+  display: flex;
+  min-height: 150px;
+  height: 100%;
+  flex-direction: column;
+  gap: 7px;
+  padding: 20px 44px 20px 20px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  color: var(--vp-c-text-2) !important;
+  background: var(--vp-c-bg-elv);
+  text-decoration: none !important;
+  transition: border-color 140ms ease, background-color 140ms ease;
+}
+
+.docs-grid__item:hover {
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 45%, var(--vp-c-divider));
+  background: color-mix(in srgb, var(--vp-c-brand-soft) 35%, var(--vp-c-bg-elv));
+}
+
+.docs-grid__item strong {
+  color: var(--vp-c-text-1);
+  font-size: 16px;
+  line-height: 1.35;
+}
+
+.docs-grid__item > span {
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.docs-grid__item small {
+  color: var(--vp-c-brand-1);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.docs-grid__item b {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  color: var(--vp-c-text-3);
+  font-weight: 500;
+  transition: color 140ms ease, transform 140ms ease;
+}
+
+.docs-grid__item:hover b {
+  color: var(--vp-c-brand-1);
+  transform: translateX(2px);
+}
+
 @media (max-width: 640px) {
+  :root {
+    --vp-nav-height: 64px;
+  }
+
+  .docs-wordmark {
+    display: none;
+  }
+
+  .docs-hub .VPLocalNav,
+  .VPNavBarSearch {
+    display: none;
+  }
+
+  .docs-nav-cta {
+    height: 36px;
+    margin-left: 0;
+    padding: 0 13px;
+  }
+
+  .docs-hub .doc-heading h1 {
+    font-size: 48px;
+  }
+
+  .docs-hub .doc-heading p {
+    font-size: 17px;
+  }
+
   .VPHomeHero {
     padding-top: 64px !important;
     padding-bottom: 48px !important;
@@ -324,6 +561,11 @@ body {
     overflow-wrap: anywhere;
   }
 
+  .vp-doc .home-install__command code {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
   .home-install__command button {
     align-self: flex-end;
   }
@@ -336,5 +578,24 @@ body {
   .home-routes a + a {
     border-top: 1px solid var(--vp-c-divider);
     border-left: 0;
+  }
+
+  .docs-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-grid.is-compact {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-grid__item,
+  .docs-grid.is-compact .docs-grid__item {
+    min-height: 0;
+  }
+}
+
+@media (min-width: 641px) and (max-width: 1180px) {
+  .docs-grid.is-compact {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/website/scripts/generate-agent-docs.mjs
+++ b/website/scripts/generate-agent-docs.mjs
@@ -93,6 +93,9 @@ function rewriteNodes(nodes) {
     if (node.type === 'mdxTextExpression') return [];
 
     if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
+      if (node.name === 'a') {
+        return [rewriteAnchor(node)];
+      }
       const children = rewriteNodes(node.children ?? []);
       const label = componentLabel(node);
       return label ? [heading(label, 3), ...children] : children;
@@ -103,6 +106,43 @@ function rewriteNodes(nodes) {
     }
     return [node];
   });
+}
+
+function rewriteAnchor(node) {
+  const href = node.attributes?.find(
+    (item) => item.type === 'mdxJsxAttribute' && item.name === 'href',
+  );
+  const url = typeof href?.value === 'string' ? href.value : '#';
+  const strong = findElement(node, 'strong');
+  const span = findElement(node, 'span');
+  const label = plainText(strong ?? node).trim() || url;
+  const description = plainText(span).trim();
+
+  return {
+    type: 'paragraph',
+    children: [
+      { type: 'link', url, children: [{ type: 'text', value: label }] },
+      ...(description ? [{ type: 'text', value: ` — ${description}` }] : []),
+    ],
+  };
+}
+
+function findElement(node, name) {
+  if (!node) return undefined;
+  if ((node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') && node.name === name) {
+    return node;
+  }
+  for (const child of node.children ?? []) {
+    const found = findElement(child, name);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function plainText(node) {
+  if (!node) return '';
+  if (node.type === 'text' || node.type === 'inlineCode') return node.value ?? '';
+  return (node.children ?? []).map(plainText).join(' ');
 }
 
 function componentLabel(node) {

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -1,24 +1,64 @@
 ---
-layout: home
-title: Pentect
-description: Let agents use secrets without seeing them.
-hero:
-  name: Pentect
-  text: Protect what you pen.
-  tagline: Keep credentials local while Codex and Claude use the context they need.
-  actions:
-    - theme: brand
-      text: Get started
-      link: /start/install/
-    - theme: alt
-      text: How it works
-      link: /start/how-it-works/
+title: Docs_
+description: Keep sensitive values local while Codex and Claude use the context they need.
+pageClass: docs-hub
+aside: false
 ---
+
+Pentect replaces sensitive values with usable handles before requests leave your machine. Known handles are restored only at trusted local boundaries.
 
 <HomeInstall />
 
-<div class="home-routes">
-  <a href="/start/how-it-works/">How it works <span>→</span></a>
-  <a href="/clients/codex/">Use with Codex <span>→</span></a>
-  <a href="/clients/claude/">Use with Claude <span>→</span></a>
-</div>
+## Start with a client
+
+Choose the surface you already use. Pentect only applies to sessions you launch through it.
+
+<DocsGrid class="is-compact">
+  <a href="/clients/codex/" class="docs-grid__item">
+    <small>CLI</small><strong>Codex CLI</strong>
+    <span>Run Codex through Pentect for the current session.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/clients/claude/" class="docs-grid__item">
+    <small>CLI</small><strong>Claude Code</strong>
+    <span>Route Anthropic Messages traffic through Pentect.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/clients/codex/" class="docs-grid__item">
+    <small>Desktop</small><strong>Codex App</strong>
+    <span>Start an isolated App session with Pentect enabled.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/clients/claude/" class="docs-grid__item">
+    <small>Desktop</small><strong>Claude Desktop</strong>
+    <span>Protect supported Claude Desktop traffic.</span><b aria-hidden="true">→</b>
+  </a>
+</DocsGrid>
+
+## Explore Pentect
+
+Go directly to the part you need.
+
+<DocsGrid>
+  <a href="/start/how-it-works/" class="docs-grid__item">
+    <strong>How it works</strong>
+    <span>Follow a value from detection to a local tool call.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/protection/structured-data/" class="docs-grid__item">
+    <strong>Structured data</strong>
+    <span>Protect dotenv, Terraform, Kubernetes, and other supported formats.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/protection/files-and-images/" class="docs-grid__item">
+    <strong>Files and images</strong>
+    <span>Understand document, upload, image, and OCR handling.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/clients/upstreams/" class="docs-grid__item">
+    <strong>Custom upstreams</strong>
+    <span>Put compatible gateways and local model servers behind Pentect.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/plugins/overview/" class="docs-grid__item">
+    <strong>Plugins</strong>
+    <span>Extend detection and middleware in a Wasm sandbox.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/reference/capabilities/" class="docs-grid__item">
+    <strong>CLI and configuration</strong>
+    <span>Browse commands, settings, compatibility, and troubleshooting.</span><b aria-hidden="true">→</b>
+  </a>
+</DocsGrid>

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -1,0 +1,126 @@
+---
+title: What Pentect can do
+description: Every user-facing Pentect capability, grouped by the job it performs.
+---
+
+## Clients
+
+| Capability | Entry point |
+| --- | --- |
+| Protect Codex CLI | `pentect codex` |
+| Protect Claude Code | `pentect claude` |
+| Launch a protected Codex App session | `pentect codex app` |
+| Launch a protected Claude Desktop session | `pentect claude app` |
+| Forward normal client arguments | Place them after `--` |
+| Select a compatible upstream for one launch | `--upstream URL` |
+| Load an additional plugin for one launch | `--plugins SOURCE` |
+| Check an app setup without launching it | `pentect codex app --check` or `pentect claude app --check` |
+
+Pentect changes only the process it launches. It does not enable a permanent
+system-wide proxy or replace the client interface.
+
+## Protected content
+
+| Capability | Behavior |
+| --- | --- |
+| Prompts and tool results | Sensitive spans are replaced before supported provider requests |
+| Completed tool calls | Known handles are resolved immediately before trusted local execution |
+| Command output | stdout and stderr are masked before returning to the model |
+| Structured configuration | Uses key and syntax context for useful labels |
+| UTF-8 uploads | Inspects and rewrites supported Files API content |
+| Documents | Inspects supported inline document formats |
+| Images | Runs local OCR and redacts detected regions |
+| QR codes and barcodes | Inspects decoded payloads during image protection |
+| Unknown provider structures | Returns an error by default |
+
+Detection covers secret and PII categories. Recognized structured sources
+include dotenv, Terraform, Kubernetes Secrets,
+kubeconfig, AWS, npm, PyPI, JSON, and other supported key/value formats.
+
+## Handles
+
+- Preserve a useful label such as `DATABASE_URL` or `KAGGLE_API_TOKEN`.
+- Use a keyed identity instead of an unsalted plaintext fingerprint.
+- Can stay stable per device, per project, or change per session.
+- Resolve only when the current local protection context knows the handle.
+- Keep unknown or invented handle-shaped text inert.
+- Expose metadata through `pentect view` without printing the value.
+
+## Local CLI
+
+| Command | What it does |
+| --- | --- |
+| `pentect mask [TEXT]` | Mask arguments or UTF-8 stdin |
+| `pentect read PATH` | Print a masked file preview |
+| `pentect exec "COMMAND"` | Resolve known handles locally and mask command output |
+| `pentect view HANDLE` | Show handle metadata without revealing plaintext |
+| `pentect resolve [PATH...]` | Resolve known handles from stdin or selected files |
+| `pentect log [--json]` | Follow local protection events without secret values |
+| `pentect doctor [--json]` | Check the installation and supported clients |
+| `pentect doctor --fix` | Offer repairable configuration changes |
+| `pentect update [VERSION]` | Install a checksummed GitHub Release binary |
+| `pentect update --check` | Check for an update without installing it |
+| `pentect uninstall` | Remove the binary while retaining project data |
+
+`mask` works in ordinary pipelines; no `--kind` flag is required:
+
+```sh
+cat .env | pentect mask
+cat terraform.tfvars | pentect mask
+```
+
+## Custom gateways
+
+Pentect can sit in front of an existing compatible gateway for a single
+launch:
+
+```text
+pentect codex --upstream http://127.0.0.1:8080/openai/v1
+pentect claude --upstream http://127.0.0.1:8080/anthropic
+```
+
+It supports the OpenAI Responses contract used by Codex and the Anthropic
+Messages contract used by Claude while preserving the configured upstream base
+path.
+
+## Configuration and local state
+
+| Capability | Setting |
+| --- | --- |
+| Stable handle identity on one device | `[handles] scope = "device"` |
+| Separate handle identity per project | `[handles] scope = "project"` |
+| New handle identity per session | `[handles] scope = "session"` |
+| Remember local file-backed recovery hints | `[files] remember = true` |
+| Share protection events between compatible local processes | `[activity] share = true` |
+| Require a Pentect-launched agent boundary for a project | `[agent] required = true` |
+| Allow unknown provider formats explicitly | `[compatibility] unknown_formats = "ignore"` |
+
+Pentect reads user configuration from `~/.pentect/config.toml` and project
+configuration from `.pentect/config.toml`. A project cannot weaken the user's
+unknown-format policy.
+
+## Plugins
+
+| Capability | Command or format |
+| --- | --- |
+| Declarative detector | Regex rules in `plugin.toml` |
+| Context-aware middleware | Sandboxed WebAssembly |
+| Create and run locally | `plugins new`, `plugins dev` |
+| Validate behavior | `plugins test`, `plugins inspect` |
+| Install from GitHub | `plugins add github:@owner/repository/path` |
+| Configure and approve access | `plugins config`, `plugins setup` |
+| Discover and maintain | `plugins search`, `plugins list`, `plugins update`, `plugins remove` |
+| Publish | `plugins publish` |
+
+Wasm plugins have no ambient WASI, filesystem, environment, process, or raw
+socket access. Optional HTTP access is limited by declared origins, methods,
+request counts, and byte limits, and requires approval.
+
+## Installation and distribution
+
+Pentect provides PowerShell and POSIX installers plus Homebrew, apt, Nix, npm,
+and Cargo installation paths. Direct binary installers verify SHA-256 checksums,
+support version selection, updating, and uninstalling, and detect installations
+owned by another package manager.
+
+Continue with [Install](/start/install/) or the [Quick start](/start/quick-start/).


### PR DESCRIPTION
## What changed
- rebuild the documentation home as an Appwrite-inspired Docs Hub
- add grouped navigation, prominent search, client and capability cards, and responsive styling
- add a complete capabilities reference
- preserve card links in generated agent-readable Markdown

## Why
The published docs were visually noisy and did not expose Pentect's capabilities or supported clients clearly.

## Validation
- `npm run build` in `website`
- 18 agent-readable Markdown pages generated
- internal links validated across 19 HTML pages
- desktop/mobile and light/dark themes inspected locally