### PR TITLE
docs: hide native scrollbars

### DIFF
--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -34,6 +34,18 @@ body {
   letter-spacing: -0.01em;
 }
 
+/* Keep wheel, touch, and keyboard scrolling without native scrollbar chrome. */
+* {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+*::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 .VPNavBar {
   background: color-mix(in srgb, var(--vp-c-bg) 88%, transparent) !important;
   backdrop-filter: blur(14px);
@@ -96,14 +108,6 @@ body {
 
 .VPSidebar .nav {
   padding-top: 22px;
-}
-
-.VPSidebar {
-  scrollbar-width: none;
-}
-
-.VPSidebar::-webkit-scrollbar {
-  display: none;
 }
 
 .VPSidebarItem.level-0 {


### PR DESCRIPTION
## Summary
- hide native scrollbar chrome across the docs UI
- preserve wheel, touch, keyboard, and anchor scrolling
- replace the sidebar-only rule with one shared cross-browser rule

## Validation
- `npm run build` in `website` 
- `git diff --check` 
- visually checked the long CLI reference at the top and `#plugins` anchor