### PR TITLE
feat: protect OpenCode and Pi over HTTP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
           node-version: "22"
       - run: npm test
       - run: npm pack --dry-run
+      - name: Verify Pi launcher package
+        working-directory: integrations/pi
+        run: |
+          npm run check
+          npm test
+          npm pack --dry-run
 
   changes:
     name: Changes

--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -1,4 +1,5 @@
 name: Publish Pi
+run-name: Publish Pi ${{ inputs.version || github.ref_name }} ${{ inputs.request_id }}
 
 on:
   push:
@@ -9,6 +10,10 @@ on:
       version:
         description: Pentect release version without the v prefix
         required: true
+        type: string
+      request_id:
+        description: Unique caller ID used to wait for this run
+        required: false
         type: string
 
 permissions:
@@ -31,6 +36,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -51,9 +57,11 @@ jobs:
             test "$GITHUB_REF_NAME" = "pi-v$version"
           fi
           test -n "$version"
-          release=$(gh release view "v$version" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease,targetCommitish)
+          release=$(gh release view "v$version" --repo "$GITHUB_REPOSITORY" --json isDraft)
           test "$(jq -r .isDraft <<<"$release")" = false
-          test "$(jq -r .isPrerelease <<<"$release")" = false
+          release_commit=$(git rev-list -n 1 "v$version")
+          test -n "$release_commit"
+          test "$(git rev-parse HEAD)" = "$release_commit"
           test "$(npm view "pentect@$version" version)" = "$version"
           echo "VERSION=$version" >> "$GITHUB_ENV"
       - name: Prepare package

--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -1,0 +1,76 @@
+name: Publish Pi
+
+on:
+  push:
+    tags:
+      - "pi-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Pentect release version without the v prefix
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-pi-${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'EdamAme-x/pentect'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: integrations/pi
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - name: Resolve and verify release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if test "$GITHUB_EVENT_NAME" = workflow_dispatch; then
+            version=$INPUT_VERSION
+          else
+            version=${GITHUB_REF_NAME#pi-v}
+            test "$GITHUB_REF_NAME" = "pi-v$version"
+          fi
+          test -n "$version"
+          release=$(gh release view "v$version" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease,targetCommitish)
+          test "$(jq -r .isDraft <<<"$release")" = false
+          test "$(jq -r .isPrerelease <<<"$release")" = false
+          test "$(npm view "pentect@$version" version)" = "$version"
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+      - name: Prepare package
+        run: |
+          set -euo pipefail
+          npm pkg set "version=$VERSION" "dependencies.pentect=$VERSION"
+          test "$(node --print "require('./package.json').version")" = "$VERSION"
+          test "$(node --print "require('./package.json').dependencies.pentect")" = "$VERSION"
+          npm run check
+          npm test
+          npm pack --dry-run
+      - name: Publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          if npm view "@pentect/pi@$VERSION" version >/dev/null 2>&1; then
+            echo "@pentect/pi@$VERSION is already published"
+          else
+            npm publish --access public
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,14 @@ jobs:
           }
           npm test
           npm pack --dry-run
+          Push-Location integrations/pi
+          try {
+            npm run check
+            npm test
+            npm pack --dry-run
+          } finally {
+            Pop-Location
+          }
       - name: Stage release notices
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -367,12 +375,14 @@ jobs:
         with:
           node-version: "22"
       - name: Install supported agent CLIs
-        run: npm install --global @openai/codex@0.146.0 @anthropic-ai/claude-code@2.1.220
+        run: npm install --global @openai/codex@0.146.0 @anthropic-ai/claude-code@2.1.220 opencode-ai@1.18.14 @mariozechner/pi-coding-agent@0.73.1
       - name: Verify launchers
         run: |
           chmod +x dist/pentect-linux-x86_64
           dist/pentect-linux-x86_64 codex -- --version
           dist/pentect-linux-x86_64 claude -- --version
+          dist/pentect-linux-x86_64 opencode -- --version
+          dist/pentect-linux-x86_64 pi -- --version
 
   lifecycle:
     name: Lifecycle (${{ matrix.os }})
@@ -478,6 +488,52 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release edit "$GITHUB_REF_NAME" --prerelease=false --latest --repo "$GITHUB_REPOSITORY"
+
+  npm-publish:
+    name: Publish npm packages
+    needs: promote
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - name: Verify release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=${GITHUB_REF_NAME#v}
+          test "$(node --print "require('./package.json').version")" = "$version"
+      - name: Publish Pentect
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=${GITHUB_REF_NAME#v}
+          if npm view "pentect@$version" version >/dev/null 2>&1; then
+            echo "pentect@$version is already published"
+          else
+            npm publish --access public
+          fi
+      - name: Trigger matching Pi launcher release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version=${GITHUB_REF_NAME#v}
+          gh workflow run publish-pi.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$GITHUB_REF_NAME" \
+            -f version="$version"
 
   package-metadata:
     name: Update package metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,7 +478,7 @@ jobs:
 
   promote:
     name: Publish stable release
-    needs: [lifecycle, apt-repository]
+    needs: [lifecycle, apt-repository, npm-publish]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -491,9 +491,9 @@ jobs:
 
   npm-publish:
     name: Publish npm packages
-    needs: promote
+    needs: [lifecycle, apt-repository]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       actions: write
       contents: read
@@ -530,10 +530,29 @@ jobs:
         run: |
           set -euo pipefail
           version=${GITHUB_REF_NAME#v}
+          request_id="$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
           gh workflow run publish-pi.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref "$GITHUB_REF_NAME" \
-            -f version="$version"
+            -f version="$version" \
+            -f request_id="$request_id"
+          title="Publish Pi $version $request_id"
+          run_id=""
+          for attempt in $(seq 1 30); do
+            run_id=$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow publish-pi.yml \
+              --event workflow_dispatch \
+              --limit 30 \
+              --json databaseId,displayTitle \
+              | jq -r --arg title "$title" \
+                '.[] | select(.displayTitle == $title) | .databaseId' \
+              | head -n 1)
+            test -n "$run_id" && break
+            sleep 2
+          done
+          test -n "$run_id"
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
 
   package-metadata:
     name: Update package metadata

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,6 +8,8 @@ through the release binary:
 | --- | --- | --- |
 | Codex CLI `0.146.0` | automated on Linux | `pentect codex` |
 | Claude Code `2.1.220` | automated on Linux | `pentect claude` |
+| OpenCode `1.18.14` | provider registration and model discovery on Windows | `pentect opencode` |
+| Pi `0.73.1` and `0.83.0` | provider registration and model discovery on Windows | `pentect pi` |
 | ChatGPT desktop app (Codex mode) | launcher and Responses protocol tests | `pentect codex app` |
 | Claude Desktop (supported Chat, attachment, and Claude Code routes) | launcher and protocol tests | `pentect claude app` |
 
@@ -46,7 +48,7 @@ or unsupported attachment formats are blocked by default.
 
 ## Upstreams
 
-Codex Responses-compatible and Anthropic Messages-compatible upstreams can be
+Codex Responses-compatible, OpenAI Chat Completions-compatible, and Anthropic Messages-compatible upstreams can be
 selected with `--upstream URL`. Existing Codex provider configuration and
 Claude's managed/user endpoint configuration are preserved as the upstream
 when Pentect inserts its local gateway. Unsupported wire protocols are rejected

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Pentect is a local security boundary for AI coding tools. It replaces secrets
 and sensitive data with opaque handles before requests reach a model provider,
 then resolves those handles only at trusted client tool boundaries.
 
-Pentect currently supports Codex CLI, Claude Code, Codex App, and Claude
-Desktop. It also provides standalone masking commands and sandboxed WebAssembly
-plugins.
+Pentect currently supports Codex CLI, Claude Code, OpenCode, Pi, Codex App, and
+Claude Desktop. It also provides standalone masking commands and sandboxed
+WebAssembly plugins.
 
 > Pentect is pre-1.0 security software. Unknown provider formats are blocked by
 > default, but no filter can promise perfect detection. Keep provider and tool
@@ -48,7 +48,7 @@ nix shell github:EdamAme-x/pentect
 nix profile install github:EdamAme-x/pentect/nix-vX.Y.Z
 
 # npm (downloads a checksummed release binary)
-npm install --global github:EdamAme-x/pentect
+npm install --global pentect
 
 # Cargo (builds from source)
 cargo install --git https://github.com/EdamAme-x/pentect --locked pentect-cli
@@ -72,6 +72,8 @@ Launch a supported CLI through Pentect:
 ```text
 pentect codex
 pentect claude
+pentect opencode --model openai/gpt-5
+pentect pi --model openai/gpt-5
 ```
 
 Use a Responses- or Messages-compatible gateway without changing permanent
@@ -80,6 +82,8 @@ client configuration:
 ```text
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 pentect claude --upstream http://127.0.0.1:8080/anthropic
+pentect opencode --model anthropic/claude-sonnet --upstream http://127.0.0.1:8080/openai/v1
+pentect pi --model anthropic/claude-sonnet --upstream http://127.0.0.1:8080/openai/v1
 ```
 
 Launch a desktop app only when explicitly requested:

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2086,6 +2086,7 @@ mod tests {
     enum MockProvider {
         Anthropic,
         OpenAi,
+        OpenAiChat,
     }
 
     fn first_valid_handle(text: &str) -> Option<&str> {
@@ -2220,6 +2221,37 @@ mod tests {
                     (
                         format!("event: response.output_item.done\ndata: {event}\n\n").into_bytes(),
                         None,
+                    )
+                }
+                MockProvider::OpenAiChat => {
+                    let arguments = format!(r#"{{"command":"echo {handle}"}}"#);
+                    let split = arguments.len() / 2;
+                    let first = serde_json::json!({
+                        "id": "chat_test",
+                        "object": "chat.completion.chunk",
+                        "choices": [{"index": 0, "delta": {"role": "assistant", "tool_calls": [{
+                            "index": 0, "id": "call_test", "type": "function",
+                            "function": {"name": "shell", "arguments": &arguments[..split]}
+                        }]}, "finish_reason": null}]
+                    });
+                    let second = serde_json::json!({
+                        "id": "chat_test",
+                        "object": "chat.completion.chunk",
+                        "choices": [{"index": 0, "delta": {"tool_calls": [{
+                            "index": 0, "function": {"arguments": &arguments[split..]}
+                        }]}, "finish_reason": null}]
+                    });
+                    let finish = serde_json::json!({
+                        "id": "chat_test",
+                        "object": "chat.completion.chunk",
+                        "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]
+                    });
+                    (
+                        format!(
+                            "data: {first}\n\ndata: {second}\n\ndata: {finish}\n\ndata: [DONE]\n\n"
+                        )
+                        .into_bytes(),
+                        Some("text/event-stream"),
                     )
                 }
             };
@@ -2384,6 +2416,39 @@ mod tests {
         drop(openai_proxy);
         openai_thread.join().unwrap();
 
+        let (chat_upstream, chat_request, chat_thread) = mock_upstream(MockProvider::OpenAiChat);
+        let chat_proxy =
+            crate::openai_http_proxy::OpenAiHttpProxyGuard::start(chat_upstream).unwrap();
+        let chat_response = reqwest::blocking::Client::new()
+            .post(format!("{}/v1/chat/completions", chat_proxy.base_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(
+                serde_json::to_vec(&serde_json::json!({
+                    "model": "test",
+                    "stream": true,
+                    "messages": [{
+                        "role": "user",
+                        "content": format!("Use this dotenv value:\nRUNPOD_API_KEY={secret}\n")
+                    }]
+                }))
+                .unwrap(),
+            )
+            .send()
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .text()
+            .unwrap();
+        let provider_body = chat_request
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .unwrap();
+        assert!(!provider_body.contains(secret.as_str()));
+        assert!(first_valid_handle(&provider_body).is_some());
+        assert!(chat_response.contains(secret.as_str()), "{chat_response}");
+        assert!(!chat_response.contains("<<RUNPOD_API_KEY_"));
+        drop(chat_proxy);
+        chat_thread.join().unwrap();
+
         for provider in [MockProvider::OpenAi, MockProvider::Anthropic] {
             let (upload_upstream, upload_request, upload_thread) = mock_upstream(provider);
             let (upload_url, guard): (String, Box<dyn std::any::Any>) = match provider {
@@ -2397,6 +2462,7 @@ mod tests {
                     let guard = ClaudeHttpProxyGuard::start(upload_upstream).unwrap();
                     (format!("{}/v1/files", guard.base_url()), Box::new(guard))
                 }
+                MockProvider::OpenAiChat => unreachable!("chat mock is not used for uploads"),
             };
             let boundary = "pentect-provider-boundary";
             let upload_body = format!(

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2445,7 +2445,10 @@ mod tests {
         assert!(!provider_body.contains(secret.as_str()));
         assert!(first_valid_handle(&provider_body).is_some());
         assert!(chat_response.contains(secret.as_str()), "{chat_response}");
-        assert!(!chat_response.contains("<<RUNPOD_API_KEY_"));
+        assert!(
+            first_valid_handle(&chat_response).is_none(),
+            "{chat_response}"
+        );
         drop(chat_proxy);
         chat_thread.join().unwrap();
 

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -7,6 +7,7 @@ mod doctor;
 mod http_files;
 mod input;
 mod installation;
+mod openai_clients;
 mod openai_http_proxy;
 mod plugins;
 mod plugins_cmd;
@@ -116,6 +117,8 @@ fn dispatch(args: Vec<String>, inherited_env_is_trusted: bool) -> Option<i32> {
             return Some(cmd_claude_app(&args));
         }
         Some("claude") => return Some(cmd_agent_tool(AgentTool::Claude, &args)),
+        Some("opencode") => return Some(cmd_agent_tool(AgentTool::OpenCode, &args)),
+        Some("pi") => return Some(cmd_agent_tool(AgentTool::Pi, &args)),
         Some("claude-app") => return Some(cmd_claude_app(&args)),
         Some("codex-app") => return Some(cmd_codex_app(&args)),
         _ => {
@@ -152,7 +155,7 @@ fn supports_process_host(args: &[String]) -> bool {
 fn usage() {
     eprintln!(
         "pentect\n\
-         pentect codex|claude\n\
+         pentect codex|claude|opencode|pi\n\
          pentect codex app\n\
          pentect claude app\n\
          pentect exec \"<command>\"\n\
@@ -187,6 +190,7 @@ fn help_text() -> &'static str {
         "Use:\n",
         "  pentect\n",
         "  pentect codex|claude [--plugins NAME|PATH.toml]\n",
+        "  pentect opencode|pi [--model ID] [--upstream URL] [--api chat|responses]\n",
         "  pentect codex app [--app PATH] [--upstream URL] [--plugins SOURCE] [--check]\n",
         "  pentect claude app [--app PATH] [--upstream URL] [--plugins SOURCE] [--check]\n",
         "  pentect exec \"<command>\"\n\n",
@@ -218,6 +222,8 @@ fn help_text() -> &'static str {
         "plugins: add, remove, list, search, inspect, test, config, setup, update\n",
         "codex app: launch Codex App through the Responses API gateway\n",
         "claude app: launch Claude Desktop through the Chat and Anthropic gateways\n",
+        "opencode: launch OpenCode through an ephemeral OpenAI-compatible provider\n",
+        "pi: launch Pi through an ephemeral OpenAI-compatible provider\n",
     )
 }
 
@@ -342,6 +348,7 @@ fn cmd_agent_tool(tool: AgentTool, args: &[String]) -> i32 {
     let status = match tool {
         AgentTool::Codex => run_codex(&opts, &pentect),
         AgentTool::Claude => run_claude(&opts, &pentect),
+        AgentTool::OpenCode | AgentTool::Pi => openai_clients::run(tool, &opts, &pentect),
     }
     .unwrap_or_else(|e| die_with_issue(&e));
     status.code().unwrap_or(1)
@@ -649,6 +656,8 @@ fn cmd_view(args: &[String]) {
 enum AgentTool {
     Codex,
     Claude,
+    OpenCode,
+    Pi,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -727,6 +736,8 @@ impl AgentTool {
         match self {
             AgentTool::Codex => "codex",
             AgentTool::Claude => "claude",
+            AgentTool::OpenCode => "opencode",
+            AgentTool::Pi => "pi",
         }
     }
 
@@ -738,6 +749,8 @@ impl AgentTool {
         match self {
             AgentTool::Codex => "--codex",
             AgentTool::Claude => "--claude",
+            AgentTool::OpenCode => "--opencode",
+            AgentTool::Pi => "--pi",
         }
     }
 }
@@ -750,6 +763,8 @@ struct AgentToolOpts {
     dry_run: bool,
     anthropic_upstream: Option<String>,
     openai_upstream: Option<String>,
+    model: Option<String>,
+    api: Option<String>,
     tool_args: Vec<String>,
 }
 
@@ -761,6 +776,8 @@ impl AgentToolOpts {
         let mut dry_run = false;
         let mut anthropic_upstream = None;
         let mut openai_upstream = None;
+        let mut model = None;
+        let mut api = None;
         let mut tool_args = Vec::new();
         let mut i = 2;
         while i < args.len() {
@@ -801,8 +818,16 @@ impl AgentToolOpts {
                 "--upstream" if tool == AgentTool::Claude => {
                     anthropic_upstream = Some(required_value(args, &mut i, "--upstream")?);
                 }
-                "--upstream" if tool == AgentTool::Codex => {
+                "--upstream"
+                    if matches!(tool, AgentTool::Codex | AgentTool::OpenCode | AgentTool::Pi) =>
+                {
                     openai_upstream = Some(required_value(args, &mut i, "--upstream")?);
+                }
+                "--model" | "-m" if matches!(tool, AgentTool::OpenCode | AgentTool::Pi) => {
+                    model = Some(required_value(args, &mut i, "--model")?);
+                }
+                "--api" if matches!(tool, AgentTool::OpenCode | AgentTool::Pi) => {
+                    api = Some(required_value(args, &mut i, "--api")?);
                 }
                 "--prompt-proxy" | "--no-prompt-proxy" => {
                     return Err("prompt protection is automatic".to_string());
@@ -820,6 +845,8 @@ impl AgentToolOpts {
             dry_run,
             anthropic_upstream,
             openai_upstream,
+            model,
+            api,
             tool_args,
         })
     }
@@ -2444,13 +2471,14 @@ mod tests {
     fn help_lists_public_commands_and_only_active_agent_integrations() {
         let help = help_text();
         assert!(help.contains("pentect codex|claude"));
+        assert!(help.contains("pentect opencode|pi"));
         assert!(help.contains("pentect codex app"));
         assert!(help.contains("pentect claude app"));
         assert!(help.contains("< input pentect mask"));
         assert!(help.contains("pentect read PATH"));
         assert!(help.contains("pentect resolve [PATH...]"));
         assert!(!help.contains("pentect scan"));
-        assert!(!help.contains("opencode"));
+        assert!(help.contains("opencode"));
         assert!(!help.contains("pentect shell"));
         assert!(!help.contains("\n  pentect up\n"));
         assert!(!help.contains("\n  pentect eval"));
@@ -2491,6 +2519,24 @@ mod tests {
             claude.anthropic_upstream.as_deref(),
             Some("https://gateway.example/anthropic")
         );
+
+        let opencode = AgentToolOpts::parse(
+            AgentTool::OpenCode,
+            &[
+                "pentect".to_string(),
+                "opencode".to_string(),
+                "--upstream".to_string(),
+                "http://127.0.0.1:8080/openai/v1".to_string(),
+                "--model".to_string(),
+                "anthropic/claude-sonnet".to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            opencode.openai_upstream.as_deref(),
+            Some("http://127.0.0.1:8080/openai/v1")
+        );
+        assert_eq!(opencode.model.as_deref(), Some("anthropic/claude-sonnet"));
     }
 
     #[test]

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -1,0 +1,336 @@
+//! Launchers for OpenAI-compatible coding agents.
+//!
+//! Both clients receive an ephemeral provider definition. User configuration
+//! files are never edited and no prompt/tool hook is installed.
+
+use serde_json::{json, Map, Value};
+use std::ffi::OsString;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use zeroize::Zeroize;
+
+const DEFAULT_UPSTREAM: &str = "https://api.openai.com/v1";
+const DEFAULT_MODEL: &str = "gpt-5";
+
+pub(crate) fn run(
+    tool: crate::AgentTool,
+    opts: &crate::AgentToolOpts,
+    pentect: &Path,
+) -> Result<std::process::ExitStatus, String> {
+    let upstream = opts
+        .openai_upstream
+        .clone()
+        .or_else(|| {
+            std::env::var("OPENAI_BASE_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_else(|| DEFAULT_UPSTREAM.to_string());
+    let (args, model) = client_args_and_model(&opts.tool_args, opts.model.as_deref())?;
+    let api = ClientApi::parse(opts.api.as_deref())?;
+    if opts.dry_run {
+        let mut shown = args;
+        match tool {
+            crate::AgentTool::OpenCode => {}
+            crate::AgentTool::Pi => {
+                shown.extend([
+                    "--extension".to_string(),
+                    "<pentect-provider>".to_string(),
+                    "--model".to_string(),
+                    format!("pentect/{model}"),
+                ]);
+            }
+            _ => return Err("internal client launcher mismatch".to_string()),
+        }
+        crate::print_dry_run(&opts.command, &shown);
+        return Ok(crate::success_status());
+    }
+
+    let active_plugins = crate::agent_tool_plugins(opts)?;
+    let memory_store = crate::start_memory_store(pentect)?;
+    let _parent_env = crate::agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
+    let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start(upstream)?;
+    let mut command = Command::new(&opts.command);
+    crate::clear_pentect_control_env(&mut command);
+    crate::apply_plugin_env(&mut command, &active_plugins)?;
+    crate::apply_pentect_env(&mut command, pentect, Some(memory_store.token.as_str()))?;
+    crate::apply_memory_store_env(&mut command, Some(&memory_store));
+
+    match tool {
+        crate::AgentTool::OpenCode => {
+            let config = opencode_config(proxy.base_url(), &model, api)?;
+            command.env("OPENCODE_CONFIG_CONTENT", config);
+            command.args(args);
+            crate::run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
+        }
+        crate::AgentTool::Pi => {
+            let extension = PiProviderFile::create()?;
+            command.env("PENTECT_PROXY_URL", proxy.base_url());
+            command.env("PENTECT_PROVIDER_MODEL", &model);
+            command.env("PENTECT_PROVIDER_API", api.pi_name());
+            command.args(args);
+            // Appended last so a caller argument cannot select an unprotected
+            // provider after Pentect has started its gateway.
+            command.args([
+                OsString::from("--extension"),
+                extension.path.as_os_str().to_owned(),
+                OsString::from("--model"),
+                OsString::from(format!("pentect/{model}")),
+            ]);
+            crate::run_native_command_with_guards(
+                command,
+                &opts.command,
+                (proxy, memory_store, extension),
+            )
+        }
+        _ => Err("internal client launcher mismatch".to_string()),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ClientApi {
+    ChatCompletions,
+    Responses,
+}
+
+impl ClientApi {
+    fn parse(value: Option<&str>) -> Result<Self, String> {
+        match value.unwrap_or("chat") {
+            "chat" | "chat-completions" => Ok(Self::ChatCompletions),
+            "responses" => Ok(Self::Responses),
+            value => Err(format!(
+                "unsupported API format '{value}'; use --api chat or --api responses"
+            )),
+        }
+    }
+
+    fn opencode_package(self) -> &'static str {
+        match self {
+            Self::ChatCompletions => "@ai-sdk/openai-compatible",
+            Self::Responses => "@ai-sdk/openai",
+        }
+    }
+
+    fn pi_name(self) -> &'static str {
+        match self {
+            Self::ChatCompletions => "openai-completions",
+            Self::Responses => "openai-responses",
+        }
+    }
+}
+
+fn client_args_and_model(
+    args: &[String],
+    explicit: Option<&str>,
+) -> Result<(Vec<String>, String), String> {
+    let mut output = Vec::with_capacity(args.len());
+    let mut model = explicit.map(str::to_string);
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if matches!(arg.as_str(), "--model" | "-m") {
+            let Some(value) = args.get(index + 1) else {
+                return Err(format!("{arg} requires a value"));
+            };
+            model = Some(value.clone());
+            index += 2;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--model=") {
+            if value.is_empty() {
+                return Err("--model requires a value".to_string());
+            }
+            model = Some(value.to_string());
+            index += 1;
+            continue;
+        }
+        output.push(arg.clone());
+        index += 1;
+    }
+    let model = model.unwrap_or_else(|| DEFAULT_MODEL.to_string());
+    validate_model(&model)?;
+    Ok((output, model))
+}
+
+fn validate_model(model: &str) -> Result<(), String> {
+    if model.trim() != model
+        || model.is_empty()
+        || model.len() > 200
+        || model.chars().any(char::is_control)
+    {
+        return Err("model ID is invalid".to_string());
+    }
+    Ok(())
+}
+
+fn opencode_config(proxy: &str, model: &str, api: ClientApi) -> Result<String, String> {
+    let mut root = match std::env::var("OPENCODE_CONFIG_CONTENT") {
+        Ok(existing) if !existing.trim().is_empty() => serde_json::from_str::<Value>(&existing)
+            .map_err(|error| format!("OPENCODE_CONFIG_CONTENT is invalid JSON: {error}"))?,
+        _ => Value::Object(Map::new()),
+    };
+    let root_object = root
+        .as_object_mut()
+        .ok_or_else(|| "OPENCODE_CONFIG_CONTENT must contain a JSON object".to_string())?;
+    let providers = root_object
+        .entry("provider")
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .ok_or_else(|| "OPENCODE_CONFIG_CONTENT.provider must be an object".to_string())?;
+    let api_key = if std::env::var_os("OPENAI_API_KEY").is_some() {
+        "{env:OPENAI_API_KEY}"
+    } else {
+        "pentect-local"
+    };
+    providers.insert(
+        "pentect".to_string(),
+        json!({
+            "npm": api.opencode_package(),
+            "name": "Pentect",
+            "options": {"baseURL": proxy, "apiKey": api_key},
+            "models": {(model): {"name": model}}
+        }),
+    );
+    root_object.insert(
+        "model".to_string(),
+        Value::String(format!("pentect/{model}")),
+    );
+    root_object.insert(
+        "small_model".to_string(),
+        Value::String(format!("pentect/{model}")),
+    );
+    // OpenCode agents and lightweight background tasks may select a provider
+    // independently of the main model. Restrict this launch to the ephemeral
+    // provider so those requests cannot bypass the local gateway.
+    root_object.insert("enabled_providers".to_string(), json!(["pentect"]));
+    root_object.insert("disabled_providers".to_string(), json!([]));
+    serde_json::to_string(&root)
+        .map_err(|error| format!("could not encode temporary OpenCode config: {error}"))
+}
+
+struct PiProviderFile {
+    path: PathBuf,
+}
+
+impl PiProviderFile {
+    fn create() -> Result<Self, String> {
+        let mut random = [0u8; 16];
+        getrandom::getrandom(&mut random)
+            .map_err(|error| format!("could not create Pi provider file name: {error}"))?;
+        let name = format!("pentect-pi-{}.mjs", data_encoding::HEXLOWER.encode(&random));
+        random.zeroize();
+        let path = std::env::temp_dir().join(name);
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .map_err(|error| format!("could not create temporary Pi provider: {error}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))
+                .map_err(|error| format!("could not protect temporary Pi provider: {error}"))?;
+        }
+        file.write_all(PI_PROVIDER.as_bytes())
+            .and_then(|_| file.flush())
+            .map_err(|error| format!("could not write temporary Pi provider: {error}"))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for PiProviderFile {
+    fn drop(&mut self) {
+        if let Err(error) = std::fs::remove_file(&self.path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                eprintln!("[pentect] could not remove temporary Pi provider: {error}");
+            }
+        }
+    }
+}
+
+const PI_PROVIDER: &str = r#"export default function (pi) {
+  const baseUrl = process.env.PENTECT_PROXY_URL;
+  const model = process.env.PENTECT_PROVIDER_MODEL;
+  const api = process.env.PENTECT_PROVIDER_API;
+  if (!baseUrl || !model || !api) throw new Error("Pentect provider environment is missing");
+  pi.registerProvider("pentect", {
+    name: "Pentect",
+    baseUrl,
+    apiKey: process.env.OPENAI_API_KEY || "pentect-local",
+    authHeader: true,
+    api,
+    models: [{
+      id: model,
+      name: model,
+      reasoning: api === "openai-responses",
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 32768
+    }]
+  });
+}
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_flags_are_consumed_wherever_the_client_puts_them() {
+        let args = vec![
+            "prompt".to_string(),
+            "--model".to_string(),
+            "anthropic/claude-sonnet".to_string(),
+            "--verbose".to_string(),
+        ];
+        let (forwarded, model) = client_args_and_model(&args, None).unwrap();
+        assert_eq!(model, "anthropic/claude-sonnet");
+        assert_eq!(forwarded, ["prompt", "--verbose"]);
+    }
+
+    #[test]
+    fn opencode_config_preserves_unrelated_inline_settings() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os("OPENCODE_CONFIG_CONTENT");
+        std::env::set_var("OPENCODE_CONFIG_CONTENT", r#"{"theme":"dark"}"#);
+        let value: Value = serde_json::from_str(
+            &opencode_config(
+                "http://127.0.0.1/token",
+                "openai/gpt-5",
+                ClientApi::ChatCompletions,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        match old {
+            Some(value) => std::env::set_var("OPENCODE_CONFIG_CONTENT", value),
+            None => std::env::remove_var("OPENCODE_CONFIG_CONTENT"),
+        }
+        assert_eq!(value["theme"], "dark");
+        assert_eq!(value["model"], "pentect/openai/gpt-5");
+        assert_eq!(value["small_model"], "pentect/openai/gpt-5");
+        assert_eq!(value["enabled_providers"], serde_json::json!(["pentect"]));
+        assert_eq!(
+            value["provider"]["pentect"]["options"]["baseURL"],
+            "http://127.0.0.1/token"
+        );
+    }
+
+    #[test]
+    fn responses_mode_selects_native_responses_adapters() {
+        assert_eq!(
+            ClientApi::parse(Some("responses"))
+                .unwrap()
+                .opencode_package(),
+            "@ai-sdk/openai"
+        );
+        assert_eq!(
+            ClientApi::parse(Some("responses")).unwrap().pi_name(),
+            "openai-responses"
+        );
+        assert!(ClientApi::parse(Some("anthropic")).is_err());
+    }
+}

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -1048,12 +1048,25 @@ fn inject_chat_handle_contract(value: &mut Value) {
             .and_then(Value::as_str)
             .is_some_and(|role| matches!(role, "system" | "developer"))
     }) {
-        if let Some(Value::String(content)) = message.get_mut("content") {
-            if !content.contains(HANDLE_CONTRACT) {
-                content.push_str("\n\n");
-                content.push_str(HANDLE_CONTRACT);
+        match message.get_mut("content") {
+            Some(Value::String(content)) => {
+                if !content.contains(HANDLE_CONTRACT) {
+                    content.push_str("\n\n");
+                    content.push_str(HANDLE_CONTRACT);
+                }
+                return;
             }
-            return;
+            Some(Value::Array(parts)) => {
+                if !parts.iter().any(|part| {
+                    part.get("text")
+                        .and_then(Value::as_str)
+                        .is_some_and(|text| text.contains(HANDLE_CONTRACT))
+                }) {
+                    parts.push(serde_json::json!({"type": "text", "text": HANDLE_CONTRACT}));
+                }
+                return;
+            }
+            _ => {}
         }
     }
     messages.insert(
@@ -1519,6 +1532,16 @@ fn streaming_response_body(
                 }
                 Some(Ok(chunk)) => {
                     if state.pending.len().saturating_add(chunk.len()) > MAX_PENDING_SSE_BYTES {
+                        if state.transform == StreamTransform::ChatCompletions
+                            && !state.chat.calls.is_empty()
+                        {
+                            state.finished = true;
+                            state.ready.push_back(Err(Box::new(io::Error::new(
+                                io::ErrorKind::PermissionDenied,
+                                "OpenAI Chat Completions tool input exceeded limit",
+                            ))));
+                            continue;
+                        }
                         eprintln!(
                             "[pentect] OpenAI SSE restoration disabled: event exceeded limit"
                         );
@@ -1597,6 +1620,12 @@ struct ChatStreamCall {
     arguments: String,
 }
 
+impl ChatStreamCall {
+    fn buffered_len(&self) -> usize {
+        self.id.len() + self.kind.len() + self.name.len() + self.arguments.len()
+    }
+}
+
 impl ChatStreamState {
     fn rewrite_block(
         &mut self,
@@ -1651,17 +1680,24 @@ impl ChatStreamState {
                     }
                     let entry = self.calls.entry(key).or_default();
                     if let Some(id) = call.get("id").and_then(Value::as_str) {
-                        entry.id.push_str(id);
-                        self.buffered_bytes = self.buffered_bytes.saturating_add(id.len());
+                        if entry.id.is_empty() {
+                            entry.id.push_str(id);
+                            self.buffered_bytes = self.buffered_bytes.saturating_add(id.len());
+                        }
                     }
                     if let Some(kind) = call.get("type").and_then(Value::as_str) {
-                        entry.kind.push_str(kind);
-                        self.buffered_bytes = self.buffered_bytes.saturating_add(kind.len());
+                        if entry.kind.is_empty() {
+                            entry.kind.push_str(kind);
+                            self.buffered_bytes = self.buffered_bytes.saturating_add(kind.len());
+                        }
                     }
                     if let Some(function) = call.get("function") {
                         if let Some(name) = function.get("name").and_then(Value::as_str) {
-                            entry.name.push_str(name);
-                            self.buffered_bytes = self.buffered_bytes.saturating_add(name.len());
+                            if entry.name.is_empty() {
+                                entry.name.push_str(name);
+                                self.buffered_bytes =
+                                    self.buffered_bytes.saturating_add(name.len());
+                            }
                         }
                         if let Some(arguments) = function.get("arguments").and_then(Value::as_str) {
                             entry.arguments.push_str(arguments);
@@ -1712,6 +1748,7 @@ impl ChatStreamState {
                 .calls
                 .remove(&(choice_index, index))
                 .unwrap_or_default();
+            self.buffered_bytes = self.buffered_bytes.saturating_sub(call.buffered_len());
             let mut plugin_call = serde_json::json!({
                 "type": "function_call",
                 "name": call.name,
@@ -2171,7 +2208,8 @@ mod tests {
             "data: {}\n\n",
             serde_json::json!({
                 "id": "chat_1", "choices": [{"index": 0, "delta": {
-                    "tool_calls": [{"index": 0, "function": {"arguments": "ok\"}"}}]
+                    "tool_calls": [{"index": 0, "id": "call_1", "type": "function",
+                    "function": {"name": "shell", "arguments": "ok\"}"}}]
                 }, "finish_reason": null}]
             })
         );
@@ -2192,11 +2230,14 @@ mod tests {
         assert_eq!(finished.len(), 2);
         let completed = String::from_utf8_lossy(&finished[0]);
         assert!(completed.contains("call_1"), "{completed}");
+        assert!(!completed.contains("call_1call_1"), "{completed}");
+        assert!(!completed.contains("shellshell"), "{completed}");
         assert!(
             completed.contains(r#"{\"command\":\"echo ok\"}"#),
             "{completed}"
         );
         assert!(state.calls.is_empty());
+        assert_eq!(state.buffered_bytes, 0);
     }
 
     #[test]
@@ -2212,6 +2253,24 @@ mod tests {
             "use <<SECRET_0123456789abcdef>>"
         );
         assert!(value["messages"][0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("opaque local secret handles"));
+    }
+
+    #[test]
+    fn chat_array_system_content_receives_the_contract_once() {
+        let mut value = serde_json::json!({
+            "messages": [{
+                "role": "developer",
+                "content": [{"type": "text", "text": "Existing instructions"}]
+            }]
+        });
+        inject_chat_handle_contract(&mut value);
+        inject_chat_handle_contract(&mut value);
+        let parts = value["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(parts.len(), 2);
+        assert!(parts[1]["text"]
             .as_str()
             .unwrap()
             .contains("opaque local secret handles"));

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -1,4 +1,4 @@
-//! OpenAI Responses API gateway used by unmodified Codex hosts.
+//! OpenAI Responses and Chat Completions gateway used by unmodified clients.
 //!
 //! Model-bound prompts and local function outputs are masked on requests.
 //! Completed client function-call arguments are resolved on responses. Local
@@ -27,6 +27,7 @@ use zeroize::Zeroize;
 
 const MAX_HTTP_BODY_BYTES: usize = 64 * 1024 * 1024;
 const MAX_PENDING_SSE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_CHAT_TOOL_CALLS: usize = 1024;
 const HANDLE_CONTRACT: &str = "Values formatted as <<LABEL_HASH>> are opaque local secret handles. Copy a handle byte-for-byte into a client function call when that function needs the represented value. Do not alter, expand, guess, or expose it. Pentect resolves handles only in completed client function-call arguments.";
 static WARNED_UNKNOWN_ENDPOINT: AtomicBool = AtomicBool::new(false);
 
@@ -222,14 +223,18 @@ async fn proxy_request_inner(
     let endpoint = classify_openai_endpoint(path_and_query);
     enforce_known_openai_endpoint(endpoint, state.block_unknown_formats)?;
     let responses_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::Responses;
+    let chat_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::ChatCompletions;
     let responses_response = matches!(
         endpoint,
         OpenAiEndpoint::Responses | OpenAiEndpoint::ResponsesResource
     );
+    let chat_response = endpoint == OpenAiEndpoint::ChatCompletions;
     let protected_request = method == hyper::Method::POST
         && matches!(
             endpoint,
-            OpenAiEndpoint::Responses | OpenAiEndpoint::InputTokens
+            OpenAiEndpoint::Responses
+                | OpenAiEndpoint::InputTokens
+                | OpenAiEndpoint::ChatCompletions
         );
     let files_upload = method == hyper::Method::POST && endpoint == OpenAiEndpoint::FilesCollection;
     let upstream_url = join_upstream_url(&state.upstream, path_and_query)?;
@@ -299,6 +304,11 @@ async fn proxy_request_inner(
                     &masker,
                     &plugins,
                     &files,
+                    if chat_path {
+                        OpenAiRequestDialect::ChatCompletions
+                    } else {
+                        OpenAiRequestDialect::Responses
+                    },
                     block_unknown_formats,
                 )
             })
@@ -354,12 +364,13 @@ async fn proxy_request_inner(
     // explicit stream flag is authoritative in that case.
     let is_event_stream = response_media_type
         .is_some_and(|value| value.eq_ignore_ascii_case("text/event-stream"))
-        || (responses_path && request_streaming && response_media_type.is_none());
-    let is_json_response =
-        response_media_type.is_some_and(|value| {
-            value.eq_ignore_ascii_case("application/json")
-                || value.to_ascii_lowercase().ends_with("+json")
-        }) || (responses_response && !request_streaming && response_media_type.is_none());
+        || ((responses_path || chat_path) && request_streaming && response_media_type.is_none());
+    let is_json_response = response_media_type.is_some_and(|value| {
+        value.eq_ignore_ascii_case("application/json")
+            || value.to_ascii_lowercase().ends_with("+json")
+    }) || ((responses_response || chat_response)
+        && !request_streaming
+        && response_media_type.is_none());
     let mut builder = Response::builder().status(status);
     let connection_headers = connection_named_headers(&response_headers);
     for (name, value) in &response_headers {
@@ -375,11 +386,17 @@ async fn proxy_request_inner(
             .unwrap_or(crate::http_files::Coverage::None)
             .as_header(),
     );
-    if is_event_stream || (!responses_response && !files_upload) {
+    if is_event_stream || (!(responses_response || chat_response) && !files_upload) {
         return builder
             .body(streaming_response_body(
                 upstream,
-                status.is_success() && responses_path && is_event_stream,
+                if status.is_success() && responses_path && is_event_stream {
+                    StreamTransform::Responses
+                } else if status.is_success() && chat_path && is_event_stream {
+                    StreamTransform::ChatCompletions
+                } else {
+                    StreamTransform::None
+                },
                 Arc::clone(&state.plugins),
             ))
             .map_err(|error| format!("could not build OpenAI streaming response: {error}"));
@@ -405,18 +422,24 @@ async fn proxy_request_inner(
             }
         }
     }
-    let response_body = if responses_response && status.is_success() && is_json_response {
-        let response_body = run_response_plugins(response_body, &state.plugins, "openai")?;
-        match rewrite_openai_json_response(&response_body) {
-            Ok(rewritten) => Bytes::from(rewritten),
-            Err(error) => {
-                eprintln!("[pentect] OpenAI response restoration skipped: {error}");
-                response_body
+    let response_body =
+        if (responses_response || chat_response) && status.is_success() && is_json_response {
+            let response_body = run_response_plugins(response_body, &state.plugins, "openai")?;
+            let rewritten = if chat_response {
+                rewrite_chat_completions_json_response(&response_body)
+            } else {
+                rewrite_openai_json_response(&response_body)
+            };
+            match rewritten {
+                Ok(rewritten) => Bytes::from(rewritten),
+                Err(error) => {
+                    eprintln!("[pentect] OpenAI response restoration skipped: {error}");
+                    response_body
+                }
             }
-        }
-    } else {
-        response_body
-    };
+        } else {
+            response_body
+        };
     builder
         .body(full_body(response_body))
         .map_err(|error| format!("could not build OpenAI response: {error}"))
@@ -464,9 +487,9 @@ fn run_openai_tool_plugins(
             }
         }
         Value::Object(object) => {
-            let is_call = object
+            let responses_call = object
                 .get("type")
-                .and_then(Value::as_str)
+                .and_then(|value| value.as_str())
                 .is_some_and(|kind| {
                     matches!(
                         kind,
@@ -479,6 +502,12 @@ fn run_openai_tool_plugins(
                 && ["arguments", "input"]
                     .iter()
                     .any(|key| object.get(*key).is_some());
+            let chat_call = object.get("type").and_then(Value::as_str) == Some("function")
+                && object
+                    .get("function")
+                    .and_then(Value::as_object)
+                    .is_some_and(|function| function.get("arguments").is_some());
+            let is_call = responses_call || chat_call;
             if is_call {
                 let run = plugins.run(
                     pentect_agent::MiddlewareStage::ToolCall,
@@ -513,11 +542,18 @@ struct ProtectedJsonBody {
     local_response: Option<Bytes>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OpenAiRequestDialect {
+    Responses,
+    ChatCompletions,
+}
+
 fn protect_openai_request_body(
     body: &Bytes,
     masker: &Mutex<pentect_agent::ActiveToolOutputMasker>,
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
     files: &HashMap<String, crate::http_files::Coverage>,
+    dialect: OpenAiRequestDialect,
     block_unknown_formats: bool,
 ) -> Result<ProtectedJsonBody, String> {
     let mut value: Value = match serde_json::from_slice(body) {
@@ -561,7 +597,7 @@ fn protect_openai_request_body(
             })
             .map_err(|error| format!("could not encode plugin response: {error}"));
     }
-    let unknown_content_kind = openai_request_unknown_content_kind(&value);
+    let unknown_content_kind = openai_request_unknown_content_kind(&value, dialect);
     let partial_schema = unknown_content_kind.is_some();
     if block_unknown_formats && (partial_schema || plugin_partial) {
         let detail = unknown_content_kind
@@ -577,6 +613,11 @@ fn protect_openai_request_body(
     if let Err(error) = mask_openai_request(&mut value, &mut masker, files) {
         if error.starts_with("image blocked:") || error.starts_with("document blocked:") {
             return Err(error);
+        }
+        if block_unknown_formats {
+            return Err(format!(
+                "unknown format blocked: OpenAI request could not be fully inspected ({error}); set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
+            ));
         }
         eprintln!("[pentect] OpenAI request protection skipped: {error}");
         return Ok(ProtectedJsonBody {
@@ -629,6 +670,43 @@ fn resolve_openai_file_reference_values<'a>(
                 }
             }
             Value::Object(object) => {
+                if object.get("type").and_then(Value::as_str) == Some("file") {
+                    let file_id = object
+                        .get("file")
+                        .and_then(Value::as_object)
+                        .and_then(|file| file.get("file_id"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    if let Some(file_id) = file_id {
+                        let known = state
+                            .files
+                            .lock()
+                            .map_err(|_| "OpenAI file registry lock was poisoned".to_string())?
+                            .get(&file_id)
+                            .copied();
+                        if known != Some(crate::http_files::Coverage::Full) {
+                            let mut remote =
+                                fetch_openai_file_content(&file_id, state, request_headers).await?;
+                            let encoded = data_encoding::BASE64.encode(&remote.bytes);
+                            remote.bytes.zeroize();
+                            if let Some(file) =
+                                object.get_mut("file").and_then(Value::as_object_mut)
+                            {
+                                file.remove("file_id");
+                                file.insert(
+                                    "file_data".to_string(),
+                                    Value::String(format!(
+                                        "data:{};base64,{encoded}",
+                                        remote.media_type
+                                    )),
+                                );
+                                file.entry("filename".to_string())
+                                    .or_insert(Value::String(remote.filename));
+                            }
+                        }
+                        return Ok(());
+                    }
+                }
                 if object.get("type").and_then(Value::as_str) == Some("input_file") {
                     if let Some(file_id) = object
                         .get("file_id")
@@ -769,6 +847,36 @@ fn resolve_openai_remote_file_values(
             }
             Value::Object(object) => {
                 let input_type = object.get("type").and_then(Value::as_str);
+                if input_type == Some("image_url") {
+                    let url = object
+                        .get("image_url")
+                        .and_then(Value::as_object)
+                        .and_then(|image| image.get("url"))
+                        .and_then(Value::as_str)
+                        .filter(|url| !url.starts_with("data:"))
+                        .map(str::to_string);
+                    if let Some(url) = url {
+                        let mut remote = crate::remote_content::fetch(&url).await?;
+                        if !remote.media_type.starts_with("image/") {
+                            remote.bytes.zeroize();
+                            return Err("remote image URL did not return an image".to_string());
+                        }
+                        let encoded = data_encoding::BASE64.encode(&remote.bytes);
+                        remote.bytes.zeroize();
+                        if let Some(image) =
+                            object.get_mut("image_url").and_then(Value::as_object_mut)
+                        {
+                            image.insert(
+                                "url".to_string(),
+                                Value::String(format!(
+                                    "data:{};base64,{encoded}",
+                                    remote.media_type
+                                )),
+                            );
+                        }
+                        return Ok(());
+                    }
+                }
                 if input_type == Some("input_file") {
                     if let Some(url) = object
                         .get("file_url")
@@ -819,7 +927,10 @@ fn resolve_openai_remote_file_values(
     })
 }
 
-fn openai_request_unknown_content_kind(value: &Value) -> Option<&str> {
+fn openai_request_unknown_content_kind(
+    value: &Value,
+    dialect: OpenAiRequestDialect,
+) -> Option<&str> {
     fn visit(value: &Value) -> Option<&str> {
         match value {
             Value::Array(items) => items.iter().find_map(visit),
@@ -866,10 +977,55 @@ fn openai_request_unknown_content_kind(value: &Value) -> Option<&str> {
             _ => None,
         }
     }
-    value.get("input").and_then(visit)
+    match dialect {
+        OpenAiRequestDialect::Responses => value
+            .get("input")
+            .map(visit)
+            .unwrap_or(Some("missing input")),
+        OpenAiRequestDialect::ChatCompletions => value
+            .get("messages")
+            .map(visit_chat_messages)
+            .unwrap_or(Some("missing messages")),
+    }
+}
+
+fn visit_chat_messages(value: &Value) -> Option<&str> {
+    let Some(messages) = value.as_array() else {
+        return Some("messages must be an array");
+    };
+    for message in messages {
+        let Some(object) = message.as_object() else {
+            return Some("non-object message");
+        };
+        let Some(content) = object.get("content") else {
+            continue;
+        };
+        let Value::Array(parts) = content else {
+            if !content.is_string() && !content.is_null() {
+                return Some("non-text message content");
+            }
+            continue;
+        };
+        for part in parts {
+            let Some(kind) = part.get("type").and_then(Value::as_str) else {
+                return Some("untyped message content");
+            };
+            if !matches!(
+                kind,
+                "text" | "image_url" | "input_text" | "input_image" | "file" | "refusal"
+            ) {
+                return Some(kind);
+            }
+        }
+    }
+    None
 }
 
 fn inject_handle_contract(value: &mut Value) {
+    if value.get("messages").is_some() {
+        inject_chat_handle_contract(value);
+        return;
+    }
     match value.get_mut("instructions") {
         Some(Value::String(instructions)) if !instructions.contains(HANDLE_CONTRACT) => {
             let existing = std::mem::take(instructions);
@@ -882,6 +1038,30 @@ fn inject_handle_contract(value: &mut Value) {
     }
 }
 
+fn inject_chat_handle_contract(value: &mut Value) {
+    let Some(messages) = value.get_mut("messages").and_then(Value::as_array_mut) else {
+        return;
+    };
+    if let Some(message) = messages.iter_mut().find(|message| {
+        message
+            .get("role")
+            .and_then(Value::as_str)
+            .is_some_and(|role| matches!(role, "system" | "developer"))
+    }) {
+        if let Some(Value::String(content)) = message.get_mut("content") {
+            if !content.contains(HANDLE_CONTRACT) {
+                content.push_str("\n\n");
+                content.push_str(HANDLE_CONTRACT);
+            }
+            return;
+        }
+    }
+    messages.insert(
+        0,
+        serde_json::json!({"role": "system", "content": HANDLE_CONTRACT}),
+    );
+}
+
 fn mask_openai_request(
     value: &mut Value,
     masker: &mut pentect_agent::ActiveToolOutputMasker,
@@ -889,6 +1069,112 @@ fn mask_openai_request(
 ) -> Result<(), String> {
     if let Some(input) = value.get_mut("input") {
         mask_openai_input(input, false, masker, files)?;
+    }
+    if let Some(messages) = value.get_mut("messages") {
+        mask_chat_messages(messages, masker, files)?;
+    }
+    Ok(())
+}
+
+fn mask_chat_messages(
+    value: &mut Value,
+    masker: &mut pentect_agent::ActiveToolOutputMasker,
+    files: &HashMap<String, crate::http_files::Coverage>,
+) -> Result<(), String> {
+    let Some(messages) = value.as_array_mut() else {
+        return Err("OpenAI Chat Completions messages must be an array".to_string());
+    };
+    for message in messages {
+        let Some(object) = message.as_object_mut() else {
+            return Err("OpenAI Chat Completions message must be an object".to_string());
+        };
+        let tool_result = object.get("role").and_then(Value::as_str) == Some("tool");
+        if let Some(content) = object.get_mut("content") {
+            mask_chat_content(content, tool_result, masker, files)?;
+        }
+        if let Some(tool_calls) = object.get_mut("tool_calls").and_then(Value::as_array_mut) {
+            for call in tool_calls {
+                if let Some(arguments) = call
+                    .get_mut("function")
+                    .and_then(Value::as_object_mut)
+                    .and_then(|function| function.get_mut("arguments"))
+                    .and_then(|value| value.as_str())
+                    .map(str::to_owned)
+                {
+                    let mut protected = arguments;
+                    mask_text(&mut protected, true, masker)?;
+                    call["function"]["arguments"] = Value::String(protected);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn mask_chat_content(
+    value: &mut Value,
+    tool_result: bool,
+    masker: &mut pentect_agent::ActiveToolOutputMasker,
+    files: &HashMap<String, crate::http_files::Coverage>,
+) -> Result<(), String> {
+    match value {
+        Value::String(text) => mask_text(text, tool_result, masker),
+        Value::Null => Ok(()),
+        Value::Array(parts) => {
+            for part in parts {
+                let Some(object) = part.as_object_mut() else {
+                    return Err(
+                        "OpenAI Chat Completions content part must be an object".to_string()
+                    );
+                };
+                match object
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                {
+                    "text" | "input_text" => {
+                        if let Some(Value::String(text)) = object.get_mut("text") {
+                            mask_text(text, tool_result, masker)?;
+                        }
+                    }
+                    "image_url" => inspect_chat_image(object)?,
+                    "input_image" => inspect_openai_image(object)?,
+                    "file" => {
+                        let Some(file) = object.get_mut("file").and_then(Value::as_object_mut)
+                        else {
+                            return Err("OpenAI Chat Completions file part is invalid".to_string());
+                        };
+                        inspect_openai_file(file, tool_result, masker, files)?;
+                    }
+                    "refusal" => {
+                        if let Some(Value::String(text)) = object.get_mut("refusal") {
+                            mask_text(text, tool_result, masker)?;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(())
+        }
+        _ => Err("OpenAI Chat Completions content has an unsupported shape".to_string()),
+    }
+}
+
+fn inspect_chat_image(object: &mut serde_json::Map<String, Value>) -> Result<(), String> {
+    let Some(image) = object.get_mut("image_url").and_then(Value::as_object_mut) else {
+        return unscanned_image_policy();
+    };
+    let Some(Value::String(url)) = image.get_mut("url") else {
+        return unscanned_image_policy();
+    };
+    let Some((metadata, encoded)) = url.split_once(',') else {
+        return unscanned_image_policy();
+    };
+    if !metadata.starts_with("data:image/") || !metadata.ends_with(";base64") {
+        return unscanned_image_policy();
+    }
+    if let Some(protected) = crate::claude_http_proxy::redact_inline_image_data(encoded)? {
+        *url = format!("data:image/png;base64,{protected}");
     }
     Ok(())
 }
@@ -910,7 +1196,7 @@ fn mask_openai_input(
         Value::Object(object) => {
             let item_type = object
                 .get("type")
-                .and_then(Value::as_str)
+                .and_then(|value| value.as_str())
                 .unwrap_or_default()
                 .to_string();
             match item_type.as_str() {
@@ -1048,6 +1334,55 @@ fn rewrite_openai_json_response(body: &[u8]) -> Result<Vec<u8>, String> {
         .map_err(|error| format!("could not encode restored OpenAI response: {error}"))
 }
 
+fn rewrite_chat_completions_json_response(body: &[u8]) -> Result<Vec<u8>, String> {
+    let mut value: Value = serde_json::from_slice(body)
+        .map_err(|error| format!("OpenAI Chat Completions response was not valid JSON: {error}"))?;
+    let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
+    rewrite_chat_tool_calls(&mut value, &mut resolve)?;
+    serde_json::to_vec(&value)
+        .map_err(|error| format!("could not encode restored Chat Completions response: {error}"))
+}
+
+fn rewrite_chat_tool_calls<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
+    let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    for choice in choices {
+        let Some(message) = choice.get_mut("message").and_then(Value::as_object_mut) else {
+            continue;
+        };
+        let Some(calls) = message.get_mut("tool_calls").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        for call in calls {
+            let tool_name = call
+                .get("function")
+                .and_then(|function| function.get("name"))
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let Some(arguments) = call
+                .get_mut("function")
+                .and_then(Value::as_object_mut)
+                .and_then(|function| function.get_mut("arguments"))
+                .and_then(|value| value.as_str())
+                .map(str::to_owned)
+            else {
+                continue;
+            };
+            let restored = crate::claude_http_proxy::resolve_tool_input_json(
+                &arguments,
+                tool_name.as_deref(),
+                resolve,
+            )?;
+            call["function"]["arguments"] = Value::String(restored);
+        }
+    }
+    Ok(())
+}
+
 fn rewrite_function_calls<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
 where
     R: FnMut(&str) -> Result<String, String>,
@@ -1143,14 +1478,22 @@ struct StreamState {
     upstream: UpstreamByteStream,
     pending: Vec<u8>,
     ready: VecDeque<Result<Frame<Bytes>, ProxyBodyError>>,
-    transform: bool,
+    transform: StreamTransform,
+    chat: ChatStreamState,
     finished: bool,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StreamTransform {
+    None,
+    Responses,
+    ChatCompletions,
+}
+
 fn streaming_response_body(
     response: reqwest::Response,
-    transform: bool,
+    transform: StreamTransform,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
 ) -> ProxyBody {
     let state = StreamState {
@@ -1158,6 +1501,7 @@ fn streaming_response_body(
         pending: Vec::new(),
         ready: VecDeque::new(),
         transform,
+        chat: ChatStreamState::default(),
         finished: false,
         plugins,
     };
@@ -1170,7 +1514,7 @@ fn streaming_response_body(
                 return None;
             }
             match state.upstream.next().await {
-                Some(Ok(chunk)) if !state.transform => {
+                Some(Ok(chunk)) if state.transform == StreamTransform::None => {
                     return Some((Ok(Frame::data(chunk)), state));
                 }
                 Some(Ok(chunk)) => {
@@ -1178,7 +1522,7 @@ fn streaming_response_body(
                         eprintln!(
                             "[pentect] OpenAI SSE restoration disabled: event exceeded limit"
                         );
-                        state.transform = false;
+                        state.transform = StreamTransform::None;
                         let mut pending = std::mem::take(&mut state.pending);
                         pending.extend_from_slice(&chunk);
                         state.ready.push_back(Ok(Frame::data(Bytes::from(pending))));
@@ -1187,8 +1531,24 @@ fn streaming_response_body(
                     state.pending.extend_from_slice(&chunk);
                     while let Some(end) = first_sse_block_end(&state.pending) {
                         let block = state.pending.drain(..end).collect::<Vec<_>>();
-                        match rewrite_openai_sse_block(&block, &state.plugins) {
-                            Ok(block) => state.ready.push_back(Ok(Frame::data(block))),
+                        let rewritten = match state.transform {
+                            StreamTransform::Responses => {
+                                rewrite_openai_sse_block(&block, &state.plugins)
+                                    .map(|block| vec![block])
+                            }
+                            StreamTransform::ChatCompletions => {
+                                state.chat.rewrite_block(&block, &state.plugins)
+                            }
+                            StreamTransform::None => Ok(vec![Bytes::from(block)]),
+                        };
+                        match rewritten {
+                            Ok(blocks) => {
+                                for block in blocks {
+                                    if !block.is_empty() {
+                                        state.ready.push_back(Ok(Frame::data(block)));
+                                    }
+                                }
+                            }
                             Err(error) => {
                                 state.finished = true;
                                 state.ready.push_back(Err(Box::new(io::Error::new(
@@ -1221,6 +1581,215 @@ fn streaming_response_body(
         }
     });
     StreamBody::new(stream).boxed_unsync()
+}
+
+#[derive(Default)]
+struct ChatStreamState {
+    calls: HashMap<(u64, u64), ChatStreamCall>,
+    buffered_bytes: usize,
+}
+
+#[derive(Default)]
+struct ChatStreamCall {
+    id: String,
+    kind: String,
+    name: String,
+    arguments: String,
+}
+
+impl ChatStreamState {
+    fn rewrite_block(
+        &mut self,
+        block: &[u8],
+        plugins: &Mutex<pentect_agent::PluginMiddleware>,
+    ) -> Result<Vec<Bytes>, String> {
+        let Ok(text) = std::str::from_utf8(block) else {
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        };
+        let Some(data) = sse_data(text) else {
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        };
+        if data == "[DONE]" {
+            if self.calls.is_empty() {
+                return Ok(vec![Bytes::copy_from_slice(block)]);
+            }
+            return Err(
+                "OpenAI Chat Completions stream ended before its tool call completed".to_string(),
+            );
+        }
+        let Ok(mut value) = serde_json::from_str::<Value>(data) else {
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        };
+        let mut has_tool_delta = false;
+        let mut completed_choices = Vec::new();
+        if let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) {
+            for choice in choices {
+                let choice_index = choice.get("index").and_then(Value::as_u64).unwrap_or(0);
+                if choice
+                    .get("finish_reason")
+                    .is_some_and(|reason| !reason.is_null())
+                {
+                    completed_choices.push(choice_index);
+                }
+                let Some(delta) = choice.get_mut("delta").and_then(Value::as_object_mut) else {
+                    continue;
+                };
+                let Some(tool_calls) = delta
+                    .remove("tool_calls")
+                    .and_then(|calls| calls.as_array().cloned())
+                else {
+                    continue;
+                };
+                has_tool_delta = true;
+                for call in tool_calls {
+                    let call_index = call.get("index").and_then(Value::as_u64).unwrap_or(0);
+                    let key = (choice_index, call_index);
+                    if !self.calls.contains_key(&key) && self.calls.len() >= MAX_CHAT_TOOL_CALLS {
+                        return Err(
+                            "OpenAI Chat Completions produced too many tool calls".to_string()
+                        );
+                    }
+                    let entry = self.calls.entry(key).or_default();
+                    if let Some(id) = call.get("id").and_then(Value::as_str) {
+                        entry.id.push_str(id);
+                        self.buffered_bytes = self.buffered_bytes.saturating_add(id.len());
+                    }
+                    if let Some(kind) = call.get("type").and_then(Value::as_str) {
+                        entry.kind.push_str(kind);
+                        self.buffered_bytes = self.buffered_bytes.saturating_add(kind.len());
+                    }
+                    if let Some(function) = call.get("function") {
+                        if let Some(name) = function.get("name").and_then(Value::as_str) {
+                            entry.name.push_str(name);
+                            self.buffered_bytes = self.buffered_bytes.saturating_add(name.len());
+                        }
+                        if let Some(arguments) = function.get("arguments").and_then(Value::as_str) {
+                            entry.arguments.push_str(arguments);
+                            self.buffered_bytes =
+                                self.buffered_bytes.saturating_add(arguments.len());
+                        }
+                    }
+                    if self.buffered_bytes > MAX_PENDING_SSE_BYTES {
+                        return Err("OpenAI Chat Completions tool input exceeded limit".to_string());
+                    }
+                }
+            }
+        }
+
+        let mut output = Vec::new();
+        for choice_index in completed_choices {
+            if self.calls.keys().any(|(choice, _)| *choice == choice_index) {
+                output.push(self.completed_tool_block(text, &value, choice_index, plugins)?);
+            }
+        }
+        let keep_original = !has_tool_delta || chat_chunk_has_visible_delta(&value);
+        if keep_original {
+            output.push(encode_sse_value(text, &value)?);
+        }
+        Ok(output)
+    }
+
+    fn completed_tool_block(
+        &mut self,
+        template: &str,
+        envelope: &Value,
+        choice_index: u64,
+        plugins: &Mutex<pentect_agent::PluginMiddleware>,
+    ) -> Result<Bytes, String> {
+        let mut indexes = self
+            .calls
+            .keys()
+            .filter_map(|(choice, index)| (*choice == choice_index).then_some(*index))
+            .collect::<Vec<_>>();
+        indexes.sort_unstable();
+        let mut calls = Vec::with_capacity(indexes.len());
+        let plugins = plugins
+            .lock()
+            .map_err(|_| "OpenAI plugin lock was poisoned".to_string())?;
+        let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
+        for index in indexes {
+            let call = self
+                .calls
+                .remove(&(choice_index, index))
+                .unwrap_or_default();
+            let mut plugin_call = serde_json::json!({
+                "type": "function_call",
+                "name": call.name,
+                "arguments": call.arguments,
+            });
+            run_openai_tool_plugins(&mut plugin_call, &plugins)?;
+            let name = plugin_call
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let arguments = plugin_call
+                .get("arguments")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let arguments = crate::claude_http_proxy::resolve_tool_input_json(
+                arguments,
+                Some(name),
+                &mut resolve,
+            )?;
+            calls.push(serde_json::json!({
+                "index": index,
+                "id": call.id,
+                "type": if call.kind.is_empty() { "function" } else { call.kind.as_str() },
+                "function": {"name": name, "arguments": arguments}
+            }));
+        }
+        let mut completed = envelope.clone();
+        completed["choices"] = serde_json::json!([{
+            "index": choice_index,
+            "delta": {"tool_calls": calls},
+            "finish_reason": null
+        }]);
+        encode_sse_value(template, &completed)
+    }
+}
+
+fn chat_chunk_has_visible_delta(value: &Value) -> bool {
+    value
+        .get("choices")
+        .and_then(Value::as_array)
+        .is_some_and(|choices| {
+            choices.iter().any(|choice| {
+                choice
+                    .get("finish_reason")
+                    .is_some_and(|reason| !reason.is_null())
+                    || choice
+                        .get("delta")
+                        .and_then(Value::as_object)
+                        .is_some_and(|delta| !delta.is_empty())
+            })
+        })
+}
+
+fn sse_data(text: &str) -> Option<&str> {
+    text.lines()
+        .find_map(|line| line.strip_prefix("data:").map(str::trim_start))
+}
+
+fn encode_sse_value(template: &str, value: &Value) -> Result<Bytes, String> {
+    let encoded = serde_json::to_string(value)
+        .map_err(|error| format!("could not encode OpenAI SSE event: {error}"))?;
+    let mut replaced = false;
+    let mut output = String::with_capacity(template.len() + encoded.len());
+    for line in template.split_inclusive('\n') {
+        if !replaced && line.trim_end_matches(['\r', '\n']).starts_with("data:") {
+            output.push_str("data: ");
+            output.push_str(&encoded);
+            if line.ends_with("\r\n") {
+                output.push_str("\r\n");
+            } else if line.ends_with('\n') {
+                output.push('\n');
+            }
+            replaced = true;
+        } else {
+            output.push_str(line);
+        }
+    }
+    Ok(Bytes::from(output))
 }
 
 fn rewrite_openai_sse_block(
@@ -1329,6 +1898,7 @@ enum OpenAiEndpoint {
     Responses,
     ResponsesResource,
     InputTokens,
+    ChatCompletions,
     FilesCollection,
     Files,
     Models,
@@ -1344,6 +1914,8 @@ fn classify_openai_endpoint(path_and_query: &str) -> OpenAiEndpoint {
         OpenAiEndpoint::Responses
     } else if path.contains("/responses/") {
         OpenAiEndpoint::ResponsesResource
+    } else if path.ends_with("/chat/completions") {
+        OpenAiEndpoint::ChatCompletions
     } else if path.ends_with("/files") {
         OpenAiEndpoint::FilesCollection
     } else if path.contains("/files/") {
@@ -1514,6 +2086,10 @@ mod tests {
             OpenAiEndpoint::InputTokens
         );
         assert_eq!(
+            classify_openai_endpoint("/v1/chat/completions"),
+            OpenAiEndpoint::ChatCompletions
+        );
+        assert_eq!(
             classify_openai_endpoint("/v1/responses/resp_123"),
             OpenAiEndpoint::ResponsesResource
         );
@@ -1551,6 +2127,97 @@ mod tests {
     }
 
     #[test]
+    fn chat_response_tool_arguments_are_restored_without_touching_text() {
+        let mut value = serde_json::json!({
+            "choices": [{"message": {
+                "content": "keep <<SECRET_0123456789abcdef>>",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "shell",
+                        "arguments": "{\"command\":\"echo <<SECRET_0123456789abcdef>>\"}"
+                    }
+                }]
+            }}]
+        });
+        let mut resolve =
+            |text: &str| Ok(text.replace("<<SECRET_0123456789abcdef>>", "safe-secret-token"));
+        rewrite_chat_tool_calls(&mut value, &mut resolve).unwrap();
+        assert_eq!(
+            value["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"],
+            r#"{"command":"echo safe-secret-token"}"#
+        );
+        assert_eq!(
+            value["choices"][0]["message"]["content"],
+            "keep <<SECRET_0123456789abcdef>>"
+        );
+    }
+
+    #[test]
+    fn chat_stream_buffers_fragmented_tool_json_until_completion() {
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let mut state = ChatStreamState::default();
+        let first = format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "id": "chat_1", "choices": [{"index": 0, "delta": {
+                    "role": "assistant", "tool_calls": [{"index": 0, "id": "call_1",
+                    "type": "function", "function": {"name": "shell", "arguments": "{\"command\":\"echo "}}]
+                }, "finish_reason": null}]
+            })
+        );
+        let second = format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "id": "chat_1", "choices": [{"index": 0, "delta": {
+                    "tool_calls": [{"index": 0, "function": {"arguments": "ok\"}"}}]
+                }, "finish_reason": null}]
+            })
+        );
+        let finish = format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "id": "chat_1", "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]
+            })
+        );
+        let first_out = state.rewrite_block(first.as_bytes(), &plugins).unwrap();
+        assert_eq!(first_out.len(), 1);
+        assert!(!String::from_utf8_lossy(&first_out[0]).contains("tool_calls"));
+        assert!(state
+            .rewrite_block(second.as_bytes(), &plugins)
+            .unwrap()
+            .is_empty());
+        let finished = state.rewrite_block(finish.as_bytes(), &plugins).unwrap();
+        assert_eq!(finished.len(), 2);
+        let completed = String::from_utf8_lossy(&finished[0]);
+        assert!(completed.contains("call_1"), "{completed}");
+        assert!(
+            completed.contains(r#"{\"command\":\"echo ok\"}"#),
+            "{completed}"
+        );
+        assert!(state.calls.is_empty());
+    }
+
+    #[test]
+    fn chat_messages_receive_the_handle_contract_without_replacing_user_text() {
+        let mut value = serde_json::json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "use <<SECRET_0123456789abcdef>>"}]
+        });
+        inject_handle_contract(&mut value);
+        assert_eq!(value["messages"][1]["role"], "user");
+        assert_eq!(
+            value["messages"][1]["content"],
+            "use <<SECRET_0123456789abcdef>>"
+        );
+        assert!(value["messages"][0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("opaque local secret handles"));
+    }
+
+    #[test]
     fn completed_custom_tool_input_is_restored_but_text_is_not() {
         let mut value = serde_json::json!({
             "type": "response.output_item.done",
@@ -1576,18 +2243,51 @@ mod tests {
         let masker = Mutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
         let plugins = Mutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
         let files = HashMap::new();
-        let error = match protect_openai_request_body(&body, &masker, &plugins, &files, true) {
+        let error = match protect_openai_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            OpenAiRequestDialect::Responses,
+            true,
+        ) {
             Ok(_) => panic!("unknown OpenAI block should be rejected"),
             Err(error) => error,
         };
         assert!(error.starts_with("unknown format blocked:"), "{error}");
         assert!(error.contains("future_block"), "{error}");
 
-        let allowed = protect_openai_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        let allowed = protect_openai_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            OpenAiRequestDialect::Responses,
+            false,
+        )
+        .unwrap();
         assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
         assert_eq!(
             serde_json::from_slice::<Value>(&allowed.body).unwrap(),
             serde_json::from_slice::<Value>(&body).unwrap()
+        );
+    }
+
+    #[test]
+    fn unknown_chat_content_and_missing_messages_are_classified() {
+        let future = serde_json::json!({
+            "messages": [{"role": "user", "content": [{"type": "future_media"}]}]
+        });
+        assert_eq!(
+            openai_request_unknown_content_kind(&future, OpenAiRequestDialect::ChatCompletions),
+            Some("future_media")
+        );
+        assert_eq!(
+            openai_request_unknown_content_kind(
+                &serde_json::json!({"model": "test"}),
+                OpenAiRequestDialect::ChatCompletions
+            ),
+            Some("missing messages")
         );
     }
 
@@ -1628,11 +2328,14 @@ mod tests {
                 {"type": "context_compaction", "encrypted_content": "opaque"}
             ]
         });
-        assert_eq!(openai_request_unknown_content_kind(&value), None);
+        assert_eq!(
+            openai_request_unknown_content_kind(&value, OpenAiRequestDialect::Responses),
+            None
+        );
 
         let future = serde_json::json!({"input": [{"type": "future_block"}]});
         assert_eq!(
-            openai_request_unknown_content_kind(&future),
+            openai_request_unknown_content_kind(&future, OpenAiRequestDialect::Responses),
             Some("future_block")
         );
     }
@@ -1644,8 +2347,24 @@ mod tests {
         let masker = Mutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
         let plugins = Mutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
         let files = HashMap::new();
-        assert!(protect_openai_request_body(&body, &masker, &plugins, &files, true).is_err());
-        let allowed = protect_openai_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        assert!(protect_openai_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            OpenAiRequestDialect::Responses,
+            true,
+        )
+        .is_err());
+        let allowed = protect_openai_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            OpenAiRequestDialect::Responses,
+            false,
+        )
+        .unwrap();
         assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
         assert_eq!(allowed.body, body);
     }

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -1,0 +1,19 @@
+# @pentect/pi
+
+Run [Pi](https://github.com/badlogic/pi-mono) through Pentect's local HTTP
+protection without changing Pi's saved configuration.
+
+```sh
+npx @pentect/pi --model openai/gpt-5
+```
+
+For a permanent command:
+
+```sh
+npm install --global @pentect/pi
+pentect-pi --model openai/gpt-5
+```
+
+The package installs matching Pentect and Pi versions. It is a small launcher,
+not a prompt hook: requests go through the same loopback gateway as
+`pentect pi`.

--- a/integrations/pi/bin/pentect-pi.js
+++ b/integrations/pi/bin/pentect-pi.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { invocation, piBinaryFromEntry } from "../lib/command.js";
+
+const require = createRequire(import.meta.url);
+
+function packageBinary(name, binary) {
+  const manifestPath = require.resolve(`${name}/package.json`);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const relative =
+    typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.[binary];
+  if (typeof relative !== "string" || relative.length === 0) {
+    throw new Error(`${name} does not provide the expected ${binary} command`);
+  }
+  return resolve(dirname(manifestPath), relative);
+}
+
+try {
+  const pentectCli = packageBinary("pentect", "pentect");
+  // Pi exports dist/index.js but intentionally does not export package.json.
+  // Its pinned package exposes the adjacent dist/cli.js as the `pi` binary.
+  const piCli = piBinaryFromEntry(
+    require.resolve("@mariozechner/pi-coding-agent"),
+  );
+  const next = invocation(pentectCli, piCli, process.argv.slice(2));
+  const result = spawnSync(next.command, next.args, { stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.signal) process.kill(process.pid, result.signal);
+  process.exitCode = result.status ?? 1;
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`pentect-pi: ${message}`);
+  process.exitCode = 1;
+}

--- a/integrations/pi/lib/command.js
+++ b/integrations/pi/lib/command.js
@@ -1,0 +1,20 @@
+import { dirname, resolve } from "node:path";
+
+export function invocation(pentectCli, piCli, userArgs, node = process.execPath) {
+  return {
+    command: node,
+    args: [
+      pentectCli,
+      "pi",
+      "--pi",
+      node,
+      "--",
+      piCli,
+      ...userArgs,
+    ],
+  };
+}
+
+export function piBinaryFromEntry(entry) {
+  return resolve(dirname(entry), "cli.js");
+}

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@pentect/pi",
+  "version": "0.0.0",
+  "description": "Run Pi through Pentect's local HTTP protection",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/EdamAme-x/pentect.git",
+    "directory": "integrations/pi"
+  },
+  "homepage": "https://pentect.dev/clients/pi/",
+  "bugs": "https://github.com/EdamAme-x/pentect/issues",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "ai-security",
+    "pi-coding-agent",
+    "secret-detection"
+  ],
+  "bin": {
+    "pentect-pi": "bin/pentect-pi.js"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "README.md"
+  ],
+  "scripts": {
+    "check": "node --check bin/pentect-pi.js && node --check lib/command.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@mariozechner/pi-coding-agent": "0.73.1",
+    "pentect": "0.0.0"
+  },
+  "engines": {
+    "node": ">=20.6.0"
+  }
+}

--- a/integrations/pi/test/command.test.js
+++ b/integrations/pi/test/command.test.js
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import test from "node:test";
+import { invocation, piBinaryFromEntry } from "../lib/command.js";
+
+test("launches the bundled Pi CLI through Pentect without a shell", () => {
+  const result = invocation(
+    "/packages/pentect/cli.js",
+    "/packages/pi/cli.js",
+    ["--model", "openai/gpt-5", "hello"],
+    "/usr/bin/node",
+  );
+
+  assert.deepEqual(result, {
+    command: "/usr/bin/node",
+    args: [
+      "/packages/pentect/cli.js",
+      "pi",
+      "--pi",
+      "/usr/bin/node",
+      "--",
+      "/packages/pi/cli.js",
+      "--model",
+      "openai/gpt-5",
+      "hello",
+    ],
+  });
+});
+
+test("finds Pi's CLI beside its public package entry", () => {
+  assert.equal(
+    piBinaryFromEntry("/packages/pi/dist/index.js"),
+    resolve("/packages/pi/dist/cli.js"),
+  );
+});

--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { chmod, mkdir, rename, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { gunzipSync } from 'node:zlib';
@@ -52,7 +52,8 @@ async function downloadBinary(base, asset, signal) {
 
 export async function install() {
   const asset = releaseAsset();
-  const version = process.env.PENTECT_VERSION?.replace(/^v/, '');
+  const metadata = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+  const version = (process.env.PENTECT_VERSION || metadata.version)?.replace(/^v/, '');
   const tag = version ? `v${version}` : 'latest';
   const base = tag === 'latest'
     ? `https://github.com/${repository}/releases/latest/download`

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -56,6 +56,8 @@ const sidebar = [
     items: [
       { text: sidebarLabel('Codex', 'terminal', '/brands/openai-blossom.svg'), link: '/clients/codex/' },
       { text: sidebarLabel('Claude', 'message', '/brands/claude.svg'), link: '/clients/claude/' },
+      { text: sidebarLabel('OpenCode', 'terminal'), link: '/clients/opencode/' },
+      { text: sidebarLabel('Pi', 'terminal'), link: '/clients/pi/' },
       { text: sidebarLabel('Custom upstreams', 'network'), link: '/clients/upstreams/' },
     ],
   },

--- a/website/.vitepress/theme/HomeInstall.vue
+++ b/website/.vitepress/theme/HomeInstall.vue
@@ -7,9 +7,9 @@ import {
   siLinux,
   siNixos,
   siNpm,
-  siRust,
 } from 'simple-icons';
 import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vitepress';
 
 type OperatingSystem = 'windows' | 'macos' | 'linux';
 type InstallerVariant = { id: string; label: string; command: string };
@@ -40,16 +40,9 @@ const operatingSystems: Array<{
 const npmInstaller = {
   id: 'npm',
   label: 'npm',
-  command: 'npm install --global github:EdamAme-x/pentect',
+  command: 'npm i -g pentect',
   icon: 'npm',
   tone: 'npm',
-};
-const cargoInstaller = {
-  id: 'cargo',
-  label: 'Cargo',
-  command: 'cargo install --git https://github.com/EdamAme-x/pentect --locked pentect-cli',
-  icon: 'rust',
-  tone: 'cargo',
 };
 const nixInstaller: Installer = {
   id: 'nix',
@@ -86,7 +79,6 @@ const installers: Record<OperatingSystem, Installer[]> = {
       tone: 'powershell',
     },
     npmInstaller,
-    cargoInstaller,
   ],
   macos: [
     {
@@ -105,7 +97,6 @@ const installers: Record<OperatingSystem, Installer[]> = {
     },
     npmInstaller,
     nixInstaller,
-    cargoInstaller,
   ],
   linux: [
     {
@@ -124,11 +115,12 @@ const installers: Record<OperatingSystem, Installer[]> = {
     },
     npmInstaller,
     nixInstaller,
-    cargoInstaller,
   ],
 };
 
 const selectedOs = ref<OperatingSystem>('windows');
+const route = useRoute();
+const showAllOptions = computed(() => !route.path.startsWith('/start/install'));
 const selectedMethod = ref('powershell');
 const selectedVariant = ref<string | null>(null);
 const copyState = ref<'idle' | 'copied' | 'failed'>('idle');
@@ -139,7 +131,6 @@ const iconSet: Record<string, string> = {
   powershell: 'M23.181 2.974c.568 0 .923.463.792 1.035l-3.659 15.982c-.13.572-.697 1.035-1.265 1.035H.819c-.568 0-.923-.463-.792-1.035L3.686 4.009c.13-.572.697-1.035 1.265-1.035zm-8.375 9.346c.251-.394.227-.905-.09-1.243L9.122 5.125c-.38-.404-1.037-.407-1.466-.003c-.429.402-.468 1.056-.088 1.46l4.662 4.96v.11l-7.42 5.374c-.45.327-.533.977-.187 1.453s.991.597 1.44.27l8.229-5.91c.28-.196.438-.365.514-.52zm-2.796 4.399a.93.93 0 0 0-.934.923c0 .51.418.923.934.923h4.433a.93.93 0 0 0 .934-.923a.93.93 0 0 0-.934-.923z',
   gnubash: siGnubash.path,
   npm: siNpm.path,
-  rust: siRust.path,
   homebrew: siHomebrew.path,
   debian: siDebian.path,
   nixos: siNixos.path,
@@ -223,7 +214,7 @@ onMounted(() => {
   <section class="home-install" aria-labelledby="install-heading">
     <div class="home-install__heading">
       <p id="install-heading">Install</p>
-      <a href="/start/install/">All options <span aria-hidden="true">→</span></a>
+      <a v-if="showAllOptions" href="/start/install/">All options <span aria-hidden="true">→</span></a>
     </div>
 
     <div class="home-install__controls">

--- a/website/scripts/generate-agent-docs.mjs
+++ b/website/scripts/generate-agent-docs.mjs
@@ -89,6 +89,24 @@ function rewriteNodes(nodes) {
     if (node.type === 'mdxTextExpression') return [];
 
     if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
+      if (node.name === 'HomeInstall') {
+        return [
+          heading('Install', 2),
+          paragraph('Choose one install method for your operating system.'),
+          heading('npm — Windows, macOS, and Linux', 3),
+          codeBlock('npm i -g pentect', 'sh'),
+          heading('PowerShell — Windows', 3),
+          codeBlock('irm https://pentect.dev/install | iex', 'powershell'),
+          heading('Shell — macOS and Linux', 3),
+          codeBlock('curl -fsSL https://pentect.dev/install.sh | sh', 'sh'),
+          heading('Homebrew — macOS and Linux', 3),
+          codeBlock('brew install EdamAme-x/pentect/pentect', 'sh'),
+          heading('Nix — temporary environment', 3),
+          codeBlock('nix shell github:EdamAme-x/pentect', 'sh'),
+          heading('APT — Debian and Ubuntu', 3),
+          codeBlock('curl -fsSL https://pentect.dev/install-apt.sh | sudo sh', 'sh'),
+        ];
+      }
       if (node.name === 'a') {
         return [rewriteAnchor(node)];
       }
@@ -203,6 +221,10 @@ function paragraph(value) {
     type: 'paragraph',
     children: [{ type: 'text', value }],
   };
+}
+
+function codeBlock(value, lang) {
+  return { type: 'code', lang, value };
 }
 
 async function findSourceFiles(directory) {

--- a/website/scripts/generate-agent-docs.mjs
+++ b/website/scripts/generate-agent-docs.mjs
@@ -99,7 +99,7 @@ function rewriteNodes(nodes) {
           codeBlock('irm https://pentect.dev/install | iex', 'powershell'),
           heading('Shell — macOS and Linux', 3),
           codeBlock('curl -fsSL https://pentect.dev/install.sh | sh', 'sh'),
-          heading('Homebrew — macOS and Linux', 3),
+          heading('Homebrew — macOS', 3),
           codeBlock('brew install EdamAme-x/pentect/pentect', 'sh'),
           heading('Nix — temporary environment', 3),
           codeBlock('nix shell github:EdamAme-x/pentect', 'sh'),

--- a/website/src/content/docs/clients/opencode.md
+++ b/website/src/content/docs/clients/opencode.md
@@ -1,0 +1,38 @@
+---
+title: OpenCode
+description: Run OpenCode through a temporary Pentect provider.
+---
+
+```sh
+pentect opencode --model openai/gpt-5
+```
+
+Pentect adds an OpenAI-compatible provider to `OPENCODE_CONFIG_CONTENT` for
+this process only. It does not edit `opencode.json` or change normal OpenCode
+launches. The main model, small model, and provider allowlist are fixed to the
+temporary provider for this launch, so background tasks and subagents cannot
+select an unprotected provider.
+
+Normal OpenCode arguments pass through. A model flag may appear anywhere:
+
+```sh
+pentect opencode "Review this project" --model openai/gpt-5
+```
+
+Chat Completions is the default. Select Responses when the upstream supports
+it:
+
+```sh
+pentect opencode --api responses --model gpt-5
+```
+
+For Bifrost or another compatible gateway, keep its complete base path:
+
+```sh
+pentect opencode --model anthropic/claude-sonnet \
+  --upstream http://127.0.0.1:8080/openai/v1
+```
+
+If no model is given, Pentect uses `gpt-5`. `OPENAI_BASE_URL` is used when
+`--upstream` is absent. Authentication still comes from the client environment
+or `PENTECT_UPSTREAM_AUTHORIZATION`.

--- a/website/src/content/docs/clients/pi.md
+++ b/website/src/content/docs/clients/pi.md
@@ -1,0 +1,40 @@
+---
+title: Pi
+description: Run Pi through a temporary Pentect provider.
+---
+
+```sh
+pentect pi --model openai/gpt-5
+```
+
+Or install Pi and the matching Pentect release together:
+
+```sh
+npx @pentect/pi --model openai/gpt-5
+```
+
+Pentect creates a small provider-only extension for this process and removes
+it when Pi exits. It does not install prompt hooks or edit Pi settings.
+
+Normal Pi arguments pass through:
+
+```sh
+pentect pi --model openai/gpt-5 -p "Review this project"
+```
+
+Chat Completions is the default. Responses can be selected explicitly:
+
+```sh
+pentect pi --api responses --model gpt-5
+```
+
+Custom and local providers can be reached through an OpenAI-compatible
+gateway such as Bifrost:
+
+```sh
+pentect pi --model anthropic/claude-sonnet \
+  --upstream http://127.0.0.1:8080/openai/v1
+```
+
+The adapter contains no API key or gateway token. Those values remain in the
+child environment and the authenticated loopback URL.

--- a/website/src/content/docs/clients/upstreams.md
+++ b/website/src/content/docs/clients/upstreams.md
@@ -9,6 +9,8 @@ gateway.
 ```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
 pentect claude --upstream http://127.0.0.1:8080/anthropic
+pentect opencode --model anthropic/claude-sonnet --upstream http://127.0.0.1:8080/openai/v1
+pentect pi --model anthropic/claude-sonnet --upstream http://127.0.0.1:8080/openai/v1
 ```
 
 The upstream URL applies to that launch only. Pentect keeps the base path when
@@ -22,19 +24,81 @@ The URL may be local or remote. Treat it as a provider endpoint: Pentect sends
 the protected request to it, and the client or gateway supplies authentication.
 Pentect does not copy credentials from one provider configuration into another.
 
+## Use Bifrost
+
+Bifrost lets one OpenAI- or Anthropic-compatible gateway route requests to
+different model providers. Pentect stays in front of it and protects the
+request before Bifrost receives it.
+
+Start a local Bifrost gateway and configure at least one provider:
+
+```sh
+npx -y @maximhq/bifrost
+```
+
+The default gateway URL is `http://127.0.0.1:8080`. Use the exact model ID
+configured in Bifrost, normally in `provider/model` form.
+
+::: code-group
+
+```sh [Codex]
+pentect codex --upstream http://127.0.0.1:8080/openai/v1 \
+  --model anthropic/claude-sonnet-4-5-20250929
+```
+
+```sh [Claude]
+pentect claude --upstream http://127.0.0.1:8080/anthropic \
+  --model openai/gpt-5
+```
+
+```sh [OpenCode]
+pentect opencode --upstream http://127.0.0.1:8080/openai/v1 \
+  --model anthropic/claude-sonnet-4-5-20250929
+```
+
+```sh [Pi]
+pentect pi --upstream http://127.0.0.1:8080/openai/v1 \
+  --model anthropic/claude-sonnet-4-5-20250929
+```
+
+:::
+
+If Bifrost virtual-key authentication is enabled, give Pentect the complete
+authorization value before launching the client:
+
+::: code-group
+
+```powershell [PowerShell]
+$env:PENTECT_UPSTREAM_AUTHORIZATION = "Bearer bf-your-virtual-key"
+```
+
+```sh [Shell]
+export PENTECT_UPSTREAM_AUTHORIZATION="Bearer bf-your-virtual-key"
+```
+
+:::
+
+Do not put a real virtual key in a project file or command history. Bifrost's
+dashboard and request logs remain available at `http://127.0.0.1:8080` and
+`http://127.0.0.1:8080/logs`. See the
+[Bifrost agent guide](https://docs.getbifrost.ai/cli-agents/overview) for
+provider setup, virtual keys, and model IDs.
+
 ## Supported API formats
 
 - Gateways that support OpenAI Responses for Codex
 - Gateways that support Anthropic Messages for Claude
+- Gateways that support OpenAI Chat Completions or Responses for OpenCode and Pi
 - Existing compatible client provider configuration
 
 Pentect tests Bifrost's `/openai/v1` and `/anthropic` paths. LiteLLM and other
 gateways can also work when they support the same APIs. Pentect does not test
 every gateway version.
 
-If your model server offers only Chat Completions, use an adapter that produces
-the full Responses or Messages contract. Pentect does not translate arbitrary
-provider APIs itself.
+OpenCode and Pi can use a Chat Completions server directly. Codex still needs
+Responses, and Claude still needs Messages. Use a gateway when the server does
+not provide the format required by the selected client. Pentect does not
+translate arbitrary provider APIs itself.
 
 ## Base paths and authentication
 
@@ -46,6 +110,8 @@ URL. The client or gateway still sends the login data.
 | --- | --- | --- |
 | Codex | OpenAI Responses, including streaming events | `/openai/v1` |
 | Claude | Anthropic Messages, including streaming events | `/anthropic` |
+| OpenCode | OpenAI Chat Completions by default; Responses with `--api responses` | `/openai/v1` |
+| Pi | OpenAI Chat Completions by default; Responses with `--api responses` | `/openai/v1` |
 
 ## Validate a gateway
 

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -28,6 +28,14 @@ when a trusted local tool needs the value.
     <small>CLI</small><strong>Claude Code</strong>
     <span>Protect Claude Code requests with Pentect.</span><b aria-hidden="true">→</b>
   </a>
+  <a href="/clients/opencode/" class="docs-grid__item">
+    <small>CLI</small><strong>OpenCode</strong>
+    <span>Run OpenCode through a temporary protected provider.</span><b aria-hidden="true">→</b>
+  </a>
+  <a href="/clients/pi/" class="docs-grid__item">
+    <small>CLI</small><strong>Pi</strong>
+    <span>Run Pi through a temporary protected provider.</span><b aria-hidden="true">→</b>
+  </a>
   <a href="/clients/codex/" class="docs-grid__item">
     <small>Desktop</small><strong>Codex App</strong>
     <span>Start one Codex App session through Pentect.</span><b aria-hidden="true">→</b>

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -9,6 +9,8 @@ description: A full list of what you can do with Pentect.
 | --- | --- |
 | Protect Codex CLI | `pentect codex` |
 | Protect Claude Code | `pentect claude` |
+| Protect OpenCode | `pentect opencode --model MODEL` |
+| Protect Pi | `pentect pi --model MODEL` |
 | Launch a protected Codex App session | `pentect codex app` |
 | Launch a protected Claude Desktop session | `pentect claude app` |
 | Pass normal client arguments | Add them normally, for example `pentect codex exec --full-auto` |
@@ -129,7 +131,7 @@ See [Plugins](/plugins/overview/) for the full workflow and
 ## Installation and distribution
 
 You can install Pentect with PowerShell, a shell script, Homebrew, apt, Nix,
-npm, or Cargo. The binary installers check SHA-256 checksums. They support
+or npm. The binary installers check SHA-256 checksums. They support
 version choice, updates, and uninstall. They also find installs managed by
 another package manager.
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -13,6 +13,8 @@ cannot complete a requested change.
 | --- | --- |
 | `pentect codex` | Launch Codex CLI through Pentect |
 | `pentect claude` | Launch Claude Code through Pentect |
+| `pentect opencode` | Launch OpenCode with a temporary Pentect provider |
+| `pentect pi` | Launch Pi with a temporary Pentect provider |
 | `pentect codex app` | Launch Codex App for this protected session |
 | `pentect claude app` | Launch Claude Desktop for this protected session |
 

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -10,6 +10,8 @@ specific public CLI versions with the release binary.
 | --- | --- | --- |
 | Codex CLI `0.146.0` | Automatic test on Linux | `pentect codex` |
 | Claude Code `2.1.220` | Automatic test on Linux | `pentect claude` |
+| OpenCode `1.18.14` | Provider registration and model discovery on Windows | `pentect opencode` |
+| Pi `0.73.1` and `0.83.0` | Provider registration and model discovery on Windows | `pentect pi` |
 | ChatGPT desktop app, Codex mode | Launcher and Responses protocol tests | `pentect codex app` |
 | Claude Desktop, supported Chat, attachment, and Code routes | Launcher and protocol tests | `pentect claude app` |
 

--- a/website/src/content/docs/start/install.md
+++ b/website/src/content/docs/start/install.md
@@ -1,147 +1,62 @@
 ---
-title: Install
-description: Install Pentect on Windows, macOS, or Linux.
+title: Install Pentect
+description: Install and update Pentect on Windows, macOS, or Linux.
+pageClass: install-page
 ---
 
-Choose the method that fits your system. Direct installers and npm download a
-prebuilt release and check its SHA-256 checksum. Cargo builds from source.
+Choose your operating system and package manager. Pentect uses a prebuilt
+binary, so the install does not compile the Rust workspace on your machine.
 
-| Method | Systems | Updates |
-| --- | --- | --- |
-| PowerShell | Windows | `pentect update` |
-| Shell | macOS and Linux | `pentect update` |
-| Homebrew | macOS and Linux | `brew upgrade pentect` |
-| APT | Debian and Ubuntu | normal APT updates |
-| Nix | macOS and Linux | Nix profile or flake updates |
-| npm | Windows, macOS, and Linux | reinstall the package |
-| Cargo | Any supported Rust host | reinstall from source |
+<HomeInstall />
 
-## Direct installer
-
-### Windows
-
-Run in PowerShell:
-
-```powershell
-irm https://pentect.dev/install | iex
-```
-
-### macOS and Linux
-
-```sh
-curl -fsSL https://pentect.dev/install.sh | sh
-```
-
-The installer selects the correct GitHub Release for the current operating
-system and CPU architecture.
-
-## Package managers
-
-::: code-group
-
-```sh [Homebrew]
-brew install EdamAme-x/pentect/pentect
-```
-
-```sh [Nix · temporary shell]
-nix shell github:EdamAme-x/pentect
-```
-
-```sh [Nix · profile]
-nix profile install github:EdamAme-x/pentect
-```
-
-```sh [npm]
-npm install --global github:EdamAme-x/pentect
-```
-
-```sh [Cargo · build from source]
-cargo install --git https://github.com/EdamAme-x/pentect --locked pentect-cli
-```
-
-```sh [APT repository · Debian / Ubuntu]
-# First install: adds the Pentect repository and installs the package
-curl -fsSL https://pentect.dev/install-apt.sh | sudo sh
-
-# Later updates use APT directly
-sudo apt update
-sudo apt install --only-upgrade pentect
-```
-
-:::
-
-The npm package installs from the Pentect GitHub repository, then downloads the
-same release binary and checks its checksum.
-`nix shell` opens a temporary environment and does not change your profile.
-Cargo builds Pentect from source, so it takes longer.
-
-## NixOS configuration
-
-For a flake-based NixOS setup, add Pentect as an input. Then add its package to
-a module that has `inputs` and `pkgs`:
-
-```nix
-# flake.nix
-inputs.pentect.url = "github:EdamAme-x/pentect";
-
-# configuration.nix or another NixOS module
-environment.systemPackages = [
-  inputs.pentect.packages.${pkgs.system}.default
-];
-```
-
-Then rebuild the same flake configuration you normally use:
-
-```sh
-sudo nixos-rebuild switch --flake .#HOSTNAME
-```
-
-`flake.lock` keeps the selected version. To update it, run
-`nix flake update pentect`, check the lockfile change, and rebuild.
-
-## Verify the installation
+## Check the install
 
 ```sh
 pentect doctor
 ```
 
-`doctor` checks Pentect and supported clients. If it finds a problem it can fix,
-it describes the change first. Apply approved fixes with:
-
-```sh
-pentect doctor --fix
-```
+`doctor` checks Pentect and the AI clients installed on your machine. To apply
+a fix after reviewing it, run `pentect doctor --fix`.
 
 ## Install a specific version
 
+Use the same installer with a version number:
+
 ::: code-group
 
-```powershell [Windows]
+```powershell [PowerShell]
 & ([scriptblock]::Create((irm https://pentect.dev/install))) -Version X.Y.Z
 ```
 
-```sh [macOS / Linux]
+```sh [Shell]
 curl -fsSL https://pentect.dev/install.sh | sh -s -- --version X.Y.Z
 ```
 
 ```sh [npm]
-npm install --global github:EdamAme-x/pentect#vX.Y.Z
-```
-
-```sh [Cargo]
-cargo install --git https://github.com/EdamAme-x/pentect --tag vX.Y.Z --locked pentect-cli
+npm i -g pentect@X.Y.Z
 ```
 
 :::
 
-::: info
-When Pentect was installed through Homebrew, Nix, or apt, update and uninstall
-it through the same package manager.
-:::
+Homebrew, APT, and Nix choose versions through their normal package-manager
+workflow. A Nix flake lock file keeps the selected revision.
 
-Package-manager updates:
+## Update
+
+Use the package manager that installed Pentect:
 
 ::: code-group
+
+```sh [Direct installer]
+pentect update
+
+# Or choose a version
+pentect update X.Y.Z
+```
+
+```sh [npm]
+npm update -g pentect
+```
 
 ```sh [Homebrew]
 brew update
@@ -164,14 +79,33 @@ sudo nixos-rebuild switch --flake .#HOSTNAME
 
 :::
 
-## Update or uninstall
+## NixOS configuration
+
+Add Pentect to your flake input and system packages:
+
+```nix
+# flake.nix
+inputs.pentect.url = "github:EdamAme-x/pentect";
+
+# configuration.nix or another NixOS module
+environment.systemPackages = [
+  inputs.pentect.packages.${pkgs.system}.default
+];
+```
+
+Then rebuild with the host name from your flake:
 
 ```sh
-pentect update
-pentect update X.Y.Z
+sudo nixos-rebuild switch --flake .#HOSTNAME
+```
+
+## Uninstall
+
+For a direct PowerShell or shell install:
+
+```sh
 pentect uninstall
 ```
 
-`pentect uninstall` removes an installation managed by the direct installer. It
-keeps `.pentect` project settings and user data. Use the original package
-manager for a package-manager installation.
+For npm, Homebrew, APT, or Nix, uninstall Pentect with that package manager.
+Project `.pentect` settings and user data are not removed automatically.

--- a/website/src/content/docs/start/install.md
+++ b/website/src/content/docs/start/install.md
@@ -87,10 +87,20 @@ Add Pentect to your flake input and system packages:
 # flake.nix
 inputs.pentect.url = "github:EdamAme-x/pentect";
 
-# configuration.nix or another NixOS module
-environment.systemPackages = [
-  inputs.pentect.packages.${pkgs.system}.default
-];
+outputs = inputs@{ nixpkgs, ... }: {
+  nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+    specialArgs = { inherit inputs; };
+    modules = [ ./configuration.nix ];
+  };
+};
+
+# configuration.nix
+{ pkgs, inputs, ... }:
+{
+  environment.systemPackages = [
+    inputs.pentect.packages.${pkgs.system}.default
+  ];
+}
 ```
 
 Then rebuild with the host name from your flake:


### PR DESCRIPTION
## Summary
- add HTTP-protected OpenCode and Pi launchers
- replace the old Pi hook package with a thin `@pentect/pi` HTTP launcher
- publish `pentect` and `@pentect/pi` from releases with npm OIDC trusted publishing
- add compatibility smoke checks and client documentation

## Local checks
- `cargo fmt --all -- --check`
- root npm tests and package dry run
- `@pentect/pi` syntax, unit tests, and package dry run
- Pi upstream package layout check
- VitePress build, 28 agent Markdown pages, and 72 internal links
- workflow YAML parsing and `git diff --check`

Heavy Rust and OCR checks are left to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added protected launch commands for OpenCode and Pi.
  - Added support for OpenAI Chat Completions alongside existing API formats.
  - Added the `@pentect/pi` package for temporary, configuration-safe Pi integration.
  - Added model, upstream, API, and argument options for both clients.
  - Added compatibility checks for OpenCode and Pi, including Windows validation.

- **Documentation**
  - Added setup guides, usage examples, upstream configuration details, and installation instructions.
  - Updated supported-client listings and npm installation guidance.

- **Bug Fixes**
  - Improved streaming tool-call handling, secret protection, and response reconstruction.
  - Installer now defaults to the package version when no version is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->