### PR TITLE
fix(docs): use real installer icons

### DIFF
--- a/website/.vitepress/theme/HomeInstall.vue
+++ b/website/.vitepress/theme/HomeInstall.vue
@@ -1,4 +1,14 @@
 <script setup lang="ts">
+import {
+  siApple,
+  siDebian,
+  siGnubash,
+  siHomebrew,
+  siLinux,
+  siNixos,
+  siNpm,
+  siRust,
+} from 'simple-icons';
 import { computed, onMounted, ref } from 'vue';
 
 type OperatingSystem = 'windows' | 'macos' | 'linux';
@@ -11,9 +21,9 @@ const operatingSystems: Array<{
   icon: string;
   tone: string;
 }> = [
-  { id: 'windows', label: 'Windows', icon: '⊞', tone: 'windows' },
-  { id: 'macos', label: 'macOS', icon: '⌘', tone: 'macos' },
-  { id: 'linux', label: 'Linux', icon: '⌁', tone: 'linux' },
+  { id: 'windows', label: 'Windows', icon: 'windows', tone: 'windows' },
+  { id: 'macos', label: 'macOS', icon: 'apple', tone: 'macos' },
+  { id: 'linux', label: 'Linux', icon: 'linux', tone: 'linux' },
 ];
 
 const npmInstaller = {
@@ -27,7 +37,7 @@ const cargoInstaller = {
   id: 'cargo',
   label: 'Cargo',
   command: 'cargo install --git https://github.com/EdamAme-x/pentect --locked pentect-cli',
-  icon: '⚙',
+  icon: 'rust',
   tone: 'cargo',
 };
 
@@ -37,7 +47,7 @@ const installers: Record<OperatingSystem, Installer[]> = {
       id: 'powershell',
       label: 'PowerShell',
       command: 'irm https://pentect.dev/install | iex',
-      icon: '>_',
+      icon: 'powershell',
       tone: 'powershell',
     },
     npmInstaller,
@@ -48,14 +58,14 @@ const installers: Record<OperatingSystem, Installer[]> = {
       id: 'homebrew',
       label: 'Homebrew',
       command: 'brew install EdamAme-x/pentect/pentect',
-      icon: 'B',
+      icon: 'homebrew',
       tone: 'homebrew',
     },
     {
       id: 'shell',
       label: 'Shell',
       command: 'curl -fsSL https://pentect.dev/install.sh | sh',
-      icon: '$_',
+      icon: 'gnubash',
       tone: 'shell',
     },
     npmInstaller,
@@ -63,14 +73,14 @@ const installers: Record<OperatingSystem, Installer[]> = {
       id: 'nix',
       label: 'Nix profile',
       command: 'nix profile install github:EdamAme-x/pentect',
-      icon: '❄',
+      icon: 'nixos',
       tone: 'nix',
     },
     {
       id: 'nix-shell',
       label: 'Nix shell',
       command: 'nix shell github:EdamAme-x/pentect',
-      icon: '❄',
+      icon: 'nixos',
       tone: 'nix',
     },
     cargoInstaller,
@@ -80,14 +90,14 @@ const installers: Record<OperatingSystem, Installer[]> = {
       id: 'shell',
       label: 'Shell',
       command: 'curl -fsSL https://pentect.dev/install.sh | sh',
-      icon: '$_',
+      icon: 'gnubash',
       tone: 'shell',
     },
     {
       id: 'apt',
       label: 'APT',
       command: 'curl -fsSL https://pentect.dev/install-apt.sh | sudo sh',
-      icon: 'A',
+      icon: 'debian',
       tone: 'apt',
     },
     npmInstaller,
@@ -95,14 +105,14 @@ const installers: Record<OperatingSystem, Installer[]> = {
       id: 'nix',
       label: 'Nix profile',
       command: 'nix profile install github:EdamAme-x/pentect',
-      icon: '❄',
+      icon: 'nixos',
       tone: 'nix',
     },
     {
       id: 'nix-shell',
       label: 'Nix shell',
       command: 'nix shell github:EdamAme-x/pentect',
-      icon: '❄',
+      icon: 'nixos',
       tone: 'nix',
     },
     cargoInstaller,
@@ -112,12 +122,28 @@ const installers: Record<OperatingSystem, Installer[]> = {
 const selectedOs = ref<OperatingSystem>('windows');
 const selectedMethod = ref('powershell');
 const copyState = ref<'idle' | 'copied' | 'failed'>('idle');
+const iconSet: Record<string, string> = {
+  windows: 'M0 0h11.377v11.372H0Zm12.623 0H24v11.372H12.623ZM0 12.623h11.377V24H0Zm12.623 0H24V24H12.623',
+  apple: siApple.path,
+  linux: siLinux.path,
+  powershell: 'M23.181 2.974c.568 0 .923.463.792 1.035l-3.659 15.982c-.13.572-.697 1.035-1.265 1.035H.819c-.568 0-.923-.463-.792-1.035L3.686 4.009c.13-.572.697-1.035 1.265-1.035zm-8.375 9.346c.251-.394.227-.905-.09-1.243L9.122 5.125c-.38-.404-1.037-.407-1.466-.003c-.429.402-.468 1.056-.088 1.46l4.662 4.96v.11l-7.42 5.374c-.45.327-.533.977-.187 1.453s.991.597 1.44.27l8.229-5.91c.28-.196.438-.365.514-.52zm-2.796 4.399a.93.93 0 0 0-.934.923c0 .51.418.923.934.923h4.433a.93.93 0 0 0 .934-.923a.93.93 0 0 0-.934-.923z',
+  gnubash: siGnubash.path,
+  npm: siNpm.path,
+  rust: siRust.path,
+  homebrew: siHomebrew.path,
+  debian: siDebian.path,
+  nixos: siNixos.path,
+};
 
 const methods = computed(() => installers[selectedOs.value]);
 const selectedInstaller = computed(
   () => methods.value.find((item) => item.id === selectedMethod.value) ?? methods.value[0],
 );
 const commandTokens = computed(() => tokenizeCommand(selectedInstaller.value.command));
+
+function iconPath(name: string) {
+  return iconSet[name] ?? '';
+}
 
 function tokenizeCommand(command: string): CommandToken[] {
   const parts = command.match(/https?:\/\/[^\s|]+|github:[^\s|]+|--?[\w-]+|\||[^\s|]+|\s+/g) ?? [command];
@@ -183,7 +209,14 @@ onMounted(() => {
           :aria-pressed="selectedOs === os.id"
           @click="chooseOs(os.id)"
         >
-          <i class="install-select__icon" :data-tone="os.tone" aria-hidden="true">{{ os.icon }}</i>
+          <svg
+            class="install-select__icon"
+            :data-tone="os.tone"
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+          >
+            <path fill="currentColor" :d="iconPath(os.icon)" />
+          </svg>
           {{ os.label }}
         </button>
       </div>
@@ -198,7 +231,14 @@ onMounted(() => {
           :aria-pressed="selectedMethod === method.id"
           @click="chooseMethod(method.id)"
         >
-          <i class="install-select__icon" :data-tone="method.tone" aria-hidden="true">{{ method.icon }}</i>
+          <svg
+            class="install-select__icon"
+            :data-tone="method.tone"
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+          >
+            <path fill="currentColor" :d="iconPath(method.icon)" />
+          </svg>
           {{ method.label }}
         </button>
       </div>

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -317,31 +317,17 @@ body {
 }
 
 .install-select__icon {
-  position: static;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 0;
+  display: block;
+  width: 18px;
+  height: 18px;
   color: var(--vp-c-text-3);
-  background: transparent;
-  font-family: var(--vp-font-family-mono);
-  font-size: 10px;
-  font-style: normal;
-  font-weight: 800;
-  line-height: 1;
   flex: none;
+  transition: color 140ms ease;
 }
 
 .install-choice button:hover .install-select__icon,
 .install-choice button.is-active .install-select__icon { color: var(--vp-c-brand-1); }
-.install-select__icon[data-tone='windows'] { font-size: 18px; }
-.install-select__icon[data-tone='macos'] { font-size: 17px; }
-.install-select__icon[data-tone='linux'] { font-size: 18px; }
-.install-select__icon[data-tone='npm'] { font-size: 7px; }
-.install-select__icon[data-tone='cargo'] { font-size: 15px; }
-.install-select__icon[data-tone='nix'] { font-size: 14px; }
+.install-select__icon[data-tone='npm'] { width: 20px; }
 
 .home-install__command {
   position: relative;
@@ -660,24 +646,22 @@ body {
   }
 
   .install-choice {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    padding-bottom: 2px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+    overflow: visible;
+    padding-bottom: 0;
   }
 
   .install-choice__label {
-    position: sticky;
-    left: 0;
-    z-index: 1;
-    width: 54px;
-    align-self: stretch;
-    display: inline-flex;
-    align-items: center;
-    background: var(--vp-c-bg);
+    position: static;
+    width: 100%;
+    padding: 0 8px 2px;
   }
 
   .install-choice button {
-    flex: none;
+    min-height: 38px;
+    padding-inline: 8px;
   }
 
   .home-install__command code {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,7 @@
         "remark-mdx": "^3.1.1",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "simple-icons": "^16.28.0",
         "typescript": "^5.9.2",
         "unified": "^11.0.5",
         "vitepress": "^1.6.4",
@@ -3358,6 +3359,25 @@
       "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/simple-icons": {
+      "version": "16.28.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.28.0.tgz",
+      "integrity": "sha512-sQPR5AtK/ijRjou7zw7mlLp08oB6FH7i0lOy5XJ2zp9mJs/yejgiOn7KvQoe2q4YJIx6VmgUSW5AOefebPt5kg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "remark-mdx": "^3.1.1",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
+    "simple-icons": "^16.28.0",
     "typescript": "^5.9.2",
     "unified": "^11.0.5",
     "vitepress": "^1.6.4",


### PR DESCRIPTION
## Summary
- replace placeholder glyphs with real SVG brand/tool icons
- bundle only the icons used by the installer
- let mobile installer options wrap below their labels instead of overlapping

## Verification
- npm run build
- no large-chunk warning
- browser-checked all OS and method icon paths
- browser-checked interactions and zero desktop overflow
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated operating system and installation method icons with clearer, accessible SVG graphics.
  * Standardized icon sizing and added smoother color transitions.
  * Improved mobile installation controls with wrapped options, full-width labels, and more compact buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->