### PR TITLE
feat: serve installers from pentect.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ plugins.
 Windows PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.ps1 | iex
+irm https://pentect.dev/install | iex
 ```
 
 Linux and macOS:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.sh | sh
+curl -fsSL https://pentect.dev/install.sh | sh
 ```
 
 The installers detect the platform, download a GitHub Release asset, and verify
@@ -58,7 +58,7 @@ Debian and Ubuntu users can configure the signed Pentect repository and install
 the package with one command:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install-apt.sh | sudo sh
+curl -fsSL https://pentect.dev/install-apt.sh | sudo sh
 ```
 
 When installed by Homebrew, Nix, or apt, use that package manager to update or

--- a/tools/build_apt_repository.sh
+++ b/tools/build_apt_repository.sh
@@ -54,7 +54,7 @@ gpg --batch --yes --local-user "$fingerprint" --armor --detach-sign --output "$d
 install -m 0644 "$public_key" "$output_dir/apt/pentect-archive-keyring.asc"
 cat > "$output_dir/apt/pentect.sources" <<'EOF'
 Types: deb
-URIs: https://edamame-x.github.io/pentect/apt
+URIs: https://pentect.dev/apt
 Suites: stable
 Components: main
 Signed-By: /etc/apt/keyrings/pentect-archive-keyring.asc

--- a/tools/install-apt.sh
+++ b/tools/install-apt.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -eu
 
-repository_url="https://edamame-x.github.io/pentect/apt"
-key_url="https://raw.githubusercontent.com/EdamAme-x/pentect/main/packaging/apt/pentect-archive-keyring.asc"
+repository_url="https://pentect.dev/apt"
+key_url="https://pentect.dev/apt/pentect-archive-keyring.asc"
 key_sha256="d6d59be8b1d87fa731577f52d98a604f2687bf97f6c5e1981dd805e78a7ff7ac"
 
 if [ "$(id -u)" -ne 0 ]; then

--- a/website/.vitepress/theme/HomeInstall.vue
+++ b/website/.vitepress/theme/HomeInstall.vue
@@ -35,7 +35,7 @@ const installers: Record<OperatingSystem, Installer[]> = {
     {
       id: 'powershell',
       label: 'PowerShell',
-      command: 'irm https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.ps1 | iex',
+      command: 'irm https://pentect.dev/install | iex',
       icon: '>_',
       tone: 'powershell',
     },
@@ -53,7 +53,7 @@ const installers: Record<OperatingSystem, Installer[]> = {
     {
       id: 'shell',
       label: 'Shell',
-      command: 'curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.sh | sh',
+      command: 'curl -fsSL https://pentect.dev/install.sh | sh',
       icon: '$_',
       tone: 'shell',
     },
@@ -78,14 +78,14 @@ const installers: Record<OperatingSystem, Installer[]> = {
     {
       id: 'shell',
       label: 'Shell',
-      command: 'curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.sh | sh',
+      command: 'curl -fsSL https://pentect.dev/install.sh | sh',
       icon: '$_',
       tone: 'shell',
     },
     {
       id: 'apt',
       label: 'APT',
-      command: 'curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install-apt.sh | sudo sh',
+      command: 'curl -fsSL https://pentect.dev/install-apt.sh | sudo sh',
       icon: 'A',
       tone: 'apt',
     },

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vitepress dev",
-    "build": "vitepress build && node scripts/generate-agent-docs.mjs",
+    "build": "vitepress build && node scripts/copy-installers.mjs && node scripts/generate-agent-docs.mjs",
     "preview": "vitepress preview"
   },
   "dependencies": {

--- a/website/scripts/copy-installers.mjs
+++ b/website/scripts/copy-installers.mjs
@@ -1,0 +1,23 @@
+import { copyFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const websiteRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repositoryRoot = resolve(websiteRoot, '..');
+const outputRoot = resolve(websiteRoot, 'dist');
+
+const installers = [
+  ['tools/install.ps1', 'install/index.html'],
+  ['tools/install.sh', 'install.sh'],
+  ['tools/install-apt.sh', 'install-apt.sh'],
+];
+
+await Promise.all(
+  installers.map(async ([source, destination]) => {
+    const output = resolve(outputRoot, destination);
+    await mkdir(dirname(output), { recursive: true });
+    await copyFile(resolve(repositoryRoot, source), output);
+  }),
+);
+
+console.log(`Published ${installers.length} installer endpoints.`);

--- a/website/src/content/docs/start/install.md
+++ b/website/src/content/docs/start/install.md
@@ -8,7 +8,7 @@ description: Install Pentect on Windows, macOS, or Linux.
 Run in PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.ps1 | iex
+irm https://pentect.dev/install | iex
 ```
 
 ## macOS and Linux
@@ -16,7 +16,7 @@ irm https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.ps1 |
 ::: code-group
 
 ```sh [Shell]
-curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.sh | sh
+curl -fsSL https://pentect.dev/install.sh | sh
 ```
 
 ```sh [Homebrew]
@@ -40,7 +40,7 @@ cargo install --git https://github.com/EdamAme-x/pentect --locked pentect-cli
 ```
 
 ```sh [APT · Debian / Ubuntu]
-curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install-apt.sh | sudo sh
+curl -fsSL https://pentect.dev/install-apt.sh | sudo sh
 ```
 
 :::
@@ -70,11 +70,11 @@ pentect doctor --fix
 ::: code-group
 
 ```powershell [Windows]
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.ps1))) -Version X.Y.Z
+& ([scriptblock]::Create((irm https://pentect.dev/install))) -Version X.Y.Z
 ```
 
 ```sh [macOS / Linux]
-curl -fsSL https://raw.githubusercontent.com/EdamAme-x/pentect/main/tools/install.sh | sh -s -- --version X.Y.Z
+curl -fsSL https://pentect.dev/install.sh | sh -s -- --version X.Y.Z
 ```
 
 :::


### PR DESCRIPTION
## What changed

- serve the PowerShell installer at `https://pentect.dev/install`
- serve shell and apt installers at `https://pentect.dev/install.sh` and `/install-apt.sh`
- copy installer sources into the built site so there is only one maintained implementation
- update the home page, install docs, README, and apt repository URLs

## Why

Public installation commands should use the Pentect domain instead of exposing GitHub Raw implementation URLs.

## Validation

- docs build generated 18 agent-readable Markdown pages
- published installer files match their source SHA-256 hashes exactly
- PowerShell and POSIX shell syntax checks passed
- local HTTP check: `/install` returns status 200, `text/html`, a PowerShell string, exact source content, and zero parser errors
- no old public installer or apt key URLs remain