### PR TITLE
docs: improve site content and navigation

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -10,6 +10,7 @@ const sidebarIcons = {
   info: '<circle cx="12" cy="12" r="9"/><path d="M12 11v5"/><path d="M12 8h.01"/>',
   download: '<path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 20h14"/>',
   flow: '<circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M8 6h8M7 8l4 8m6-8-4 8"/>',
+  examples: '<path d="M5 4h14v16H5Z"/><path d="M8 8h8M8 12h5M8 16h7"/>',
   terminal: '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/>',
   message: '<path d="M5 18 3 21l4-1.5A9 9 0 1 0 5 18Z"/><path d="M8 11h8M8 14h5"/>',
   network: '<circle cx="5" cy="12" r="2"/><circle cx="19" cy="6" r="2"/><circle cx="19" cy="18" r="2"/><path d="m7 11 10-4m-10 6 10 4"/>',
@@ -44,6 +45,7 @@ const sidebar = [
       { text: sidebarLabel('What is Pentect?', 'info'), link: '/start/what-is-pentect/' },
       { text: sidebarLabel('Install', 'download'), link: '/start/install/' },
       { text: sidebarLabel('How it works', 'flow'), link: '/start/how-it-works/' },
+      { text: sidebarLabel('Examples', 'examples'), link: '/start/examples/' },
     ],
   },
   {
@@ -97,7 +99,7 @@ export default defineConfig({
   lang: 'en-US',
   title: 'Pentect',
   titleTemplate: ':title — Pentect',
-  description: 'Let agents use secrets without seeing them.',
+  description: 'Protect sensitive data before it reaches an AI model, while local tools keep working.',
   cleanUrls: true,
   lastUpdated: true,
   rewrites(id) {

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -32,6 +32,7 @@
 
 body {
   letter-spacing: -0.01em;
+  text-rendering: optimizeLegibility;
 }
 
 /* Keep wheel, touch, and keyboard scrolling without native scrollbar chrome. */
@@ -232,6 +233,22 @@ body {
 .VPHome .vp-doc.container {
   max-width: 1152px;
   padding: 0 24px 96px;
+}
+
+.vp-doc {
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+.vp-doc > p,
+.vp-doc > ul,
+.vp-doc > ol {
+  max-width: 760px;
+}
+
+.vp-doc a {
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
 }
 
 .home-install {
@@ -497,6 +514,50 @@ body {
   line-height: 1.7;
 }
 
+.home-flow {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 4px 0 64px;
+  border-block: 1px solid var(--vp-c-divider);
+}
+
+.home-flow__step {
+  display: flex;
+  min-height: 170px;
+  flex-direction: column;
+  gap: 9px;
+  padding: 24px 28px 24px 0;
+}
+
+.home-flow__step + .home-flow__step {
+  border-left: 1px solid var(--vp-c-divider);
+  padding-left: 28px;
+}
+
+.home-flow__step small {
+  color: var(--vp-c-brand-1);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+}
+
+.home-flow__step strong {
+  color: var(--vp-c-text-1);
+  font-size: 17px;
+}
+
+.home-flow__step span {
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.home-flow__step code {
+  padding: 1px 4px;
+  color: var(--vp-c-text-1);
+  font-size: 12px;
+}
+
 .docs-hub .vp-doc > h2 {
   margin-top: 64px;
   border-top: 0;
@@ -534,6 +595,25 @@ body {
 .vp-doc table {
   display: table;
   width: 100%;
+  border-collapse: collapse;
+}
+
+.vp-doc th {
+  color: var(--vp-c-text-3);
+  font-size: 11px;
+  letter-spacing: .055em;
+  text-transform: uppercase;
+}
+
+.vp-doc td,
+.vp-doc th {
+  padding: 11px 14px;
+}
+
+.vp-doc .custom-block {
+  border: 0;
+  border-left: 3px solid var(--vp-c-brand-1);
+  border-radius: 0;
 }
 
 .vp-doc div[class*='language-'] {
@@ -706,6 +786,28 @@ body {
   .home-routes {
     grid-template-columns: 1fr;
     margin-top: 42px;
+  }
+
+  .home-flow {
+    grid-template-columns: 1fr;
+    margin-bottom: 44px;
+  }
+
+  .home-flow__step {
+    min-height: 0;
+    padding: 20px 0;
+  }
+
+  .home-flow__step + .home-flow__step {
+    border-top: 1px solid var(--vp-c-divider);
+    border-left: 0;
+    padding-left: 0;
+  }
+
+  .vp-doc table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
   }
 
   .home-routes a + a {

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vitepress dev",
-    "build": "vitepress build && node scripts/copy-installers.mjs && node scripts/generate-agent-docs.mjs",
+    "build": "vitepress build && node scripts/copy-installers.mjs && node scripts/generate-agent-docs.mjs && node scripts/check-docs.mjs",
+    "check": "node scripts/check-docs.mjs",
     "preview": "vitepress preview"
   },
   "dependencies": {

--- a/website/scripts/check-docs.mjs
+++ b/website/scripts/check-docs.mjs
@@ -1,0 +1,67 @@
+import { access, readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const sourceRoot = path.join(root, 'src', 'content', 'docs');
+const distRoot = path.join(root, 'dist');
+const sourceFiles = await findFiles(sourceRoot, /\.mdx?$/i);
+const problems = [];
+let checked = 0;
+
+for (const file of sourceFiles) {
+  const source = await readFile(file, 'utf8');
+  const urls = [
+    ...source.matchAll(/\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g),
+    ...source.matchAll(/\bhref=["']([^"']+)["']/g),
+  ].map((match) => match[1]);
+
+  for (const url of urls) {
+    if (!url.startsWith('/') || url.startsWith('//')) continue;
+    checked += 1;
+    const pathname = decodeURIComponent(url.split(/[?#]/, 1)[0]);
+    const relative = pathname.replace(/^\/+/, '');
+    const candidates = path.extname(relative)
+      ? [path.join(distRoot, relative)]
+      : [path.join(distRoot, relative, 'index.html')];
+    if (pathname === '/') candidates[0] = path.join(distRoot, 'index.html');
+
+    if (!(await anyExists(candidates))) {
+      problems.push(`${path.relative(root, file)} -> ${url}`);
+    }
+  }
+}
+
+const generatedMarkdown = await findFiles(distRoot, /index\.md$/i);
+if (generatedMarkdown.length !== sourceFiles.length) {
+  problems.push(
+    `generated Markdown page count is ${generatedMarkdown.length}; expected ${sourceFiles.length}`,
+  );
+}
+
+if (problems.length) {
+  throw new Error(`Documentation checks failed:\n${problems.map((item) => `- ${item}`).join('\n')}`);
+}
+
+console.log(`Checked ${sourceFiles.length} pages and ${checked} internal links.`);
+
+async function anyExists(paths) {
+  for (const candidate of paths) {
+    try {
+      await access(candidate);
+      return true;
+    } catch {
+      // Try the next valid representation.
+    }
+  }
+  return false;
+}
+
+async function findFiles(directory, pattern) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nested = await Promise.all(entries.map((entry) => {
+    const target = path.join(directory, entry.name);
+    return entry.isDirectory() ? findFiles(target, pattern) : [target];
+  }));
+  return nested.flat().filter((file) => pattern.test(file));
+}

--- a/website/scripts/generate-agent-docs.mjs
+++ b/website/scripts/generate-agent-docs.mjs
@@ -39,10 +39,12 @@ for (const sourcePath of sourceFiles) {
   const slug = frontmatterValue(attributes, 'slug') ?? defaultSlug;
   const route = slug ? `/${slug.replace(/^\/+|\/+$/g, '')}/` : '/';
   const outputDirectory = path.join(distRoot, route.slice(1));
-  const tree = processor.parse(body);
+  const agentTitle = title.endsWith('_') ? title.slice(0, -1) : title;
+  const agentBody = body.replace(/^:::\s*(?:code-group|tip|info|warning|danger)?\s*$/gm, '');
+  const tree = processor.parse(agentBody);
   const description = frontmatterValue(attributes, 'description');
   tree.children = [
-    heading(title),
+    heading(agentTitle),
     ...(description ? [paragraph(description)] : []),
     ...rewriteNodes(tree.children),
   ];
@@ -89,6 +91,19 @@ function rewriteNodes(nodes) {
     if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
       if (node.name === 'a') {
         return [rewriteAnchor(node)];
+      }
+      if (node.name === 'div' && componentClass(node).includes('home-flow')) {
+        return (node.children ?? [])
+          .filter((child) => componentClass(child).includes('home-flow__step'))
+          .flatMap((step) => {
+            const number = componentAttribute(step, 'data-number');
+            const title = componentAttribute(step, 'data-title');
+            const description = componentAttribute(step, 'data-description');
+            return [
+              heading([number, title].filter(Boolean).join(' — '), 3),
+              ...(description ? [paragraph(description)] : []),
+            ];
+          });
       }
       const children = rewriteNodes(node.children ?? []);
       const label = componentLabel(node);
@@ -162,6 +177,17 @@ function componentLabel(node) {
     (item) => item.type === 'mdxJsxAttribute' && item.name === attributeName,
   );
   return typeof attribute?.value === 'string' ? attribute.value : undefined;
+}
+
+function componentClass(node) {
+  return componentAttribute(node, 'class');
+}
+
+function componentAttribute(node, name) {
+  const attribute = node?.attributes?.find(
+    (item) => item.type === 'mdxJsxAttribute' && item.name === name,
+  );
+  return typeof attribute?.value === 'string' ? attribute.value : '';
 }
 
 function heading(value, depth = 1) {

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -1,9 +1,19 @@
 ---
 title: Docs_
-description: Let agents use secrets without seeing them.
+description: Protect sensitive data before it reaches an AI model, while local tools keep working.
 pageClass: docs-hub
 aside: false
 ---
+
+Pentect runs locally between supported AI clients and their providers. It
+replaces sensitive values with useful handles, then restores those handles only
+when a trusted local tool needs the value.
+
+<div class="home-flow" aria-label="How Pentect protects a request">
+  <div class="home-flow__step" data-number="01" data-title="Detect locally" data-description="Check text, config files, uploads, images, and tool output."><small>01</small><strong>Detect locally</strong><span>Check text, config files, uploads, images, and tool output.</span></div>
+  <div class="home-flow__step" data-number="02" data-title="Send a handle" data-description="The provider sees a DATABASE_URL handle, not the value."><small>02</small><strong>Send a handle</strong><span>The provider sees <code>&lt;&lt;DATABASE_URL_...&gt;&gt;</code>, not the value.</span></div>
+  <div class="home-flow__step" data-number="03" data-title="Use it locally" data-description="Restore known handles only at a trusted tool boundary."><small>03</small><strong>Use it locally</strong><span>Restore known handles only at a trusted tool boundary.</span></div>
+</div>
 
 <HomeInstall />
 
@@ -52,7 +62,28 @@ aside: false
     <span>Build, test, and publish custom checks with regex or Wasm.</span><b aria-hidden="true">→</b>
   </a>
   <a href="/reference/capabilities/" class="docs-grid__item">
-    <strong>CLI and configuration</strong>
-    <span>Browse commands, settings, compatibility, and troubleshooting.</span><b aria-hidden="true">→</b>
+    <strong>Everything Pentect can do</strong>
+    <span>Browse clients, protected content, commands, settings, and plugins.</span><b aria-hidden="true">→</b>
+  </a>
+</DocsGrid>
+
+## Common tasks
+
+<DocsGrid>
+  <a href="/start/quick-start/" class="docs-grid__item">
+    <small>5 minutes</small><strong>Protect your first agent session</strong>
+    <span>Install Pentect, launch Codex or Claude, and confirm a handle.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/start/examples/" class="docs-grid__item">
+    <small>Recipes</small><strong>Use Pentect in real work</strong>
+    <span>Mask a file, use a custom gateway, keep aliases, and apply project policy.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/reference/troubleshooting/" class="docs-grid__item">
+    <small>Help</small><strong>Fix a blocked request</strong>
+    <span>Find the protected path first, then use compatibility mode only when needed.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/protection/security-model/" class="docs-grid__item">
+    <small>Trust</small><strong>Understand the boundary</strong>
+    <span>See what stays local, what plugins can access, and what Pentect does not cover.</span><b aria-hidden="true">→</b>
   </a>
 </DocsGrid>

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -3,6 +3,10 @@ title: CLI reference
 description: Pentect commands and what they do.
 ---
 
+Run `pentect help` for the short list installed with your version. Pentect
+returns a non-zero exit code when it blocks input, cannot start a client, or
+cannot complete a requested change.
+
 ## Launch clients
 
 | Command | Purpose |
@@ -23,6 +27,10 @@ pentect codex exec --full-auto
 pentect claude --model sonnet
 ```
 
+`--check` validates app discovery and routing without leaving the app open.
+`--plugins` accepts a local plugin directory or a
+`github:@OWNER/REPOSITORY/path` source. Separate multiple sources with commas.
+
 ## Protect local input and execution
 
 | Command | Purpose |
@@ -37,6 +45,20 @@ pentect claude --model sonnet
 Use `resolve` with care. It writes real values to the selected file or output.
 Use `exec` instead when a command can take a handle directly.
 
+`mask` accepts text as arguments or reads UTF-8 standard input:
+
+::: code-group
+
+```sh [macOS / Linux]
+printf '%s' 'TOKEN=example' | pentect mask
+```
+
+```powershell [Windows]
+'TOKEN=example' | pentect mask
+```
+
+:::
+
 ## Installation health
 
 | Command | Purpose |
@@ -44,8 +66,10 @@ Use `exec` instead when a command can take a handle directly.
 | `pentect doctor` | Check readiness |
 | `pentect doctor --json` | Print results as JSON |
 | `pentect doctor --fix` | Show and apply approved fixes |
+| `pentect doctor --fix --yes` | Apply all offered fixes without another prompt |
 | `pentect update [VERSION]` | Install a verified GitHub Release binary |
 | `pentect update --check` | Check without installing |
+| `pentect update --force` | Reinstall even when the selected version is already present |
 | `pentect uninstall` | Remove Pentect but keep project data |
 | `pentect version` | Print the installed version |
 
@@ -70,5 +94,8 @@ Use `exec` instead when a command can take a handle directly.
 `SOURCE` can be a local directory or `github:@OWNER/REPOSITORY/path`. Use
 `--plugins SOURCE` on a client or mask command when you need a plugin for only
 one launch.
+
+Approval flags skip an interactive confirmation; they do not skip checksum,
+build-record, manifest, or sandbox checks.
 
 See [Plugins](/plugins/overview/) for the full workflow.

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -16,6 +16,10 @@ specific public CLI versions with the release binary.
 API tests cover text, streaming, completed tool calls, structured data, file
 links, broken data, and custom gateway paths.
 
+The version numbers are release gates, not strict version locks. A newer client
+may work, but a new request or stream shape can be blocked until Pentect learns
+it. Run `pentect update --check` after a client update.
+
 ## API format adapters
 
 You can use an API adapter when a model provider does not offer OpenAI Responses
@@ -40,6 +44,12 @@ Short-lived CI machines do not install and control the official desktop apps.
 Because of this, Pentect does not list any desktop version as fully tested.
 Windows tests use fake secrets. They test app launch, routing, and local handle
 use without printing the value.
+
+| Desktop surface | Current scope |
+| --- | --- |
+| Codex App | Supported Codex mode using the Responses protocol |
+| Claude Desktop | Supported Chat, attachment, and Code routes |
+| Other app modes | Not claimed unless listed here |
 
 ## Not covered
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -7,6 +7,22 @@ Pentect reads user settings from `~/.pentect/config.toml` and project settings
 from `.pentect/config.toml`. Project settings win when allowed. A repository
 cannot lower the user's protection for unknown formats.
 
+You can leave both files absent. Pentect uses safe defaults. Restart a protected
+client after changing a setting.
+
+## Settings at a glance
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `handles.scope` | `device` | Choose how stable handle IDs are |
+| `compatibility.unknown_formats` | `error` | Block request formats Pentect cannot inspect |
+| `image.ocr` | `on` | Check supported images locally |
+| `image.redaction` | `black` | Cover detected image regions |
+| `image.unscanned` | `block` | Stop when image or document content cannot be checked |
+| `files.remember` | `true` | Remember safe local file-to-handle information |
+| `activity.share` | `true` | Share events with compatible local Pentect processes |
+| `agent.required` | `false` | Require supported agents to start through Pentect |
+
 ## Handle identity
 
 ```toml
@@ -55,6 +71,28 @@ fetch_seconds = 8
 ```
 
 `redaction` accepts `black` or `blur`. `unscanned` accepts `block` or `allow`.
+Size values are bytes except `max_edge` and `max_pixels`. Keep the defaults
+unless a trusted file is larger than a limit.
+
+## Encoded values
+
+Pentect can inspect common encoded text and compressed data before detection:
+
+```toml
+[decode]
+enabled = true
+max_depth = 3
+min_bytes = 16
+max_bytes = 262144
+max_inflate_bytes = 8388608
+mask_unknown = false
+unknown_min_bytes = 24
+```
+
+Use `"unlimited"` for `max_depth`, `max_bytes`, or `max_inflate_bytes` only
+when another limit controls the input. `mask_unknown = true` also masks long
+opaque encoded values that Pentect cannot identify. It can create false
+positives, so it is off by default.
 
 ## Files and activity
 
@@ -69,6 +107,9 @@ share = true
 `files.remember` keeps local information that helps restore handles from files.
 `activity.share` lets compatible Pentect processes share protection events.
 
+Project values normally override user values. `agent.required` is stricter: if
+either file sets it to `true`, the effective value is true.
+
 ## Require the agent to start through Pentect
 
 ```toml
@@ -82,3 +123,16 @@ Use this when the project must stop if the agent was not started by Pentect.
 Environment variables for handles always start with `PENTECT_`. You cannot
 change this prefix.
 :::
+
+## Plugin settings
+
+Do not edit plugin state by hand. Use the CLI so values stay valid:
+
+```sh
+pentect plugins config PLUGIN policy.level=strict
+pentect plugins config PLUGIN --unset policy.level
+pentect plugins setup PLUGIN
+```
+
+`plugins add` records an enabled source in the project config. Wasm access is
+approved separately and tied to the manifest and binary hashes.

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -17,6 +17,14 @@ pentect doctor --json
 
 Read the suggested fix before you run `pentect doctor --fix`.
 
+Also record the versions involved:
+
+```sh
+pentect version
+codex --version
+claude --version
+```
+
 ## A handle cannot be resolved
 
 The Pentect session that created a handle also restores it. If a handle came
@@ -35,6 +43,38 @@ stays in the current local session or in a file location that Pentect remembers.
    or Messages API.
 4. Try the default provider. This shows whether the problem is the client or
    the gateway.
+
+For a desktop app, check discovery without keeping the app open:
+
+```sh
+pentect codex app --check
+pentect claude app --check
+```
+
+If auto-discovery fails, pass the executable with `--app PATH`.
+
+## A file or image was blocked
+
+1. Check whether the file is UTF-8 text, a supported image, or a supported PDF.
+2. For text, pipe it through `pentect mask` to isolate the problem.
+3. For an image, check its size against the `[image]` limits and keep OCR on.
+4. Convert an unknown binary format before sending it.
+
+`image.unscanned = "allow"` is available for content already checked by
+another trusted system. It sends unchecked content and should not be the first
+fix. See [Files and images](/protection/files-and-images/).
+
+## A plugin does not run
+
+```sh
+pentect plugins inspect NAME
+pentect plugins test NAME
+pentect plugins setup NAME
+```
+
+`inspect` shows requested hooks and access. `test` checks the manifest and
+Wasm exports. Run `setup` after a reviewed plugin update changes its approved
+access. For a required plugin, a plugin error stops the protected action.
 
 ## An unknown provider format was blocked
 

--- a/website/src/content/docs/start/examples.md
+++ b/website/src/content/docs/start/examples.md
@@ -1,0 +1,126 @@
+---
+title: Examples
+description: Copyable ways to use Pentect in everyday work.
+---
+
+Each example uses fake data. Start a client through Pentect before you use a
+handle in that client.
+
+## Read a config file safely
+
+Ask a protected Codex or Claude session to read `.env`. The provider receives
+the key names and handles:
+
+```dotenv
+DATABASE_URL=<<DATABASE_URL_4ce8a3b0a6f64e12>>
+PAYMENTS_TOKEN=<<PAYMENTS_TOKEN_9ef3a9b7b1cf0210>>
+```
+
+You can check the same result without an agent:
+
+::: code-group
+
+```sh [macOS / Linux]
+cat .env | pentect mask
+```
+
+```powershell [Windows]
+Get-Content .env -Raw | pentect mask
+```
+
+:::
+
+## Let a local command use a handle
+
+`pentect exec` restores handles before the command runs, then masks its output:
+
+```sh
+pentect exec 'curl -H "Authorization: Bearer <<API_TOKEN_...>>" https://api.example.test/me'
+```
+
+Prefer this to `pentect resolve` when a command can accept the handle directly.
+`resolve` writes the real value to a file or standard output.
+
+## Keep your normal client command
+
+Add a small function to your shell profile. Client arguments still pass
+through:
+
+::: code-group
+
+```powershell [PowerShell]
+function codex { & pentect codex @args }
+function claude { & pentect claude @args }
+```
+
+```sh [Bash / Zsh]
+codex() { command pentect codex "$@"; }
+claude() { command pentect claude "$@"; }
+```
+
+```fish [Fish]
+function codex
+    command pentect codex $argv
+end
+function claude
+    command pentect claude $argv
+end
+```
+
+:::
+
+Now commands such as `codex exec --full-auto` and `claude --model sonnet` use
+Pentect without changing their normal arguments.
+
+## Use a local model or gateway
+
+Point one launch at a gateway that supports the client API:
+
+```sh
+pentect codex --upstream http://127.0.0.1:8080/openai/v1
+pentect claude --upstream http://127.0.0.1:8080/anthropic
+```
+
+Codex needs OpenAI Responses. Claude needs Anthropic Messages. A Chat
+Completions endpoint alone is not enough. See [Custom upstreams](/clients/upstreams/).
+
+## Apply a project policy
+
+Create `.pentect/config.toml` in the project:
+
+```toml
+[handles]
+scope = "project"
+
+[agent]
+required = true
+```
+
+This gives the project its own handle identity and requires supported agents to
+start through Pentect. A project cannot turn off the user's unknown-format
+protection.
+
+## Add one custom detector
+
+Create `plugins/company/plugin.toml`:
+
+```toml
+schema = "pentect.plugin.v1"
+name = "company-ids"
+description = "Protect internal case IDs."
+
+[[detector]]
+label = "CASE_ID"
+pattern = '''\bCASE-[0-9]{8}\b'''
+category = "identifier"
+confidence = "high"
+```
+
+Try it for one command:
+
+```sh
+echo "CASE-12345678" | pentect mask --plugins ./plugins/company
+```
+
+Continue with [Build a plugin](/plugins/build/) when you need Wasm, settings,
+network access, or request policy.

--- a/website/src/content/docs/start/install.md
+++ b/website/src/content/docs/start/install.md
@@ -3,7 +3,22 @@ title: Install
 description: Install Pentect on Windows, macOS, or Linux.
 ---
 
-## Windows
+Choose the method that fits your system. Direct installers and npm download a
+prebuilt release and check its SHA-256 checksum. Cargo builds from source.
+
+| Method | Systems | Updates |
+| --- | --- | --- |
+| PowerShell | Windows | `pentect update` |
+| Shell | macOS and Linux | `pentect update` |
+| Homebrew | macOS and Linux | `brew upgrade pentect` |
+| APT | Debian and Ubuntu | normal APT updates |
+| Nix | macOS and Linux | Nix profile or flake updates |
+| npm | Windows, macOS, and Linux | reinstall the package |
+| Cargo | Any supported Rust host | reinstall from source |
+
+## Direct installer
+
+### Windows
 
 Run in PowerShell:
 
@@ -11,13 +26,18 @@ Run in PowerShell:
 irm https://pentect.dev/install | iex
 ```
 
-## macOS and Linux
+### macOS and Linux
 
-::: code-group
-
-```sh [Shell]
+```sh
 curl -fsSL https://pentect.dev/install.sh | sh
 ```
+
+The installer selects the correct GitHub Release for the current operating
+system and CPU architecture.
+
+## Package managers
+
+::: code-group
 
 ```sh [Homebrew]
 brew install EdamAme-x/pentect/pentect
@@ -50,10 +70,8 @@ sudo apt install --only-upgrade pentect
 
 :::
 
-The direct installers find your platform, download the correct GitHub Release,
-and check its SHA-256 checksum.
-
-The npm package installs the same release binary and checks its checksum.
+The npm package installs from the Pentect GitHub repository, then downloads the
+same release binary and checks its checksum.
 `nix shell` opens a temporary environment and does not change your profile.
 Cargo builds Pentect from source, so it takes longer.
 
@@ -88,7 +106,7 @@ pentect doctor
 ```
 
 `doctor` checks Pentect and supported clients. If it finds a problem it can fix,
-review the change before you run:
+it describes the change first. Apply approved fixes with:
 
 ```sh
 pentect doctor --fix
@@ -104,6 +122,14 @@ pentect doctor --fix
 
 ```sh [macOS / Linux]
 curl -fsSL https://pentect.dev/install.sh | sh -s -- --version X.Y.Z
+```
+
+```sh [npm]
+npm install --global github:EdamAme-x/pentect#vX.Y.Z
+```
+
+```sh [Cargo]
+cargo install --git https://github.com/EdamAme-x/pentect --tag vX.Y.Z --locked pentect-cli
 ```
 
 :::
@@ -145,3 +171,7 @@ pentect update
 pentect update X.Y.Z
 pentect uninstall
 ```
+
+`pentect uninstall` removes an installation managed by the direct installer. It
+keeps `.pentect` project settings and user data. Use the original package
+manager for a package-manager installation.

--- a/website/src/content/docs/start/quick-start.md
+++ b/website/src/content/docs/start/quick-start.md
@@ -3,7 +3,10 @@ title: Quick start
 description: Protect a real Codex or Claude session in a few commands.
 ---
 
-1. Check that Pentect can find your client.
+Install Pentect first, then use one protected launch. You do not need to change
+the permanent settings of Codex or Claude.
+
+1. Check Pentect and the client.
 
    ```sh
    pentect doctor
@@ -17,13 +20,13 @@ description: Protect a real Codex or Claude session in a few commands.
    pentect claude
    ```
 
-3. Work normally.
+3. Work normally in the client that opens.
 
    Ask the agent to read a local config file or do a task that needs a
    credential. The model sees a handle such as
    `<<DATABASE_URL_4ce8a3b0a6f64e12>>` instead of the real value.
 
-4. Watch local protection events when needed.
+4. Watch local protection events when you need to verify a flow.
 
    ```sh
    pentect log
@@ -42,6 +45,10 @@ The agent can copy the handle into a local tool call. Pentect restores it just
 before the tool runs. Pentect then masks sensitive command output before it
 returns to the provider. `pentect log` records the event and label, not the real
 value.
+
+The client should still stream responses, run tools, and accept its normal
+flags. If a request format cannot be checked, Pentect returns an error instead
+of sending it by default.
 
 Normal client arguments pass through unchanged:
 
@@ -112,3 +119,4 @@ functions. It does not create a proxy for the whole system.
 - See [Structured data](/protection/structured-data/) for dotenv, Terraform, Kubernetes, and JSON behavior.
 - Review [Files and images](/protection/files-and-images/) before sending uploads.
 - Run `pentect doctor` again after changing a client installation or provider.
+- Copy a complete task from [Examples](/start/examples/).


### PR DESCRIPTION
## What
- make the docs home explain the product flow before installation
- add practical examples for files, handles, aliases, gateways, project policy, and plugins
- expand install, CLI, configuration, compatibility, and troubleshooting references
- improve typography, tables, callouts, responsive layout, and dark mode
- clean agent-readable Markdown and add a built-in internal-link check

## Validation
- cd website && npm run build
- 23 VitePress pages generated
- 23 agent-readable Markdown pages generated
- 51 internal links checked
- desktop, mobile, light, and dark layouts inspected locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Examples page and linked it from the getting started area.
  * Expanded the docs homepage with a clearer protection flow and quick links to common tasks.
  * Added more CLI, configuration, installation, compatibility, and troubleshooting guidance.

* **Documentation**
  * Improved example-driven onboarding, including safe masking, command handling, local usage, and plugin setup.
  * Refreshed layout and styling for documentation pages, tables, callouts, and mobile display.

* **Tests / Chores**
  * Added automated checks to validate documentation links and page coverage during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->