### PR TITLE
chore: prepare v0.0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.24"
+version = "0.0.25"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
Prepare a new protected tag after the failed v0.0.24 prerelease could not move to the release workflow fix. Updates the CLI, Cargo lock, and npm package versions together.