### PR TITLE
docs: flatten UI and expand guides

### DIFF
--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -77,7 +77,7 @@ body {
   height: 38px;
   margin-left: 8px;
   padding: 0 16px;
-  border-radius: 8px;
+  border-radius: 3px;
   color: #fff !important;
   background: var(--vp-c-brand-1);
   font-size: 13px;
@@ -97,7 +97,7 @@ body {
 .VPNavBarSearch .DocSearch-Button {
   height: 40px;
   border: 1px solid var(--vp-c-divider);
-  border-radius: 8px;
+  border-radius: 3px;
   background: var(--vp-c-bg-soft);
 }
 
@@ -121,12 +121,13 @@ body {
 .VPSidebarItem.level-0.is-link > .item > .link {
   margin: 0 -10px;
   padding: 3px 10px;
-  border-radius: 7px;
+  border-left: 2px solid transparent;
 }
 
 .VPSidebarItem.level-0.is-link > .item > .link:hover,
 .VPSidebarItem.level-0.is-link.is-active > .item > .link {
-  background: var(--vp-c-bg-soft);
+  border-left-color: var(--vp-c-brand-1);
+  background: transparent;
 }
 
 .VPSidebarItem.level-0:not(.is-link) > .item > .text {
@@ -212,7 +213,7 @@ body {
 }
 
 .VPButton {
-  border-radius: 8px !important;
+  border-radius: 3px !important;
   box-shadow: none !important;
 }
 
@@ -224,9 +225,8 @@ body {
 .home-install {
   overflow: hidden;
   margin: 0 auto;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 18px;
-  background: var(--vp-c-bg-elv);
+  border-block: 1px solid var(--vp-c-divider);
+  background: transparent;
 }
 
 .home-install__heading {
@@ -234,7 +234,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  padding: 22px 24px;
+  padding: 20px 0;
 }
 
 .home-install__heading p {
@@ -262,7 +262,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 18px;
-  padding: 0 24px 24px;
+  padding: 0 0 24px;
 }
 
 .install-choice {
@@ -287,9 +287,10 @@ body {
   align-items: center;
   gap: 8px;
   min-height: 42px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 8px;
-  padding: 7px 11px 7px 8px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  padding: 7px 8px 9px;
   color: var(--vp-c-text-2);
   background: transparent;
   font-size: 14px;
@@ -299,20 +300,20 @@ body {
 }
 
 .install-choice button:hover {
-  border-color: color-mix(in srgb, var(--vp-c-text-1) 28%, var(--vp-c-divider));
+  border-bottom-color: var(--vp-c-divider);
   color: var(--vp-c-text-1);
 }
 
 .install-choice button:focus-visible {
   outline: none;
-  border-color: var(--vp-c-brand-1);
-  box-shadow: 0 0 0 3px var(--vp-c-brand-soft);
+  border-bottom-color: var(--vp-c-brand-1);
+  box-shadow: none;
 }
 
 .install-choice button.is-active {
-  border-color: var(--vp-c-text-1);
+  border-bottom-color: var(--vp-c-brand-1);
   color: var(--vp-c-text-1);
-  background: var(--vp-c-bg-soft);
+  background: transparent;
 }
 
 .install-select__icon {
@@ -322,9 +323,9 @@ body {
   justify-content: center;
   width: 24px;
   height: 24px;
-  border-radius: 5px;
-  color: #fff;
-  background: #4f554a;
+  border-radius: 0;
+  color: var(--vp-c-text-3);
+  background: transparent;
   font-family: var(--vp-font-family-mono);
   font-size: 10px;
   font-style: normal;
@@ -333,21 +334,19 @@ body {
   flex: none;
 }
 
-.install-select__icon[data-tone='windows'] { background: #087cd5; font-size: 18px; }
-.install-select__icon[data-tone='macos'] { background: #343732; font-size: 17px; }
-.install-select__icon[data-tone='linux'] { background: #e6b422; color: #222; font-size: 18px; }
-.install-select__icon[data-tone='powershell'] { background: #2671be; }
-.install-select__icon[data-tone='shell'] { background: #3d443a; }
-.install-select__icon[data-tone='npm'] { background: #cb3837; font-size: 7px; }
-.install-select__icon[data-tone='cargo'] { background: #6d4c35; font-size: 15px; }
-.install-select__icon[data-tone='homebrew'] { background: #d89b20; color: #292016; }
-.install-select__icon[data-tone='apt'] { background: #a80030; }
-.install-select__icon[data-tone='nix'] { background: #5277c3; font-size: 14px; }
+.install-choice button:hover .install-select__icon,
+.install-choice button.is-active .install-select__icon { color: var(--vp-c-brand-1); }
+.install-select__icon[data-tone='windows'] { font-size: 18px; }
+.install-select__icon[data-tone='macos'] { font-size: 17px; }
+.install-select__icon[data-tone='linux'] { font-size: 18px; }
+.install-select__icon[data-tone='npm'] { font-size: 7px; }
+.install-select__icon[data-tone='cargo'] { font-size: 15px; }
+.install-select__icon[data-tone='nix'] { font-size: 14px; }
 
 .home-install__command {
   position: relative;
   min-width: 0;
-  border-top: 1px solid var(--vp-c-divider);
+  border-top: 0;
   background: #0d0d0d;
 }
 
@@ -379,7 +378,7 @@ body {
   opacity: 0;
   transform: translateY(-50%) translateX(4px);
   border: 0;
-  border-radius: 7px;
+  border-radius: 2px;
   padding: 0;
   color: #bcbcbc;
   background: #242424;
@@ -535,14 +534,15 @@ body {
 
 .vp-doc div[class*='language-'] {
   border: 1px solid var(--vp-c-divider);
-  border-radius: 10px;
+  border-radius: 3px;
 }
 
 .docs-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: 0;
   margin: 20px 0 40px !important;
+  border-top: 1px solid var(--vp-c-divider);
   padding: 0 !important;
 }
 
@@ -557,22 +557,27 @@ body {
 .docs-grid__item {
   position: relative;
   display: flex;
-  min-height: 150px;
+  min-height: 132px;
   height: 100%;
   flex-direction: column;
   gap: 7px;
-  padding: 20px 44px 20px 20px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 10px;
+  padding: 22px 46px 22px 0;
+  border-bottom: 1px solid var(--vp-c-divider);
+  border-radius: 0;
   color: var(--vp-c-text-2) !important;
-  background: var(--vp-c-bg-elv);
+  background: transparent;
   text-decoration: none !important;
   transition: border-color 140ms ease, background-color 140ms ease;
 }
 
 .docs-grid__item:hover {
-  border-color: color-mix(in srgb, var(--vp-c-brand-1) 45%, var(--vp-c-divider));
-  background: color-mix(in srgb, var(--vp-c-brand-soft) 35%, var(--vp-c-bg-elv));
+  border-color: var(--vp-c-brand-1);
+  background: transparent;
+}
+
+.docs-grid__item:nth-child(even) {
+  border-left: 1px solid var(--vp-c-divider);
+  padding-left: 22px;
 }
 
 .docs-grid__item strong {
@@ -646,12 +651,12 @@ body {
   }
 
   .home-install__heading {
-    padding: 20px;
+    padding: 18px 0;
   }
 
   .home-install__controls {
     gap: 16px;
-    padding: 0 20px 20px;
+    padding: 0 0 20px;
   }
 
   .install-choice {
@@ -668,7 +673,7 @@ body {
     align-self: stretch;
     display: inline-flex;
     align-items: center;
-    background: var(--vp-c-bg-elv);
+    background: var(--vp-c-bg);
   }
 
   .install-choice button {
@@ -713,6 +718,11 @@ body {
   .docs-grid__item,
   .docs-grid.is-compact .docs-grid__item {
     min-height: 0;
+  }
+
+  .docs-grid__item:nth-child(even) {
+    border-left: 0;
+    padding-left: 0;
   }
 }
 

--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -19,6 +19,20 @@ Arguments after `claude` are forwarded to Claude Code. The app command launches
 the installed app with a local Messages-compatible gateway and an isolated
 certificate configuration for that process.
 
+| Launch | Scope |
+| --- | --- |
+| `pentect claude` | One Claude Code process and its children |
+| `pentect claude app` | One supported Claude Desktop launch |
+| `pentect claude --upstream URL` | One CLI launch using a Messages-compatible upstream |
+| `pentect claude --plugins NAME` | One launch with the selected plugin set |
+
+Normal Claude Code arguments pass through directly:
+
+```sh
+pentect claude --model sonnet
+pentect claude --permission-mode plan
+```
+
 ## Protected flow
 
 Supported Chat, attachment, and Claude Code traffic is inspected before it
@@ -28,6 +42,25 @@ opaque handles without exposing their plaintext to the model.
 ```sh
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```
+
+The upstream owns authentication and model routing. Pentect preserves the
+Anthropic Messages contract and protects supported request content, response
+events, and completed tool calls.
+
+## Claude Desktop
+
+Desktop support is opt-in for each launch. Validate discovery first, or select
+an executable explicitly when automatic discovery is not enough:
+
+```sh
+pentect claude app --check
+pentect claude app --app /path/to/claude
+```
+
+Run `pentect log` in another terminal to verify that a test secret becomes a
+handle before relying on the setup. Desktop features can use different network
+routes, so coverage is feature-specific rather than a claim about every screen
+in the app.
 
 ::: warning
 Pentect does not claim coverage for remote Cowork execution, Voice,

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -19,6 +19,20 @@ Arguments after `codex` are forwarded to the Codex CLI. The app command
 launches the installed desktop app with Pentect routing for that process; it
 does not permanently change the app's global configuration.
 
+| Launch | Scope |
+| --- | --- |
+| `pentect codex` | One Codex CLI process and its children |
+| `pentect codex app` | One Codex App launch |
+| `pentect codex --upstream URL` | One CLI launch using a compatible upstream |
+| `pentect codex --plugins NAME` | One launch with the selected plugin set |
+
+Client flags do not need a separator:
+
+```sh
+pentect codex exec --full-auto
+pentect codex --model o3
+```
+
 ## Protected flow
 
 Pentect inserts a local Responses-compatible gateway for the launched client.
@@ -33,6 +47,29 @@ protocol is supported. You can also select an upstream for one launch:
 ```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 ```
+
+Pentect preserves the configured base path when it composes Responses API
+routes. Authentication remains owned by Codex and the upstream; Pentect does
+not replace provider credentials.
+
+## Codex App
+
+Use `--check` to validate discovery and routing without keeping an app session
+open. If automatic discovery does not find the executable, pass it explicitly:
+
+```sh
+pentect codex app --check
+pentect codex app --app /path/to/codex
+```
+
+This is opt-in per launch. Opening Codex App normally does not silently install
+a global proxy or change unrelated ChatGPT traffic.
+
+## Verify protection
+
+Run `pentect log` in another terminal, then ask Codex to read a test dotenv file.
+The model-visible text should contain a handle and the log should show a masked
+event. Do not use a production credential for the first check.
 
 ::: warning
 Codex App coverage applies to its supported Codex mode. Pentect does not claim

--- a/website/src/content/docs/clients/upstreams.md
+++ b/website/src/content/docs/clients/upstreams.md
@@ -14,6 +14,10 @@ pentect claude --upstream http://127.0.0.1:8080/anthropic
 The upstream URL is selected for that launch only. Pentect preserves its base
 path when composing provider endpoints.
 
+Pentect sits in front of the gateway; it does not embed or replace it. The
+client connects to Pentect locally, and Pentect forwards the transformed
+provider request to the upstream you selected.
+
 ## Supported contracts
 
 - OpenAI Responses-compatible upstreams for Codex
@@ -23,6 +27,30 @@ path when composing provider endpoints.
 Bifrost's `/openai/v1` and `/anthropic` paths are included in Pentect's routing
 tests. LiteLLM and other gateways can use the same protocol contracts; Pentect
 does not certify every gateway provider or release.
+
+## Base paths and authentication
+
+Pass the provider-compatible base URL, not a single model endpoint. For example,
+`http://127.0.0.1:8080/openai/v1` remains the base when Pentect composes a
+Responses route. Authentication headers and provider credentials continue to
+come from the client or gateway configuration.
+
+| Client | Required upstream contract | Example base path |
+| --- | --- | --- |
+| Codex | OpenAI Responses, including streaming events | `/openai/v1` |
+| Claude | Anthropic Messages, including streaming events | `/anthropic` |
+
+## Validate a gateway
+
+1. Confirm the client works with its default provider.
+2. Confirm the gateway works directly with the same client and model.
+3. Launch once with `--upstream` and a non-sensitive prompt.
+4. Run `pentect log` while testing a disposable value.
+5. Exercise streaming and one completed tool call—not only plain chat text.
+
+An OpenAI-compatible chat-completions endpoint is not automatically a
+Responses endpoint. Likewise, a gateway can accept Messages JSON while emitting
+incompatible stream events.
 
 ## Unsupported protocols
 

--- a/website/src/content/docs/plugins/build.md
+++ b/website/src/content/docs/plugins/build.md
@@ -37,6 +37,85 @@ control over whether the next middleware runs.
 The Rust SDK is published as
 [`pentect-plugin`](https://crates.io/crates/pentect-plugin).
 
+## Manifest-only detector
+
+The smallest plugin is one `plugin.toml` file:
+
+```toml
+schema = "pentect.plugin.v1"
+name = "example-regex"
+description = "Detect ACME case identifiers."
+
+[[detector]]
+label = "ACME_CASE"
+pattern = '''\bACME-[0-9]{8}\b'''
+category = "identifier"
+confidence = "high"
+```
+
+This form needs no binary, build step, postscript, or native dependency.
+
+## Wasm middleware
+
+Add the SDK to a `cdylib` crate and export only the hooks you implement:
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+pentect-plugin = "0.1"
+```
+
+```rust
+use pentect_plugin::{Finding, Inspect, PluginResult};
+
+fn inspect(context: &mut Inspect) -> PluginResult {
+    if let Some(start) = context.input().text.find("ACME-") {
+        context.add_finding(Finding::new(start, start + 5, "ACME_ID"))?;
+    }
+    Ok(())
+}
+
+pentect_plugin::export!(inspect);
+```
+
+Finding offsets are UTF-8 byte offsets. The inspect hook adds findings; it does
+not replace its input. `prepare`, `finalize`, `request`, `response`, and
+`tool_call` may replace payloads. `request` may respond directly. Every hook may
+block. Returning `Ok(())` continues automatically, so simple middleware does
+not need boilerplate `next()` calls.
+
+Build the portable module:
+
+```sh
+rustup target add wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown
+```
+
+Set `binary = "my-plugin.wasm"` in `plugin.toml`. Pentect discovers hooks from
+the module exports and rejects native executables or path-traversing binary
+names.
+
+## Configuration and network access
+
+Plugins do not inherit the user's environment. Configuration is stored by
+Pentect and exposed through the SDK only when approved. HTTP access likewise
+uses a Pentect host function with an origin allowlist; the module receives no
+raw socket access.
+
+Before publishing, run:
+
+```sh
+pentect plugins dev ./my-plugin
+pentect plugins test my-plugin
+pentect plugins inspect my-plugin
+```
+
+Test empty input, non-ASCII offsets, overlapping findings, maximum-size input,
+and every stop path. Keep the manifest, Wasm artifact, and release checksum in
+the same tagged release so users can approve an immutable build.
+
 ::: info
 Plugin permissions are part of the user-facing security contract. Declare
 only the access the plugin needs; installation approval is not a substitute

--- a/website/src/content/docs/plugins/overview.md
+++ b/website/src/content/docs/plugins/overview.md
@@ -10,6 +10,14 @@ Pentect plugins come in two forms:
 
 Native executable plugins and postscripts are not supported.
 
+| Form | Best for | Runtime |
+| --- | --- | --- |
+| Manifest detector | Deterministic pattern and label rules | Built into Pentect's detection pass |
+| Wasm middleware | Context, branching, configuration, request or response control | Fuel- and memory-bounded WebAssembly sandbox |
+
+A manifest detector is the default choice. Use Wasm only when a regular
+expression cannot express the required behavior.
+
 ## Install a plugin
 
 ```sh
@@ -18,6 +26,13 @@ pentect plugins add github:@owner/repository/path
 
 The configured plugin set applies consistently to `mask`, local execution,
 Codex, Claude, and supported desktop-app launchers.
+
+Plugins may also be selected for a single client launch:
+
+```sh
+pentect codex --plugins jp-pii
+pentect claude --plugins jp-pii,company-policy
+```
 
 ## Manage plugins
 
@@ -33,8 +48,26 @@ pentect plugins remove NAME
 Remote manifests are pinned locally. They change only after an explicit add,
 setup, or update operation—not because a cache timer expired.
 
+## Installation lifecycle
+
+1. `add` resolves the source and stores the manifest.
+2. `setup` downloads and verifies a Wasm binary when the plugin has one.
+3. Pentect shows the discovered hooks and requested access for approval.
+4. A binary digest, manifest state, and approval are locked together locally.
+5. `update` fetches a newer version explicitly. Changed binary or hook access requires approval again.
+
+Use `inspect` before approval and `test` after setup. A modified installed
+binary is rejected until it is verified again.
+
 ## Sandbox and permissions
 
 Wasm middleware runs without WASI. It has no ambient filesystem, environment,
 process, or socket access. Network destinations and permissions that can change
 payloads require explicit user approval.
+
+Available hooks are `prepare`, `inspect`, `finalize`, `request`, `response`,
+`tool_call`, and `file`. A successful hook continues to the next plugin
+automatically. A plugin can block at any hook; only the request hook can return
+a response directly. Outbound HTTP is limited to approved origins, methods,
+sizes, request counts, and timeouts. Private or insecure origins require
+additional explicit approval.

--- a/website/src/content/docs/protection/files-and-images.md
+++ b/website/src/content/docs/protection/files-and-images.md
@@ -7,6 +7,14 @@ Pentect inspects supported file content before it is uploaded or included in a
 provider request. Textual formats can preserve opaque handles. Images use local
 OCR and visual redaction because pixels cannot carry a textual handle in place.
 
+| Content | Default treatment | Provider receives |
+| --- | --- | --- |
+| UTF-8 text | Detect and replace | Text with handles |
+| Supported PDF | Extract and inspect supported content | Protected document content |
+| Supported image | Local OCR and visual redaction | Redacted pixels |
+| Unknown binary | Block | Nothing |
+| Unverified file ID or remote reference | Apply unscanned-content policy | Nothing when set to `block` |
+
 ## Files API
 
 Supported UTF-8 uploads are inspected and rewritten before forwarding. Binary
@@ -14,11 +22,20 @@ uploads that Pentect cannot inspect or safely rewrite are blocked by default.
 Convert an unsupported upload to UTF-8 text, a supported image, or PDF when
 possible. There is no blanket binary-upload bypass.
 
+Inspection happens before forwarding the upload. Later requests that refer to a
+file ID are accepted only when Pentect can associate the reference with content
+it already covered; an arbitrary provider-side ID is not treated as proof that
+the file is safe.
+
 ## File IDs and remote URLs
 
 Pentect accepts a file reference only when it can establish safe coverage for
 the referenced content. Otherwise the configured unscanned-content policy
 applies. Public URLs are not classified as secrets merely because they are URLs.
+
+Pentect distinguishes the URL string from the content behind it. A public URL
+can remain visible while an unverified download is still blocked from entering
+a protected request.
 
 ## Images
 
@@ -36,3 +53,20 @@ unscanned = "block" # or "allow"
 Allowing unscanned images trades protection for compatibility. Use it only
 when another trusted layer already inspects the content. Set `unscanned` back
 to `"block"` and relaunch the client to restore the default.
+
+## Choosing the failure policy
+
+Keep `unscanned = "block"` when provider-bound content may contain credentials,
+personal data, or internal documents. Use `"allow"` only for a workflow where
+another trusted control has already inspected the exact bytes. The setting is a
+compatibility escape hatch, not a second detection mode.
+
+If a file is blocked:
+
+1. Check the content type and size reported by the client.
+2. Convert textual data to UTF-8 rather than wrapping it in an unknown binary.
+3. For images, confirm OCR is enabled and the image stays within configured limits.
+4. Capture the normal error details and report a compatibility issue if the format should be supported.
+
+See [Configuration](/reference/configuration/) for limits and
+[Troubleshooting](/reference/troubleshooting/) for unknown-format recovery.

--- a/website/src/content/docs/protection/structured-data.md
+++ b/website/src/content/docs/protection/structured-data.md
@@ -21,10 +21,48 @@ Built-in structured detection covers common forms including:
 - AWS, npm, and PyPI configuration
 - JSON and other recognized key/value structures
 
+The label comes from the structure when the structure identifies the field. A
+dotenv assignment, Terraform attribute, Kubernetes Secret key, and JSON object
+key can therefore keep a useful name:
+
+::: code-group
+
+```dotenv [dotenv]
+DATABASE_URL=<<DATABASE_URL_4ce8a3b0a6f64e12>>
+```
+
+```hcl [Terraform]
+api_token = "<<API_TOKEN_85268c441f88c284>>"
+```
+
+```yaml [Kubernetes]
+stringData:
+  password: <<PASSWORD_f013c9d470d12b11>>
+```
+
+```json [JSON]
+{"client_secret":"<<CLIENT_SECRET_5705e45cbb897a52>>"}
+```
+
+:::
+
+Comments, quoting, whitespace, and mildly malformed dotenv assignments are
+handled without requiring a perfect parser round trip. Values that are empty,
+comments, or clearly non-sensitive remain readable.
+
+## When detectors disagree
+
 Detection results can overlap. Pentect resolves overlap using structural label
-evidence, detector confidence, covered range, and detector specificity. Equally
-credible conflicting secret labels fall back to a generic `SECRET`; PII labels
-fall back to `PII`.
+evidence in this order:
+
+1. A label established by the containing format, such as a dotenv or Kubernetes key.
+2. Higher detector confidence.
+3. A detection that covers the complete sensitive value.
+4. A more specific built-in detector.
+5. A canonical `SECRET` or `PII` label when equally credible labels still conflict.
+
+Overlapping spans become one masked union and one handle. Edge-adjacent values
+remain separate. The result does not depend on plugin execution order.
 
 ## Mask from a pipeline
 
@@ -38,3 +76,7 @@ PowerShell:
 ```powershell
 Get-Content .env -Raw | pentect mask
 ```
+
+`pentect mask` reads standard input and writes transformed text to standard
+output, so it composes with existing tools. It does not need a format flag;
+Pentect recognizes supported structure from the input itself.

--- a/website/src/content/docs/start/how-it-works.md
+++ b/website/src/content/docs/start/how-it-works.md
@@ -36,6 +36,38 @@ supported request and response structures without replacing the client UI.
    Tool output is inspected before it returns to the provider, preventing a
    locally restored value from simply leaking back in stdout or a file read.
 
+## Request and response lifecycle
+
+| Stage | Input | Output |
+| --- | --- | --- |
+| Client request | Provider-shaped JSON, streaming metadata, or supported files | Same protocol with protected values replaced |
+| Provider response | Text, events, and completed tool calls | Protocol preserved; known handles remain references |
+| Local execution | Completed tool arguments | Known handles resolved just before execution |
+| Tool result | stdout, stderr, and supported structured output | Sensitive values replaced before the next provider request |
+
+Pentect transforms protocol fields rather than scraping the terminal UI. This
+keeps streaming and normal client interaction intact while putting protection
+at the network and local execution boundaries.
+
+## Handle identity
+
+A handle combines a useful label with a keyed digest. Structured sources can
+provide the label—`DATABASE_URL` in dotenv, for example—while detectors provide
+labels for unstructured text. The digest identifies the protected value without
+embedding it in the handle.
+
+Known handles can be resolved by the store that created them. Unknown
+handle-shaped text is never guessed or matched to a different value. Handle
+stability is configurable; see [Configuration](/reference/configuration/).
+
+## Content that needs a different treatment
+
+Text can carry a reusable handle. Images instead require local OCR and pixel
+redaction, while unsupported binary content follows the unscanned-content
+policy. [Files and images](/protection/files-and-images/) lists the exact
+behavior and controls. [Plugins](/plugins/overview/) can add detection or
+middleware without changing the client integration.
+
 ## Why handles instead of `[REDACTED]`?
 
 Plain redaction removes both the value and its identity. A Pentect handle keeps

--- a/website/src/content/docs/start/quick-start.md
+++ b/website/src/content/docs/start/quick-start.md
@@ -29,6 +29,27 @@ description: Protect a real Codex or Claude session in a few commands.
    pentect log
    ```
 
+## What success looks like
+
+If a protected file contains `DATABASE_URL=postgres://...`, the provider sees a
+reference such as this instead of the credential:
+
+```dotenv
+DATABASE_URL=<<DATABASE_URL_4ce8a3b0a6f64e12>>
+```
+
+The agent can copy that handle into a completed local tool call. Pentect
+resolves a known handle immediately before execution, then masks sensitive
+stdout before it returns to the provider. `pentect log` records the protection
+event and label, not the plaintext value.
+
+Normal client arguments pass through unchanged:
+
+```sh
+pentect codex exec --full-auto
+pentect claude --model sonnet
+```
+
 ## Launch through Pentect by default
 
 Add these functions to your shell profile, then restart the terminal. Existing
@@ -85,3 +106,10 @@ terminal.
 These functions affect only that shell. Pentect protects each client process
 launched through them; it does not create a system-wide proxy.
 :::
+
+## Next steps
+
+- Use [Codex](/clients/codex/) or [Claude](/clients/claude/) for client-specific options.
+- See [Structured data](/protection/structured-data/) for dotenv, Terraform, Kubernetes, and JSON behavior.
+- Review [Files and images](/protection/files-and-images/) before sending uploads.
+- Run `pentect doctor` again after changing a client installation or provider.

--- a/website/src/content/docs/start/what-is-pentect.md
+++ b/website/src/content/docs/start/what-is-pentect.md
@@ -7,6 +7,9 @@ Pentect is a local security boundary for AI coding tools. It replaces secrets
 and sensitive data with opaque handles before requests reach a model provider,
 then resolves those handles only at trusted local tool boundaries.
 
+Use it when a coding agent needs to work with configuration, credentials, or
+sensitive files without sending their plaintext to the model provider.
+
 ## The problem with redaction
 
 Conventional redaction protects a value by removing its meaning:
@@ -30,6 +33,23 @@ never needs the plaintext.
 
 Pentect protects supported AI client traffic; it is not a password manager or
 secret vault. It complements existing permissions, sandboxing, and access controls.
+
+Pentect does not grant an agent access to a secret. It changes how already
+accessible content crosses the model boundary. The local client and its tools
+still run with the permissions of the user who launched them.
+
+## One request, end to end
+
+| Boundary | What Pentect does |
+| --- | --- |
+| Local input | Detects supported sensitive values and creates handles |
+| Provider request | Sends the transformed content, not the known plaintext |
+| Model response | Preserves handles in text and completed tool arguments |
+| Local tool boundary | Resolves only handles known to the current store |
+| Tool result | Inspects and masks sensitive output before the next request |
+
+The client UI stays the same. Pentect launches the existing client with a local
+provider-compatible gateway for that process.
 
 ## Supported surfaces
 


### PR DESCRIPTION
## Summary
- replace rounded card-heavy styling with a flat, rule-based documentation UI
- expand client, upstream, structured-data, file, lifecycle, and plugin documentation
- document the real plugin manifest and Rust Wasm SDK flow

## Verification
- npm run build (website)
- 18 agent-readable Markdown pages generated
- browser-checked light/dark layouts and installer interactions
- no desktop horizontal overflow
- git diff --check