### PR TITLE
docs: add actionable recovery steps

### DIFF
--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -32,5 +32,7 @@ pentect claude --upstream http://127.0.0.1:8080/anthropic
 ::: warning
 Pentect does not claim coverage for remote Cowork execution, Voice,
 experimental binary transports, or unknown future opaque routes. Unsupported
-formats follow the configured compatibility policy.
+formats follow the configured compatibility policy. See the
+[unknown-format recovery steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
+for protected alternatives and the explicit pass-through setting.
 :::

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -36,5 +36,7 @@ pentect codex --upstream http://127.0.0.1:8080/openai/v1
 
 ::: warning
 Codex App coverage applies to its supported Codex mode. Pentect does not claim
-protection for ChatGPT Chat, Work, Voice, or unknown future opaque routes.
+protection for ChatGPT Chat, Work, Voice, or unknown future opaque routes. If a
+request is blocked, follow the [unknown-format recovery steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
+instead of disabling Pentect for the whole app.
 :::

--- a/website/src/content/docs/clients/upstreams.md
+++ b/website/src/content/docs/clients/upstreams.md
@@ -28,4 +28,7 @@ does not certify every gateway provider or release.
 
 Pentect rejects an unsupported wire protocol before launching the client. A
 provider being OpenAI-like is not sufficient if its request or streaming format
-does not match a supported contract.
+does not match a supported contract. First retry without `--upstream` to confirm
+the client works with its default provider. If the custom gateway must be used,
+follow the [unknown-format recovery steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
+or report its protocol for support.

--- a/website/src/content/docs/protection/files-and-images.md
+++ b/website/src/content/docs/protection/files-and-images.md
@@ -11,6 +11,8 @@ OCR and visual redaction because pixels cannot carry a textual handle in place.
 
 Supported UTF-8 uploads are inspected and rewritten before forwarding. Binary
 uploads that Pentect cannot inspect or safely rewrite are blocked by default.
+Convert an unsupported upload to UTF-8 text, a supported image, or PDF when
+possible. There is no blanket binary-upload bypass.
 
 ## File IDs and remote URLs
 
@@ -32,4 +34,5 @@ unscanned = "block" # or "allow"
 ```
 
 Allowing unscanned images trades protection for compatibility. Use it only
-when another trusted layer already inspects the content.
+when another trusted layer already inspects the content. Set `unscanned` back
+to `"block"` and relaunch the client to restore the default.

--- a/website/src/content/docs/protection/security-model.md
+++ b/website/src/content/docs/protection/security-model.md
@@ -41,6 +41,10 @@ unknown_formats = "ignore"
 Project configuration cannot weaken this setting. This prevents a repository
 from silently choosing a less protective policy.
 
+See [Unknown provider format troubleshooting](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
+for protected alternatives, copyable setup commands, restart instructions, and
+how to restore the default.
+
 ::: danger
 Compatibility mode can allow content Pentect does not understand to reach an
 upstream. Do not enable it merely to suppress an unexplained error.

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -99,6 +99,9 @@ Pentect reads user configuration from `~/.pentect/config.toml` and project
 configuration from `.pentect/config.toml`. A project cannot weaken the user's
 unknown-format policy.
 
+For exact recovery and rollback steps, see
+[Unknown provider format troubleshooting](/reference/troubleshooting/#an-unknown-provider-format-was-blocked).
+
 ## Plugins
 
 | Capability | Command or format |

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -34,4 +34,5 @@ without printing the value.
 - Every provider and release behind a third-party gateway
 
 Unknown or unsupported content blocks by default rather than silently claiming
-protection.
+protection. If you encounter that error, first retry the default upstream, then
+follow the [unknown-format recovery steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked).

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -31,7 +31,13 @@ unknown_formats = "error" # default
 ```
 
 Set `ignore` only in the user configuration to continue past provider content
-Pentect does not understand.
+Pentect does not understand. Restart the Pentect-launched client after changing
+the value. `ignore` passes the affected unknown request upstream without
+inspection; change it back to `error` to restore the default.
+
+Project configuration may enforce `error`, but it cannot set `ignore`. See
+[Unknown provider format troubleshooting](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
+for copyable Windows, macOS, and Linux steps.
 
 ## Images
 

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -36,11 +36,64 @@ the active local protection context or an explicitly remembered file pointer.
 4. Retry with the default upstream to separate client discovery from gateway
    compatibility.
 
-## An unknown format was blocked
+## An unknown provider format was blocked
 
-This is the default security behavior. Capture the ordinary error details and
-open a compatibility issue if the format should be supported. User-level
-compatibility mode exists, but may expose content Pentect cannot inspect.
+This error means the client sent a provider request or content block that
+Pentect does not know how to inspect. The request was not sent upstream.
+
+### Try the protected path first
+
+1. Run `pentect doctor`, then check for a fix with `pentect update --check`.
+   Install it with `pentect update` if one is available.
+2. Retry without `--upstream`. If that works, the custom gateway is using a
+   different wire format from OpenAI Responses or Anthropic Messages.
+3. If the error followed a client update, retry the last known working client
+   version or report the new format so Pentect can add support.
+4. Use `pentect log` to capture the route and error category. Logs do not
+   include plaintext protected values.
+
+### Temporarily pass the request through
+
+If you trust the destination and need compatibility immediately, add this to
+the **user** configuration at `~/.pentect/config.toml`:
+
+```toml
+[compatibility]
+unknown_formats = "ignore"
+```
+
+Create the directory and open the file with:
+
+::: code-group
+
+```powershell [Windows]
+New-Item -ItemType Directory -Force "$HOME\.pentect" | Out-Null
+notepad "$HOME\.pentect\config.toml"
+```
+
+```sh [macOS / Linux]
+mkdir -p ~/.pentect
+${EDITOR:-vi} ~/.pentect/config.toml
+```
+
+:::
+
+If `[compatibility]` already exists, change its `unknown_formats` value instead
+of adding a second table. Then close and relaunch the Pentect-launched client.
+There is intentionally no per-project or one-launch bypass: a repository must
+not be able to weaken this user decision.
+
+With `ignore`, an unknown request can reach the upstream without Pentect
+inspecting or masking that request. Supported requests remain protected. To
+restore the default, change the value back to `"error"` and relaunch the
+client.
+
+### Report a format Pentect should support
+
+Open a [compatibility report](https://github.com/EdamAme-x/pentect/issues/new?template=bug_report.yml)
+with the Pentect version, client and version, command, upstream type, route, and
+the complete error text. Replace credentials and private content with synthetic
+values before attaching a request sample.
 
 ## Follow protection events
 


### PR DESCRIPTION
## Summary
- replace the vague unknown-format warning with a complete recovery flow
- document update checks, default-upstream diagnosis, user-level pass-through configuration, restart, rollback, and issue reporting
- add copyable Windows, macOS, and Linux setup commands
- link Codex, Claude, upstream, compatibility, configuration, and security pages to the recovery steps
- clarify the supported alternatives for blocked binary files and unscanned images

## Root cause
The docs described why Pentect blocked unknown content but did not tell users how to recover or deliberately choose compatibility.

## Validation
- `npm run build` in `website` 
- generated all 18 agent-readable Markdown pages
- `git diff --check` 
- visually verified the troubleshooting page and OS tabs in the local production preview