### PR TITLE
docs: shorten home page copy

### DIFF
--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -1,11 +1,9 @@
 ---
 title: Docs_
-description: Keep sensitive values local while Codex and Claude use the context they need.
+description: Keep secrets out of AI requests.
 pageClass: docs-hub
 aside: false
 ---
-
-Pentect replaces sensitive values with usable handles before requests leave your machine. Known handles are restored only at trusted local boundaries.
 
 <HomeInstall />
 


### PR DESCRIPTION
## What changed

- replace the long home-page pitch with one direct sentence
- remove the repeated masking explanation before the install UI

## Result

The page now opens with: `Keep secrets out of AI requests.`

## Validation

- `npm run build` in `website`
- generated 18 agent-readable Markdown pages
- `git diff --check`