### PR TITLE
docs: refine home installer UI

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -95,7 +95,7 @@ export default defineConfig({
   },
   head: [
     ['link', { rel: 'icon', href: '/pentect-logo-transparent.png' }],
-    ['meta', { name: 'theme-color', content: '#f7f5ef' }],
+    ['meta', { name: 'theme-color', content: '#ffffff' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { name: 'twitter:card', content: 'summary' }],
   ],

--- a/website/.vitepress/theme/HomeInstall.vue
+++ b/website/.vitepress/theme/HomeInstall.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue';
 
 type OperatingSystem = 'windows' | 'macos' | 'linux';
 type Installer = { id: string; label: string; command: string; icon: string; tone: string };
+type CommandToken = { text: string; kind: 'space' | 'command' | 'option' | 'string' | 'operator' | 'argument' };
 
 const operatingSystems: Array<{
   id: OperatingSystem;
@@ -113,12 +114,30 @@ const selectedMethod = ref('powershell');
 const copyState = ref<'idle' | 'copied' | 'failed'>('idle');
 
 const methods = computed(() => installers[selectedOs.value]);
-const selectedOperatingSystem = computed(
-  () => operatingSystems.find((item) => item.id === selectedOs.value) ?? operatingSystems[0],
-);
 const selectedInstaller = computed(
   () => methods.value.find((item) => item.id === selectedMethod.value) ?? methods.value[0],
 );
+const commandTokens = computed(() => tokenizeCommand(selectedInstaller.value.command));
+
+function tokenizeCommand(command: string): CommandToken[] {
+  const parts = command.match(/https?:\/\/[^\s|]+|github:[^\s|]+|--?[\w-]+|\||[^\s|]+|\s+/g) ?? [command];
+  let expectsCommand = true;
+
+  return parts.map((text) => {
+    if (/^\s+$/.test(text)) return { text, kind: 'space' };
+    if (text === '|') {
+      expectsCommand = true;
+      return { text, kind: 'operator' };
+    }
+    if (expectsCommand) {
+      expectsCommand = false;
+      return { text, kind: 'command' };
+    }
+    if (text.startsWith('-')) return { text, kind: 'option' };
+    if (/^(?:https?:\/\/|github:)/.test(text)) return { text, kind: 'string' };
+    return { text, kind: 'argument' };
+  });
+}
 
 function chooseOs(os: OperatingSystem) {
   selectedOs.value = os;
@@ -149,70 +168,66 @@ onMounted(() => {
 <template>
   <section class="home-install" aria-labelledby="install-heading">
     <div class="home-install__heading">
-      <div>
-        <p>Install</p>
-        <h2 id="install-heading">Start with one command.</h2>
-      </div>
+      <p id="install-heading">Install</p>
       <a href="/start/install/">All options <span aria-hidden="true">→</span></a>
     </div>
 
-    <p class="home-install__sentence">
-      <span>Install Pentect for</span>
-      <label class="install-select">
-        <span
-          class="install-select__icon"
-          :data-tone="selectedOperatingSystem.tone"
-          aria-hidden="true"
-        >{{ selectedOperatingSystem.icon }}</span>
-        <select
-          v-model="selectedOs"
-          aria-label="Operating system"
-          @change="chooseOs(selectedOs)"
+    <div class="home-install__controls">
+      <div class="install-choice" role="group" aria-label="Operating system">
+        <span class="install-choice__label">OS</span>
+        <button
+          v-for="os in operatingSystems"
+          :key="os.id"
+          type="button"
+          :class="{ 'is-active': selectedOs === os.id }"
+          :aria-pressed="selectedOs === os.id"
+          @click="chooseOs(os.id)"
         >
-          <option v-for="os in operatingSystems" :key="os.id" :value="os.id">
-            {{ os.label }}
-          </option>
-        </select>
-        <span class="install-select__chevron" aria-hidden="true">⌄</span>
-      </label>
-      <span>using</span>
-      <label class="install-select">
-        <span
-          class="install-select__icon"
-          :data-tone="selectedInstaller.tone"
-          aria-hidden="true"
-        >{{ selectedInstaller.icon }}</span>
-        <select
-          v-model="selectedMethod"
-          aria-label="Installation method"
-          @change="chooseMethod(selectedMethod)"
-        >
-          <option v-for="method in methods" :key="method.id" :value="method.id">
-            {{ method.label }}
-          </option>
-        </select>
-        <span class="install-select__chevron" aria-hidden="true">⌄</span>
-      </label>
-    </p>
-
-    <div class="home-install__command">
-      <div class="home-install__code">
-        <code>{{ selectedInstaller.command }}</code>
-      </div>
-      <div class="home-install__command-footer">
-        <span>
-          <i
-            class="install-select__icon"
-            :data-tone="selectedInstaller.tone"
-            aria-hidden="true"
-          >{{ selectedInstaller.icon }}</i>
-          {{ selectedInstaller.label }}
-        </span>
-        <button type="button" @click="copyCommand">
-          <span aria-hidden="true">▣</span>
-          {{ copyState === 'copied' ? 'Copied' : 'Copy command' }}
+          <i class="install-select__icon" :data-tone="os.tone" aria-hidden="true">{{ os.icon }}</i>
+          {{ os.label }}
         </button>
       </div>
+
+      <div class="install-choice" role="group" aria-label="Installation method">
+        <span class="install-choice__label">Method</span>
+        <button
+          v-for="method in methods"
+          :key="method.id"
+          type="button"
+          :class="{ 'is-active': selectedMethod === method.id }"
+          :aria-pressed="selectedMethod === method.id"
+          @click="chooseMethod(method.id)"
+        >
+          <i class="install-select__icon" :data-tone="method.tone" aria-hidden="true">{{ method.icon }}</i>
+          {{ method.label }}
+        </button>
+      </div>
+    </div>
+
+    <div class="home-install__command">
+      <code aria-live="polite">
+        <span
+          v-for="(token, index) in commandTokens"
+          :key="`${index}-${token.text}`"
+          :class="`shell-token shell-token--${token.kind}`"
+        >{{ token.text }}</span>
+      </code>
+      <button
+        type="button"
+        class="home-install__copy"
+        :class="{ 'is-copied': copyState === 'copied' }"
+        :aria-label="copyState === 'copied' ? 'Copied' : 'Copy command'"
+        :title="copyState === 'copied' ? 'Copied' : 'Copy command'"
+        @click="copyCommand"
+      >
+        <svg v-if="copyState === 'copied'" aria-hidden="true" viewBox="0 0 24 24">
+          <path d="m5 12 4 4L19 6" />
+        </svg>
+        <svg v-else aria-hidden="true" viewBox="0 0 24 24">
+          <rect x="8" y="8" width="11" height="11" rx="2" />
+          <path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3" />
+        </svg>
+      </button>
     </div>
     <p v-if="copyState === 'failed'" class="home-install__status" role="status">
       Select the command and copy it manually.

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -3,15 +3,15 @@
   --vp-c-brand-2: #c83c24;
   --vp-c-brand-3: #a92f1c;
   --vp-c-brand-soft: rgba(221, 72, 45, 0.12);
-  --vp-c-bg: #f8f6f0;
-  --vp-c-bg-alt: #f1efe8;
-  --vp-c-bg-elv: #fdfcf8;
-  --vp-c-bg-soft: #f0eee7;
-  --vp-c-text-1: #242620;
-  --vp-c-text-2: #62645d;
-  --vp-c-text-3: #8a8c84;
-  --vp-c-divider: #dcddd5;
-  --vp-c-gutter: #e7e6df;
+  --vp-c-bg: #ffffff;
+  --vp-c-bg-alt: #f7f7f7;
+  --vp-c-bg-elv: #ffffff;
+  --vp-c-bg-soft: #f4f4f4;
+  --vp-c-text-1: #171717;
+  --vp-c-text-2: #5f5f5f;
+  --vp-c-text-3: #888888;
+  --vp-c-divider: #e2e2e2;
+  --vp-c-gutter: #ededed;
   --vp-font-family-base: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --vp-font-family-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   --vp-nav-height: 72px;
@@ -19,15 +19,15 @@
 }
 
 .dark {
-  --vp-c-bg: #181b17;
-  --vp-c-bg-alt: #20231e;
-  --vp-c-bg-elv: #242721;
-  --vp-c-bg-soft: #252821;
-  --vp-c-text-1: #f3f1ea;
-  --vp-c-text-2: #b7b9b0;
-  --vp-c-text-3: #85897f;
-  --vp-c-divider: #353931;
-  --vp-c-gutter: #282c25;
+  --vp-c-bg: #0d0d0d;
+  --vp-c-bg-alt: #141414;
+  --vp-c-bg-elv: #121212;
+  --vp-c-bg-soft: #1a1a1a;
+  --vp-c-text-1: #f5f5f5;
+  --vp-c-text-2: #b5b5b5;
+  --vp-c-text-3: #7d7d7d;
+  --vp-c-divider: #292929;
+  --vp-c-gutter: #1d1d1d;
 }
 
 body {
@@ -231,14 +231,13 @@ body {
 
 .home-install__heading {
   display: flex;
-  align-items: end;
+  align-items: center;
   justify-content: space-between;
   gap: 24px;
-  padding: 30px 32px 24px;
+  padding: 22px 24px;
 }
 
-.home-install__heading p,
-.home-install__heading h2 {
+.home-install__heading p {
   margin: 0;
   border: 0;
   padding: 0;
@@ -252,13 +251,6 @@ body {
   text-transform: uppercase;
 }
 
-.home-install__heading h2 {
-  margin-top: 5px;
-  font-size: clamp(24px, 3vw, 34px);
-  line-height: 1.2;
-  letter-spacing: -0.04em;
-}
-
 .home-install__heading a {
   flex: none;
   color: var(--vp-c-text-2);
@@ -266,54 +258,65 @@ body {
   font-weight: 550;
 }
 
-.home-install__sentence {
+.home-install__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 0 24px 24px;
+}
+
+.install-choice {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 10px;
-  margin: 0 !important;
-  padding: 2px 32px 30px;
-  color: var(--vp-c-text-1);
-  font-size: 17px;
-  line-height: 1.4;
+  gap: 8px;
 }
 
-.install-select {
-  position: relative;
+.install-choice__label {
+  width: 62px;
+  flex: none;
+  color: var(--vp-c-text-3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.install-choice button {
   display: inline-flex;
   align-items: center;
-  min-width: 142px;
-}
-
-.install-select select {
-  width: 100%;
-  height: 44px;
-  appearance: none;
+  gap: 8px;
+  min-height: 42px;
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
-  padding: 0 36px 0 43px;
-  color: var(--vp-c-text-1);
-  background: var(--vp-c-bg);
-  font: inherit;
+  padding: 7px 11px 7px 8px;
+  color: var(--vp-c-text-2);
+  background: transparent;
   font-size: 14px;
-  font-weight: 650;
+  font-weight: 600;
   cursor: pointer;
+  transition: border-color 140ms ease, color 140ms ease, background-color 140ms ease;
+}
+
+.install-choice button:hover {
+  border-color: color-mix(in srgb, var(--vp-c-text-1) 28%, var(--vp-c-divider));
+  color: var(--vp-c-text-1);
+}
+
+.install-choice button:focus-visible {
   outline: none;
-}
-
-.install-select select:hover {
-  border-color: color-mix(in srgb, var(--vp-c-brand-1) 38%, var(--vp-c-divider));
-}
-
-.install-select select:focus-visible {
   border-color: var(--vp-c-brand-1);
   box-shadow: 0 0 0 3px var(--vp-c-brand-soft);
 }
 
+.install-choice button.is-active {
+  border-color: var(--vp-c-text-1);
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+}
+
 .install-select__icon {
-  position: absolute;
-  left: 10px;
-  z-index: 1;
+  position: static;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -327,7 +330,7 @@ body {
   font-style: normal;
   font-weight: 800;
   line-height: 1;
-  pointer-events: none;
+  flex: none;
 }
 
 .install-select__icon[data-tone='windows'] { background: #087cd5; font-size: 18px; }
@@ -341,79 +344,79 @@ body {
 .install-select__icon[data-tone='apt'] { background: #a80030; }
 .install-select__icon[data-tone='nix'] { background: #5277c3; font-size: 14px; }
 
-.install-select__chevron {
-  position: absolute;
-  right: 12px;
-  color: var(--vp-c-text-3);
-  font-size: 16px;
-  line-height: 1;
-  pointer-events: none;
-}
-
 .home-install__command {
-  display: block;
+  position: relative;
   min-width: 0;
   border-top: 1px solid var(--vp-c-divider);
-  background: #191c18;
-}
-
-.home-install__code {
-  min-width: 0;
-  padding: 24px;
+  background: #0d0d0d;
 }
 
 .vp-doc .home-install__command code {
   display: block;
   overflow-x: auto;
-  padding: 0;
-  color: #f4f2eb;
+  padding: 24px 68px 24px 24px;
+  color: #eeeeee;
   background: transparent;
   font-size: 13px;
   white-space: nowrap;
 }
 
-.home-install__command-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  min-height: 48px;
-  padding: 8px 12px 8px 20px;
-  border-top: 1px solid rgba(255, 255, 255, 0.09);
-  color: #b9bdb4;
-  font-size: 12px;
-}
+.shell-token--command { color: #ff7b63; }
+.shell-token--option { color: #c6a0ff; }
+.shell-token--string { color: #8bd5ca; }
+.shell-token--operator { color: #f4bf75; }
+.shell-token--argument { color: #d9e0ee; }
 
-.home-install__command-footer > span {
+.home-install__copy {
+  position: absolute;
+  top: 50%;
+  right: 16px;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-}
-
-.home-install__command-footer .install-select__icon {
-  position: static;
-  width: 20px;
-  height: 20px;
-}
-
-.home-install__command button {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  flex: none;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  opacity: 0;
+  transform: translateY(-50%) translateX(4px);
   border: 0;
   border-radius: 7px;
-  padding: 7px 12px;
-  color: #d8dbd2;
-  background: #353930;
-  font: inherit;
-  font-size: 12px;
+  padding: 0;
+  color: #bcbcbc;
+  background: #242424;
   cursor: pointer;
+  transition: opacity 140ms ease, transform 140ms ease, color 140ms ease, background-color 140ms ease;
 }
 
-.home-install__command button:hover {
+.home-install__command:hover .home-install__copy,
+.home-install__command:focus-within .home-install__copy {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+.home-install__copy:hover {
   color: #fff;
-  background: #42473d;
+  background: #333333;
+}
+
+.home-install__copy:focus-visible {
+  opacity: 1;
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+  transform: translateY(-50%) translateX(0);
+}
+
+.home-install__copy.is-copied {
+  color: #8bd5ca;
+}
+
+.home-install__copy svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .home-install__status {
@@ -456,9 +459,7 @@ body {
 }
 
 .docs-hub .VPDoc {
-  background:
-    radial-gradient(circle at 72% 8%, rgba(221, 72, 45, 0.10), transparent 32rem),
-    var(--vp-c-bg);
+  background: var(--vp-c-bg);
 }
 
 .docs-hub .VPDoc .container {
@@ -645,27 +646,33 @@ body {
   }
 
   .home-install__heading {
-    align-items: start;
-    flex-direction: column;
-    padding: 24px 20px 20px;
-  }
-
-  .home-install__sentence {
-    align-items: stretch;
-    padding: 0 20px 24px;
-    font-size: 15px;
-  }
-
-  .home-install__sentence > span {
-    align-self: center;
-  }
-
-  .install-select {
-    flex: 1 1 145px;
-  }
-
-  .home-install__code {
     padding: 20px;
+  }
+
+  .home-install__controls {
+    gap: 16px;
+    padding: 0 20px 20px;
+  }
+
+  .install-choice {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .install-choice__label {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    width: 54px;
+    align-self: stretch;
+    display: inline-flex;
+    align-items: center;
+    background: var(--vp-c-bg-elv);
+  }
+
+  .install-choice button {
+    flex: none;
   }
 
   .home-install__command code {
@@ -674,12 +681,15 @@ body {
   }
 
   .vp-doc .home-install__command code {
+    padding: 20px 62px 20px 20px;
     white-space: normal;
     overflow-wrap: anywhere;
   }
 
-  .home-install__command-footer {
-    padding-left: 14px;
+  .home-install__copy {
+    right: 12px;
+    opacity: 1;
+    transform: translateY(-50%);
   }
 
   .home-routes {

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -1,15 +1,13 @@
 ---
 title: Docs_
-description: Keep secrets out of AI requests.
+description: Let agents use secrets without seeing them.
 pageClass: docs-hub
 aside: false
 ---
 
 <HomeInstall />
 
-## Start with a client
-
-Choose the surface you already use. Pentect only applies to sessions you launch through it.
+## Clients
 
 <DocsGrid class="is-compact">
   <a href="/clients/codex/" class="docs-grid__item">
@@ -30,9 +28,7 @@ Choose the surface you already use. Pentect only applies to sessions you launch 
   </a>
 </DocsGrid>
 
-## Explore Pentect
-
-Go directly to the part you need.
+## Explore
 
 <DocsGrid>
   <a href="/start/how-it-works/" class="docs-grid__item">


### PR DESCRIPTION
## What changed

- clarify the home copy as `Let agents use secrets without seeing them.`
- remove redundant “Start with…” copy and simplify section headings
- replace the warm radial background with explicit white and near-black themes
- replace installer selects with visible icon-backed OS and method controls
- syntax-highlight every token in the selected install command
- reduce copy to a right-side icon that appears on hover, while remaining visible on touch layouts

## Validation

- `npm run build` generated the site, three installer endpoints, and 18 agent-readable Markdown pages
- desktop light and dark themes visually verified
- Linux selection updates the command and token classes correctly
- 390px responsive layout has no page overflow and keeps copy accessible
- no browser runtime errors or warnings
- no plain-text documentation code fences remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer installation options with selectable operating systems and methods.
  * Added syntax-highlighted installation commands and an accessible copy button.
  * Improved responsive behavior for installation controls on smaller screens.

* **Documentation**
  * Updated the homepage messaging about using secrets securely.
  * Simplified section headings and refreshed the documentation site’s visual theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->