### PR TITLE
docs: add persistent Pentect wrappers

### DIFF
--- a/website/src/content/docs/plugins/build.md
+++ b/website/src/content/docs/plugins/build.md
@@ -5,26 +5,26 @@ description: Start a Pentect plugin and test it locally.
 
 1. Create a plugin project.
 
-   ```text
+   ```sh
    pentect plugins new my-plugin
    ```
 
 2. Run it from the local directory.
 
-   ```text
+   ```sh
    pentect plugins dev ./my-plugin
    ```
 
 3. Test its declared behavior and permissions.
 
-   ```text
+   ```sh
    pentect plugins test my-plugin
    pentect plugins inspect my-plugin
    ```
 
 4. Publish the prepared plugin.
 
-   ```text
+   ```sh
    pentect plugins publish ./my-plugin
    ```
 

--- a/website/src/content/docs/start/how-it-works.md
+++ b/website/src/content/docs/start/how-it-works.md
@@ -13,7 +13,7 @@ supported request and response structures without replacing the client UI.
 
 2. **Replace with an opaque handle**
 
-   ```text
+   ```dotenv
    KAGGLE_API_TOKEN=KGAT_example
    KAGGLE_API_TOKEN=<<KAGGLE_API_TOKEN_85268c441f88c284>>
    ```

--- a/website/src/content/docs/start/quick-start.md
+++ b/website/src/content/docs/start/quick-start.md
@@ -5,13 +5,13 @@ description: Protect a real Codex or Claude session in a few commands.
 
 1. Check that Pentect can find your client.
 
-   ```text
+   ```sh
    pentect doctor
    ```
 
 2. Launch the client through Pentect.
 
-   ```text
+   ```sh
    pentect codex
    # or
    pentect claude
@@ -25,9 +25,45 @@ description: Protect a real Codex or Claude session in a few commands.
 
 4. Watch local protection events when needed.
 
-   ```text
+   ```sh
    pentect log
    ```
+
+## Launch through Pentect by default
+
+Add these functions to your shell profile, then restart the terminal. Existing
+Codex and Claude arguments continue to work normally.
+
+::: code-group
+
+```powershell [PowerShell · $PROFILE]
+function codex { & pentect codex @args }
+function claude { & pentect claude @args }
+```
+
+```sh [Bash · ~/.bashrc or Zsh · ~/.zshrc]
+codex() { command pentect codex "$@"; }
+claude() { command pentect claude "$@"; }
+```
+
+```fish [Fish · ~/.config/fish/config.fish]
+function codex
+    command pentect codex $argv
+end
+
+function claude
+    command pentect claude $argv
+end
+```
+
+:::
+
+After that, launch either client as usual:
+
+```sh
+codex exec --full-auto
+claude --model sonnet
+```
 
 ## Try masking without an agent
 
@@ -46,6 +82,6 @@ The output contains reusable handles. Plaintext is not printed back to the
 terminal.
 
 ::: tip
-Pentect does not create a permanent global proxy. `pentect codex` and
-`pentect claude` protect only the client process launched by that command.
+These functions affect only that shell. Pentect protects each client process
+launched through them; it does not create a system-wide proxy.
 :::


### PR DESCRIPTION
## What changed

- document persistent PowerShell, Bash/Zsh, and Fish wrappers for Codex and Claude
- forward existing client arguments unchanged through Pentect
- finish syntax highlighting for previously plain-text command and dotenv examples

## Why

Users can keep typing `codex` or `claude` while ensuring every client process launched from that shell goes through Pentect.

## Validation

- `npm run build` in `website`
- generated 18 agent-readable Markdown pages
- `git diff --check`
- verified the Quick start layout and profile tabs in Chrome