### PR TITLE
docs: highlight command examples

### DIFF
--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -5,11 +5,11 @@ description: Run Claude Code and supported Claude Desktop routes through Pentect
 
 ::: code-group
 
-```text [Claude Code]
+```sh [Claude Code]
 pentect claude
 ```
 
-```text [Claude Desktop]
+```sh [Claude Desktop]
 pentect claude app
 ```
 
@@ -25,7 +25,7 @@ Supported Chat, attachment, and Claude Code traffic is inspected before it
 reaches the Anthropic-compatible upstream. Completed local tool calls can use
 opaque handles without exposing their plaintext to the model.
 
-```text
+```sh
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```
 

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -5,11 +5,11 @@ description: Run Codex CLI and Codex App through Pentect.
 
 ::: code-group
 
-```text [CLI]
+```sh [CLI]
 pentect codex
 ```
 
-```text [App]
+```sh [App]
 pentect codex app
 ```
 
@@ -30,7 +30,7 @@ tool-call arguments while preserving streaming responses.
 Existing Codex provider configuration is retained as the upstream when its wire
 protocol is supported. You can also select an upstream for one launch:
 
-```text
+```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 ```
 

--- a/website/src/content/docs/clients/upstreams.md
+++ b/website/src/content/docs/clients/upstreams.md
@@ -6,7 +6,7 @@ description: Route supported OpenAI Responses and Anthropic Messages traffic thr
 Pentect can protect a client while forwarding requests to an existing local or
 remote gateway.
 
-```text
+```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```

--- a/website/src/content/docs/plugins/overview.md
+++ b/website/src/content/docs/plugins/overview.md
@@ -12,7 +12,7 @@ Native executable plugins and postscripts are not supported.
 
 ## Install a plugin
 
-```text
+```sh
 pentect plugins add github:@owner/repository/path
 ```
 
@@ -21,7 +21,7 @@ Codex, Claude, and supported desktop-app launchers.
 
 ## Manage plugins
 
-```text
+```sh
 pentect plugins list
 pentect plugins inspect NAME
 pentect plugins config NAME key=value

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -72,7 +72,7 @@ cat terraform.tfvars | pentect mask
 Pentect can sit in front of an existing compatible gateway for a single
 launch:
 
-```text
+```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -18,7 +18,7 @@ Client launchers accept `--upstream URL` for a compatible upstream and
 
 Codex and Claude arguments are forwarded directly:
 
-```text
+```sh
 pentect codex exec --full-auto
 pentect claude --model sonnet
 ```
@@ -51,7 +51,7 @@ Prefer `exec` when a command can consume a handle directly.
 
 ## Plugins
 
-```text
+```sh
 pentect plugins new NAME
 pentect plugins dev PATH
 pentect plugins publish PATH

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -24,7 +24,7 @@ does not expose OpenAI Responses or Anthropic Messages directly. The adapter
 converts the API format; Pentect continues to inspect the supported client-side
 contract.
 
-```text
+```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -5,13 +5,13 @@ description: Diagnose launch, compatibility, handle, and installation problems.
 
 ## Start with doctor
 
-```text
+```sh
 pentect doctor
 ```
 
 For automation or an issue report:
 
-```text
+```sh
 pentect doctor --json
 ```
 
@@ -97,7 +97,7 @@ values before attaching a request sample.
 
 ## Follow protection events
 
-```text
+```sh
 pentect log
 pentect log --json
 ```

--- a/website/src/content/docs/start/install.md
+++ b/website/src/content/docs/start/install.md
@@ -54,14 +54,14 @@ Pentect from source and therefore takes longer than the binary installers.
 
 ## Verify the installation
 
-```text
+```sh
 pentect doctor
 ```
 
 `doctor` checks whether Pentect and supported clients are ready. If it reports
 a repairable problem, review the proposed change before using:
 
-```text
+```sh
 pentect doctor --fix
 ```
 
@@ -86,7 +86,7 @@ it through the same package manager.
 
 ## Update or uninstall
 
-```text
+```sh
 pentect update
 pentect update X.Y.Z
 pentect uninstall

--- a/website/src/content/docs/start/what-is-pentect.md
+++ b/website/src/content/docs/start/what-is-pentect.md
@@ -11,14 +11,14 @@ then resolves those handles only at trusted local tool boundaries.
 
 Conventional redaction protects a value by removing its meaning:
 
-```text
+```dotenv
 DATABASE_URL=[REDACTED]
 ```
 
 The model can no longer use that value in a command. Pentect preserves a typed,
 stable reference instead:
 
-```text
+```dotenv
 DATABASE_URL=<<DATABASE_URL_4ce8a3b0a6f64e12>>
 ```
 


### PR DESCRIPTION
## Summary
- use shell syntax highlighting for executable CLI examples across the docs
- use dotenv highlighting for redaction examples
- remove all remaining plain-text code fences

## Validation
- `npm run build` in `website` 
- generated all 18 agent-readable Markdown pages
- verified no `text` fences remain
- `git diff --check` 
- visually verified command, option, and URL highlighting on Custom gateways