### PR TITLE
docs: clarify direct client arguments

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1949,7 +1949,7 @@ fn codex_effective_routing(opts: &AgentToolOpts) -> Result<CodexHttpRouting, Str
         })
         .ok_or_else(|| {
             format!(
-                "could not determine upstream for Codex provider '{provider}'; pass `pentect codex --upstream URL -- ...`"
+                "could not determine upstream for Codex provider '{provider}'; pass `pentect codex --upstream URL`"
             )
         })?;
     if provider != "openai" {
@@ -2491,6 +2491,33 @@ mod tests {
             claude.anthropic_upstream.as_deref(),
             Some("https://gateway.example/anthropic")
         );
+    }
+
+    #[test]
+    fn agent_options_forward_client_arguments_without_separator() {
+        let codex = AgentToolOpts::parse(
+            AgentTool::Codex,
+            &[
+                "pentect".to_string(),
+                "codex".to_string(),
+                "exec".to_string(),
+                "--full-auto".to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(codex.tool_args, ["exec", "--full-auto"]);
+
+        let claude = AgentToolOpts::parse(
+            AgentTool::Claude,
+            &[
+                "pentect".to_string(),
+                "claude".to_string(),
+                "--model".to_string(),
+                "sonnet".to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(claude.tool_args, ["--model", "sonnet"]);
     }
 
     #[test]

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -11,7 +11,7 @@ description: Every user-facing Pentect capability, grouped by the job it perform
 | Protect Claude Code | `pentect claude` |
 | Launch a protected Codex App session | `pentect codex app` |
 | Launch a protected Claude Desktop session | `pentect claude app` |
-| Forward normal client arguments | Place them after `--` |
+| Forward normal client arguments | Pass them normally, for example `pentect codex exec --full-auto` |
 | Select a compatible upstream for one launch | `--upstream URL` |
 | Load an additional plugin for one launch | `--plugins SOURCE` |
 | Check an app setup without launching it | `pentect codex app --check` or `pentect claude app --check` |

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -16,6 +16,13 @@ Client launchers accept `--upstream URL` for a compatible upstream and
 `--plugins SOURCE` for a one-off plugin addition. App launchers also accept
 `--app PATH` and `--check`.
 
+Codex and Claude arguments are forwarded directly:
+
+```text
+pentect codex exec --full-auto
+pentect claude --model sonnet
+```
+
 ## Protect local input and execution
 
 | Command | Purpose |


### PR DESCRIPTION
## Summary
- document that Codex and Claude arguments are passed normally without a separator
- add direct forwarding examples for both clients
- remove the stale `-- ...` suggestion from the Codex upstream error
- add a regression test for separator-free client arguments

## Root cause
The CLI already forwarded the first unrecognized argument and everything after it, but the capabilities page incorrectly said normal arguments must follow `--`.

## Validation
- targeted Rust parser test
- real debug-binary dry-runs for Codex and Claude
- `npm run build` in `website` 
- generated all 18 agent-readable Markdown pages
- `git diff --check`