### PR TITLE
docs: add sidebar icons

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -4,48 +4,72 @@ import { fileURLToPath } from 'node:url';
 const site = process.env.PENTECT_DOCS_SITE ?? 'https://pentect.dev';
 const base = process.env.PENTECT_DOCS_BASE ?? '/';
 
+const sidebarIcons = {
+  home: '<path d="m3 11 9-8 9 8"/><path d="M5 10v10h14V10"/><path d="M9 20v-6h6v6"/>',
+  play: '<circle cx="12" cy="12" r="9"/><path d="m10 8 6 4-6 4Z"/>',
+  info: '<circle cx="12" cy="12" r="9"/><path d="M12 11v5"/><path d="M12 8h.01"/>',
+  download: '<path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 20h14"/>',
+  flow: '<circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M8 6h8M7 8l4 8m6-8-4 8"/>',
+  terminal: '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/>',
+  message: '<path d="M5 18 3 21l4-1.5A9 9 0 1 0 5 18Z"/><path d="M8 11h8M8 14h5"/>',
+  network: '<circle cx="5" cy="12" r="2"/><circle cx="19" cy="6" r="2"/><circle cx="19" cy="18" r="2"/><path d="m7 11 10-4m-10 6 10 4"/>',
+  data: '<path d="M8 4 4 8l4 4"/><path d="m16 12 4 4-4 4"/><path d="m14 3-4 18"/>',
+  image: '<rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m3 16 5-4 4 3 3-2 6 5"/>',
+  shield: '<path d="M12 3 5 6v5c0 4.7 2.9 8 7 10 4.1-2 7-5.3 7-10V6Z"/><path d="m9 12 2 2 4-4"/>',
+  plugin: '<path d="M8 3h3v4a2 2 0 1 0 4 0V3h3v6h3v6h-4v2a4 4 0 0 1-4 4h-2a4 4 0 0 1-4-4v-2H3V9h5Z"/>',
+  build: '<path d="m14 6 4-3 3 3-3 4"/><path d="m16 8-9 9"/><path d="m5 15 4 4-2 2-4-4Z"/>',
+  grid: '<rect x="4" y="4" width="6" height="6" rx="1"/><rect x="14" y="4" width="6" height="6" rx="1"/><rect x="4" y="14" width="6" height="6" rx="1"/><rect x="14" y="14" width="6" height="6" rx="1"/>',
+  settings: '<path d="M4 7h10M18 7h2M4 17h2m4 0h10"/><circle cx="16" cy="7" r="2"/><circle cx="8" cy="17" r="2"/>',
+  check: '<circle cx="12" cy="12" r="9"/><path d="m8 12 3 3 5-6"/>',
+  wrench: '<path d="M14 6a4 4 0 0 0-5 5L3 17l4 4 6-6a4 4 0 0 0 5-5l-3 2-3-3Z"/>',
+};
+
+function sidebarLabel(label: string, icon: keyof typeof sidebarIcons) {
+  return `<span class="sidebar-link-label"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">${sidebarIcons[icon]}</svg><span>${label}</span></span>`;
+}
+
 const sidebar = [
-  { text: 'Home', link: '/' },
-  { text: 'Quick start', link: '/start/quick-start/' },
+  { text: sidebarLabel('Home', 'home'), link: '/' },
+  { text: sidebarLabel('Quick start', 'play'), link: '/start/quick-start/' },
   {
     text: 'Get started',
     items: [
-      { text: 'What is Pentect?', link: '/start/what-is-pentect/' },
-      { text: 'Install', link: '/start/install/' },
-      { text: 'How it works', link: '/start/how-it-works/' },
+      { text: sidebarLabel('What is Pentect?', 'info'), link: '/start/what-is-pentect/' },
+      { text: sidebarLabel('Install', 'download'), link: '/start/install/' },
+      { text: sidebarLabel('How it works', 'flow'), link: '/start/how-it-works/' },
     ],
   },
   {
     text: 'Clients',
     items: [
-      { text: 'Codex', link: '/clients/codex/' },
-      { text: 'Claude', link: '/clients/claude/' },
-      { text: 'Custom upstreams', link: '/clients/upstreams/' },
+      { text: sidebarLabel('Codex', 'terminal'), link: '/clients/codex/' },
+      { text: sidebarLabel('Claude', 'message'), link: '/clients/claude/' },
+      { text: sidebarLabel('Custom upstreams', 'network'), link: '/clients/upstreams/' },
     ],
   },
   {
     text: 'Protection',
     items: [
-      { text: 'Structured data', link: '/protection/structured-data/' },
-      { text: 'Files and images', link: '/protection/files-and-images/' },
-      { text: 'Security model', link: '/protection/security-model/' },
+      { text: sidebarLabel('Structured data', 'data'), link: '/protection/structured-data/' },
+      { text: sidebarLabel('Files and images', 'image'), link: '/protection/files-and-images/' },
+      { text: sidebarLabel('Security model', 'shield'), link: '/protection/security-model/' },
     ],
   },
   {
     text: 'Plugins',
     items: [
-      { text: 'Overview', link: '/plugins/overview/' },
-      { text: 'Build a plugin', link: '/plugins/build/' },
+      { text: sidebarLabel('Overview', 'plugin'), link: '/plugins/overview/' },
+      { text: sidebarLabel('Build a plugin', 'build'), link: '/plugins/build/' },
     ],
   },
   {
     text: 'Reference',
     items: [
-      { text: 'Capabilities', link: '/reference/capabilities/' },
-      { text: 'CLI', link: '/reference/cli/' },
-      { text: 'Configuration', link: '/reference/configuration/' },
-      { text: 'Compatibility', link: '/reference/compatibility/' },
-      { text: 'Troubleshooting', link: '/reference/troubleshooting/' },
+      { text: sidebarLabel('Capabilities', 'grid'), link: '/reference/capabilities/' },
+      { text: sidebarLabel('CLI', 'terminal'), link: '/reference/cli/' },
+      { text: sidebarLabel('Configuration', 'settings'), link: '/reference/configuration/' },
+      { text: sidebarLabel('Compatibility', 'check'), link: '/reference/compatibility/' },
+      { text: sidebarLabel('Troubleshooting', 'wrench'), link: '/reference/troubleshooting/' },
     ],
   },
 ];

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -133,6 +133,30 @@ body {
   text-transform: uppercase;
 }
 
+.sidebar-link-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.sidebar-link-label svg {
+  flex: none;
+  width: 17px;
+  height: 17px;
+  color: var(--vp-c-text-3);
+  transition: color 140ms ease;
+}
+
+.VPSidebarItem.is-link > .item > .link:hover .sidebar-link-label svg,
+.VPSidebarItem.is-active > .item > .link .sidebar-link-label svg {
+  color: var(--vp-c-brand-1);
+}
+
+.VPSidebarItem.is-active > .item > .link .sidebar-link-label {
+  color: var(--vp-c-brand-1);
+}
+
 .VPNavBarTitle .logo {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
## What changed
- add distinct inline SVG icons to every documentation sidebar link
- keep group headings visually quiet
- color the active and hovered icon with the Pentect accent

## Why
The text-only sidebar was difficult to scan and did not match the visual navigation used by the rest of the docs.

## Validation
- `npm run build` in `website`
- 18 agent-readable Markdown pages generated
- inspected all sidebar icons in desktop light and dark themes