### PR TITLE
docs: remove obsolete option guidance

### DIFF
--- a/website/src/content/docs/protection/structured-data.md
+++ b/website/src/content/docs/protection/structured-data.md
@@ -38,6 +38,3 @@ PowerShell:
 ```powershell
 Get-Content .env -Raw | pentect mask
 ```
-
-No `--kind` flag is required for ordinary input. Pentect infers the format from
-the source or content where available.

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -62,8 +62,6 @@ kubeconfig, AWS, npm, PyPI, JSON, and other supported key/value formats.
 | `pentect update --check` | Check for an update without installing it |
 | `pentect uninstall` | Remove the binary while retaining project data |
 
-`mask` works in ordinary pipelines; no `--kind` flag is required:
-
 ```sh
 cat .env | pentect mask
 cat terraform.tfvars | pentect mask


### PR DESCRIPTION
## Summary
- remove the unnecessary claim that `--kind` is not required
- keep the pipeline examples without introducing a nonexistent user concept
- remove the same wording from both Capabilities and Structured data

## Validation
- `npm run build` in `website` 
- generated all 18 agent-readable Markdown pages
- verified no obsolete option guidance remains
- `git diff --check`