### PR TITLE
fix: launch Pi through its ESM package entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
           npm test
           npm pack --dry-run
           npm pkg set "dependencies.pentect=$(npm view pentect version)"
-          npm install --no-audit --no-fund --no-package-lock
-          node bin/pentect-pi.js --version
+          node ../../tools/smoke_pi_package.mjs 0.73.1
 
   changes:
     name: Changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           npm run check
           npm test
           npm pack --dry-run
+          npm pkg set "dependencies.pentect=$(npm view pentect version)"
+          npm install --no-audit --no-fund --no-package-lock
+          node bin/pentect-pi.js --version
 
   changes:
     name: Changes

--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -73,6 +73,8 @@ jobs:
           npm run check
           npm test
           npm pack --dry-run
+          npm install --no-audit --no-fund --no-package-lock
+          node bin/pentect-pi.js --version
       - name: Publish
         shell: bash
         run: |

--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -73,8 +73,7 @@ jobs:
           npm run check
           npm test
           npm pack --dry-run
-          npm install --no-audit --no-fund --no-package-lock
-          node bin/pentect-pi.js --version
+          node ../../tools/smoke_pi_package.mjs 0.73.1
       - name: Publish
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Validate POSIX installer
         run: |
           sh -n tools/install.sh tools/install-apt.sh tools/package_deb.sh tools/build_apt_repository.sh tools/propose_automation_pr.sh
+          node --check tools/smoke_pi_package.mjs
           sh tools/test_propose_automation_pr.sh
       - name: Validate PowerShell installer
         shell: pwsh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.26"
+version = "0.0.27"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/integrations/pi/bin/pentect-pi.js
+++ b/integrations/pi/bin/pentect-pi.js
@@ -4,7 +4,11 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { createRequire } from "node:module";
-import { invocation, piBinaryFromEntry } from "../lib/command.js";
+import {
+  invocation,
+  packageEntryPath,
+  piBinaryFromEntry,
+} from "../lib/command.js";
 
 const require = createRequire(import.meta.url);
 
@@ -24,7 +28,7 @@ try {
   // Pi exports dist/index.js but intentionally does not export package.json.
   // Its pinned package exposes the adjacent dist/cli.js as the `pi` binary.
   const piCli = piBinaryFromEntry(
-    require.resolve("@mariozechner/pi-coding-agent"),
+    packageEntryPath("@mariozechner/pi-coding-agent"),
   );
   const next = invocation(pentectCli, piCli, process.argv.slice(2));
   const result = spawnSync(next.command, next.args, { stdio: "inherit" });

--- a/integrations/pi/lib/command.js
+++ b/integrations/pi/lib/command.js
@@ -1,4 +1,5 @@
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export function invocation(pentectCli, piCli, userArgs, node = process.execPath) {
   return {
@@ -17,4 +18,8 @@ export function invocation(pentectCli, piCli, userArgs, node = process.execPath)
 
 export function piBinaryFromEntry(entry) {
   return resolve(dirname(entry), "cli.js");
+}
+
+export function packageEntryPath(specifier, resolver = import.meta.resolve) {
+  return fileURLToPath(resolver(specifier));
 }

--- a/integrations/pi/test/command.test.js
+++ b/integrations/pi/test/command.test.js
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import test from "node:test";
-import { invocation, piBinaryFromEntry } from "../lib/command.js";
+import { pathToFileURL } from "node:url";
+import {
+  invocation,
+  packageEntryPath,
+  piBinaryFromEntry,
+} from "../lib/command.js";
 
 test("launches the bundled Pi CLI through Pentect without a shell", () => {
   const result = invocation(
@@ -32,4 +37,14 @@ test("finds Pi's CLI beside its public package entry", () => {
     piBinaryFromEntry("/packages/pi/dist/index.js"),
     resolve("/packages/pi/dist/cli.js"),
   );
+});
+
+test("resolves ESM-only package entries with import conditions", () => {
+  const expected = resolve("/packages/pi/dist/index.js");
+  const entry = packageEntryPath("pi-package", (specifier) => {
+    assert.equal(specifier, "pi-package");
+    return pathToFileURL(expected).href;
+  });
+
+  assert.equal(entry, expected);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/tools/smoke_pi_package.mjs
+++ b/tools/smoke_pi_package.mjs
@@ -1,0 +1,81 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const expectedVersion = process.argv[2];
+if (!expectedVersion) throw new Error("expected Pi version is required");
+
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const tempDir = mkdtempSync(join(tmpdir(), "pentect-pi-smoke-"));
+
+function runResult(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    shell: process.platform === "win32" && command.endsWith(".cmd"),
+    ...options,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `${command} exited with ${result.status}`);
+  }
+  return result;
+}
+
+function run(command, args, options = {}) {
+  return runResult(command, args, options).stdout;
+}
+
+try {
+  const packed = JSON.parse(
+    run(
+      npm,
+      ["pack", "--json", "--pack-destination", tempDir],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    ),
+  );
+  if (!Array.isArray(packed) || typeof packed[0]?.filename !== "string") {
+    throw new Error("npm pack did not return a tarball filename");
+  }
+
+  const prefix = join(tempDir, "install");
+  run(
+    npm,
+    [
+      "install",
+      "--global",
+      "--prefix",
+      prefix,
+      join(tempDir, packed[0].filename),
+      "--no-audit",
+      "--no-fund",
+    ],
+    { stdio: "inherit" },
+  );
+
+  const launcher =
+    process.platform === "win32"
+      ? process.execPath
+      : join(prefix, "bin", "pentect-pi");
+  const launcherArgs =
+    process.platform === "win32"
+      ? [
+          join(
+            prefix,
+            "node_modules",
+            "@pentect",
+            "pi",
+            "bin",
+            "pentect-pi.js",
+          ),
+          "--version",
+        ]
+      : ["--version"];
+  const versionResult = runResult(launcher, launcherArgs);
+  const actualVersion = `${versionResult.stdout}${versionResult.stderr}`.trim();
+  if (actualVersion !== expectedVersion) {
+    throw new Error(`expected Pi ${expectedVersion}, got ${actualVersion}`);
+  }
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- resolve Pi with Node's ESM import conditions
- add installed-package smoke checks to CI and npm publishing
- prepare v0.0.27 patch release

## Verification
- Pi unit tests
- installed Pi launcher reports 0.73.1 through Pentect
- root npm tests
- cargo fmt
- workflow YAML validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Pi launcher compatibility with packages that provide ESM-only entry points.
  * Updated the Pi launcher release to version 0.0.27.

* **Bug Fixes**
  * Improved package entry-point resolution for more reliable command startup.

* **Tests**
  * Added coverage for resolving ESM package entries and verifying launcher version output.

* **Chores**
  * Updated release verification steps to install dependencies consistently without modifying lockfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->