### PR TITLE
docs: rewrite documentation in plain English

### DIFF
--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -1,6 +1,6 @@
 ---
 title: Claude
-description: Run Claude Code and supported Claude Desktop routes through Pentect.
+description: Run Claude Code and supported Claude Desktop features through Pentect.
 ---
 
 ::: code-group
@@ -15,15 +15,15 @@ pentect claude app
 
 :::
 
-Arguments after `claude` are forwarded to Claude Code. The app command launches
-the installed app with a local Messages-compatible gateway and an isolated
-certificate configuration for that process.
+Pentect passes arguments after `claude` to Claude Code. The app command starts
+Claude Desktop with a local gateway that supports the Messages API. It uses a
+separate certificate setup for that process.
 
 | Launch | Scope |
 | --- | --- |
 | `pentect claude` | One Claude Code process and its children |
 | `pentect claude app` | One supported Claude Desktop launch |
-| `pentect claude --upstream URL` | One CLI launch using a Messages-compatible upstream |
+| `pentect claude --upstream URL` | One CLI launch using a gateway that supports Messages |
 | `pentect claude --plugins NAME` | One launch with the selected plugin set |
 
 Normal Claude Code arguments pass through directly:
@@ -35,37 +35,35 @@ pentect claude --permission-mode plan
 
 ## Protected flow
 
-Supported Chat, attachment, and Claude Code traffic is inspected before it
-reaches the Anthropic-compatible upstream. Completed local tool calls can use
-opaque handles without exposing their plaintext to the model.
+Pentect checks supported Chat, attachment, and Claude Code requests before they
+reach the selected provider. Local tool calls can use handles without showing
+the real values to the model.
 
 ```sh
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```
 
-The upstream owns authentication and model routing. Pentect preserves the
-Anthropic Messages contract and protects supported request content, response
-events, and completed tool calls.
+The selected provider manages login and model routing. Pentect keeps the
+Anthropic Messages API format and protects supported requests, response events,
+and completed tool calls.
 
 ## Claude Desktop
 
-Desktop support is opt-in for each launch. Validate discovery first, or select
-an executable explicitly when automatic discovery is not enough:
+Desktop protection affects only the launch started by Pentect. Test app
+discovery first. If Pentect cannot find the app, pass its path:
 
 ```sh
 pentect claude app --check
 pentect claude app --app /path/to/claude
 ```
 
-Run `pentect log` in another terminal to verify that a test secret becomes a
-handle before relying on the setup. Desktop features can use different network
-routes, so coverage is feature-specific rather than a claim about every screen
-in the app.
+Run `pentect log` in another terminal and test with a fake secret. Check that it
+becomes a handle before you use real data. Desktop features can use different
+network routes, so Pentect protects only the listed features.
 
 ::: warning
-Pentect does not claim coverage for remote Cowork execution, Voice,
-experimental binary transports, or unknown future opaque routes. Unsupported
-formats follow the configured compatibility policy. See the
-[unknown-format recovery steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
-for protected alternatives and the explicit pass-through setting.
+Pentect does not protect remote Cowork tasks, Voice, test binary formats, or
+unknown future routes. Unsupported formats use your compatibility setting. See
+the [unknown-format steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
+for safer options and the pass-through setting.
 :::

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -15,15 +15,15 @@ pentect codex app
 
 :::
 
-Arguments after `codex` are forwarded to the Codex CLI. The app command
-launches the installed desktop app with Pentect routing for that process; it
-does not permanently change the app's global configuration.
+Pentect passes arguments after `codex` to the Codex CLI. The app command starts
+the installed desktop app through Pentect. It does not make a permanent change
+to the app.
 
 | Launch | Scope |
 | --- | --- |
 | `pentect codex` | One Codex CLI process and its children |
 | `pentect codex app` | One Codex App launch |
-| `pentect codex --upstream URL` | One CLI launch using a compatible upstream |
+| `pentect codex --upstream URL` | One CLI launch using a compatible gateway |
 | `pentect codex --plugins NAME` | One launch with the selected plugin set |
 
 Client flags do not need a separator:
@@ -35,45 +35,44 @@ pentect codex --model o3
 
 ## Protected flow
 
-Pentect inserts a local Responses-compatible gateway for the launched client.
-It protects supported prompt content, tool results, file inputs, and completed
-tool-call arguments while preserving streaming responses.
+Pentect starts a local gateway that supports the Responses API. It protects
+prompts, tool results, files, and completed tool-call arguments. Streaming
+responses still work.
 
 ## Existing providers
 
-Existing Codex provider configuration is retained as the upstream when its wire
-protocol is supported. You can also select an upstream for one launch:
+Pentect keeps your current Codex provider when it uses a supported API format.
+You can also choose a provider or gateway for one launch:
 
 ```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 ```
 
-Pentect preserves the configured base path when it composes Responses API
-routes. Authentication remains owned by Codex and the upstream; Pentect does
-not replace provider credentials.
+Pentect keeps the base path when it builds Responses API URLs. Codex and the
+selected provider still manage login details and credentials.
 
 ## Codex App
 
-Use `--check` to validate discovery and routing without keeping an app session
-open. If automatic discovery does not find the executable, pass it explicitly:
+Use `--check` to test app discovery and routing without leaving the app open.
+If Pentect cannot find the app, pass its path:
 
 ```sh
 pentect codex app --check
 pentect codex app --app /path/to/codex
 ```
 
-This is opt-in per launch. Opening Codex App normally does not silently install
-a global proxy or change unrelated ChatGPT traffic.
+This affects only the launch started by Pentect. Opening Codex App normally
+does not use Pentect or change other ChatGPT traffic.
 
 ## Verify protection
 
-Run `pentect log` in another terminal, then ask Codex to read a test dotenv file.
-The model-visible text should contain a handle and the log should show a masked
-event. Do not use a production credential for the first check.
+Run `pentect log` in another terminal. Then ask Codex to read a test dotenv
+file. The model should see a handle, and the log should show a mask event. Use
+a test value, not a real production credential.
 
 ::: warning
-Codex App coverage applies to its supported Codex mode. Pentect does not claim
-protection for ChatGPT Chat, Work, Voice, or unknown future opaque routes. If a
-request is blocked, follow the [unknown-format recovery steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
-instead of disabling Pentect for the whole app.
+Pentect protects the supported Codex mode in the app. It does not protect
+ChatGPT Chat, Work, Voice, or unknown future routes. If Pentect blocks a
+request, follow the [unknown-format steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked).
+Do not turn off Pentect for the whole app.
 :::

--- a/website/src/content/docs/clients/upstreams.md
+++ b/website/src/content/docs/clients/upstreams.md
@@ -1,62 +1,59 @@
 ---
 title: Custom upstreams
-description: Route supported OpenAI Responses and Anthropic Messages traffic through another gateway.
+description: Use Pentect with another gateway or local model server.
 ---
 
-Pentect can protect a client while forwarding requests to an existing local or
-remote gateway.
+Pentect can protect a client and send its requests to another local or remote
+gateway.
 
 ```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```
 
-The upstream URL is selected for that launch only. Pentect preserves its base
-path when composing provider endpoints.
+The upstream URL applies to that launch only. Pentect keeps the base path when
+it builds provider URLs.
 
-Pentect sits in front of the gateway; it does not embed or replace it. The
-client connects to Pentect locally, and Pentect forwards the transformed
-provider request to the upstream you selected.
+Pentect runs in front of the gateway. It does not include or replace the
+gateway. The client connects to Pentect, and Pentect sends the protected
+request to the gateway you chose.
 
-## Supported contracts
+## Supported API formats
 
-- OpenAI Responses-compatible upstreams for Codex
-- Anthropic Messages-compatible upstreams for Claude
+- Gateways that support OpenAI Responses for Codex
+- Gateways that support Anthropic Messages for Claude
 - Existing compatible client provider configuration
 
-Bifrost's `/openai/v1` and `/anthropic` paths are included in Pentect's routing
-tests. LiteLLM and other gateways can use the same protocol contracts; Pentect
-does not certify every gateway provider or release.
+Pentect tests Bifrost's `/openai/v1` and `/anthropic` paths. LiteLLM and other
+gateways can also work when they support the same APIs. Pentect does not test
+every gateway version.
 
 ## Base paths and authentication
 
-Pass the provider-compatible base URL, not a single model endpoint. For example,
-`http://127.0.0.1:8080/openai/v1` remains the base when Pentect composes a
-Responses route. Authentication headers and provider credentials continue to
-come from the client or gateway configuration.
+Pass the base URL for the provider API, not a URL for one model. For example,
+Pentect keeps `http://127.0.0.1:8080/openai/v1` when it builds a Responses API
+URL. The client or gateway still sends the login data.
 
-| Client | Required upstream contract | Example base path |
+| Client | Required API format | Example base path |
 | --- | --- | --- |
 | Codex | OpenAI Responses, including streaming events | `/openai/v1` |
 | Claude | Anthropic Messages, including streaming events | `/anthropic` |
 
 ## Validate a gateway
 
-1. Confirm the client works with its default provider.
-2. Confirm the gateway works directly with the same client and model.
-3. Launch once with `--upstream` and a non-sensitive prompt.
-4. Run `pentect log` while testing a disposable value.
-5. Exercise streaming and one completed tool call—not only plain chat text.
+1. Check that the client works with its normal provider.
+2. Check that the gateway works with the same client and model.
+3. Start the client with `--upstream` and a safe test prompt.
+4. Run `pentect log` and test with a fake secret.
+5. Test streaming and one completed tool call, not only normal chat.
 
-An OpenAI-compatible chat-completions endpoint is not automatically a
-Responses endpoint. Likewise, a gateway can accept Messages JSON while emitting
-incompatible stream events.
+An OpenAI-compatible Chat Completions API is not always a Responses API. A
+gateway may also accept Messages JSON but return a different stream format.
 
 ## Unsupported protocols
 
-Pentect rejects an unsupported wire protocol before launching the client. A
-provider being OpenAI-like is not sufficient if its request or streaming format
-does not match a supported contract. First retry without `--upstream` to confirm
-the client works with its default provider. If the custom gateway must be used,
-follow the [unknown-format recovery steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
-or report its protocol for support.
+Pentect rejects an unsupported API format before it starts the client. An API
+that looks similar to OpenAI is not enough. Its requests and stream events must
+match a supported API. First try again without `--upstream`. If you still need
+the custom gateway, follow the [unknown-format steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
+or ask us to support its API format.

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -16,11 +16,11 @@ aside: false
   </a>
   <a href="/clients/claude/" class="docs-grid__item">
     <small>CLI</small><strong>Claude Code</strong>
-    <span>Route Anthropic Messages traffic through Pentect.</span><b aria-hidden="true">→</b>
+    <span>Protect Claude Code requests with Pentect.</span><b aria-hidden="true">→</b>
   </a>
   <a href="/clients/codex/" class="docs-grid__item">
     <small>Desktop</small><strong>Codex App</strong>
-    <span>Start an isolated App session with Pentect enabled.</span><b aria-hidden="true">→</b>
+    <span>Start one Codex App session through Pentect.</span><b aria-hidden="true">→</b>
   </a>
   <a href="/clients/claude/" class="docs-grid__item">
     <small>Desktop</small><strong>Claude Desktop</strong>
@@ -33,7 +33,7 @@ aside: false
 <DocsGrid>
   <a href="/start/how-it-works/" class="docs-grid__item">
     <strong>How it works</strong>
-    <span>Follow a value from detection to a local tool call.</span><b aria-hidden="true">→</b>
+    <span>See how Pentect protects and restores a value.</span><b aria-hidden="true">→</b>
   </a>
   <a href="/protection/structured-data/" class="docs-grid__item">
     <strong>Structured data</strong>
@@ -41,15 +41,15 @@ aside: false
   </a>
   <a href="/protection/files-and-images/" class="docs-grid__item">
     <strong>Files and images</strong>
-    <span>Understand document, upload, image, and OCR handling.</span><b aria-hidden="true">→</b>
+    <span>Learn how Pentect checks uploads, images, and documents.</span><b aria-hidden="true">→</b>
   </a>
   <a href="/clients/upstreams/" class="docs-grid__item">
     <strong>Custom upstreams</strong>
-    <span>Put compatible gateways and local model servers behind Pentect.</span><b aria-hidden="true">→</b>
+    <span>Use Pentect with a compatible gateway or local model.</span><b aria-hidden="true">→</b>
   </a>
   <a href="/plugins/overview/" class="docs-grid__item">
     <strong>Plugins</strong>
-    <span>Extend detection and middleware in a Wasm sandbox.</span><b aria-hidden="true">→</b>
+    <span>Add custom checks safely with regex or Wasm.</span><b aria-hidden="true">→</b>
   </a>
   <a href="/reference/capabilities/" class="docs-grid__item">
     <strong>CLI and configuration</strong>

--- a/website/src/content/docs/plugins/build.md
+++ b/website/src/content/docs/plugins/build.md
@@ -1,6 +1,6 @@
 ---
 title: Build a plugin
-description: Start a Pentect plugin and test it locally.
+description: Create a Pentect plugin and test it on your computer.
 ---
 
 1. Create a plugin project.
@@ -15,14 +15,14 @@ description: Start a Pentect plugin and test it locally.
    pentect plugins dev ./my-plugin
    ```
 
-3. Test its declared behavior and permissions.
+3. Test its behavior and requested access.
 
    ```sh
    pentect plugins test my-plugin
    pentect plugins inspect my-plugin
    ```
 
-4. Publish the prepared plugin.
+4. Publish the plugin when it is ready.
 
    ```sh
    pentect plugins publish ./my-plugin
@@ -30,9 +30,9 @@ description: Start a Pentect plugin and test it locally.
 
 ## Choose the smallest plugin form
 
-Use a manifest-only regex detector when matching and labeling spans is enough.
-Choose Wasm middleware only when you need context, branching, configuration, or
-control over whether the next middleware runs.
+Use a manifest-only regex detector when you only need to find and label text.
+Use Wasm when you need context, choices, settings, or control over what runs
+next.
 
 The Rust SDK is published as
 [`pentect-plugin`](https://crates.io/crates/pentect-plugin).
@@ -53,7 +53,7 @@ category = "identifier"
 confidence = "high"
 ```
 
-This form needs no binary, build step, postscript, or native dependency.
+This form needs no binary, build step, setup script, or native library.
 
 ## Wasm middleware
 
@@ -80,11 +80,11 @@ fn inspect(context: &mut Inspect) -> PluginResult {
 pentect_plugin::export!(inspect);
 ```
 
-Finding offsets are UTF-8 byte offsets. The inspect hook adds findings; it does
-not replace its input. `prepare`, `finalize`, `request`, `response`, and
-`tool_call` may replace payloads. `request` may respond directly. Every hook may
-block. Returning `Ok(())` continues automatically, so simple middleware does
-not need boilerplate `next()` calls.
+Finding positions use UTF-8 byte offsets. The `inspect` hook adds results but
+does not change its input. `prepare`, `finalize`, `request`, `response`, and
+`tool_call` may change data. `request` may return a response directly. Every
+hook may block. `Ok(())` moves to the next step, so you do not need to call
+`next()`.
 
 Build the portable module:
 
@@ -93,16 +93,16 @@ rustup target add wasm32-unknown-unknown
 cargo build --release --target wasm32-unknown-unknown
 ```
 
-Set `binary = "my-plugin.wasm"` in `plugin.toml`. Pentect discovers hooks from
-the module exports and rejects native executables or path-traversing binary
-names.
+Set `binary = "my-plugin.wasm"` in `plugin.toml`. Pentect finds hooks from the
+module exports. It rejects native apps and binary paths that leave the plugin
+folder.
 
 ## Configuration and network access
 
-Plugins do not inherit the user's environment. Configuration is stored by
-Pentect and exposed through the SDK only when approved. HTTP access likewise
-uses a Pentect host function with an origin allowlist; the module receives no
-raw socket access.
+Plugins do not receive the user's environment variables. Pentect stores plugin
+settings and gives them to the SDK only after approval. HTTP access also goes
+through Pentect and can reach only approved hosts. Plugins do not get raw
+network sockets.
 
 Before publishing, run:
 
@@ -112,12 +112,11 @@ pentect plugins test my-plugin
 pentect plugins inspect my-plugin
 ```
 
-Test empty input, non-ASCII offsets, overlapping findings, maximum-size input,
-and every stop path. Keep the manifest, Wasm artifact, and release checksum in
-the same tagged release so users can approve an immutable build.
+Test empty input, non-ASCII text, overlapping results, the largest allowed
+input, and every block path. Put the manifest, Wasm file, and checksum in the
+same tagged release. This lets users approve one exact build.
 
 ::: info
-Plugin permissions are part of the user-facing security contract. Declare
-only the access the plugin needs; installation approval is not a substitute
-for narrow permissions.
+Plugin permissions protect the user. Ask only for the access your plugin needs.
+Approval during install does not make broad permissions safe.
 :::

--- a/website/src/content/docs/plugins/overview.md
+++ b/website/src/content/docs/plugins/overview.md
@@ -1,22 +1,22 @@
 ---
 title: Plugins
-description: Extend Pentect with declarative detectors or sandboxed Wasm middleware.
+description: Add custom checks with regex rules or safe Wasm code.
 ---
 
 Pentect plugins come in two forms:
 
-1. Manifest-only regex detectors for compact pattern matching.
-2. WebAssembly middleware for logic that cannot be expressed as an automaton.
+1. Regex rules in a manifest for simple pattern checks.
+2. WebAssembly (Wasm) code for checks that need more logic.
 
 Native executable plugins and postscripts are not supported.
 
 | Form | Best for | Runtime |
 | --- | --- | --- |
-| Manifest detector | Deterministic pattern and label rules | Built into Pentect's detection pass |
-| Wasm middleware | Context, branching, configuration, request or response control | Fuel- and memory-bounded WebAssembly sandbox |
+| Manifest detector | Clear pattern and label rules | Runs as part of Pentect's normal checks |
+| Wasm middleware | Context, choices, settings, or request and response control | Runs in a Wasm sandbox with time and memory limits |
 
-A manifest detector is the default choice. Use Wasm only when a regular
-expression cannot express the required behavior.
+Start with a manifest detector. Use Wasm only when a regular expression cannot
+do the job.
 
 ## Install a plugin
 
@@ -24,8 +24,8 @@ expression cannot express the required behavior.
 pentect plugins add github:@owner/repository/path
 ```
 
-The configured plugin set applies consistently to `mask`, local execution,
-Codex, Claude, and supported desktop-app launchers.
+Your plugin setup works with `mask`, local commands, Codex, Claude, and
+supported desktop apps.
 
 Plugins may also be selected for a single client launch:
 
@@ -45,29 +45,28 @@ pentect plugins update NAME
 pentect plugins remove NAME
 ```
 
-Remote manifests are pinned locally. They change only after an explicit add,
-setup, or update operation—not because a cache timer expired.
+Pentect saves the exact remote manifest locally. It changes only when you run
+an add, setup, or update command. A cache timer cannot change it.
 
 ## Installation lifecycle
 
-1. `add` resolves the source and stores the manifest.
+1. `add` finds the source and saves the manifest.
 2. `setup` downloads and verifies a Wasm binary when the plugin has one.
-3. Pentect shows the discovered hooks and requested access for approval.
-4. A binary digest, manifest state, and approval are locked together locally.
-5. `update` fetches a newer version explicitly. Changed binary or hook access requires approval again.
+3. Pentect shows the plugin hooks and requested access for your approval.
+4. Pentect links the binary hash, manifest, and approval together.
+5. `update` gets a newer version. You must approve a changed binary or new access again.
 
-Use `inspect` before approval and `test` after setup. A modified installed
-binary is rejected until it is verified again.
+Use `inspect` before approval and `test` after setup. If an installed binary
+changes, Pentect blocks it until you check it again.
 
 ## Sandbox and permissions
 
-Wasm middleware runs without WASI. It has no ambient filesystem, environment,
-process, or socket access. Network destinations and permissions that can change
-payloads require explicit user approval.
+Wasm code runs without WASI. It cannot directly use files, environment
+variables, processes, or network sockets. You must approve network targets and
+any access that can change data.
 
-Available hooks are `prepare`, `inspect`, `finalize`, `request`, `response`,
-`tool_call`, and `file`. A successful hook continues to the next plugin
-automatically. A plugin can block at any hook; only the request hook can return
-a response directly. Outbound HTTP is limited to approved origins, methods,
-sizes, request counts, and timeouts. Private or insecure origins require
-additional explicit approval.
+Plugins can use these hooks: `prepare`, `inspect`, `finalize`, `request`,
+`response`, `tool_call`, and `file`. After a hook succeeds, Pentect runs the
+next plugin. Any hook can block an action. Only `request` can return a response
+directly. HTTP calls have limits for approved hosts, methods, size, number of
+requests, and time. Private or insecure hosts need extra approval.

--- a/website/src/content/docs/protection/files-and-images.md
+++ b/website/src/content/docs/protection/files-and-images.md
@@ -1,47 +1,45 @@
 ---
 title: Files and images
-description: How Pentect handles uploads, file references, remote content, and OCR.
+description: Learn how Pentect checks uploads, file links, images, and OCR.
 ---
 
-Pentect inspects supported file content before it is uploaded or included in a
-provider request. Textual formats can preserve opaque handles. Images use local
-OCR and visual redaction because pixels cannot carry a textual handle in place.
+Pentect checks supported files before they are uploaded or added to a provider
+request. Text files can use handles. Images use local OCR and visual masking
+because text handles cannot replace pixels.
 
 | Content | Default treatment | Provider receives |
 | --- | --- | --- |
 | UTF-8 text | Detect and replace | Text with handles |
-| Supported PDF | Extract and inspect supported content | Protected document content |
-| Supported image | Local OCR and visual redaction | Redacted pixels |
+| Supported PDF | Read and check supported content | Protected document content |
+| Supported image | Local OCR and visual masking | Masked pixels |
 | Unknown binary | Block | Nothing |
-| Unverified file ID or remote reference | Apply unscanned-content policy | Nothing when set to `block` |
+| File ID or remote file that Pentect cannot check | Use the unscanned setting | Nothing when set to `block` |
 
 ## Files API
 
-Supported UTF-8 uploads are inspected and rewritten before forwarding. Binary
-uploads that Pentect cannot inspect or safely rewrite are blocked by default.
-Convert an unsupported upload to UTF-8 text, a supported image, or PDF when
-possible. There is no blanket binary-upload bypass.
+Pentect checks and rewrites supported UTF-8 uploads before sending them. It
+blocks binary files that it cannot check or safely rewrite. If possible,
+convert an unsupported file to UTF-8 text, a supported image, or PDF. There is
+no setting that allows every binary upload.
 
-Inspection happens before forwarding the upload. Later requests that refer to a
-file ID are accepted only when Pentect can associate the reference with content
-it already covered; an arbitrary provider-side ID is not treated as proof that
-the file is safe.
+Pentect checks an upload before sending it. A later request can use its file ID
+only when Pentect knows the content behind that ID. A provider file ID alone
+does not prove that the file is safe.
 
 ## File IDs and remote URLs
 
-Pentect accepts a file reference only when it can establish safe coverage for
-the referenced content. Otherwise the configured unscanned-content policy
-applies. Public URLs are not classified as secrets merely because they are URLs.
+Pentect accepts a file link only when it can confirm that the file was checked.
+Otherwise it uses the unscanned-content setting. A public URL is not treated as
+a secret just because it is a URL.
 
-Pentect distinguishes the URL string from the content behind it. A public URL
-can remain visible while an unverified download is still blocked from entering
-a protected request.
+Pentect treats the URL and the downloaded file as two different things. The URL
+can stay visible while Pentect blocks a file it could not check.
 
 ## Images
 
-OCR runs locally. Detected sensitive regions are redacted before the provider
-receives the image. Limits bound image count, byte size, pixel dimensions,
-download time, and total processing time.
+OCR runs on your computer. Pentect covers sensitive areas before it sends the
+image. Limits control the number of images, file size, image size, download
+time, and total check time.
 
 ```toml
 [image]
@@ -50,23 +48,22 @@ redaction = "black" # or "blur"
 unscanned = "block" # or "allow"
 ```
 
-Allowing unscanned images trades protection for compatibility. Use it only
-when another trusted layer already inspects the content. Set `unscanned` back
-to `"block"` and relaunch the client to restore the default.
+Allowing unchecked images can make more tools work, but it is less safe. Use it
+only when another trusted tool checks the image first. Change `unscanned` back
+to `"block"` and restart the client to restore the default.
 
 ## Choosing the failure policy
 
-Keep `unscanned = "block"` when provider-bound content may contain credentials,
-personal data, or internal documents. Use `"allow"` only for a workflow where
-another trusted control has already inspected the exact bytes. The setting is a
-compatibility escape hatch, not a second detection mode.
+Keep `unscanned = "block"` when a file may contain credentials, personal data,
+or private documents. Use `"allow"` only when another trusted tool has checked
+the exact file. This setting skips a safety check. It is not another scan mode.
 
 If a file is blocked:
 
-1. Check the content type and size reported by the client.
-2. Convert textual data to UTF-8 rather than wrapping it in an unknown binary.
-3. For images, confirm OCR is enabled and the image stays within configured limits.
-4. Capture the normal error details and report a compatibility issue if the format should be supported.
+1. Check the file type and size shown by the client.
+2. Convert text data to UTF-8 instead of placing it in an unknown binary file.
+3. For images, turn on OCR and check the image limits.
+4. Copy the error and report a compatibility issue if Pentect should support the format.
 
 See [Configuration](/reference/configuration/) for limits and
 [Troubleshooting](/reference/troubleshooting/) for unknown-format recovery.

--- a/website/src/content/docs/protection/security-model.md
+++ b/website/src/content/docs/protection/security-model.md
@@ -1,57 +1,56 @@
 ---
 title: Security model
-description: Trust boundaries, defaults, guarantees, and explicit limitations.
+description: What Pentect protects, what it trusts, and where its limits are.
 ---
 
-Pentect protects supported content at the boundary between a local AI client
-and a model provider. It assumes the local user and explicitly authorized local
-tools are trusted to use the credentials they already possess.
+Pentect protects supported content between a local AI client and a model
+provider. It trusts the local user and approved local tools to use credentials
+they already have.
 
 ## Security properties
 
-- Sensitive values are replaced before supported provider requests leave the
-  local process boundary.
-- Recovery data stays in the local Pentect session and is not placed in the
-  model request.
-- Known handles resolve only at supported trusted client tool boundaries.
+- Pentect replaces sensitive values before supported requests leave the local
+  process.
+- Data needed to restore a handle stays in the local Pentect session. It is not
+  added to the model request.
+- Pentect restores known handles only before supported local tools run.
 - Tool output is masked before it returns to the provider.
 - Unknown provider formats and unsupported content are blocked by default.
-- Wasm plugins run without WASI, filesystem, environment, process, or raw
-  socket access.
+- Wasm plugins cannot directly use WASI, files, environment variables,
+  processes, or network sockets.
 
 ## What Pentect does not guarantee
 
-- Perfect detection of every secret or PII format
-- Safety after a trusted local tool uses a credential against an external
-  service
-- Protection for unsupported clients, opaque transports, or future routes
-- Replacement for least privilege, credential rotation, endpoint controls, or
-  client sandboxing
+- Finding every possible secret or type of personal data
+- Safety after a trusted local tool sends a credential to another service
+- Protection for unsupported clients, hidden binary traffic, or future routes
+- A replacement for limited permissions, key changes, network rules, or client
+  sandboxes
 
 ## Compatibility mode
 
-Unknown provider formats default to an error. A user can explicitly relax this
-only in the user-level configuration:
+Pentect returns an error for unknown provider formats by default. Only the user
+config can change this:
 
 ```toml
 [compatibility]
 unknown_formats = "ignore"
 ```
 
-Project configuration cannot weaken this setting. This prevents a repository
-from silently choosing a less protective policy.
+A project cannot make this setting less safe. This stops a repository from
+silently turning off the default check.
 
 See [Unknown provider format troubleshooting](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
 for protected alternatives, copyable setup commands, restart instructions, and
 how to restore the default.
 
 ::: danger
-Compatibility mode can allow content Pentect does not understand to reach an
-upstream. Do not enable it merely to suppress an unexplained error.
+Compatibility mode can send content that Pentect does not understand. Do not
+turn it on only to hide an error that you have not checked.
 :::
 
 ## Reporting a vulnerability
 
-Do not open a public issue for a suspected vulnerability. Follow the private
-reporting process in the repository's
+Do not open a public issue for a possible security problem. Use the private
+steps in the repository's
 [security policy](https://github.com/EdamAme-x/pentect/security/policy).

--- a/website/src/content/docs/protection/structured-data.md
+++ b/website/src/content/docs/protection/structured-data.md
@@ -1,10 +1,10 @@
 ---
 title: Structured data
-description: Preserve useful labels while masking secrets in common configuration formats.
+description: Keep useful field names while masking secrets in common config files.
 ---
 
-Pentect uses syntax and surrounding structure when it can. This produces more
-useful handles than treating every detected value as a generic secret.
+Pentect uses file syntax and field names when possible. This creates clearer
+handles than using `SECRET` for every value.
 
 ```dotenv
 RUNPOD_API_KEY=<<RUNPOD_API_KEY_6b1275e3e3fadb9f>>
@@ -13,17 +13,16 @@ KAGGLE_API_TOKEN=<<KAGGLE_API_TOKEN_039fe674477b5763>>
 
 ## Recognized sources
 
-Built-in structured detection covers common forms including:
+Built-in checks support common formats, including:
 
-- dotenv files, including comments and mildly malformed assignments
+- dotenv files, including comments and small syntax errors
 - Terraform variables and values
 - Kubernetes Secrets and kubeconfig data
 - AWS, npm, and PyPI configuration
 - JSON and other recognized key/value structures
 
-The label comes from the structure when the structure identifies the field. A
-dotenv assignment, Terraform attribute, Kubernetes Secret key, and JSON object
-key can therefore keep a useful name:
+When a file clearly names a field, Pentect uses that name for the handle. This
+works with dotenv keys, Terraform fields, Kubernetes Secret keys, and JSON keys:
 
 ::: code-group
 
@@ -46,23 +45,21 @@ stringData:
 
 :::
 
-Comments, quoting, whitespace, and mildly malformed dotenv assignments are
-handled without requiring a perfect parser round trip. Values that are empty,
-comments, or clearly non-sensitive remain readable.
+Pentect handles comments, quotes, spaces, and small dotenv syntax errors. Empty
+values, comments, and values that are clearly safe stay visible.
 
 ## When detectors disagree
 
-Detection results can overlap. Pentect resolves overlap using structural label
-evidence in this order:
+Two checks can find the same text. Pentect chooses the label in this order:
 
-1. A label established by the containing format, such as a dotenv or Kubernetes key.
-2. Higher detector confidence.
-3. A detection that covers the complete sensitive value.
-4. A more specific built-in detector.
-5. A canonical `SECRET` or `PII` label when equally credible labels still conflict.
+1. A field name from the file format, such as a dotenv or Kubernetes key.
+2. The result with higher confidence.
+3. The result that covers the full sensitive value.
+4. The more specific built-in check.
+5. `SECRET` or `PII` when two equally strong labels still disagree.
 
-Overlapping spans become one masked union and one handle. Edge-adjacent values
-remain separate. The result does not depend on plugin execution order.
+Overlapping results become one handle that covers the full area. Values that
+only touch at their edges stay separate. Plugin order does not change the result.
 
 ## Mask from a pipeline
 
@@ -77,6 +74,6 @@ PowerShell:
 Get-Content .env -Raw | pentect mask
 ```
 
-`pentect mask` reads standard input and writes transformed text to standard
-output, so it composes with existing tools. It does not need a format flag;
-Pentect recognizes supported structure from the input itself.
+`pentect mask` reads standard input and writes protected text to standard
+output. You can use it in a normal pipe. Pentect finds the format on its own,
+so you do not need a format option.

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 ---
 title: What Pentect can do
-description: Every user-facing Pentect capability, grouped by the job it performs.
+description: A full list of what you can do with Pentect.
 ---
 
 ## Clients
@@ -11,40 +11,40 @@ description: Every user-facing Pentect capability, grouped by the job it perform
 | Protect Claude Code | `pentect claude` |
 | Launch a protected Codex App session | `pentect codex app` |
 | Launch a protected Claude Desktop session | `pentect claude app` |
-| Forward normal client arguments | Pass them normally, for example `pentect codex exec --full-auto` |
-| Select a compatible upstream for one launch | `--upstream URL` |
-| Load an additional plugin for one launch | `--plugins SOURCE` |
+| Pass normal client arguments | Add them normally, for example `pentect codex exec --full-auto` |
+| Select a compatible gateway for one launch | `--upstream URL` |
+| Add a plugin for one launch | `--plugins SOURCE` |
 | Check an app setup without launching it | `pentect codex app --check` or `pentect claude app --check` |
 
-Pentect changes only the process it launches. It does not enable a permanent
-system-wide proxy or replace the client interface.
+Pentect changes only the process it starts. It does not create a permanent
+proxy for the whole system or replace the client UI.
 
 ## Protected content
 
 | Capability | Behavior |
 | --- | --- |
-| Prompts and tool results | Sensitive spans are replaced before supported provider requests |
-| Completed tool calls | Known handles are resolved immediately before trusted local execution |
-| Command output | stdout and stderr are masked before returning to the model |
-| Structured configuration | Uses key and syntax context for useful labels |
-| UTF-8 uploads | Inspects and rewrites supported Files API content |
-| Documents | Inspects supported inline document formats |
-| Images | Runs local OCR and redacts detected regions |
-| QR codes and barcodes | Inspects decoded payloads during image protection |
+| Prompts and tool results | Replaces sensitive text before supported requests are sent |
+| Completed tool calls | Restores known handles just before a trusted local tool runs |
+| Command output | Masks stdout and stderr before they return to the model |
+| Structured config | Uses field names and syntax to create useful labels |
+| UTF-8 uploads | Checks and rewrites supported Files API content |
+| Documents | Checks supported document formats sent in a request |
+| Images | Runs local OCR and covers sensitive areas |
+| QR codes and barcodes | Checks the text found in codes inside images |
 | Unknown provider structures | Returns an error by default |
 
-Detection covers secret and PII categories. Recognized structured sources
-include dotenv, Terraform, Kubernetes Secrets,
-kubeconfig, AWS, npm, PyPI, JSON, and other supported key/value formats.
+Pentect checks for secrets and personal data. Supported config formats include
+dotenv, Terraform, Kubernetes Secrets, kubeconfig, AWS, npm, PyPI, JSON, and
+other key/value formats.
 
 ## Handles
 
-- Preserve a useful label such as `DATABASE_URL` or `KAGGLE_API_TOKEN`.
-- Use a keyed identity instead of an unsalted plaintext fingerprint.
-- Can stay stable per device, per project, or change per session.
-- Resolve only when the current local protection context knows the handle.
-- Keep unknown or invented handle-shaped text inert.
-- Expose metadata through `pentect view` without printing the value.
+- Keep a useful label such as `DATABASE_URL` or `KAGGLE_API_TOKEN`.
+- Use a private key when creating the handle ID.
+- Can stay the same per device or project, or change each session.
+- Are restored only when the current local session knows them.
+- Do not restore unknown or invented handle-like text.
+- Show handle details through `pentect view` without printing the value.
 
 ## Local CLI
 
@@ -52,15 +52,15 @@ kubeconfig, AWS, npm, PyPI, JSON, and other supported key/value formats.
 | --- | --- |
 | `pentect mask [TEXT]` | Mask arguments or UTF-8 stdin |
 | `pentect read PATH` | Print a masked file preview |
-| `pentect exec "COMMAND"` | Resolve known handles locally and mask command output |
-| `pentect view HANDLE` | Show handle metadata without revealing plaintext |
-| `pentect resolve [PATH...]` | Resolve known handles from stdin or selected files |
+| `pentect exec "COMMAND"` | Restore known handles and mask command output |
+| `pentect view HANDLE` | Show handle details without revealing the real value |
+| `pentect resolve [PATH...]` | Restore known handles from stdin or selected files |
 | `pentect log [--json]` | Follow local protection events without secret values |
 | `pentect doctor [--json]` | Check the installation and supported clients |
 | `pentect doctor --fix` | Offer repairable configuration changes |
 | `pentect update [VERSION]` | Install a checksummed GitHub Release binary |
 | `pentect update --check` | Check for an update without installing it |
-| `pentect uninstall` | Remove the binary while retaining project data |
+| `pentect uninstall` | Remove Pentect but keep project data |
 
 ```sh
 cat .env | pentect mask
@@ -69,17 +69,15 @@ cat terraform.tfvars | pentect mask
 
 ## Custom gateways
 
-Pentect can sit in front of an existing compatible gateway for a single
-launch:
+Pentect can use an existing compatible gateway for one launch:
 
 ```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```
 
-It supports the OpenAI Responses contract used by Codex and the Anthropic
-Messages contract used by Claude while preserving the configured upstream base
-path.
+It supports the OpenAI Responses API used by Codex and the Anthropic Messages
+API used by Claude. It keeps the base path from your gateway URL.
 
 ## Configuration and local state
 
@@ -88,14 +86,14 @@ path.
 | Stable handle identity on one device | `[handles] scope = "device"` |
 | Separate handle identity per project | `[handles] scope = "project"` |
 | New handle identity per session | `[handles] scope = "session"` |
-| Remember local file-backed recovery hints | `[files] remember = true` |
+| Remember where file-based handles came from | `[files] remember = true` |
 | Share protection events between compatible local processes | `[activity] share = true` |
-| Require a Pentect-launched agent boundary for a project | `[agent] required = true` |
-| Allow unknown provider formats explicitly | `[compatibility] unknown_formats = "ignore"` |
+| Require the agent to start through Pentect | `[agent] required = true` |
+| Allow unknown provider formats after a user choice | `[compatibility] unknown_formats = "ignore"` |
 
-Pentect reads user configuration from `~/.pentect/config.toml` and project
-configuration from `.pentect/config.toml`. A project cannot weaken the user's
-unknown-format policy.
+Pentect reads user settings from `~/.pentect/config.toml` and project settings
+from `.pentect/config.toml`. A project cannot lower the user's protection for
+unknown formats.
 
 For exact recovery and rollback steps, see
 [Unknown provider format troubleshooting](/reference/troubleshooting/#an-unknown-provider-format-was-blocked).
@@ -104,8 +102,8 @@ For exact recovery and rollback steps, see
 
 | Capability | Command or format |
 | --- | --- |
-| Declarative detector | Regex rules in `plugin.toml` |
-| Context-aware middleware | Sandboxed WebAssembly |
+| Regex detector | Regex rules in `plugin.toml` |
+| Plugin code with more logic | Sandboxed WebAssembly |
 | Create and run locally | `plugins new`, `plugins dev` |
 | Validate behavior | `plugins test`, `plugins inspect` |
 | Install from GitHub | `plugins add github:@owner/repository/path` |
@@ -113,15 +111,15 @@ For exact recovery and rollback steps, see
 | Discover and maintain | `plugins search`, `plugins list`, `plugins update`, `plugins remove` |
 | Publish | `plugins publish` |
 
-Wasm plugins have no ambient WASI, filesystem, environment, process, or raw
-socket access. Optional HTTP access is limited by declared origins, methods,
-request counts, and byte limits, and requires approval.
+Wasm plugins cannot directly use WASI, files, environment variables, processes,
+or network sockets. Optional HTTP access needs approval and has limits for
+hosts, methods, request count, and data size.
 
 ## Installation and distribution
 
-Pentect provides PowerShell and POSIX installers plus Homebrew, apt, Nix, npm,
-and Cargo installation paths. Direct binary installers verify SHA-256 checksums,
-support version selection, updating, and uninstalling, and detect installations
-owned by another package manager.
+You can install Pentect with PowerShell, a shell script, Homebrew, apt, Nix,
+npm, or Cargo. The binary installers check SHA-256 checksums. They support
+version choice, updates, and uninstall. They also find installs managed by
+another package manager.
 
 Continue with [Install](/start/install/) or the [Quick start](/start/quick-start/).

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-description: User-facing Pentect commands and their purpose.
+description: Pentect commands and what they do.
 ---
 
 ## Launch clients
@@ -12,8 +12,8 @@ description: User-facing Pentect commands and their purpose.
 | `pentect codex app` | Launch Codex App for this protected session |
 | `pentect claude app` | Launch Claude Desktop for this protected session |
 
-Client launchers accept `--upstream URL` for a compatible upstream and
-`--plugins SOURCE` for a one-off plugin addition. App launchers also accept
+Use `--upstream URL` to choose a compatible gateway for one launch. Use
+`--plugins SOURCE` to add a plugin for one launch. App commands also support
 `--app PATH` and `--check`.
 
 Codex and Claude arguments are forwarded directly:
@@ -29,24 +29,24 @@ pentect claude --model sonnet
 | --- | --- |
 | `pentect mask [TEXT]` | Mask arguments or UTF-8 stdin |
 | `pentect read PATH` | Print a masked preview of a file |
-| `pentect exec "COMMAND"` | Resolve known handles locally, run the command, and mask stdout/stderr |
-| `pentect view HANDLE` | Show handle metadata without revealing its value |
-| `pentect resolve [PATH...]` | Resolve known handles from stdin or in selected files |
+| `pentect exec "COMMAND"` | Restore known handles, run the command, and mask its output |
+| `pentect view HANDLE` | Show handle details without revealing its value |
+| `pentect resolve [PATH...]` | Restore known handles from stdin or selected files |
 | `pentect log [--json]` | Follow local protection events |
 
-Use `resolve` carefully: resolving a file writes plaintext to its destination.
-Prefer `exec` when a command can consume a handle directly.
+Use `resolve` with care. It writes real values to the selected file or output.
+Use `exec` instead when a command can take a handle directly.
 
 ## Installation health
 
 | Command | Purpose |
 | --- | --- |
 | `pentect doctor` | Check readiness |
-| `pentect doctor --json` | Emit machine-readable diagnostics |
-| `pentect doctor --fix` | Offer safe repairs |
+| `pentect doctor --json` | Print results as JSON |
+| `pentect doctor --fix` | Show and apply approved fixes |
 | `pentect update [VERSION]` | Install a verified GitHub Release binary |
 | `pentect update --check` | Check without installing |
-| `pentect uninstall` | Remove the binary while retaining project data |
+| `pentect uninstall` | Remove Pentect but keep project data |
 | `pentect version` | Print the installed version |
 
 ## Plugins

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -1,57 +1,55 @@
 ---
 title: Compatibility
-description: Release-tested clients, protocols, and explicit coverage limits.
+description: Clients and API formats tested for this release.
 ---
 
-Pentect validates its gateways against provider-shaped mock servers. Releases
-also launch pinned public CLI builds through the release binary.
+Pentect tests its gateways with mock provider servers. Each release also starts
+specific public CLI versions with the release binary.
 
-| Client | Release gate | Protected launch |
+| Client | Test | Protected launch |
 | --- | --- | --- |
-| Codex CLI `0.146.0` | Automated on Linux | `pentect codex` |
-| Claude Code `2.1.220` | Automated on Linux | `pentect claude` |
+| Codex CLI `0.146.0` | Automatic test on Linux | `pentect codex` |
+| Claude Code `2.1.220` | Automatic test on Linux | `pentect claude` |
 | ChatGPT desktop app, Codex mode | Launcher and Responses protocol tests | `pentect codex app` |
 | Claude Desktop, supported Chat, attachment, and Code routes | Launcher and protocol tests | `pentect claude app` |
 
-Protocol tests cover text, streaming responses, completed tool calls,
-structured content, file references, malformed content, and custom upstream
-path preservation.
+API tests cover text, streaming, completed tool calls, structured data, file
+links, broken data, and custom gateway paths.
 
 ## API format adapters
 
-Pentect can connect through a protocol adapter when the target model provider
-does not expose OpenAI Responses or Anthropic Messages directly. The adapter
-converts the API format; Pentect continues to inspect the supported client-side
-contract.
+You can use an API adapter when a model provider does not offer OpenAI Responses
+or Anthropic Messages. The adapter changes the provider API into a format
+Pentect supports. Pentect then checks the normal client-side format.
 
 ```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```
 
-[Bifrost](https://docs.getbifrost.ai/cli-agents/overview) provides OpenAI and
-Anthropic protocol adapters, and Pentect tests its `/openai/v1` and `/anthropic`
-path composition. LiteLLM and other gateways can also be used when they expose
-the same contracts, but Pentect does not certify each gateway release.
+[Bifrost](https://docs.getbifrost.ai/cli-agents/overview) can provide both API
+formats. Pentect tests its `/openai/v1` and `/anthropic` paths. LiteLLM and other
+gateways can also work when they offer the same APIs. Pentect does not test
+every gateway release.
 
 See [Custom upstreams](/clients/upstreams/) for setup and recovery steps.
 
-## Desktop qualification
+## Desktop testing
 
-Ephemeral release runners do not install and drive the signed vendor desktop
-apps. Pentect therefore does not describe a desktop app version as fully
-release-verified until that automation exists. Windows smoke testing uses
-synthetic secrets and verifies launcher, routing, and local-resolution behavior
-without printing the value.
+Short-lived CI machines do not install and control the official desktop apps.
+Because of this, Pentect does not list any desktop version as fully tested.
+Windows tests use fake secrets. They test app launch, routing, and local handle
+use without printing the value.
 
 ## Not covered
 
 - ChatGPT Chat, Work, and Voice routes outside supported Codex mode
 - Remote Claude Cowork execution and Voice
-- Experimental binary transports
-- Unknown future opaque routes
+- Test binary formats
+- Unknown future routes
 - Every provider and release behind a third-party gateway
 
-Unknown or unsupported content blocks by default rather than silently claiming
-protection. If you encounter that error, first retry the default upstream, then
+Pentect blocks unknown or unsupported content by default. It does not claim to
+protect content that it cannot check. If you see this error, first try the
+default provider, then
 follow the [unknown-format recovery steps](/reference/troubleshooting/#an-unknown-provider-format-was-blocked).

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1,11 +1,11 @@
 ---
 title: Configuration
-description: Pentect user and project configuration with secure defaults.
+description: Change Pentect settings for a user or project.
 ---
 
-Pentect reads user configuration from `~/.pentect/config.toml` and project
-configuration from `.pentect/config.toml`. Project values take precedence where
-allowed, but a repository cannot weaken user-level unknown-format protection.
+Pentect reads user settings from `~/.pentect/config.toml` and project settings
+from `.pentect/config.toml`. Project settings win when allowed. A repository
+cannot lower the user's protection for unknown formats.
 
 ## Handle identity
 
@@ -16,12 +16,12 @@ scope = "device"
 
 | Value | Behavior |
 | --- | --- |
-| `device` | Default. The same value produces the same handle identity on this device. |
-| `project` | Derives a distinct identity for each project on this device. |
-| `session` | Generates a new identity for each session. |
+| `device` | Default. The same value gets the same handle ID on this device. |
+| `project` | The same value gets a different handle ID in each project. |
+| `session` | The same value gets a new handle ID in each session. |
 
-Handle hashes are keyed. They are stable references, not unsalted fingerprints
-of the plaintext.
+Pentect creates handle hashes with a private key. They are stable references,
+not simple fingerprints of the real value.
 
 ## Unknown provider formats
 
@@ -30,12 +30,11 @@ of the plaintext.
 unknown_formats = "error" # default
 ```
 
-Set `ignore` only in the user configuration to continue past provider content
-Pentect does not understand. Restart the Pentect-launched client after changing
-the value. `ignore` passes the affected unknown request upstream without
-inspection; change it back to `error` to restore the default.
+Set `ignore` only in the user config. It sends an unknown request without
+checking it. Restart the client after changing this value. Change it back to
+`error` to restore the default.
 
-Project configuration may enforce `error`, but it cannot set `ignore`. See
+Project config can require `error`, but it cannot set `ignore`. See
 [Unknown provider format troubleshooting](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
 for copyable Windows, macOS, and Linux steps.
 
@@ -67,21 +66,19 @@ remember = true
 share = true
 ```
 
-`files.remember` keeps local recovery hints for file-backed handles.
-`activity.share` allows compatible local Pentect processes to share protection
-events.
+`files.remember` keeps local information that helps restore handles from files.
+`activity.share` lets compatible Pentect processes share protection events.
 
-## Require the Pentect agent boundary
+## Require the agent to start through Pentect
 
 ```toml
 [agent]
 required = true
 ```
 
-Use this when the project must not silently continue without a Pentect-launched
-agent session.
+Use this when the project must stop if the agent was not started by Pentect.
 
 ::: info
-Handle environment bindings always use the `PENTECT_` prefix. The prefix is
-intentionally not configurable.
+Environment variables for handles always start with `PENTECT_`. You cannot
+change this prefix.
 :::

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-description: Diagnose launch, compatibility, handle, and installation problems.
+description: Fix common launch, API, handle, and install problems.
 ---
 
 ## Start with doctor
@@ -9,53 +9,53 @@ description: Diagnose launch, compatibility, handle, and installation problems.
 pentect doctor
 ```
 
-For automation or an issue report:
+For scripts or an issue report:
 
 ```sh
 pentect doctor --json
 ```
 
-Use `pentect doctor --fix` only after reviewing the proposed repair.
+Read the suggested fix before you run `pentect doctor --fix`.
 
 ## A handle cannot be resolved
 
-Handles resolve through the running Pentect session that registered them. If a
-handle came from another session, re-read the source through the current
-Pentect-launched client instead of copying a stale handle.
+The Pentect session that created a handle also restores it. If a handle came
+from an old session, read the source again in the current Pentect client. Do
+not copy an old handle.
 
-Stable handle identity does not make recovery data global or persistent. It
-prevents confusing handle churn; the plaintext mapping remains constrained to
-the active local protection context or an explicitly remembered file pointer.
+A stable handle ID does not save the real value forever or share it everywhere.
+It only keeps the displayed handle from changing too often. The real value
+stays in the current local session or in a file location that Pentect remembers.
 
 ## The client does not launch
 
 1. Run `pentect doctor`.
-2. Confirm the unwrapped `codex` or `claude` command starts normally.
-3. If you use a custom upstream, confirm it implements the required Responses
-   or Messages contract.
-4. Retry with the default upstream to separate client discovery from gateway
-   compatibility.
+2. Check that normal `codex` or `claude` starts without Pentect.
+3. If you use a custom gateway, check that it supports the required Responses
+   or Messages API.
+4. Try the default provider. This shows whether the problem is the client or
+   the gateway.
 
 ## An unknown provider format was blocked
 
-This error means the client sent a provider request or content block that
-Pentect does not know how to inspect. The request was not sent upstream.
+This error means Pentect does not know how to check part of the request. Pentect
+did not send the request to the provider.
 
 ### Try the protected path first
 
-1. Run `pentect doctor`, then check for a fix with `pentect update --check`.
-   Install it with `pentect update` if one is available.
-2. Retry without `--upstream`. If that works, the custom gateway is using a
-   different wire format from OpenAI Responses or Anthropic Messages.
-3. If the error followed a client update, retry the last known working client
-   version or report the new format so Pentect can add support.
-4. Use `pentect log` to capture the route and error category. Logs do not
-   include plaintext protected values.
+1. Run `pentect doctor`, then run `pentect update --check`. If an update is
+   available, install it with `pentect update`.
+2. Try again without `--upstream`. If this works, the custom gateway uses a
+   different API format.
+3. If the error started after a client update, try the last working client
+   version. You can also report the new format.
+4. Run `pentect log` to record the route and error type. Logs do not include
+   real protected values.
 
 ### Temporarily pass the request through
 
-If you trust the destination and need compatibility immediately, add this to
-the **user** configuration at `~/.pentect/config.toml`:
+If you trust the provider and must continue now, add this to your **user**
+config at `~/.pentect/config.toml`:
 
 ```toml
 [compatibility]
@@ -78,22 +78,21 @@ ${EDITOR:-vi} ~/.pentect/config.toml
 
 :::
 
-If `[compatibility]` already exists, change its `unknown_formats` value instead
-of adding a second table. Then close and relaunch the Pentect-launched client.
-There is intentionally no per-project or one-launch bypass: a repository must
-not be able to weaken this user decision.
+If `[compatibility]` already exists, change its `unknown_formats` value. Do not
+add the table twice. Then close and restart the client through Pentect. A
+project cannot change this setting because only the user should make this
+choice.
 
-With `ignore`, an unknown request can reach the upstream without Pentect
-inspecting or masking that request. Supported requests remain protected. To
-restore the default, change the value back to `"error"` and relaunch the
-client.
+With `ignore`, Pentect sends an unknown request without checking or masking it.
+Known request types stay protected. To restore the default, change the value to
+`"error"` and restart the client.
 
 ### Report a format Pentect should support
 
-Open a [compatibility report](https://github.com/EdamAme-x/pentect/issues/new?template=bug_report.yml)
-with the Pentect version, client and version, command, upstream type, route, and
-the complete error text. Replace credentials and private content with synthetic
-values before attaching a request sample.
+Open a [compatibility report](https://github.com/EdamAme-x/pentect/issues/new?template=bug_report.yml).
+Include the Pentect version, client version, command, gateway type, route, and
+full error. Replace credentials and private data with fake values before you
+attach a request sample.
 
 ## Follow protection events
 
@@ -102,9 +101,9 @@ pentect log
 pentect log --json
 ```
 
-Logs report actions and counts, not plaintext protected values.
+Logs show actions and counts, not real protected values.
 
 ::: warning
-Do not paste real credentials into a public issue. Reproduce with a synthetic
-value that has the same format.
+Do not paste real credentials into a public issue. Use a fake value with the
+same format.
 :::

--- a/website/src/content/docs/start/how-it-works.md
+++ b/website/src/content/docs/start/how-it-works.md
@@ -1,81 +1,78 @@
 ---
 title: How it works
-description: Follow a sensitive value from local input to a trusted tool call.
+description: See how Pentect protects a value and restores it for a local tool.
 ---
 
-Pentect sits between a supported AI client and its model provider. It transforms
-supported request and response structures without replacing the client UI.
+Pentect runs between a supported AI client and its model provider. It protects
+requests and responses without changing the client UI.
 
 1. **Detect locally**
 
-   Pentect inspects prompts, supported tool results, configuration formats,
-   uploads, and images before protected content crosses the provider boundary.
+   Pentect checks prompts, tool results, config files, uploads, and images
+   before they are sent to the provider.
 
-2. **Replace with an opaque handle**
+2. **Replace the value with a handle**
 
    ```dotenv
    KAGGLE_API_TOKEN=KGAT_example
    KAGGLE_API_TOKEN=<<KAGGLE_API_TOKEN_85268c441f88c284>>
    ```
 
-   Labels may come from structure, such as a dotenv key. The keyed hash gives
-   the same protected value a stable reference within the configured scope.
+   Pentect can use a field name, such as a dotenv key, as the handle label.
+   Pentect uses a private key to create the handle ID. Your settings control
+   how long this ID stays the same.
 
 3. **Let the model use the reference**
 
-   The model can reason about the named value and place the handle in a tool
-   call without learning its plaintext.
+   The model can understand the label and put the handle in a tool call. It
+   does not need the real value.
 
-4. **Resolve only at the trusted boundary**
+4. **Restore only before a local tool runs**
 
-   Pentect resolves known handles immediately before the local client executes
-   a completed tool call. Unknown handle-shaped text remains inert.
+   Pentect restores known handles just before the local client runs a tool
+   call. Text that only looks like a handle is not restored.
 
 5. **Mask results on the way back**
 
-   Tool output is inspected before it returns to the provider, preventing a
-   locally restored value from simply leaking back in stdout or a file read.
+   Pentect checks tool output before it returns to the provider. This stops a
+   restored value from leaking through command output or a file read.
 
 ## Request and response lifecycle
 
 | Stage | Input | Output |
 | --- | --- | --- |
-| Client request | Provider-shaped JSON, streaming metadata, or supported files | Same protocol with protected values replaced |
-| Provider response | Text, events, and completed tool calls | Protocol preserved; known handles remain references |
-| Local execution | Completed tool arguments | Known handles resolved just before execution |
-| Tool result | stdout, stderr, and supported structured output | Sensitive values replaced before the next provider request |
+| Client request | API data, stream data, or supported files | The same format, with sensitive values replaced |
+| Provider response | Text, events, and completed tool calls | The same format, with handles kept as references |
+| Local execution | Completed tool arguments | Known handles restored just before the tool runs |
+| Tool result | stdout, stderr, and supported data | Sensitive values replaced before the next request |
 
-Pentect transforms protocol fields rather than scraping the terminal UI. This
-keeps streaming and normal client interaction intact while putting protection
-at the network and local execution boundaries.
+Pentect works with API fields instead of reading the terminal screen. Streaming
+and normal client controls continue to work.
 
 ## Handle identity
 
-A handle combines a useful label with a keyed digest. Structured sources can
-provide the label—`DATABASE_URL` in dotenv, for example—while detectors provide
-labels for unstructured text. The digest identifies the protected value without
-embedding it in the handle.
+A handle has a useful label and a keyed hash. A config key can provide the
+label, such as `DATABASE_URL` in a dotenv file. A detector provides the label
+for plain text. The hash identifies the value without putting it in the handle.
 
-Known handles can be resolved by the store that created them. Unknown
-handle-shaped text is never guessed or matched to a different value. Handle
-stability is configurable; see [Configuration](/reference/configuration/).
+Only the local store that knows a handle can restore it. Pentect never guesses
+an unknown handle or connects it to another value. You can choose how long a
+handle stays stable in [Configuration](/reference/configuration/).
 
 ## Content that needs a different treatment
 
-Text can carry a reusable handle. Images instead require local OCR and pixel
-redaction, while unsupported binary content follows the unscanned-content
-policy. [Files and images](/protection/files-and-images/) lists the exact
-behavior and controls. [Plugins](/plugins/overview/) can add detection or
-middleware without changing the client integration.
+Text can contain a reusable handle. Images need local OCR and visual masking.
+Unknown binary files follow the unscanned-content setting. See
+[Files and images](/protection/files-and-images/) for details. Plugins can add
+new checks without changing the client setup.
 
 ## Why handles instead of `[REDACTED]`?
 
-Plain redaction removes both the value and its identity. A Pentect handle keeps
-enough context for an agent to finish work while preserving the security
-boundary.
+Plain masking removes both the value and its name. A Pentect handle keeps
+enough context for the agent to finish the task.
 
 ::: warning
-A handle is a reference, not an authorization decision. If a local tool is
-allowed to use the credential, it can act with that credential's privileges.
-Use scoped, revocable credentials and narrow tool permissions.
+A handle is only a reference. It does not control permission. A local tool that
+uses a credential gets that credential's access. Use limited credentials that
+you can revoke, and give tools only the permissions they need.
 :::

--- a/website/src/content/docs/start/install.md
+++ b/website/src/content/docs/start/install.md
@@ -50,17 +50,17 @@ sudo apt install --only-upgrade pentect
 
 :::
 
-The direct installers detect the current platform, download a GitHub Release
-asset, and verify its SHA-256 checksum.
+The direct installers find your platform, download the correct GitHub Release,
+and check its SHA-256 checksum.
 
-The npm package installs the same checksummed release binary. `nix shell` opens
-a temporary environment without adding Pentect to your profile. Cargo builds
-Pentect from source and therefore takes longer than the binary installers.
+The npm package installs the same release binary and checks its checksum.
+`nix shell` opens a temporary environment and does not change your profile.
+Cargo builds Pentect from source, so it takes longer.
 
 ## NixOS configuration
 
-With a flake-based NixOS configuration, add Pentect as an input and include its
-package in a module where `inputs` and `pkgs` are available:
+For a flake-based NixOS setup, add Pentect as an input. Then add its package to
+a module that has `inputs` and `pkgs`:
 
 ```nix
 # flake.nix
@@ -78,8 +78,8 @@ Then rebuild the same flake configuration you normally use:
 sudo nixos-rebuild switch --flake .#HOSTNAME
 ```
 
-This keeps Pentect declarative and pinned by `flake.lock`. Update the input with
-`nix flake update pentect`, review the lockfile change, and rebuild.
+`flake.lock` keeps the selected version. To update it, run
+`nix flake update pentect`, check the lockfile change, and rebuild.
 
 ## Verify the installation
 
@@ -87,8 +87,8 @@ This keeps Pentect declarative and pinned by `flake.lock`. Update the input with
 pentect doctor
 ```
 
-`doctor` checks whether Pentect and supported clients are ready. If it reports
-a repairable problem, review the proposed change before using:
+`doctor` checks Pentect and supported clients. If it finds a problem it can fix,
+review the change before you run:
 
 ```sh
 pentect doctor --fix

--- a/website/src/content/docs/start/quick-start.md
+++ b/website/src/content/docs/start/quick-start.md
@@ -19,9 +19,9 @@ description: Protect a real Codex or Claude session in a few commands.
 
 3. Work normally.
 
-   Ask the agent to read a local configuration file or perform a task that
-   requires a credential. Protected values appear to the model as handles such
-   as `<<DATABASE_URL_4ce8a3b0a6f64e12>>`.
+   Ask the agent to read a local config file or do a task that needs a
+   credential. The model sees a handle such as
+   `<<DATABASE_URL_4ce8a3b0a6f64e12>>` instead of the real value.
 
 4. Watch local protection events when needed.
 
@@ -31,17 +31,17 @@ description: Protect a real Codex or Claude session in a few commands.
 
 ## What success looks like
 
-If a protected file contains `DATABASE_URL=postgres://...`, the provider sees a
-reference such as this instead of the credential:
+If a file contains `DATABASE_URL=postgres://...`, the provider sees a handle
+instead of the credential:
 
 ```dotenv
 DATABASE_URL=<<DATABASE_URL_4ce8a3b0a6f64e12>>
 ```
 
-The agent can copy that handle into a completed local tool call. Pentect
-resolves a known handle immediately before execution, then masks sensitive
-stdout before it returns to the provider. `pentect log` records the protection
-event and label, not the plaintext value.
+The agent can copy the handle into a local tool call. Pentect restores it just
+before the tool runs. Pentect then masks sensitive command output before it
+returns to the provider. `pentect log` records the event and label, not the real
+value.
 
 Normal client arguments pass through unchanged:
 
@@ -99,12 +99,11 @@ PowerShell:
 Get-Content .env -Raw | pentect mask
 ```
 
-The output contains reusable handles. Plaintext is not printed back to the
-terminal.
+The output contains reusable handles. Pentect does not print the real values.
 
 ::: tip
-These functions affect only that shell. Pentect protects each client process
-launched through them; it does not create a system-wide proxy.
+These functions affect only that shell. Pentect protects clients started by the
+functions. It does not create a proxy for the whole system.
 :::
 
 ## Next steps

--- a/website/src/content/docs/start/what-is-pentect.md
+++ b/website/src/content/docs/start/what-is-pentect.md
@@ -1,60 +1,57 @@
 ---
 title: What is Pentect?
-description: A local security boundary between AI coding tools and model providers.
+description: Protect sensitive data before an AI request leaves your computer.
 ---
 
-Pentect is a local security boundary for AI coding tools. It replaces secrets
-and sensitive data with opaque handles before requests reach a model provider,
-then resolves those handles only at trusted local tool boundaries.
+Pentect runs locally between an AI coding tool and its model provider. It
+replaces secrets and sensitive data with handles before a request leaves your
+computer. A handle is a safe reference such as `<<DATABASE_URL_...>>`.
 
-Use it when a coding agent needs to work with configuration, credentials, or
-sensitive files without sending their plaintext to the model provider.
+Use Pentect when an agent needs a credential or sensitive file. The agent can
+use the handle without receiving the real value.
 
-## The problem with redaction
+## Why normal masking is not enough
 
-Conventional redaction protects a value by removing its meaning:
+Normal masking hides both the value and its name:
 
 ```dotenv
 DATABASE_URL=[REDACTED]
 ```
 
-The model can no longer use that value in a command. Pentect preserves a typed,
-stable reference instead:
+The model cannot use this value in a command. Pentect keeps a named reference:
 
 ```dotenv
 DATABASE_URL=<<DATABASE_URL_4ce8a3b0a6f64e12>>
 ```
 
-The model can copy the handle into a completed tool call. Pentect resolves it
-immediately before the trusted local client executes that call. The provider
-never needs the plaintext.
+The model can copy this handle into a tool call. Pentect restores the real value
+just before the local tool runs. The model provider does not need to see it.
 
 ## Scope
 
-Pentect protects supported AI client traffic; it is not a password manager or
-secret vault. It complements existing permissions, sandboxing, and access controls.
+Pentect protects supported AI requests. It is not a password manager or secret
+vault. Keep using normal permissions, sandboxes, and access controls.
 
-Pentect does not grant an agent access to a secret. It changes how already
-accessible content crosses the model boundary. The local client and its tools
-still run with the permissions of the user who launched them.
+Pentect does not give an agent new access. It only changes what the model
+provider can see. Local tools still use the permissions of the current user.
 
 ## One request, end to end
 
-| Boundary | What Pentect does |
+| Step | What Pentect does |
 | --- | --- |
-| Local input | Detects supported sensitive values and creates handles |
-| Provider request | Sends the transformed content, not the known plaintext |
-| Model response | Preserves handles in text and completed tool arguments |
-| Local tool boundary | Resolves only handles known to the current store |
-| Tool result | Inspects and masks sensitive output before the next request |
+| Local input | Finds supported sensitive values and creates handles |
+| Request to the provider | Sends handles instead of known real values |
+| Model response | Keeps handles in text and tool arguments |
+| Before a local tool runs | Restores handles that the current session knows |
+| Tool result | Checks and masks output before the next request |
 
-The client UI stays the same. Pentect launches the existing client with a local
-provider-compatible gateway for that process.
+The client UI stays the same. Pentect starts the client with a local gateway for
+that process only.
 
 ## Supported surfaces
 
-Pentect currently integrates with Codex CLI, Claude Code, Codex App, and
-supported Claude Desktop routes. It also provides standalone masking and
-execution commands, custom upstream routing, and sandboxed plugins.
+Pentect supports Codex CLI, Claude Code, Codex App, and selected Claude Desktop
+features. It also offers local masking commands, custom gateways, and safe
+plugins.
 
 See [Compatibility](/reference/compatibility/) for the release-tested matrix.


### PR DESCRIPTION
## What changed

- rewrote all 18 documentation pages with shorter sentences and common words
- explained required technical terms in plain English
- kept commands, settings, supported behavior, and safety guidance intact
- improved generated agent-readable Markdown at the same time

## Why

The docs should be readable for people around Eiken Grade 2 / CEFR B1 level, including readers who do not use English every day.

## Checks

- `npm run build` in `website`
- all internal Markdown links resolve
- generated all 18 agent-readable Markdown pages
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified supported Claude, Codex, custom upstream, and desktop workflows, including launch scope, streaming, tools, files, and unsupported routes.
  - Expanded guidance for plugin creation, testing, permissions, sandboxing, hooks, and publishing.
  - Improved explanations of file/image inspection, structured masking, security limitations, compatibility settings, and protection flows.
  - Updated CLI, installation, configuration, capabilities, troubleshooting, and quick-start guidance, including diagnostics, handle restoration, uninstalling, and checksum verification.
  - Refreshed overview pages and documented supported formats, limits, provider behavior, and common failure resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->