### PR TITLE
docs: accent title suffix

### DIFF
--- a/website/.vitepress/theme/Layout.vue
+++ b/website/.vitepress/theme/Layout.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
 import DefaultTheme from 'vitepress/theme';
 import { useData } from 'vitepress';
+import { computed } from 'vue';
 
 const { frontmatter } = useData();
+const title = computed(() => String(frontmatter.value.title ?? ''));
+const hasAccentSuffix = computed(() => title.value.endsWith('_'));
+const titleBase = computed(() => hasAccentSuffix.value ? title.value.slice(0, -1) : title.value);
 </script>
 
 <template>
@@ -15,7 +19,7 @@ const { frontmatter } = useData();
     </template>
     <template #doc-before>
       <header v-if="frontmatter.title" class="doc-heading">
-        <h1>{{ frontmatter.title }}</h1>
+        <h1>{{ titleBase }}<span v-if="hasAccentSuffix" class="doc-heading__accent" aria-hidden="true">_</span></h1>
         <p v-if="frontmatter.description">{{ frontmatter.description }}</p>
       </header>
     </template>

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -505,6 +505,10 @@ body {
   letter-spacing: -0.055em;
 }
 
+.doc-heading__accent {
+  color: var(--vp-c-brand-1);
+}
+
 .doc-heading p {
   max-width: 660px;
   margin: 14px 0 0;


### PR DESCRIPTION
## What changed
- render a trailing underscore in documentation titles as a separate accent element
- color the `Docs_` suffix with the Pentect brand color

## Why
The white underscore looked unfinished and missed the accent treatment used by the reference design.

## Validation
- `npm run build` in `website`
- inspected the title in the dark theme and confirmed baseline and spacing