### PR TITLE
fix: check Windows plugin inspection output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,7 +414,7 @@ jobs:
           try {
             & $binary plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --yes
             $inspection = & $binary plugins inspect openai-privacy-filter
-            if ($inspection -notmatch 'hooks: inspect') { throw 'official plugin was not installed' }
+            if (-not ($inspection -match 'hooks: inspect')) { throw 'official plugin was not installed' }
           } finally {
             Pop-Location
           }


### PR DESCRIPTION
The v0.0.24 prerelease lifecycle installed the official plugin successfully, but PowerShell -notmatch returned every non-matching output line and caused a false failure. Check whether the output array contains a matching line instead.