### PR TITLE
chore: prepare v0.0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.25"
+version = "0.0.26"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump the Pentect CLI and npm package to 0.0.26
- keep Cargo.lock aligned for the release tag

## Checks
- Cargo formatting and metadata version check
- npm tests and package dry run
- third-party license and package metadata checks
- `git diff --check`