### PR TITLE
Improve protected launches and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ pentect claude --set-default
 
 Pentect shows the profile and change before asking for approval. Undo it with
 `pentect codex --unset-default` or `pentect claude --unset-default`.
+Shell defaults support Bash, Zsh, Fish, and PowerShell.
 
 Use a Responses- or Messages-compatible gateway without changing permanent
 client configuration:
@@ -112,7 +113,8 @@ pentect claude app --install-launcher
 ```
 
 This adds `Codex via Pentect` or `Claude via Pentect` for the current user. It
-does not modify the official App. Remove it later with `--remove-launcher`.
+does not modify the official App. Launchers support Windows and macOS. Remove
+one later with `--remove-launcher`.
 
 These commands protect Codex mode and supported Claude Desktop Chat, Code, and
 attachment traffic; they do not claim coverage for every Chat, Work, Cowork,

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ pentect opencode --model openai/gpt-5
 pentect pi --model openai/gpt-5
 ```
 
+To keep using the normal `codex` or `claude` command, let Pentect add a small
+function to your shell profile:
+
+```text
+pentect codex --set-default
+pentect claude --set-default
+```
+
+Pentect shows the profile and change before asking for approval. Undo it with
+`pentect codex --unset-default` or `pentect claude --unset-default`.
+
 Use a Responses- or Messages-compatible gateway without changing permanent
 client configuration:
 
@@ -92,6 +103,16 @@ Launch a desktop app only when explicitly requested:
 pentect codex app
 pentect claude app
 ```
+
+Install an optional clickable launcher when you use a protected App regularly:
+
+```text
+pentect codex app --install-launcher
+pentect claude app --install-launcher
+```
+
+This adds `Codex via Pentect` or `Claude via Pentect` for the current user. It
+does not modify the official App. Remove it later with `--remove-launcher`.
 
 These commands protect Codex mode and supported Claude Desktop Chat, Code, and
 attachment traffic; they do not claim coverage for every Chat, Work, Cowork,

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -46,6 +46,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_Console",
     "Win32_System_IO",
     "Win32_System_JobObjects",

--- a/crates/pentect-cli/src/app_launcher.rs
+++ b/crates/pentect-cli/src/app_launcher.rs
@@ -1,0 +1,438 @@
+use std::fs;
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+#[cfg(windows)]
+use std::process::{Command, Stdio};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Action {
+    Install,
+    Remove,
+}
+
+pub(crate) fn run_if_requested(tool: &str, args: &[String]) -> Result<Option<()>, String> {
+    let Some((action, assume_yes, flag)) = parse_request(tool, args)? else {
+        return Ok(None);
+    };
+    let target = launcher_target(tool)?;
+    let verb = match action {
+        Action::Install => "install",
+        Action::Remove => "remove",
+    };
+    println!(
+        "This will {verb} the Pentect launcher for {tool}.\nLauncher: {}",
+        target.display()
+    );
+    if !assume_yes {
+        if !io::stdin().is_terminal() {
+            return Err(format!(
+                "input is not interactive; rerun `pentect {tool} app {flag} --yes`"
+            ));
+        }
+        print!("\nContinue? [y/N] ");
+        io::stdout().flush().map_err(|error| error.to_string())?;
+        let mut answer = String::new();
+        io::stdin()
+            .read_line(&mut answer)
+            .map_err(|error| error.to_string())?;
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            println!("No changes made.");
+            return Ok(Some(()));
+        }
+    }
+
+    let changed = match action {
+        Action::Install => install(tool, &target)?,
+        Action::Remove => remove(tool, &target)?,
+    };
+    if changed {
+        match action {
+            Action::Install => {
+                println!("Installed: {}", target.display());
+                println!("Pin this launcher if you want quick protected App launches.");
+            }
+            Action::Remove => println!("Removed: {}", target.display()),
+        }
+    } else {
+        match action {
+            Action::Install => println!("The Pentect launcher is already installed."),
+            Action::Remove => println!("No Pentect launcher was installed."),
+        }
+    }
+    Ok(Some(()))
+}
+
+fn parse_request<'a>(
+    tool: &str,
+    args: &'a [String],
+) -> Result<Option<(Action, bool, &'a str)>, String> {
+    let legacy_command = format!("{tool}-app");
+    let start = if args.get(1).is_some_and(|arg| arg == tool)
+        && args.get(2).is_some_and(|arg| arg == "app")
+    {
+        3
+    } else if args.get(1).is_some_and(|arg| arg == &legacy_command) {
+        2
+    } else {
+        return Ok(None);
+    };
+    let Some(flag) = args.get(start).map(String::as_str) else {
+        return Ok(None);
+    };
+    let action = match flag {
+        "--install-launcher" => Action::Install,
+        "--remove-launcher" => Action::Remove,
+        _ => return Ok(None),
+    };
+    let mut assume_yes = false;
+    for arg in &args[start + 1..] {
+        match arg.as_str() {
+            "--yes" if !assume_yes => assume_yes = true,
+            _ => return Err(format!("unexpected option for {flag}: {arg}")),
+        }
+    }
+
+    Ok(Some((action, assume_yes, flag)))
+}
+
+#[cfg(any(windows, target_os = "macos"))]
+fn display_name(tool: &str) -> &'static str {
+    match tool {
+        "codex" => "Codex via Pentect",
+        "claude" => "Claude via Pentect",
+        _ => "AI App via Pentect",
+    }
+}
+
+#[cfg(any(windows, target_os = "macos"))]
+fn app_executable(tool: &str) -> Option<PathBuf> {
+    let path = match tool {
+        "codex" => crate::codex_app::default_codex_app_path(),
+        "claude" => crate::claude_app_proxy::default_claude_app_path(),
+        _ => return None,
+    };
+    path.is_file().then_some(path)
+}
+
+#[cfg(windows)]
+fn launcher_target(tool: &str) -> Result<PathBuf, String> {
+    let app_data = std::env::var_os("APPDATA")
+        .map(PathBuf::from)
+        .ok_or_else(|| "APPDATA is unavailable".to_string())?;
+    Ok(app_data
+        .join("Microsoft")
+        .join("Windows")
+        .join("Start Menu")
+        .join("Programs")
+        .join("Pentect")
+        .join(format!("{}.lnk", display_name(tool))))
+}
+
+#[cfg(target_os = "macos")]
+fn launcher_target(tool: &str) -> Result<PathBuf, String> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is unavailable".to_string())?;
+    Ok(home
+        .join("Applications")
+        .join(format!("{}.app", display_name(tool))))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn launcher_target(_tool: &str) -> Result<PathBuf, String> {
+    Err("desktop App launchers are currently supported on Windows and macOS".into())
+}
+
+fn owner_marker(target: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        return target.with_extension("pentect-launcher");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return target
+            .join("Contents")
+            .join("Resources")
+            .join("pentect-launcher");
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        target.join("pentect-launcher")
+    }
+}
+
+fn marker_contents(tool: &str) -> String {
+    format!("pentect-app-launcher-v1\ntool={tool}\n")
+}
+
+fn is_owned(target: &Path, tool: &str) -> bool {
+    fs::read_to_string(owner_marker(target)).is_ok_and(|value| value == marker_contents(tool))
+}
+
+#[cfg(any(windows, target_os = "macos"))]
+fn launcher_executable() -> Result<PathBuf, String> {
+    let arg0 = std::env::args_os().next().map(PathBuf::from);
+    if let Some(path) = arg0
+        .as_ref()
+        .filter(|path| path.is_absolute() && path.is_file())
+    {
+        return Ok(path.clone());
+    }
+    if let Some(path) = arg0.as_ref().filter(|path| path.components().count() > 1) {
+        let absolute = std::env::current_dir()
+            .map_err(|error| format!("could not read the current directory: {error}"))?
+            .join(path);
+        if absolute.is_file() {
+            return Ok(absolute);
+        }
+    }
+    if let Some(name) = arg0.as_ref().and_then(|path| path.file_name()) {
+        if let Some(paths) = std::env::var_os("PATH") {
+            for directory in std::env::split_paths(&paths) {
+                let candidate = directory.join(name);
+                if candidate.is_file() {
+                    return Ok(candidate);
+                }
+            }
+        }
+    }
+    std::env::current_exe()
+        .map_err(|error| format!("could not locate the Pentect executable: {error}"))
+}
+
+#[cfg(windows)]
+fn install(tool: &str, target: &Path) -> Result<bool, String> {
+    if target.exists() && !is_owned(target, tool) {
+        return Err(format!(
+            "refusing to replace launcher not owned by Pentect: '{}'",
+            target.display()
+        ));
+    }
+    let pentect = launcher_executable()?;
+    let powershell = crate::windows_system_executable(r"WindowsPowerShell\v1.0\powershell.exe");
+    if !powershell.is_file() {
+        return Err(format!(
+            "PowerShell was not found at '{}'",
+            powershell.display()
+        ));
+    }
+    let parent = target
+        .parent()
+        .ok_or_else(|| "launcher path has no parent directory".to_string())?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("could not create '{}': {error}", parent.display()))?;
+
+    let command = format!(
+        "& '{}' {tool} app; if ($LASTEXITCODE -ne 0) {{ (New-Object -ComObject WScript.Shell).Popup('Pentect could not start the protected App. Run pentect {tool} app in a terminal for details.',0,'Pentect',16) | Out-Null }}",
+        pentect.to_string_lossy().replace('\'', "''")
+    );
+    let arguments =
+        format!("-NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -Command \"{command}\"");
+    let description = match tool {
+        "codex" => "Launch Codex App through Pentect",
+        "claude" => "Launch Claude Desktop through Pentect",
+        _ => "Launch an AI App through Pentect",
+    };
+    let icon = app_executable(tool).unwrap_or_else(|| pentect.clone());
+    let script = concat!(
+        "$w=New-Object -ComObject WScript.Shell;",
+        "$s=$w.CreateShortcut($env:PENTECT_LAUNCHER_PATH);",
+        "$s.TargetPath=$env:PENTECT_LAUNCHER_TARGET;",
+        "$s.Arguments=$env:PENTECT_LAUNCHER_ARGS;",
+        "$s.WorkingDirectory=$env:USERPROFILE;",
+        "$s.Description=$env:PENTECT_LAUNCHER_DESCRIPTION;",
+        "$s.IconLocation=$env:PENTECT_LAUNCHER_ICON;",
+        "$s.Save()"
+    );
+    let status = Command::new(&powershell)
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            script,
+        ])
+        .env("PENTECT_LAUNCHER_PATH", target)
+        .env("PENTECT_LAUNCHER_TARGET", &powershell)
+        .env("PENTECT_LAUNCHER_ARGS", arguments)
+        .env("PENTECT_LAUNCHER_DESCRIPTION", description)
+        .env("PENTECT_LAUNCHER_ICON", format!("{},0", icon.display()))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| format!("could not create the Windows launcher: {error}"))?;
+    if !status.success() || !target.is_file() {
+        return Err("Windows did not create the App launcher".into());
+    }
+    if let Err(error) = fs::write(owner_marker(target), marker_contents(tool)) {
+        let _ = fs::remove_file(target);
+        return Err(format!("could not record launcher ownership: {error}"));
+    }
+    Ok(true)
+}
+
+#[cfg(target_os = "macos")]
+fn install(tool: &str, target: &Path) -> Result<bool, String> {
+    if target.exists() && !is_owned(target, tool) {
+        return Err(format!(
+            "refusing to replace launcher not owned by Pentect: '{}'",
+            target.display()
+        ));
+    }
+    let pentect = launcher_executable()?;
+    let contents = target.join("Contents");
+    let macos = contents.join("MacOS");
+    let resources = contents.join("Resources");
+    fs::create_dir_all(&macos)
+        .and_then(|_| fs::create_dir_all(&resources))
+        .map_err(|error| format!("could not create '{}': {error}", target.display()))?;
+    let executable = macos.join("launch");
+    let quoted = pentect.to_string_lossy().replace('\'', "'\\''");
+    fs::write(&executable, format!(
+        "#!/bin/sh\n'{quoted}' {tool} app\nstatus=$?\nif [ \"$status\" -ne 0 ]; then\n    osascript -e 'display notification \"Run pentect {tool} app in a terminal for details.\" with title \"Pentect could not start the protected App\"' >/dev/null 2>&1\nfi\nexit \"$status\"\n"
+    ))
+    .map_err(|error| format!("could not write '{}': {error}", executable.display()))?;
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))
+        .map_err(|error| format!("could not make '{}': {error}", executable.display()))?;
+    let icon_name = copy_macos_app_icon(tool, &resources)?;
+    let icon_entry = icon_name.map_or_else(String::new, |name| {
+        format!("<key>CFBundleIconFile</key><string>{name}</string>")
+    });
+    let bundle_id = format!("dev.pentect.launcher.{tool}");
+    let plist = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\"><dict><key>CFBundleExecutable</key><string>launch</string><key>CFBundleIdentifier</key><string>{bundle_id}</string><key>CFBundleName</key><string>{}</string><key>CFBundlePackageType</key><string>APPL</string>{icon_entry}</dict></plist>\n",
+        display_name(tool)
+    );
+    fs::write(contents.join("Info.plist"), plist)
+        .and_then(|_| fs::write(owner_marker(target), marker_contents(tool)))
+        .map_err(|error| format!("could not finish '{}': {error}", target.display()))?;
+    Ok(true)
+}
+
+#[cfg(target_os = "macos")]
+fn copy_macos_app_icon(tool: &str, resources: &Path) -> Result<Option<String>, String> {
+    let Some(executable) = app_executable(tool) else {
+        return Ok(None);
+    };
+    let Some(contents) = executable.parent().and_then(Path::parent) else {
+        return Ok(None);
+    };
+    let source_dir = contents.join("Resources");
+    let Ok(entries) = fs::read_dir(source_dir) else {
+        return Ok(None);
+    };
+    let Some(source) = entries.flatten().map(|entry| entry.path()).find(|path| {
+        path.extension()
+            .is_some_and(|extension| extension == "icns")
+    }) else {
+        return Ok(None);
+    };
+    let name = "AppIcon.icns";
+    fs::copy(&source, resources.join(name))
+        .map_err(|error| format!("could not copy App icon '{}': {error}", source.display()))?;
+    Ok(Some(name.to_string()))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn install(_tool: &str, _target: &Path) -> Result<bool, String> {
+    Err("desktop App launchers are currently supported on Windows and macOS".into())
+}
+
+fn remove(tool: &str, target: &Path) -> Result<bool, String> {
+    if !target.exists() {
+        #[cfg(windows)]
+        {
+            let marker = owner_marker(target);
+            if fs::read_to_string(&marker).is_ok_and(|value| value == marker_contents(tool)) {
+                fs::remove_file(&marker).map_err(|error| {
+                    format!(
+                        "could not remove stale launcher marker '{}': {error}",
+                        marker.display()
+                    )
+                })?;
+                return Ok(true);
+            }
+        }
+        return Ok(false);
+    }
+    if !is_owned(target, tool) {
+        return Err(format!(
+            "refusing to remove launcher not owned by Pentect: '{}'",
+            target.display()
+        ));
+    }
+    #[cfg(windows)]
+    {
+        fs::remove_file(target)
+            .map_err(|error| format!("could not remove '{}': {error}", target.display()))?;
+        let marker = owner_marker(target);
+        fs::remove_file(&marker)
+            .map_err(|error| format!("could not remove '{}': {error}", marker.display()))?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        fs::remove_dir_all(target)
+            .map_err(|error| format!("could not remove '{}': {error}", target.display()))?;
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_nested_and_legacy_routes() {
+        let nested = vec![
+            "pentect".into(),
+            "codex".into(),
+            "app".into(),
+            "--install-launcher".into(),
+        ];
+        let legacy = vec![
+            "pentect".into(),
+            "claude-app".into(),
+            "--remove-launcher".into(),
+        ];
+        assert_eq!(
+            parse_request("codex", &nested).unwrap(),
+            Some((Action::Install, false, "--install-launcher"))
+        );
+        assert_eq!(
+            parse_request("claude", &legacy).unwrap(),
+            Some((Action::Remove, false, "--remove-launcher"))
+        );
+        assert_eq!(parse_request("codex", &legacy).unwrap(), None);
+    }
+
+    #[test]
+    fn ownership_marker_is_tool_specific() {
+        assert_ne!(marker_contents("codex"), marker_contents("claude"));
+        assert!(marker_contents("codex").starts_with("pentect-app-launcher-v1"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn creates_and_removes_a_real_windows_shortcut_in_a_temp_directory() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!(
+            "pentect-app-launcher-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&directory).unwrap();
+        let target = directory.join("Codex via Pentect.lnk");
+
+        assert!(install("codex", &target).unwrap());
+        assert!(target.is_file());
+        assert!(is_owned(&target, "codex"));
+        assert!(install("claude", &target).is_err());
+        assert!(remove("codex", &target).unwrap());
+        assert!(!target.exists());
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/crates/pentect-cli/src/app_launcher.rs
+++ b/crates/pentect-cli/src/app_launcher.rs
@@ -171,31 +171,6 @@ fn is_owned(target: &Path, tool: &str) -> bool {
 
 #[cfg(any(windows, target_os = "macos"))]
 fn launcher_executable() -> Result<PathBuf, String> {
-    let arg0 = std::env::args_os().next().map(PathBuf::from);
-    if let Some(path) = arg0
-        .as_ref()
-        .filter(|path| path.is_absolute() && path.is_file())
-    {
-        return Ok(path.clone());
-    }
-    if let Some(path) = arg0.as_ref().filter(|path| path.components().count() > 1) {
-        let absolute = std::env::current_dir()
-            .map_err(|error| format!("could not read the current directory: {error}"))?
-            .join(path);
-        if absolute.is_file() {
-            return Ok(absolute);
-        }
-    }
-    if let Some(name) = arg0.as_ref().and_then(|path| path.file_name()) {
-        if let Some(paths) = std::env::var_os("PATH") {
-            for directory in std::env::split_paths(&paths) {
-                let candidate = directory.join(name);
-                if candidate.is_file() {
-                    return Ok(candidate);
-                }
-            }
-        }
-    }
     std::env::current_exe()
         .map_err(|error| format!("could not locate the Pentect executable: {error}"))
 }
@@ -204,7 +179,7 @@ fn launcher_executable() -> Result<PathBuf, String> {
 fn install(tool: &str, target: &Path) -> Result<bool, String> {
     if target.exists() && !is_owned(target, tool) {
         return Err(format!(
-            "refusing to replace launcher not owned by Pentect: '{}'",
+            "refusing to replace launcher not owned by Pentect: '{}'; if this is an interrupted Pentect install, remove that bundle manually and try again",
             target.display()
         ));
     }
@@ -359,7 +334,7 @@ fn remove(tool: &str, target: &Path) -> Result<bool, String> {
     }
     if !is_owned(target, tool) {
         return Err(format!(
-            "refusing to remove launcher not owned by Pentect: '{}'",
+            "refusing to remove launcher not owned by Pentect: '{}'; if this is an interrupted Pentect install, remove it manually",
             target.display()
         ));
     }

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -80,6 +80,7 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
             .as_deref()
             .unwrap_or("https://api.anthropic.com");
         crate::upstream::parse_base(upstream, "Anthropic Messages")?;
+        crate::upstream::header_overrides(&options.upstream_header_env)?;
         if !installed {
             return Err("Claude Desktop was not found; pass --app PATH".to_string());
         }

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -98,10 +98,12 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         );
     }
 
-    let anthropic = crate::claude_http_proxy::ClaudeHttpProxyGuard::start(
+    let anthropic = crate::claude_http_proxy::ClaudeHttpProxyGuard::start_with_header_env(
         options
             .upstream
+            .clone()
             .unwrap_or_else(|| "https://api.anthropic.com".to_string()),
+        &options.upstream_header_env,
     )?;
     let proxy = ClaudeAppProxyGuard::start()?;
     let user_data_dir = claude_user_data_dir()?;
@@ -114,6 +116,7 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     );
 
     let mut command = Command::new(&app);
+    crate::upstream::hide_header_source_env(&mut command, &options.upstream_header_env);
     command
         .arg(format!("--proxy-server={}", proxy.proxy_url()))
         .arg(format!(
@@ -178,6 +181,7 @@ fn terminate_child_process(pid: u32) {
 struct ClaudeAppOptions {
     app: Option<PathBuf>,
     upstream: Option<String>,
+    upstream_header_env: Vec<String>,
     check: bool,
 }
 
@@ -185,6 +189,7 @@ impl ClaudeAppOptions {
     fn parse(args: &[String]) -> Result<Self, String> {
         let mut app = None;
         let mut upstream = None;
+        let mut upstream_header_env = Vec::new();
         let mut check = false;
         let mut index = if args.get(1).is_some_and(|arg| arg == "claude")
             && args.get(2).is_some_and(|arg| arg == "app")
@@ -213,6 +218,13 @@ impl ClaudeAppOptions {
                     upstream = Some(value.clone());
                     index += 2;
                 }
+                "--upstream-header-env" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or_else(|| "--upstream-header-env requires a value".to_string())?;
+                    upstream_header_env.push(value.clone());
+                    index += 2;
+                }
                 "--plugins" => {
                     if args
                         .get(index + 1)
@@ -228,6 +240,7 @@ impl ClaudeAppOptions {
         Ok(Self {
             app,
             upstream,
+            upstream_header_env,
             check,
         })
     }
@@ -1935,7 +1948,7 @@ fn text_response(status: StatusCode, message: &str) -> Response<ProxyBody> {
         .expect("static text response")
 }
 
-fn default_claude_app_path() -> PathBuf {
+pub(crate) fn default_claude_app_path() -> PathBuf {
     #[cfg(windows)]
     {
         if let Some(path) = find_windows_claude_app() {

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -60,8 +60,17 @@ pub(crate) struct ClaudeHttpProxyGuard {
 }
 
 impl ClaudeHttpProxyGuard {
+    #[cfg(test)]
     pub(crate) fn start(upstream: String) -> Result<Self, String> {
+        Self::start_with_header_env(upstream, &[])
+    }
+
+    pub(crate) fn start_with_header_env(
+        upstream: String,
+        header_env: &[String],
+    ) -> Result<Self, String> {
         let upstream = parse_upstream_base(&upstream)?;
+        let headers = crate::upstream::header_overrides(header_env)?;
         let auth = random_auth_token()?;
         let (ready_tx, ready_rx) = mpsc::channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -81,7 +90,9 @@ impl ClaudeHttpProxyGuard {
                 }
             };
             runtime.block_on(async move {
-                if let Err(error) = run_proxy(upstream, thread_auth, ready_tx, shutdown_rx).await {
+                if let Err(error) =
+                    run_proxy(upstream, headers, thread_auth, ready_tx, shutdown_rx).await
+                {
                     eprintln!("[pentect] Claude HTTP proxy stopped: {error}");
                 }
             });
@@ -122,7 +133,7 @@ struct ProxyState {
     files: StdMutex<HashMap<String, crate::http_files::Coverage>>,
     requests: Arc<Semaphore>,
     block_unknown_formats: bool,
-    authorization: crate::upstream::AuthorizationOverride,
+    headers: crate::upstream::HeaderOverrides,
 }
 
 impl Drop for ProxyState {
@@ -133,6 +144,7 @@ impl Drop for ProxyState {
 
 async fn run_proxy(
     upstream: reqwest::Url,
+    headers: crate::upstream::HeaderOverrides,
     auth: String,
     ready_tx: mpsc::Sender<Result<String, String>>,
     mut shutdown_rx: oneshot::Receiver<()>,
@@ -157,7 +169,7 @@ async fn run_proxy(
         files: StdMutex::new(HashMap::new()),
         requests: Arc::new(Semaphore::new(32)),
         block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
-        authorization: crate::upstream::authorization_override()?,
+        headers,
     });
     // Keep authentication in the base URL path. Claude settings can replace
     // ANTHROPIC_CUSTOM_HEADERS after process start, so a header token is not
@@ -334,7 +346,7 @@ async fn proxy_request_inner(
     let mut upstream_request = state.client.request(method, upstream_url);
     let connection_headers = connection_named_headers(&headers);
     for (name, value) in &headers {
-        if state.authorization.forward_incoming_header(name.as_str())
+        if state.headers.forward_incoming_header(name.as_str())
             && ((!(protected_request || files_upload) && name == hyper::header::CONTENT_LENGTH)
                 || should_forward_request_header(name.as_str()))
             && !connection_headers.contains(&name.as_str().to_ascii_lowercase())
@@ -342,9 +354,7 @@ async fn proxy_request_inner(
             upstream_request = upstream_request.header(name, value);
         }
     }
-    if let Some(value) = state.authorization.replacement() {
-        upstream_request = upstream_request.header(hyper::header::AUTHORIZATION, value);
-    }
+    upstream_request = state.headers.apply(upstream_request);
     let upstream_response = upstream_request
         .body(body)
         .send()

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -57,7 +57,10 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     }
 
     let routing = crate::codex_app_routing(options.upstream)?;
-    let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start(routing.upstream)?;
+    let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env(
+        routing.upstream,
+        &options.upstream_header_env,
+    )?;
     let config_lock = Arc::new(Mutex::new(Some(CodexConfigLock::acquire()?)));
     let config_override = Some(CodexConfigOverride::install(
         &routing.provider,
@@ -73,6 +76,7 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     eprintln!("[pentect] Responses API prompts, files, and completed tool calls are protected");
 
     let mut command = Command::new(&app);
+    crate::upstream::hide_header_source_env(&mut command, &options.upstream_header_env);
     command
         .env("OPENAI_BASE_URL", proxy.base_url())
         .stdin(Stdio::null())
@@ -413,6 +417,7 @@ fn set_provider_gateway(
 struct CodexAppOptions {
     app: Option<PathBuf>,
     upstream: Option<String>,
+    upstream_header_env: Vec<String>,
     check: bool,
 }
 
@@ -420,6 +425,7 @@ impl CodexAppOptions {
     fn parse(args: &[String]) -> Result<Self, String> {
         let mut app = None;
         let mut upstream = None;
+        let mut upstream_header_env = Vec::new();
         let mut check = false;
         let mut index = if args.get(1).is_some_and(|arg| arg == "codex")
             && args.get(2).is_some_and(|arg| arg == "app")
@@ -444,6 +450,13 @@ impl CodexAppOptions {
                     upstream = Some(value.clone());
                     index += 2;
                 }
+                "--upstream-header-env" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or_else(|| "--upstream-header-env requires a value".to_string())?;
+                    upstream_header_env.push(value.clone());
+                    index += 2;
+                }
                 "--check" | "--dry-run" => {
                     check = true;
                     index += 1;
@@ -463,12 +476,13 @@ impl CodexAppOptions {
         Ok(Self {
             app,
             upstream,
+            upstream_header_env,
             check,
         })
     }
 }
 
-fn default_codex_app_path() -> PathBuf {
+pub(crate) fn default_codex_app_path() -> PathBuf {
     #[cfg(windows)]
     {
         if let Some(path) = find_windows_codex_app() {
@@ -690,6 +704,8 @@ mod tests {
             "Codex.exe".to_string(),
             "--upstream".to_string(),
             "https://example.test/v1".to_string(),
+            "--upstream-header-env".to_string(),
+            "x-bf-vk=BIFROST_API_KEY".to_string(),
             "--dry-run".to_string(),
         ];
         assert_eq!(
@@ -697,6 +713,7 @@ mod tests {
             CodexAppOptions {
                 app: Some(PathBuf::from("Codex.exe")),
                 upstream: Some("https://example.test/v1".to_string()),
+                upstream_header_env: vec!["x-bf-vk=BIFROST_API_KEY".to_string()],
                 check: true,
             }
         );
@@ -717,6 +734,7 @@ mod tests {
             CodexAppOptions {
                 app: None,
                 upstream: None,
+                upstream_header_env: Vec::new(),
                 check: true,
             }
         );

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -36,6 +36,7 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
             }
         );
         let routing = crate::codex_app_routing(options.upstream)?;
+        crate::upstream::header_overrides(&options.upstream_header_env)?;
         println!("Provider: {}", routing.provider);
         println!("Protection: OpenAI Responses API (HTTP)");
         if !installed {

--- a/crates/pentect-cli/src/default_launch.rs
+++ b/crates/pentect-cli/src/default_launch.rs
@@ -155,13 +155,72 @@ fn update_profile(
     } else {
         None
     };
-    if let Err(error) = fs::write(profile, updated) {
+    if let Err(error) = write_profile_atomically(profile, updated.as_bytes()) {
         if let Some(backup) = &backup {
             let _ = fs::copy(backup, profile);
         }
         return Err(format!("could not update '{}': {error}", profile.display()));
     }
     Ok(ProfileUpdate::Changed { backup })
+}
+
+fn write_profile_atomically(profile: &Path, contents: &[u8]) -> io::Result<()> {
+    let parent = profile.parent().unwrap_or_else(|| Path::new("."));
+    let name = profile
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("profile");
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let staging = parent.join(format!(
+        ".{name}.pentect-staging-{}-{nonce}",
+        std::process::id()
+    ));
+    let result = (|| {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&staging)?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+        if let Ok(metadata) = fs::metadata(profile) {
+            fs::set_permissions(&staging, metadata.permissions())?;
+        }
+        atomic_replace(&staging, profile)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&staging);
+    }
+    result
+}
+
+#[cfg(not(windows))]
+fn atomic_replace(from: &Path, to: &Path) -> io::Result<()> {
+    fs::rename(from, to)
+}
+
+#[cfg(windows)]
+fn atomic_replace(from: &Path, to: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+    let from: Vec<u16> = from.as_os_str().encode_wide().chain(Some(0)).collect();
+    let to: Vec<u16> = to.as_os_str().encode_wide().chain(Some(0)).collect();
+    let moved = unsafe {
+        MoveFileExW(
+            from.as_ptr(),
+            to.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if moved == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 fn install_block(
@@ -215,7 +274,12 @@ fn marker_range(existing: &str, start: &str, end: &str) -> Result<Option<(usize,
         (None, None) => Ok(None),
         (Some(start_at), Some(end_at)) if end_at >= start_at => {
             let to = end_at + end.len();
-            if existing[to..].contains(start) || existing[to..].contains(end) {
+            let inside = &existing[start_at + start.len()..end_at];
+            if inside.contains(start)
+                || inside.contains(end)
+                || existing[to..].contains(start)
+                || existing[to..].contains(end)
+            {
                 return Err(
                     "multiple Pentect default blocks found; edit the profile manually".into(),
                 );
@@ -295,11 +359,8 @@ fn detect_shell() -> Result<ShellKind, String> {
 
 #[cfg(windows)]
 fn profile_path(shell: ShellKind) -> Result<PathBuf, String> {
-    let executable = match shell {
-        ShellKind::PowerShell => "powershell.exe",
-        ShellKind::Pwsh => "pwsh.exe",
-    };
-    let output = Command::new(executable)
+    let executable = powershell_executable(shell)?;
+    let output = Command::new(&executable)
         .args([
             "-NoLogo",
             "-NoProfile",
@@ -318,7 +379,54 @@ fn profile_path(shell: ShellKind) -> Result<PathBuf, String> {
     if path.is_empty() {
         return Err("PowerShell returned an empty profile path".into());
     }
-    Ok(PathBuf::from(path))
+    let path = PathBuf::from(path);
+    if !path.is_absolute() || path.file_name().is_none() {
+        return Err(format!(
+            "{} returned an invalid profile path",
+            executable.display()
+        ));
+    }
+    Ok(path)
+}
+
+#[cfg(windows)]
+fn powershell_executable(shell: ShellKind) -> Result<PathBuf, String> {
+    if shell == ShellKind::PowerShell {
+        let path = crate::windows_system_executable(r"WindowsPowerShell\v1.0\powershell.exe");
+        return path
+            .is_file()
+            .then_some(path)
+            .ok_or_else(|| "Windows PowerShell was not found".to_string());
+    }
+
+    let mut system = sysinfo::System::new();
+    system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    let mut pid = sysinfo::get_current_pid().map_err(|error| error.to_string())?;
+    for _ in 0..8 {
+        let Some(process) = system.process(pid) else {
+            break;
+        };
+        if matches!(
+            process
+                .name()
+                .to_string_lossy()
+                .to_ascii_lowercase()
+                .as_str(),
+            "pwsh" | "pwsh.exe"
+        ) {
+            if let Some(path) = process
+                .exe()
+                .filter(|path| path.is_absolute() && path.is_file())
+            {
+                return Ok(path.to_path_buf());
+            }
+        }
+        let Some(parent) = process.parent() else {
+            break;
+        };
+        pid = parent;
+    }
+    Err("could not locate the PowerShell executable that launched Pentect".to_string())
 }
 
 #[cfg(not(windows))]

--- a/crates/pentect-cli/src/default_launch.rs
+++ b/crates/pentect-cli/src/default_launch.rs
@@ -1,0 +1,429 @@
+use std::fs;
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+#[cfg(windows)]
+use std::process::Command;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Action {
+    Set,
+    Unset,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ShellKind {
+    #[cfg(windows)]
+    PowerShell,
+    #[cfg(windows)]
+    Pwsh,
+    #[cfg(not(windows))]
+    Bash,
+    #[cfg(not(windows))]
+    Zsh,
+    #[cfg(not(windows))]
+    Fish,
+}
+
+pub(crate) fn run_if_requested(tool: &str, args: &[String]) -> Result<Option<()>, String> {
+    let Some(first) = args.first().map(String::as_str) else {
+        return Ok(None);
+    };
+    let action = match first {
+        "--set-default" => Action::Set,
+        "--unset-default" => Action::Unset,
+        _ => return Ok(None),
+    };
+    if !matches!(tool, "codex" | "claude") {
+        return Err(format!("--set-default is not supported for {tool}"));
+    }
+
+    let mut assume_yes = false;
+    for arg in &args[1..] {
+        match arg.as_str() {
+            "--yes" if !assume_yes => assume_yes = true,
+            _ => return Err(format!("unexpected option for {first}: {arg}")),
+        }
+    }
+
+    let shell = detect_shell()?;
+    let profile = profile_path(shell)?;
+    let definition = definition(shell, tool);
+    let verb = match action {
+        Action::Set => "make",
+        Action::Unset => "stop making",
+    };
+    println!(
+        "This will {verb} `{tool}` launch through Pentect by default.\nProfile: {}",
+        profile.display()
+    );
+    if action == Action::Set {
+        println!("\n{definition}");
+    }
+
+    if !assume_yes {
+        if !io::stdin().is_terminal() {
+            return Err(format!(
+                "input is not interactive; rerun `pentect {tool} {first} --yes`"
+            ));
+        }
+        print!("\nContinue? [y/N] ");
+        io::stdout().flush().map_err(|error| error.to_string())?;
+        let mut answer = String::new();
+        io::stdin()
+            .read_line(&mut answer)
+            .map_err(|error| error.to_string())?;
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            println!("No changes made.");
+            return Ok(Some(()));
+        }
+    }
+
+    match update_profile(&profile, tool, &definition, action)? {
+        ProfileUpdate::Changed { backup } => {
+            match action {
+                Action::Set => println!("`{tool}` now launches through Pentect by default."),
+                Action::Unset => {
+                    println!("`{tool}` no longer launches through Pentect by default.")
+                }
+            }
+            if let Some(backup) = backup {
+                println!("Backup: {}", backup.display());
+            }
+            println!("Restart the terminal to apply the change.");
+        }
+        ProfileUpdate::Unchanged => match action {
+            Action::Set => println!("`{tool}` already launches through Pentect by default."),
+            Action::Unset => println!("No Pentect default was configured for `{tool}`."),
+        },
+    }
+    Ok(Some(()))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ProfileUpdate {
+    Changed { backup: Option<PathBuf> },
+    Unchanged,
+}
+
+fn update_profile(
+    profile: &Path,
+    tool: &str,
+    definition: &str,
+    action: Action,
+) -> Result<ProfileUpdate, String> {
+    let existing = match fs::read_to_string(profile) {
+        Ok(content) => content,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(format!("could not read '{}': {error}", profile.display())),
+    };
+    let newline = if existing.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let start = format!("# >>> pentect {tool} default >>>");
+    let end = format!("# <<< pentect {tool} default <<<");
+    let updated = match action {
+        Action::Set => install_block(&existing, &start, &end, definition, newline)?,
+        Action::Unset => remove_block(&existing, &start, &end)?,
+    };
+    let Some(updated) = updated else {
+        return Ok(ProfileUpdate::Unchanged);
+    };
+
+    if fs::symlink_metadata(profile).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return Err(format!(
+            "refusing to modify symlink '{}'; add or remove the shown block manually",
+            profile.display()
+        ));
+    }
+    if let Some(parent) = profile.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create '{}': {error}", parent.display()))?;
+    }
+
+    let backup = if profile.is_file() {
+        let backup = backup_path(profile);
+        fs::copy(profile, &backup).map_err(|error| {
+            format!(
+                "could not back up '{}' to '{}': {error}",
+                profile.display(),
+                backup.display()
+            )
+        })?;
+        Some(backup)
+    } else {
+        None
+    };
+    if let Err(error) = fs::write(profile, updated) {
+        if let Some(backup) = &backup {
+            let _ = fs::copy(backup, profile);
+        }
+        return Err(format!("could not update '{}': {error}", profile.display()));
+    }
+    Ok(ProfileUpdate::Changed { backup })
+}
+
+fn install_block(
+    existing: &str,
+    start: &str,
+    end: &str,
+    definition: &str,
+    newline: &str,
+) -> Result<Option<String>, String> {
+    let block = format!("{start}{newline}{definition}{newline}{end}");
+    match marker_range(existing, start, end)? {
+        Some((from, to)) => {
+            if existing[from..to] == block {
+                Ok(None)
+            } else {
+                let mut updated = existing.to_string();
+                updated.replace_range(from..to, &block);
+                Ok(Some(updated))
+            }
+        }
+        None => {
+            let mut updated = existing.to_string();
+            if !updated.is_empty() && !updated.ends_with('\n') {
+                updated.push_str(newline);
+            }
+            updated.push_str(&block);
+            updated.push_str(newline);
+            Ok(Some(updated))
+        }
+    }
+}
+
+fn remove_block(existing: &str, start: &str, end: &str) -> Result<Option<String>, String> {
+    let Some((from, mut to)) = marker_range(existing, start, end)? else {
+        return Ok(None);
+    };
+    if existing[to..].starts_with("\r\n") {
+        to += 2;
+    } else if existing[to..].starts_with('\n') {
+        to += 1;
+    }
+    let mut updated = existing.to_string();
+    updated.replace_range(from..to, "");
+    Ok(Some(updated))
+}
+
+fn marker_range(existing: &str, start: &str, end: &str) -> Result<Option<(usize, usize)>, String> {
+    let start_at = existing.find(start);
+    let end_at = existing.find(end);
+    match (start_at, end_at) {
+        (None, None) => Ok(None),
+        (Some(start_at), Some(end_at)) if end_at >= start_at => {
+            let to = end_at + end.len();
+            if existing[to..].contains(start) || existing[to..].contains(end) {
+                return Err(
+                    "multiple Pentect default blocks found; edit the profile manually".into(),
+                );
+            }
+            Ok(Some((start_at, to)))
+        }
+        _ => Err("incomplete Pentect default block found; edit the profile manually".into()),
+    }
+}
+
+fn backup_path(profile: &Path) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let name = profile
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("profile");
+    profile.with_file_name(format!("{name}.pentect-backup-{nonce}"))
+}
+
+fn definition(shell: ShellKind, tool: &str) -> String {
+    match shell {
+        #[cfg(windows)]
+        ShellKind::PowerShell | ShellKind::Pwsh => {
+            format!("function global:{tool} {{ & pentect {tool} @args }}")
+        }
+        #[cfg(not(windows))]
+        ShellKind::Bash | ShellKind::Zsh => {
+            format!(r#"{tool}() {{ command pentect {tool} "$@"; }}"#)
+        }
+        #[cfg(not(windows))]
+        ShellKind::Fish => format!("function {tool}\n    command pentect {tool} $argv\nend"),
+    }
+}
+
+#[cfg(windows)]
+fn detect_shell() -> Result<ShellKind, String> {
+    let mut system = sysinfo::System::new();
+    system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    let mut pid = sysinfo::get_current_pid().map_err(|error| error.to_string())?;
+    for _ in 0..8 {
+        let Some(process) = system.process(pid) else {
+            break;
+        };
+        let name = process.name().to_string_lossy().to_ascii_lowercase();
+        if matches!(name.as_str(), "pwsh" | "pwsh.exe") {
+            return Ok(ShellKind::Pwsh);
+        }
+        if matches!(name.as_str(), "powershell" | "powershell.exe") {
+            return Ok(ShellKind::PowerShell);
+        }
+        let Some(parent) = process.parent() else {
+            break;
+        };
+        pid = parent;
+    }
+    Err("could not detect PowerShell; run this command from PowerShell".into())
+}
+
+#[cfg(not(windows))]
+fn detect_shell() -> Result<ShellKind, String> {
+    let shell = std::env::var_os("SHELL")
+        .and_then(|value| PathBuf::from(value).file_name().map(|name| name.to_owned()))
+        .and_then(|name| name.to_str().map(str::to_ascii_lowercase))
+        .ok_or_else(|| "could not detect the shell from SHELL".to_string())?;
+    match shell.as_str() {
+        "bash" => Ok(ShellKind::Bash),
+        "zsh" => Ok(ShellKind::Zsh),
+        "fish" => Ok(ShellKind::Fish),
+        _ => Err(format!(
+            "unsupported shell '{shell}'; use Bash, Zsh, Fish, or PowerShell"
+        )),
+    }
+}
+
+#[cfg(windows)]
+fn profile_path(shell: ShellKind) -> Result<PathBuf, String> {
+    let executable = match shell {
+        ShellKind::PowerShell => "powershell.exe",
+        ShellKind::Pwsh => "pwsh.exe",
+    };
+    let output = Command::new(executable)
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "[Console]::OutputEncoding=[Text.UTF8Encoding]::new($false); [Console]::Write($PROFILE.CurrentUserAllHosts)",
+        ])
+        .output()
+        .map_err(|error| format!("could not query the PowerShell profile: {error}"))?;
+    if !output.status.success() {
+        return Err("could not query the PowerShell profile".into());
+    }
+    let path = String::from_utf8(output.stdout)
+        .map_err(|_| "PowerShell returned a non-UTF-8 profile path".to_string())?;
+    let path = path.trim();
+    if path.is_empty() {
+        return Err("PowerShell returned an empty profile path".into());
+    }
+    Ok(PathBuf::from(path))
+}
+
+#[cfg(not(windows))]
+fn profile_path(shell: ShellKind) -> Result<PathBuf, String> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is unavailable".to_string())?;
+    match shell {
+        ShellKind::Bash => Ok(home.join(".bashrc")),
+        ShellKind::Zsh => Ok(home.join(".zshrc")),
+        ShellKind::Fish => Ok(home.join(".config").join("fish").join("config.fish")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installs_updates_and_removes_one_owned_block() {
+        let start = "# >>> pentect codex default >>>";
+        let end = "# <<< pentect codex default <<<";
+        let original = "export EDITOR=vim\n";
+        let installed = install_block(
+            original,
+            start,
+            end,
+            r#"codex() { command pentect codex "$@"; }"#,
+            "\n",
+        )
+        .unwrap()
+        .unwrap();
+        assert!(installed.starts_with(original));
+        assert!(installed.contains("command pentect codex"));
+        assert!(install_block(
+            &installed,
+            start,
+            end,
+            r#"codex() { command pentect codex "$@"; }"#,
+            "\n",
+        )
+        .unwrap()
+        .is_none());
+        assert_eq!(
+            remove_block(&installed, start, end).unwrap().unwrap(),
+            original
+        );
+    }
+
+    #[test]
+    fn preserves_crlf_when_installing() {
+        let installed = install_block(
+            "# profile\r\n",
+            "# >>> pentect claude default >>>",
+            "# <<< pentect claude default <<<",
+            "function global:claude { & pentect claude @args }",
+            "\r\n",
+        )
+        .unwrap()
+        .unwrap();
+        assert!(!installed.replace("\r\n", "").contains('\n'));
+    }
+
+    #[test]
+    fn rejects_incomplete_or_duplicate_markers() {
+        let start = "# >>> pentect codex default >>>";
+        let end = "# <<< pentect codex default <<<";
+        assert!(marker_range(start, start, end).is_err());
+        assert!(marker_range(&format!("{start}\n{end}\n{start}\n{end}"), start, end).is_err());
+    }
+
+    #[test]
+    fn updates_a_profile_with_a_backup_and_removes_only_its_block() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!(
+            "pentect-default-launch-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&directory).unwrap();
+        let profile = directory.join("profile");
+        fs::write(&profile, "# user content\n").unwrap();
+
+        let installed = update_profile(
+            &profile,
+            "codex",
+            r#"codex() { command pentect codex "$@"; }"#,
+            Action::Set,
+        )
+        .unwrap();
+        let ProfileUpdate::Changed {
+            backup: Some(backup),
+        } = installed
+        else {
+            panic!("expected a changed profile with a backup");
+        };
+        assert_eq!(fs::read_to_string(backup).unwrap(), "# user content\n");
+        assert!(fs::read_to_string(&profile)
+            .unwrap()
+            .contains("command pentect codex"));
+
+        update_profile(&profile, "codex", "unused", Action::Unset).unwrap();
+        assert_eq!(fs::read_to_string(&profile).unwrap(), "# user content\n");
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -194,12 +194,12 @@ fn help_text() -> &'static str {
         "Use:\n",
         "  pentect\n",
         "  pentect codex|claude [--upstream URL] [--upstream-header-env HEADER=ENV_NAME] [--plugins NAME|PATH.toml]\n",
-        "  pentect codex|claude --set-default | --unset-default\n",
+        "  pentect codex|claude (--set-default | --unset-default) [--yes]\n",
         "  pentect opencode|pi [--model ID] [--upstream URL] [--api chat|responses]\n",
         "  --upstream-header-env HEADER=ENV_NAME  read an upstream credential without putting it in command arguments\n",
-        "  pentect codex app [--app PATH] [--upstream URL] [--plugins SOURCE] [--check]\n",
-        "  pentect claude app [--app PATH] [--upstream URL] [--plugins SOURCE] [--check]\n",
-        "  pentect codex|claude app --install-launcher | --remove-launcher\n",
+        "  pentect codex app [--app PATH] [--upstream URL] [--upstream-header-env HEADER=ENV_NAME] [--plugins SOURCE] [--check]\n",
+        "  pentect claude app [--app PATH] [--upstream URL] [--upstream-header-env HEADER=ENV_NAME] [--plugins SOURCE] [--check]\n",
+        "  pentect codex|claude app (--install-launcher | --remove-launcher) [--yes]\n",
         "  pentect exec \"<command>\"\n\n",
         "  pentect doctor [--json | --fix [--yes]]\n",
         "  pentect update [VERSION] [--check | --force]\n",
@@ -2519,7 +2519,14 @@ mod tests {
         let help = help_text();
         assert!(help.contains("pentect codex|claude"));
         assert!(help.contains("--set-default | --unset-default"));
-        assert!(help.contains("--install-launcher | --remove-launcher"));
+        assert!(help.contains("(--set-default | --unset-default) [--yes]"));
+        assert!(help.contains("(--install-launcher | --remove-launcher) [--yes]"));
+        assert!(help.contains(
+            "codex app [--app PATH] [--upstream URL] [--upstream-header-env HEADER=ENV_NAME]"
+        ));
+        assert!(help.contains(
+            "claude app [--app PATH] [--upstream URL] [--upstream-header-env HEADER=ENV_NAME]"
+        ));
         assert!(help.contains("pentect opencode|pi"));
         assert!(help.contains("pentect codex app"));
         assert!(help.contains("pentect claude app"));

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1,8 +1,10 @@
 //! Pentect CLI: local secret masking boundary for AI agents.
 
+mod app_launcher;
 mod claude_app_proxy;
 mod claude_http_proxy;
 mod codex_app;
+mod default_launch;
 mod doctor;
 mod http_files;
 mod input;
@@ -156,8 +158,10 @@ fn usage() {
     eprintln!(
         "pentect\n\
          pentect codex|claude|opencode|pi\n\
+         pentect codex|claude --set-default | --unset-default\n\
          pentect codex app\n\
          pentect claude app\n\
+         pentect codex|claude app --install-launcher | --remove-launcher\n\
          pentect exec \"<command>\"\n\
          pentect doctor [--json | --fix [--yes]]\n\
          pentect update [VERSION] [--check]\n\
@@ -189,10 +193,13 @@ fn help_text() -> &'static str {
         "pentect protects AI tool boundaries.\n\n",
         "Use:\n",
         "  pentect\n",
-        "  pentect codex|claude [--plugins NAME|PATH.toml]\n",
+        "  pentect codex|claude [--upstream URL] [--upstream-header-env HEADER=ENV_NAME] [--plugins NAME|PATH.toml]\n",
+        "  pentect codex|claude --set-default | --unset-default\n",
         "  pentect opencode|pi [--model ID] [--upstream URL] [--api chat|responses]\n",
+        "  --upstream-header-env HEADER=ENV_NAME  read an upstream credential without putting it in command arguments\n",
         "  pentect codex app [--app PATH] [--upstream URL] [--plugins SOURCE] [--check]\n",
         "  pentect claude app [--app PATH] [--upstream URL] [--plugins SOURCE] [--check]\n",
+        "  pentect codex|claude app --install-launcher | --remove-launcher\n",
         "  pentect exec \"<command>\"\n\n",
         "  pentect doctor [--json | --fix [--yes]]\n",
         "  pentect update [VERSION] [--check | --force]\n",
@@ -220,6 +227,10 @@ fn help_text() -> &'static str {
         "update: verified GitHub Release binary\n",
         "uninstall: remove the binary; keep project data\n",
         "plugins: add, remove, list, search, inspect, test, config, setup, update\n",
+        "--set-default: make the normal client command launch through Pentect\n",
+        "--unset-default: remove the shell-profile change made by Pentect\n",
+        "--install-launcher: add a protected App launcher for this user\n",
+        "--remove-launcher: remove the App launcher created by Pentect\n",
         "codex app: launch Codex App through the Responses API gateway\n",
         "claude app: launch Claude Desktop through the Chat and Anthropic gateways\n",
         "opencode: launch OpenCode through an ephemeral OpenAI-compatible provider\n",
@@ -334,6 +345,12 @@ fn cmd_agent_from(start: usize, args: &[String], inherited_env_is_trusted: bool)
 }
 
 fn cmd_agent_tool(tool: AgentTool, args: &[String]) -> i32 {
+    if default_launch::run_if_requested(tool.name(), &args[2..])
+        .unwrap_or_else(|error| die(error))
+        .is_some()
+    {
+        return 0;
+    }
     let opts = match AgentToolOpts::parse(tool, args) {
         Ok(o) => o,
         Err(e) => die(&e),
@@ -355,6 +372,12 @@ fn cmd_agent_tool(tool: AgentTool, args: &[String]) -> i32 {
 }
 
 fn cmd_claude_app(args: &[String]) -> i32 {
+    if app_launcher::run_if_requested("claude", args)
+        .unwrap_or_else(|error| die(error))
+        .is_some()
+    {
+        return 0;
+    }
     if claude_app_proxy::check_mode(args).unwrap_or_else(|error| die(error)) {
         return claude_app_proxy::cmd_claude_app(args);
     }
@@ -372,6 +395,12 @@ fn cmd_claude_app(args: &[String]) -> i32 {
 }
 
 fn cmd_codex_app(args: &[String]) -> i32 {
+    if app_launcher::run_if_requested("codex", args)
+        .unwrap_or_else(|error| die(error))
+        .is_some()
+    {
+        return 0;
+    }
     if codex_app::check_mode(args).unwrap_or_else(|error| die(error)) {
         return codex_app::cmd_codex_app(args);
     }
@@ -765,6 +794,7 @@ struct AgentToolOpts {
     openai_upstream: Option<String>,
     model: Option<String>,
     api: Option<String>,
+    upstream_header_env: Vec<String>,
     tool_args: Vec<String>,
 }
 
@@ -778,6 +808,7 @@ impl AgentToolOpts {
         let mut openai_upstream = None;
         let mut model = None;
         let mut api = None;
+        let mut upstream_header_env = Vec::new();
         let mut tool_args = Vec::new();
         let mut i = 2;
         while i < args.len() {
@@ -829,6 +860,13 @@ impl AgentToolOpts {
                 "--api" if matches!(tool, AgentTool::OpenCode | AgentTool::Pi) => {
                     api = Some(required_value(args, &mut i, "--api")?);
                 }
+                "--upstream-header-env" => {
+                    upstream_header_env.push(required_value(
+                        args,
+                        &mut i,
+                        "--upstream-header-env",
+                    )?);
+                }
                 "--prompt-proxy" | "--no-prompt-proxy" => {
                     return Err("prompt protection is automatic".to_string());
                 }
@@ -847,6 +885,7 @@ impl AgentToolOpts {
             openai_upstream,
             model,
             api,
+            upstream_header_env,
             tool_args,
         })
     }
@@ -864,7 +903,10 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
     let active_plugins = agent_tool_plugins(opts)?;
     let memory_store = start_memory_store(pentect)?;
     let _parent_env = agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
-    let http_proxy = openai_http_proxy::OpenAiHttpProxyGuard::start(routing.upstream.clone())?;
+    let http_proxy = openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env(
+        routing.upstream.clone(),
+        &opts.upstream_header_env,
+    )?;
     // These overrides are appended so a caller-supplied routing override
     // cannot bypass the local gateway. Codex accepts global config flags after
     // its subcommand and uses the last value for duplicate keys.
@@ -872,6 +914,7 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
 
     let mut cmd = Command::new(&opts.command);
     clear_pentect_control_env(&mut cmd);
+    upstream::hide_header_source_env(&mut cmd, &opts.upstream_header_env);
     apply_plugin_env(&mut cmd, &active_plugins)?;
     apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()))?;
     apply_memory_store_env(&mut cmd, Some(&memory_store));
@@ -898,10 +941,14 @@ fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::Exit
     let _parent_env = agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
     let mut cmd = Command::new(&opts.command);
     clear_pentect_control_env(&mut cmd);
+    upstream::hide_header_source_env(&mut cmd, &opts.upstream_header_env);
     apply_plugin_env(&mut cmd, &active_plugins)?;
     apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()))?;
     apply_memory_store_env(&mut cmd, Some(&memory_store));
-    let http_proxy = claude_http_proxy::ClaudeHttpProxyGuard::start(upstream)?;
+    let http_proxy = claude_http_proxy::ClaudeHttpProxyGuard::start_with_header_env(
+        upstream,
+        &opts.upstream_header_env,
+    )?;
     cmd.env("ANTHROPIC_BASE_URL", http_proxy.base_url());
     // Claude Code reapplies settings.env after process start. Put the local
     // route in the CLI settings layer as well, while preserving a caller's
@@ -2471,6 +2518,8 @@ mod tests {
     fn help_lists_public_commands_and_only_active_agent_integrations() {
         let help = help_text();
         assert!(help.contains("pentect codex|claude"));
+        assert!(help.contains("--set-default | --unset-default"));
+        assert!(help.contains("--install-launcher | --remove-launcher"));
         assert!(help.contains("pentect opencode|pi"));
         assert!(help.contains("pentect codex app"));
         assert!(help.contains("pentect claude app"));
@@ -2493,6 +2542,8 @@ mod tests {
                 "codex".to_string(),
                 "--upstream".to_string(),
                 "https://gateway.example/v1".to_string(),
+                "--upstream-header-env".to_string(),
+                "x-bf-vk=BIFROST_API_KEY".to_string(),
                 "--".to_string(),
                 "exec".to_string(),
                 "hello".to_string(),
@@ -2503,6 +2554,7 @@ mod tests {
             codex.openai_upstream.as_deref(),
             Some("https://gateway.example/v1")
         );
+        assert_eq!(codex.upstream_header_env, ["x-bf-vk=BIFROST_API_KEY"]);
         assert_eq!(codex.tool_args, ["exec", "hello"]);
 
         let claude = AgentToolOpts::parse(

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -51,9 +51,13 @@ pub(crate) fn run(
     let active_plugins = crate::agent_tool_plugins(opts)?;
     let memory_store = crate::start_memory_store(pentect)?;
     let _parent_env = crate::agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
-    let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start(upstream)?;
+    let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env(
+        upstream,
+        &opts.upstream_header_env,
+    )?;
     let mut command = Command::new(&opts.command);
     crate::clear_pentect_control_env(&mut command);
+    crate::upstream::hide_header_source_env(&mut command, &opts.upstream_header_env);
     crate::apply_plugin_env(&mut command, &active_plugins)?;
     crate::apply_pentect_env(&mut command, pentect, Some(memory_store.token.as_str()))?;
     crate::apply_memory_store_env(&mut command, Some(&memory_store));

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -43,8 +43,17 @@ pub(crate) struct OpenAiHttpProxyGuard {
 }
 
 impl OpenAiHttpProxyGuard {
+    #[cfg(test)]
     pub(crate) fn start(upstream: String) -> Result<Self, String> {
+        Self::start_with_header_env(upstream, &[])
+    }
+
+    pub(crate) fn start_with_header_env(
+        upstream: String,
+        header_env: &[String],
+    ) -> Result<Self, String> {
         let upstream = parse_upstream_base(&upstream)?;
+        let headers = crate::upstream::header_overrides(header_env)?;
         let auth = random_auth_token()?;
         let (ready_tx, ready_rx) = mpsc::channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -64,7 +73,9 @@ impl OpenAiHttpProxyGuard {
                 }
             };
             runtime.block_on(async move {
-                if let Err(error) = run_proxy(upstream, thread_auth, ready_tx, shutdown_rx).await {
+                if let Err(error) =
+                    run_proxy(upstream, headers, thread_auth, ready_tx, shutdown_rx).await
+                {
                     eprintln!("[pentect] OpenAI HTTP gateway stopped: {error}");
                 }
             });
@@ -105,7 +116,7 @@ struct ProxyState {
     files: Mutex<HashMap<String, crate::http_files::Coverage>>,
     requests: Arc<Semaphore>,
     block_unknown_formats: bool,
-    authorization: crate::upstream::AuthorizationOverride,
+    headers: crate::upstream::HeaderOverrides,
 }
 
 impl Drop for ProxyState {
@@ -116,6 +127,7 @@ impl Drop for ProxyState {
 
 async fn run_proxy(
     upstream: reqwest::Url,
+    headers: crate::upstream::HeaderOverrides,
     auth: String,
     ready_tx: mpsc::Sender<Result<String, String>>,
     mut shutdown_rx: oneshot::Receiver<()>,
@@ -139,7 +151,7 @@ async fn run_proxy(
         files: Mutex::new(HashMap::new()),
         requests: Arc::new(Semaphore::new(32)),
         block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
-        authorization: crate::upstream::authorization_override()?,
+        headers,
     });
     let _ = ready_tx.send(Ok(local_base_url));
 
@@ -330,7 +342,7 @@ async fn proxy_request_inner(
     let mut upstream_request = state.client.request(method, upstream_url);
     let connection_headers = connection_named_headers(&headers);
     for (name, value) in &headers {
-        if state.authorization.forward_incoming_header(name.as_str())
+        if state.headers.forward_incoming_header(name.as_str())
             && ((!(protected_request || files_upload) && name == hyper::header::CONTENT_LENGTH)
                 || should_forward_request_header(name.as_str()))
             && !connection_headers.contains(&name.as_str().to_ascii_lowercase())
@@ -338,9 +350,7 @@ async fn proxy_request_inner(
             upstream_request = upstream_request.header(name, value);
         }
     }
-    if let Some(value) = state.authorization.replacement() {
-        upstream_request = upstream_request.header(hyper::header::AUTHORIZATION, value);
-    }
+    upstream_request = state.headers.apply(upstream_request);
     let upstream = upstream_request
         .body(body)
         .send()
@@ -765,12 +775,14 @@ async fn fetch_openai_file_content(
     let mut request = state.client.get(url);
     let connection_headers = connection_named_headers(request_headers);
     for (name, value) in request_headers {
-        if should_forward_request_header(name.as_str())
+        if state.headers.forward_incoming_header(name.as_str())
+            && should_forward_request_header(name.as_str())
             && !connection_headers.contains(&name.as_str().to_ascii_lowercase())
         {
             request = request.header(name, value);
         }
     }
+    request = state.headers.apply(request);
     let response = request
         .send()
         .await

--- a/crates/pentect-cli/src/upstream.rs
+++ b/crates/pentect-cli/src/upstream.rs
@@ -8,21 +8,106 @@ const IDENTITY_ENV: &str = "PENTECT_UPSTREAM_IDENTITY";
 const AUTHORIZATION_ENV: &str = "PENTECT_UPSTREAM_AUTHORIZATION";
 
 #[derive(Clone)]
-pub(crate) enum AuthorizationOverride {
-    Forward,
-    Remove,
-    Replace(reqwest::header::HeaderValue),
+struct HeaderOverride {
+    name: reqwest::header::HeaderName,
+    value: Option<reqwest::header::HeaderValue>,
 }
 
-impl AuthorizationOverride {
+#[derive(Clone, Default)]
+pub(crate) struct HeaderOverrides {
+    values: Vec<HeaderOverride>,
+    suppress_origin_auth: bool,
+}
+
+impl HeaderOverrides {
     pub(crate) fn forward_incoming_header(&self, name: &str) -> bool {
-        matches!(self, Self::Forward) || !is_origin_auth_header(name)
+        !(self.suppress_origin_auth && is_origin_auth_header(name))
+            && !self
+                .values
+                .iter()
+                .any(|header| header.name.as_str().eq_ignore_ascii_case(name))
     }
 
-    pub(crate) fn replacement(&self) -> Option<&reqwest::header::HeaderValue> {
-        match self {
-            Self::Replace(value) => Some(value),
-            Self::Forward | Self::Remove => None,
+    pub(crate) fn apply(&self, mut request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        for header in &self.values {
+            if let Some(value) = &header.value {
+                request = request.header(&header.name, value);
+            }
+        }
+        request
+    }
+}
+
+pub(crate) fn header_overrides(specs: &[String]) -> Result<HeaderOverrides, String> {
+    if specs.len() > 32 {
+        return Err("too many --upstream-header-env options (maximum 32)".to_string());
+    }
+    let mut overrides = HeaderOverrides::default();
+    if let Some(value) = std::env::var_os(AUTHORIZATION_ENV) {
+        let value = if value.is_empty() {
+            None
+        } else {
+            let mut value = value
+                .into_string()
+                .map_err(|_| format!("{AUTHORIZATION_ENV} is not valid Unicode"))?;
+            let header = sensitive_header_value(&value, AUTHORIZATION_ENV);
+            value.zeroize();
+            Some(header?)
+        };
+        overrides.suppress_origin_auth = true;
+        overrides.values.push(HeaderOverride {
+            name: reqwest::header::AUTHORIZATION,
+            value,
+        });
+    }
+
+    for spec in specs {
+        let (name, env_name) = spec.split_once('=').ok_or_else(|| {
+            "--upstream-header-env must use HEADER=ENV_NAME (for example x-bf-vk=BIFROST_API_KEY)"
+                .to_string()
+        })?;
+        let name = reqwest::header::HeaderName::from_bytes(name.trim().as_bytes())
+            .map_err(|_| format!("invalid upstream header name '{name}'"))?;
+        reject_unsafe_override_header(&name)?;
+        if overrides
+            .values
+            .iter()
+            .any(|existing| existing.name == name)
+        {
+            return Err(format!(
+                "upstream header '{}' is configured more than once",
+                name
+            ));
+        }
+        let env_name = env_name.trim();
+        if env_name.is_empty() || env_name.contains('=') || env_name.contains('\0') {
+            return Err("upstream header environment variable name is invalid".to_string());
+        }
+        let mut value = std::env::var(env_name).map_err(|_| {
+            format!("environment variable {env_name} is not set or is not valid Unicode")
+        })?;
+        if value.is_empty() {
+            return Err(format!("environment variable {env_name} is empty"));
+        }
+        if value.len() > 16 * 1024 {
+            value.zeroize();
+            return Err(format!("environment variable {env_name} is too large"));
+        }
+        let header = sensitive_header_value(&value, env_name);
+        value.zeroize();
+        overrides.suppress_origin_auth = true;
+        overrides.values.push(HeaderOverride {
+            name,
+            value: Some(header?),
+        });
+    }
+    Ok(overrides)
+}
+
+pub(crate) fn hide_header_source_env(command: &mut std::process::Command, specs: &[String]) {
+    for spec in specs {
+        if let Some((_, env_name)) = spec.split_once('=') {
+            command.env_remove(env_name.trim());
         }
     }
 }
@@ -31,22 +116,35 @@ fn is_origin_auth_header(name: &str) -> bool {
     name.eq_ignore_ascii_case("authorization")
         || name.eq_ignore_ascii_case("x-api-key")
         || name.eq_ignore_ascii_case("api-key")
+        || name.eq_ignore_ascii_case("x-goog-api-key")
 }
 
-pub(crate) fn authorization_override() -> Result<AuthorizationOverride, String> {
-    let Some(value) = std::env::var_os(AUTHORIZATION_ENV) else {
-        return Ok(AuthorizationOverride::Forward);
-    };
-    if value.is_empty() {
-        return Ok(AuthorizationOverride::Remove);
-    }
-    let value = value
-        .into_string()
-        .map_err(|_| format!("{AUTHORIZATION_ENV} is not valid Unicode"))?;
-    let mut header = reqwest::header::HeaderValue::from_str(&value)
-        .map_err(|_| format!("{AUTHORIZATION_ENV} is not a valid HTTP header value"))?;
+fn sensitive_header_value(
+    value: &str,
+    source: &str,
+) -> Result<reqwest::header::HeaderValue, String> {
+    let mut header = reqwest::header::HeaderValue::from_str(value)
+        .map_err(|_| format!("{source} is not a valid HTTP header value"))?;
     header.set_sensitive(true);
-    Ok(AuthorizationOverride::Replace(header))
+    Ok(header)
+}
+
+fn reject_unsafe_override_header(name: &reqwest::header::HeaderName) -> Result<(), String> {
+    if matches!(
+        name.as_str(),
+        "connection"
+            | "content-length"
+            | "host"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    ) {
+        return Err(format!("upstream header '{name}' cannot be overridden"));
+    }
+    Ok(())
 }
 
 pub(crate) fn parse_base(value: &str, protocol: &str) -> Result<reqwest::Url, String> {
@@ -219,20 +317,50 @@ mod tests {
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         {
             let _env = EnvRestore::set(AUTHORIZATION_ENV, "");
-            assert!(matches!(
-                authorization_override().unwrap(),
-                AuthorizationOverride::Remove
-            ));
+            let overrides = header_overrides(&[]).unwrap();
+            assert!(!overrides.forward_incoming_header("authorization"));
         }
         {
             let _env = EnvRestore::set(AUTHORIZATION_ENV, "Bearer gateway-token");
-            let override_value = authorization_override().unwrap();
-            assert!(!override_value.forward_incoming_header("authorization"));
-            assert!(!override_value.forward_incoming_header("x-api-key"));
-            assert!(!override_value.forward_incoming_header("api-key"));
-            assert!(override_value.forward_incoming_header("anthropic-version"));
-            assert!(override_value.replacement().is_some());
-            assert!(override_value.replacement().unwrap().is_sensitive());
+            let overrides = header_overrides(&[]).unwrap();
+            assert!(!overrides.forward_incoming_header("authorization"));
+            assert!(!overrides.forward_incoming_header("x-api-key"));
+            assert!(overrides.forward_incoming_header("anthropic-version"));
+            assert!(overrides.values[0].value.as_ref().unwrap().is_sensitive());
         }
+    }
+
+    #[test]
+    fn named_header_reads_secret_from_environment() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let _secret = EnvRestore::set("PENTECT_TEST_BIFROST_KEY", "bf-test-key");
+        let overrides =
+            header_overrides(&["x-bf-vk=PENTECT_TEST_BIFROST_KEY".to_string()]).unwrap();
+        assert!(!overrides.forward_incoming_header("X-BF-VK"));
+        assert!(!overrides.forward_incoming_header("authorization"));
+        assert!(overrides.values[0].value.as_ref().unwrap().is_sensitive());
+        let request = overrides
+            .apply(reqwest::Client::new().get("https://example.test"))
+            .build()
+            .unwrap();
+        assert_eq!(request.headers().get("x-bf-vk").unwrap(), "bf-test-key");
+
+        let mut command = std::process::Command::new("example");
+        command.env("PENTECT_TEST_BIFROST_KEY", "bf-test-key");
+        hide_header_source_env(
+            &mut command,
+            &["x-bf-vk=PENTECT_TEST_BIFROST_KEY".to_string()],
+        );
+        assert!(command
+            .get_envs()
+            .any(|(name, value)| name == "PENTECT_TEST_BIFROST_KEY" && value.is_none()));
+    }
+
+    #[test]
+    fn named_header_rejects_missing_values_and_transport_headers() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        std::env::remove_var("PENTECT_TEST_MISSING_KEY");
+        assert!(header_overrides(&["x-bf-vk=PENTECT_TEST_MISSING_KEY".to_string()]).is_err());
+        assert!(header_overrides(&["host=PENTECT_TEST_MISSING_KEY".to_string()]).is_err());
     }
 }

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -16,6 +16,7 @@ const sidebarIcons = {
   terminal: '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/>',
   message: '<path d="M5 18 3 21l4-1.5A9 9 0 1 0 5 18Z"/><path d="M8 11h8M8 14h5"/>',
   network: '<circle cx="5" cy="12" r="2"/><circle cx="19" cy="6" r="2"/><circle cx="19" cy="18" r="2"/><path d="m7 11 10-4m-10 6 10 4"/>',
+  gateway: '<path d="M4 7h11"/><path d="m12 4 3 3-3 3"/><path d="M20 17H9"/><path d="m12 14-3 3 3 3"/><path d="M4 4v16M20 4v16"/>',
   data: '<path d="M8 4 4 8l4 4"/><path d="m16 12 4 4-4 4"/><path d="m14 3-4 18"/>',
   image: '<rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m3 16 5-4 4 3 3-2 6 5"/>',
   shield: '<path d="M12 3 5 6v5c0 4.7 2.9 8 7 10 4.1-2 7-5.3 7-10V6Z"/><path d="m9 12 2 2 4-4"/>',
@@ -56,14 +57,15 @@ const sidebar = [
     items: [
       { text: sidebarLabel('Codex', 'terminal', '/brands/openai-blossom.svg'), link: '/clients/codex/' },
       { text: sidebarLabel('Claude', 'message', '/brands/claude.svg'), link: '/clients/claude/' },
-      { text: sidebarLabel('OpenCode', 'terminal'), link: '/clients/opencode/' },
-      { text: sidebarLabel('Pi', 'terminal'), link: '/clients/pi/' },
-      { text: sidebarLabel('Custom upstreams', 'network'), link: '/clients/upstreams/' },
+      { text: sidebarLabel('OpenCode', 'terminal', '/brands/opencode.svg'), link: '/clients/opencode/' },
+      { text: sidebarLabel('Pi', 'terminal', '/brands/pi.svg'), link: '/clients/pi/' },
+      { text: sidebarLabel('Custom upstreams', 'gateway'), link: '/clients/upstreams/' },
     ],
   },
   {
     text: 'Protection',
     items: [
+      { text: sidebarLabel('Prompts and tool results', 'message'), link: '/protection/prompts-and-tools/' },
       { text: sidebarLabel('Structured data', 'data'), link: '/protection/structured-data/' },
       { text: sidebarLabel('Files and images', 'image'), link: '/protection/files-and-images/' },
       { text: sidebarLabel('Security model', 'shield'), link: '/protection/security-model/' },

--- a/website/.vitepress/theme/Layout.vue
+++ b/website/.vitepress/theme/Layout.vue
@@ -1,12 +1,52 @@
 <script setup lang="ts">
 import DefaultTheme from 'vitepress/theme';
-import { useData } from 'vitepress';
-import { computed } from 'vue';
+import { useData, useRoute } from 'vitepress';
+import { computed, nextTick, onMounted, watch } from 'vue';
 
 const { frontmatter } = useData();
+const route = useRoute();
 const title = computed(() => String(frontmatter.value.title ?? ''));
 const hasAccentSuffix = computed(() => title.value.endsWith('_'));
 const titleBase = computed(() => hasAccentSuffix.value ? title.value.slice(0, -1) : title.value);
+
+function normalizedTabLabel(label: HTMLLabelElement) {
+  return label.textContent?.trim().toLowerCase() ?? '';
+}
+
+function selectPlatformCodeTabs() {
+  const platform = navigator.userAgentData?.platform ?? navigator.platform ?? navigator.userAgent;
+  const isWindows = /windows|win32|win64/i.test(platform);
+
+  for (const group of document.querySelectorAll<HTMLElement>('.vp-code-group')) {
+    const labels = [...group.querySelectorAll<HTMLLabelElement>('.tabs label')];
+    const names = labels.map(normalizedTabLabel);
+    const hasWindows = names.some((name) => name.includes('windows') || name.includes('powershell'));
+    const hasUnix = names.some((name) =>
+      name.includes('macos') ||
+      name.includes('linux') ||
+      name.includes('bash') ||
+      name.includes('zsh') ||
+      name === 'shell'
+    );
+
+    if (!hasWindows || !hasUnix) continue;
+
+    const selected = labels.find((label) => {
+      const name = normalizedTabLabel(label);
+      return isWindows
+        ? name.includes('windows') || name.includes('powershell')
+        : name.includes('macos') || name.includes('linux') || name.includes('bash') || name.includes('zsh') || name === 'shell';
+    });
+
+    selected?.click();
+  }
+}
+
+onMounted(() => selectPlatformCodeTabs());
+watch(() => route.path, async () => {
+  await nextTick();
+  selectPlatformCodeTabs();
+});
 </script>
 
 <template>
@@ -15,7 +55,7 @@ const titleBase = computed(() => hasAccentSuffix.value ? title.value.slice(0, -1
       <span class="docs-wordmark">Docs</span>
     </template>
     <template #nav-bar-content-after>
-      <a class="docs-nav-cta" href="/start/quick-start/">Get started</a>
+      <a class="docs-nav-cta" href="/start/install/">Install</a>
     </template>
     <template #doc-before>
       <header v-if="frontmatter.title" class="doc-heading">

--- a/website/.vitepress/theme/QuickInstall.vue
+++ b/website/.vitepress/theme/QuickInstall.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { siApple, siLinux } from 'simple-icons';
+import { computed, onMounted, ref } from 'vue';
+
+type OperatingSystem = 'windows' | 'macos' | 'linux';
+
+const selectedOs = ref<OperatingSystem>('windows');
+const copyState = ref<'idle' | 'copied' | 'failed'>('idle');
+
+const installers = {
+  windows: {
+    label: 'Windows',
+    command: 'irm https://pentect.dev/install | iex',
+    icon: 'M0 0h11.377v11.372H0Zm12.623 0H24v11.372H12.623ZM0 12.623h11.377V24H0Zm12.623 0H24V24H12.623',
+  },
+  macos: {
+    label: 'macOS',
+    command: 'curl -fsSL https://pentect.dev/install.sh | sh',
+    icon: siApple.path,
+  },
+  linux: {
+    label: 'Linux',
+    command: 'curl -fsSL https://pentect.dev/install.sh | sh',
+    icon: siLinux.path,
+  },
+};
+
+const installer = computed(() => installers[selectedOs.value]);
+const commandTokens = computed(() => tokenizeCommand(installer.value.command));
+
+function tokenizeCommand(command: string) {
+  const parts = command.match(/https?:\/\/[^\s|]+|--?[\w-]+|\||[^\s|]+|[\t ]+/g) ?? [command];
+  let expectsCommand = true;
+  return parts.map((text) => {
+    if (/^[\t ]+$/.test(text)) return { text, kind: 'space' };
+    if (text === '|') {
+      expectsCommand = true;
+      return { text, kind: 'operator' };
+    }
+    if (expectsCommand) {
+      expectsCommand = false;
+      return { text, kind: 'command' };
+    }
+    if (text.startsWith('-')) return { text, kind: 'option' };
+    if (text.startsWith('http')) return { text, kind: 'string' };
+    return { text, kind: 'argument' };
+  });
+}
+
+async function copyCommand() {
+  try {
+    await navigator.clipboard.writeText(installer.value.command);
+    copyState.value = 'copied';
+  } catch {
+    copyState.value = 'failed';
+  }
+}
+
+onMounted(() => {
+  const agent = navigator.userAgent.toLowerCase();
+  selectedOs.value = agent.includes('mac') ? 'macos' : agent.includes('win') ? 'windows' : 'linux';
+});
+</script>
+
+<template>
+  <section class="quick-install" aria-labelledby="quick-install-heading">
+    <div class="quick-install__meta">
+      <span id="quick-install-heading">Install</span>
+      <span class="quick-install__platform">
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path fill="currentColor" :d="installer.icon" />
+        </svg>
+        {{ installer.label }}
+      </span>
+    </div>
+
+    <div class="quick-install__command">
+      <code>
+        <span
+          v-for="(token, index) in commandTokens"
+          :key="`${index}-${token.text}`"
+          :class="`shell-token shell-token--${token.kind}`"
+        >{{ token.text }}</span>
+      </code>
+      <button
+        type="button"
+        class="quick-install__copy"
+        :class="{ 'is-copied': copyState === 'copied' }"
+        :aria-label="copyState === 'copied' ? 'Copied' : 'Copy install command'"
+        :title="copyState === 'copied' ? 'Copied' : 'Copy install command'"
+        @click="copyCommand"
+      >
+        <svg v-if="copyState === 'copied'" aria-hidden="true" viewBox="0 0 24 24">
+          <path d="m5 12 4 4L19 6" />
+        </svg>
+        <svg v-else aria-hidden="true" viewBox="0 0 24 24">
+          <rect x="8" y="8" width="11" height="11" rx="2" />
+          <path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3" />
+        </svg>
+      </button>
+    </div>
+
+    <a class="quick-install__more" href="/start/install/">
+      All options <span aria-hidden="true">→</span>
+    </a>
+    <p v-if="copyState === 'failed'" class="quick-install__status" role="status">
+      Select the command and copy it manually.
+    </p>
+  </section>
+</template>

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import DefaultTheme from 'vitepress/theme';
 import DocsGrid from './DocsGrid.vue';
 import HomeInstall from './HomeInstall.vue';
+import QuickInstall from './QuickInstall.vue';
 import Layout from './Layout.vue';
 import './style.css';
 
@@ -10,5 +11,6 @@ export default {
   enhanceApp({ app }) {
     app.component('DocsGrid', DocsGrid);
     app.component('HomeInstall', HomeInstall);
+    app.component('QuickInstall', QuickInstall);
   },
 };

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -429,7 +429,7 @@ body {
   width: 18px;
   height: 18px;
   fill: none;
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 1.8;
   stroke-linecap: round;
   stroke-linejoin: round;

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -443,6 +443,143 @@ body {
   text-align: right;
 }
 
+.quick-install {
+  display: grid;
+  grid-template-columns: 132px minmax(0, 1fr) auto;
+  align-items: stretch;
+  overflow: hidden;
+  margin: 38px 0 0;
+  border-block: 1px solid var(--vp-c-divider);
+}
+
+.quick-install__meta {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 7px;
+  border-right: 1px solid var(--vp-c-divider);
+  padding: 17px 20px 17px 0;
+}
+
+.quick-install__meta > span:first-child {
+  color: var(--vp-c-brand-1);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.quick-install__platform {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.quick-install__platform svg {
+  width: 15px;
+  height: 15px;
+  color: var(--vp-c-text-3);
+}
+
+.quick-install__command {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  background: var(--vp-c-bg-soft);
+}
+
+.vp-doc .quick-install__command code {
+  display: block;
+  overflow-x: auto;
+  width: 100%;
+  padding: 22px 62px 22px 24px;
+  color: var(--vp-c-text-1);
+  background: transparent;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.quick-install__copy {
+  position: absolute;
+  top: 50%;
+  right: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  opacity: .55;
+  transform: translateY(-50%);
+  border: 0;
+  border-radius: 3px;
+  padding: 0;
+  color: var(--vp-c-text-2);
+  background: color-mix(in srgb, var(--vp-c-bg) 78%, transparent);
+  cursor: pointer;
+  transition: opacity 140ms ease, color 140ms ease, background-color 140ms ease;
+}
+
+.quick-install__command:hover .quick-install__copy,
+.quick-install__copy:focus-visible {
+  opacity: 1;
+}
+
+.quick-install__copy:hover {
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg);
+}
+
+.quick-install__copy:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: -2px;
+}
+
+.quick-install__copy.is-copied {
+  color: #2a9d78;
+}
+
+.quick-install__copy svg {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.quick-install__more {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-left: 1px solid var(--vp-c-divider);
+  padding: 0 20px;
+  color: var(--vp-c-text-2) !important;
+  font-size: 13px;
+  font-weight: 650;
+  text-decoration: none !important;
+  white-space: nowrap;
+}
+
+.quick-install__more:hover {
+  color: var(--vp-c-brand-1) !important;
+}
+
+.quick-install__status {
+  grid-column: 1 / -1;
+  margin: 0;
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 8px 12px;
+  color: var(--vp-c-text-2);
+  font-size: 12px;
+  text-align: right;
+}
+
 .install-choice--variant {
   padding-left: 70px;
 }
@@ -487,8 +624,8 @@ body {
 }
 
 .docs-hub .doc-heading {
-  max-width: 720px;
-  margin-bottom: 26px;
+  max-width: 820px;
+  margin-bottom: 32px;
   border-bottom: 0;
   padding-bottom: 0;
 }
@@ -502,60 +639,12 @@ body {
 }
 
 .docs-hub .doc-heading p {
-  max-width: 630px;
-  font-size: 20px;
-}
-
-.docs-hub .vp-doc > p:first-of-type {
-  max-width: 680px;
-  margin-bottom: 34px;
-  color: var(--vp-c-text-2);
-  font-size: 16px;
-  line-height: 1.7;
-}
-
-.home-flow {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin: 4px 0 64px;
-  border-block: 1px solid var(--vp-c-divider);
-}
-
-.home-flow__step {
-  display: flex;
-  min-height: 170px;
-  flex-direction: column;
-  gap: 9px;
-  padding: 24px 28px 24px 0;
-}
-
-.home-flow__step + .home-flow__step {
-  border-left: 1px solid var(--vp-c-divider);
-  padding-left: 28px;
-}
-
-.home-flow__step small {
-  color: var(--vp-c-brand-1);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: .08em;
-}
-
-.home-flow__step strong {
+  max-width: 760px;
   color: var(--vp-c-text-1);
-  font-size: 17px;
-}
-
-.home-flow__step span {
-  color: var(--vp-c-text-2);
-  font-size: 14px;
-  line-height: 1.55;
-}
-
-.home-flow__step code {
-  padding: 1px 4px;
-  color: var(--vp-c-text-1);
-  font-size: 12px;
+  font-size: clamp(23px, 2.4vw, 30px);
+  font-weight: 520;
+  line-height: 1.3;
+  letter-spacing: -0.025em;
 }
 
 .docs-hub .vp-doc > h2 {
@@ -788,20 +877,42 @@ body {
     margin-top: 42px;
   }
 
-  .home-flow {
+  .quick-install {
     grid-template-columns: 1fr;
-    margin-bottom: 44px;
+    margin-top: 28px;
   }
 
-  .home-flow__step {
-    min-height: 0;
-    padding: 20px 0;
+  .quick-install__meta {
+    grid-column: 1 / -1;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    border-right: 0;
+    border-bottom: 1px solid var(--vp-c-divider);
+    padding: 13px 0;
   }
 
-  .home-flow__step + .home-flow__step {
+  .quick-install__command {
+    min-width: 0;
+  }
+
+  .vp-doc .quick-install__command code {
+    padding: 18px 54px 18px 14px;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .quick-install__copy {
+    right: 10px;
+    opacity: 1;
+  }
+
+  .quick-install__more {
+    min-height: 44px;
+    justify-content: flex-end;
     border-top: 1px solid var(--vp-c-divider);
     border-left: 0;
-    padding-left: 0;
+    padding: 0 14px;
   }
 
   .vp-doc table {

--- a/website/public/brands/opencode.svg
+++ b/website/public/brands/opencode.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="OpenCode">
+  <path d="M22 24H2V0h20zM17 4.8H7v14.4h10z"/>
+</svg>

--- a/website/public/brands/pi.svg
+++ b/website/public/brands/pi.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Pi">
+  <path d="M0 0v24h6v-6h6v-6H6V6h6v6h6V0Zm18 12v12h6V12Z"/>
+</svg>

--- a/website/scripts/generate-agent-docs.mjs
+++ b/website/scripts/generate-agent-docs.mjs
@@ -115,7 +115,7 @@ function rewriteNodes(nodes) {
           codeBlock('irm https://pentect.dev/install | iex', 'powershell'),
           heading('Shell — macOS and Linux', 3),
           codeBlock('curl -fsSL https://pentect.dev/install.sh | sh', 'sh'),
-          linkParagraph('All install options', '/start/install/index.md'),
+          linkParagraph('All install options', agentMarkdownUrl('/start/install/index.md')),
         ];
       }
       if (node.name === 'a') {

--- a/website/scripts/generate-agent-docs.mjs
+++ b/website/scripts/generate-agent-docs.mjs
@@ -107,6 +107,17 @@ function rewriteNodes(nodes) {
           codeBlock('curl -fsSL https://pentect.dev/install-apt.sh | sudo sh', 'sh'),
         ];
       }
+      if (node.name === 'QuickInstall') {
+        return [
+          heading('Install', 2),
+          paragraph('Use the recommended installer for your operating system, or open the install page for every package manager.'),
+          heading('PowerShell — Windows', 3),
+          codeBlock('irm https://pentect.dev/install | iex', 'powershell'),
+          heading('Shell — macOS and Linux', 3),
+          codeBlock('curl -fsSL https://pentect.dev/install.sh | sh', 'sh'),
+          linkParagraph('All install options', '/start/install/index.md'),
+        ];
+      }
       if (node.name === 'a') {
         return [rewriteAnchor(node)];
       }
@@ -220,6 +231,17 @@ function paragraph(value) {
   return {
     type: 'paragraph',
     children: [{ type: 'text', value }],
+  };
+}
+
+function linkParagraph(label, url) {
+  return {
+    type: 'paragraph',
+    children: [{
+      type: 'link',
+      url,
+      children: [{ type: 'text', value: label }],
+    }],
   };
 }
 

--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -32,6 +32,30 @@ Prerequisites:
 | `pentect claude --upstream URL` | One CLI launch using a gateway that supports Messages |
 | `pentect claude --plugins NAME` | One launch with the selected plugin set |
 
+## Use a clickable App launcher
+
+For regular use, create a separate protected launcher:
+
+```sh
+pentect claude app --install-launcher
+```
+
+Windows adds `Claude via Pentect` under Start menu → Pentect. macOS adds it to
+`~/Applications`. Pin that launcher and use it for protected Desktop sessions.
+It starts the same `pentect claude app` gateways in the background and does not
+modify the official App.
+
+Quit Claude Desktop first. If it is already running, Pentect stops and asks you
+to close it so the new process can receive the proxy settings.
+
+```sh
+pentect claude app --remove-launcher
+```
+
+The launcher uses normal App discovery and the default upstream. Use the
+terminal command when you need a one-time `--app`, `--upstream`, or `--plugins`
+option.
+
 Normal Claude Code arguments pass through directly:
 
 ```sh

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -33,6 +33,30 @@ Prerequisites:
 | `pentect codex --upstream URL` | One CLI launch using a compatible gateway |
 | `pentect codex --plugins NAME` | One launch with the selected plugin set |
 
+## Use a clickable App launcher
+
+For regular use, create a separate protected launcher:
+
+```sh
+pentect codex app --install-launcher
+```
+
+Windows adds `Codex via Pentect` under Start menu → Pentect. macOS adds it to
+`~/Applications`. Pin that launcher and use it for protected App sessions. It
+starts the same `pentect codex app` gateway in the background and does not
+modify the official App.
+
+Quit ChatGPT/Codex first. If it is already running, Pentect stops and asks you
+to close it so the new process can receive the protected routing.
+
+```sh
+pentect codex app --remove-launcher
+```
+
+The launcher uses normal App discovery and your current Codex provider. Use the
+terminal command when you need a one-time `--app`, `--upstream`, or `--plugins`
+option.
+
 Client flags do not need a separator:
 
 ```sh

--- a/website/src/content/docs/clients/upstreams.md
+++ b/website/src/content/docs/clients/upstreams.md
@@ -3,8 +3,9 @@ title: Custom upstreams
 description: Use Pentect with another gateway or local model server.
 ---
 
-Pentect can protect a client and send its requests to another local or remote
-gateway.
+Put Pentect in front of a local model server or an existing gateway. The
+gateway stays in charge of models, provider credentials, routing, and usage
+limits.
 
 ```sh
 pentect codex --upstream http://127.0.0.1:8080/openai/v1
@@ -13,16 +14,8 @@ pentect opencode --model anthropic/claude-sonnet --upstream http://127.0.0.1:808
 pentect pi --model anthropic/claude-sonnet --upstream http://127.0.0.1:8080/openai/v1
 ```
 
-The upstream URL applies to that launch only. Pentect keeps the base path when
-it builds provider URLs.
-
-Pentect runs in front of the gateway. It does not include or replace the
-gateway. The client connects to Pentect, and Pentect sends the protected
-request to the gateway you chose.
-
-The URL may be local or remote. Treat it as a provider endpoint: Pentect sends
-the protected request to it, and the client or gateway supplies authentication.
-Pentect does not copy credentials from one provider configuration into another.
+The URL applies to one launch. Pentect keeps its base path, masks the request,
+and then sends it to that gateway.
 
 ## Use Bifrost
 
@@ -30,7 +23,7 @@ Bifrost lets one OpenAI- or Anthropic-compatible gateway route requests to
 different model providers. Pentect stays in front of it and protects the
 request before Bifrost receives it.
 
-Start a local Bifrost gateway and configure at least one provider:
+Start Bifrost and configure at least one provider:
 
 ```sh
 npx -y @maximhq/bifrost
@@ -63,23 +56,38 @@ pentect pi --upstream http://127.0.0.1:8080/openai/v1 \
 
 :::
 
-If Bifrost virtual-key authentication is enabled, give Pentect the complete
-authorization value before launching the client:
+### Virtual keys
+
+Keep the key in an environment variable and tell Pentect which request header
+should receive it. Only the environment-variable name appears in the command.
+Pentect removes that variable from the launched AI client.
 
 ::: code-group
 
 ```powershell [PowerShell]
-$env:PENTECT_UPSTREAM_AUTHORIZATION = "Bearer bf-your-virtual-key"
+$secret = Read-Host "Bifrost virtual key" -AsSecureString
+$env:BIFROST_API_KEY = [Net.NetworkCredential]::new('', $secret).Password
+pentect codex --upstream http://127.0.0.1:8080/openai/v1 `
+  --upstream-header-env x-bf-vk=BIFROST_API_KEY
 ```
 
 ```sh [Shell]
-export PENTECT_UPSTREAM_AUTHORIZATION="Bearer bf-your-virtual-key"
+read -rsp "Bifrost virtual key: " BIFROST_API_KEY && echo
+export BIFROST_API_KEY
+pentect codex --upstream http://127.0.0.1:8080/openai/v1 \
+  --upstream-header-env x-bf-vk=BIFROST_API_KEY
 ```
 
 :::
 
-Do not put a real virtual key in a project file or command history. Bifrost's
-dashboard and request logs remain available at `http://127.0.0.1:8080` and
+`x-bf-vk` is Bifrost's dedicated virtual-key header. You can repeat
+`--upstream-header-env HEADER=ENV_NAME` when another gateway needs more than
+one header. Pentect replaces matching client headers and does not forward the
+client's original provider credential when a custom upstream credential is
+configured.
+
+Do not put a real key in a project file or command argument. Bifrost's dashboard
+and request logs remain available at `http://127.0.0.1:8080` and
 `http://127.0.0.1:8080/logs`. See the
 [Bifrost agent guide](https://docs.getbifrost.ai/cli-agents/overview) for
 provider setup, virtual keys, and model IDs.
@@ -100,11 +108,11 @@ Responses, and Claude still needs Messages. Use a gateway when the server does
 not provide the format required by the selected client. Pentect does not
 translate arbitrary provider APIs itself.
 
-## Base paths and authentication
+## Base paths
 
 Pass the base URL for the provider API, not a URL for one model. For example,
 Pentect keeps `http://127.0.0.1:8080/openai/v1` when it builds a Responses API
-URL. The client or gateway still sends the login data.
+URL.
 
 | Client | Required API format | Example base path |
 | --- | --- | --- |

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -1,32 +1,22 @@
 ---
 title: Docs_
-description: Protect sensitive data before it reaches an AI model, while local tools keep working.
+description: AI can use your secrets without ever seeing them.
 pageClass: docs-hub
 aside: false
 ---
 
-Pentect runs locally between supported AI clients and their providers. It
-replaces sensitive values with useful handles, then restores those handles only
-when a trusted local tool needs the value.
-
-<div class="home-flow" aria-label="How Pentect protects a request">
-  <div class="home-flow__step" data-number="01" data-title="Detect locally" data-description="Check text, config files, uploads, images, and tool output."><small>01</small><strong>Detect locally</strong><span>Check text, config files, uploads, images, and tool output.</span></div>
-  <div class="home-flow__step" data-number="02" data-title="Send a handle" data-description="The provider sees a DATABASE_URL handle, not the value."><small>02</small><strong>Send a handle</strong><span>The provider sees <code>&lt;&lt;DATABASE_URL_...&gt;&gt;</code>, not the value.</span></div>
-  <div class="home-flow__step" data-number="03" data-title="Use it locally" data-description="Restore known handles only at a trusted tool boundary."><small>03</small><strong>Use it locally</strong><span>Restore known handles only at a trusted tool boundary.</span></div>
-</div>
-
-<HomeInstall />
+<QuickInstall />
 
 ## Clients
 
 <DocsGrid class="is-compact">
   <a href="/clients/codex/" class="docs-grid__item">
-    <small>CLI</small><strong>Codex CLI</strong>
-    <span>Run Codex through Pentect for the current session.</span><b aria-hidden="true">→</b>
+    <small>CLI + Desktop</small><strong>Codex</strong>
+    <span>Protect Codex CLI or launch Codex App through Pentect.</span><b aria-hidden="true">→</b>
   </a>
   <a href="/clients/claude/" class="docs-grid__item">
-    <small>CLI</small><strong>Claude Code</strong>
-    <span>Protect Claude Code requests with Pentect.</span><b aria-hidden="true">→</b>
+    <small>Code + Desktop</small><strong>Claude</strong>
+    <span>Protect Claude Code or supported Claude Desktop traffic.</span><b aria-hidden="true">→</b>
   </a>
   <a href="/clients/opencode/" class="docs-grid__item">
     <small>CLI</small><strong>OpenCode</strong>
@@ -36,19 +26,15 @@ when a trusted local tool needs the value.
     <small>CLI</small><strong>Pi</strong>
     <span>Run Pi through a temporary protected provider.</span><b aria-hidden="true">→</b>
   </a>
-  <a href="/clients/codex/" class="docs-grid__item">
-    <small>Desktop</small><strong>Codex App</strong>
-    <span>Start one Codex App session through Pentect.</span><b aria-hidden="true">→</b>
-  </a>
-  <a href="/clients/claude/" class="docs-grid__item">
-    <small>Desktop</small><strong>Claude Desktop</strong>
-    <span>Protect supported Claude Desktop traffic.</span><b aria-hidden="true">→</b>
-  </a>
 </DocsGrid>
 
 ## Explore
 
 <DocsGrid>
+  <a href="/protection/prompts-and-tools/" class="docs-grid__item">
+    <strong>Prompts and tool results</strong>
+    <span>Protect pasted secrets, accidental output, MCP results, and browser screenshots.</span><b aria-hidden="true">→</b>
+  </a>
   <a href="/start/how-it-works/" class="docs-grid__item">
     <strong>How it works</strong>
     <span>See how Pentect protects and restores a value.</span><b aria-hidden="true">→</b>

--- a/website/src/content/docs/protection/files-and-images.md
+++ b/website/src/content/docs/protection/files-and-images.md
@@ -55,19 +55,22 @@ coverage for that upload. An unrelated or old ID is not trusted by name.
 
 ## Images
 
-OCR runs on your computer. Pentect covers sensitive areas before it sends the
-image. Limits control the number of images, file size, image size, download
-time, and total check time.
+When OCR is enabled, it runs on your computer and Pentect covers detected
+sensitive areas before sending the image. Limits control the number of images,
+file size, image size, download time, and total check time.
 
 This also applies when a supported browser or MCP tool returns a screenshot as
-part of a tool result. Pentect checks the image before that result enters the
-next provider request. If the tool also returns page text, HTML, clipboard
+part of a tool result. Pentect applies the configured image policy before that
+result enters the next provider request. If the tool also returns page text, HTML, clipboard
 text, or structured JSON, Pentect checks those values as text.
 
 For example, when an agent creates an API key in a browser, the key may appear
 in a page snapshot, structured tool result, or screenshot. Supported text
-results become handles. Supported screenshots are scanned locally and any
-detected sensitive pixels are covered.
+results become handles. With OCR enabled, supported screenshots are scanned
+locally and detected sensitive pixels are covered. If OCR is disabled or a
+scan cannot finish, the `unscanned` policy decides whether to block the image
+or send it unchecked; `unscanned = "allow"` can expose content Pentect did not
+inspect.
 
 OCR also checks text found in QR codes and common barcodes. Pentect removes
 supported image metadata when it rewrites an image. A scan can still miss text,

--- a/website/src/content/docs/protection/files-and-images.md
+++ b/website/src/content/docs/protection/files-and-images.md
@@ -59,6 +59,16 @@ OCR runs on your computer. Pentect covers sensitive areas before it sends the
 image. Limits control the number of images, file size, image size, download
 time, and total check time.
 
+This also applies when a supported browser or MCP tool returns a screenshot as
+part of a tool result. Pentect checks the image before that result enters the
+next provider request. If the tool also returns page text, HTML, clipboard
+text, or structured JSON, Pentect checks those values as text.
+
+For example, when an agent creates an API key in a browser, the key may appear
+in a page snapshot, structured tool result, or screenshot. Supported text
+results become handles. Supported screenshots are scanned locally and any
+detected sensitive pixels are covered.
+
 OCR also checks text found in QR codes and common barcodes. Pentect removes
 supported image metadata when it rewrites an image. A scan can still miss text,
 especially with low contrast, unusual writing, or unsupported image content.
@@ -94,3 +104,5 @@ If a file is blocked:
 
 See [Configuration](/reference/configuration/) for limits and
 [Troubleshooting](/reference/troubleshooting/) for unknown-format recovery.
+See [Prompts and tool results](/protection/prompts-and-tools/) for browser, MCP,
+clipboard, and accidental-output examples.

--- a/website/src/content/docs/protection/prompts-and-tools.md
+++ b/website/src/content/docs/protection/prompts-and-tools.md
@@ -1,0 +1,133 @@
+---
+title: Prompts and tool results
+description: See how Pentect protects pasted secrets, accidental output, MCP results, and browser screenshots.
+---
+
+Secrets do not only come from `.env` files. They can appear in a prompt, a
+terminal response, a browser page, structured MCP data, or a screenshot.
+Pentect checks these values before the supported client sends its next request
+to the model provider.
+
+## A secret pasted into a prompt
+
+You may paste a token while asking the agent to test an API:
+
+```text
+Test the account with OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX
+```
+
+When the protected client sends that prompt, Pentect replaces the detected
+value first:
+
+```text
+Test the account with OPENAI_API_KEY=<<OPENAI_API_KEY_...>>
+```
+
+The client UI can still show what you typed locally. The provider receives the
+protected request. This applies only when the client was started through
+Pentect and the request uses a supported format.
+
+## A secret appears by accident
+
+A tool may print more than expected. Common examples include:
+
+- a command that prints its environment;
+- a log containing a connection string;
+- a file-read result containing a token;
+- clipboard text copied from an admin page;
+- JSON returned by an MCP server or connector.
+
+Pentect checks supported tool results before they become part of the next model
+request. Text and structured values are replaced with handles. The model can
+continue using the safe reference without receiving the original value.
+
+This protection happens on the provider boundary. Pentect cannot take back a
+value that another program already sent outside the protected flow.
+
+## An MCP browser creates an API key
+
+An agent can use a browser tool to create a credential without asking you to
+copy it into chat. A protected flow looks like this:
+
+1. The model asks the local browser or MCP tool to create the key.
+2. The website shows the new key on your computer.
+3. The tool returns page text, HTML, JSON, clipboard text, or an image.
+4. Pentect checks the supported tool result before the client sends it back to
+   the provider.
+5. The provider sees a handle such as `<<APIKEY_...>>`.
+6. A later local tool can use that known handle through the protected tool
+   boundary or its `PENTECT_<LABEL>_<ID>` environment binding.
+
+For example, an MCP result like this:
+
+```json
+{
+  "structuredContent": {
+    "apiKey": "sk-ABCDEFGHIJKLMNOPQRSTUVWX"
+  }
+}
+```
+
+is sent to the provider with the value replaced:
+
+```json
+{
+  "structuredContent": {
+    "apiKey": "<<APIKEY_...>>"
+  }
+}
+```
+
+Pentect does not grant the browser permission to create or use a key. Browser
+confirmation, site permissions, and the MCP server's own access rules still
+apply. If the browser tool sends a secret directly to a website, that network
+side effect happens outside Pentect's provider boundary.
+
+## Screenshots and OCR
+
+A screenshot may contain a token even when the tool result has no useful text.
+For supported image payloads, Pentect runs OCR locally and covers detected
+sensitive regions before the image is sent to the provider.
+
+Pentect also checks text found in supported QR codes and barcodes. When an
+image must be rewritten, it removes supported metadata and sends protected
+pixels instead of the original image.
+
+If an image cannot be checked, the default setting blocks it. You can choose to
+allow unchecked media, but then the provider may receive content Pentect did
+not inspect:
+
+```toml
+[image]
+unscanned = "allow"
+```
+
+OCR is not perfect. Low contrast, small text, unusual fonts, handwriting,
+cropped content, or an unsupported image format can be missed. Keep browser
+and tool permissions limited even when OCR is enabled.
+
+See [Files and images](/protection/files-and-images/) for supported formats,
+limits, remote URLs, PDF behavior, and image settings.
+
+## What is covered
+
+| Source | What Pentect does before the provider request |
+| --- | --- |
+| Prompt text | Replaces detected sensitive values with handles |
+| Terminal, file, and log output | Masks supported text returned by a local tool |
+| MCP text or structured result | Checks supported strings and structured fields |
+| Clipboard text returned by a tool | Masks detected values |
+| Supported screenshot or inline image | Runs local OCR and covers detected regions |
+| Unknown media or result format | Blocks it by default when it cannot be checked safely |
+
+## What is not covered
+
+- A request made by a client that was not started through Pentect
+- Data already sent before Pentect saw it
+- A direct network side effect performed inside a browser, MCP server, or local
+  tool
+- Content hidden in an unsupported or unchecked format
+- A sensitive value that no detector or OCR engine finds
+
+Pentect reduces exposure to the model provider. It does not replace browser
+approval, MCP permissions, restricted credentials, or normal access control.

--- a/website/src/content/docs/protection/prompts-and-tools.md
+++ b/website/src/content/docs/protection/prompts-and-tools.md
@@ -86,16 +86,16 @@ side effect happens outside Pentect's provider boundary.
 ## Screenshots and OCR
 
 A screenshot may contain a token even when the tool result has no useful text.
-For supported image payloads, Pentect runs OCR locally and covers detected
-sensitive regions before the image is sent to the provider.
+With OCR enabled, Pentect scans supported image payloads locally and covers
+detected sensitive regions before the image is sent to the provider.
 
 Pentect also checks text found in supported QR codes and barcodes. When an
 image must be rewritten, it removes supported metadata and sends protected
 pixels instead of the original image.
 
-If an image cannot be checked, the default setting blocks it. You can choose to
-allow unchecked media, but then the provider may receive content Pentect did
-not inspect:
+If OCR is disabled or an image cannot be checked, the default setting blocks
+it. You can choose to allow unchecked media, but then the provider may receive
+content Pentect did not inspect:
 
 ```toml
 [image]

--- a/website/src/content/docs/protection/security-model.md
+++ b/website/src/content/docs/protection/security-model.md
@@ -19,8 +19,9 @@ permissions.
   added to the model request.
 - Pentect restores known handles only before supported local tools run.
 - Tool output is masked before it returns to the provider.
-- Supported MCP and connector results are checked as text, structured data, or
-  media before they enter the next provider request.
+- Supported MCP and connector text and structured data are checked before they
+  enter the next provider request. Media follows the configured OCR and
+  `unscanned` policy; allowing unchecked media can bypass inspection.
 - Unknown provider formats and unsupported content are blocked by default.
 - Wasm plugins cannot directly use WASI, files, environment variables,
   processes, or network sockets.

--- a/website/src/content/docs/protection/security-model.md
+++ b/website/src/content/docs/protection/security-model.md
@@ -19,6 +19,8 @@ permissions.
   added to the model request.
 - Pentect restores known handles only before supported local tools run.
 - Tool output is masked before it returns to the provider.
+- Supported MCP and connector results are checked as text, structured data, or
+  media before they enter the next provider request.
 - Unknown provider formats and unsupported content are blocked by default.
 - Wasm plugins cannot directly use WASI, files, environment variables,
   processes, or network sockets.
@@ -52,6 +54,7 @@ do not receive them.
 
 - Finding every possible secret or type of personal data
 - Safety after a trusted local tool sends a credential to another service
+- Protection for a browser or MCP server's direct network side effects
 - Protection for unsupported clients, hidden binary traffic, or future routes
 - A replacement for limited permissions, key changes, network rules, or client
   sandboxes
@@ -75,6 +78,9 @@ silently turning off the default check.
 See [Unknown provider format troubleshooting](/reference/troubleshooting/#an-unknown-provider-format-was-blocked)
 for protected alternatives, copyable setup commands, restart instructions, and
 how to restore the default.
+
+For concrete prompt, MCP, browser, and screenshot flows, read
+[Prompts and tool results](/protection/prompts-and-tools/).
 
 ::: danger
 Compatibility mode can send content that Pentect does not understand. Do not

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -26,15 +26,15 @@ proxy for the whole system or replace the client UI.
 | Capability | Behavior |
 | --- | --- |
 | Prompts and tool results | Replaces sensitive text before supported requests are sent |
-| MCP and connector results | Checks supported text, structured values, clipboard text, and media |
+| MCP and connector results | Checks supported text, structured values, and clipboard text; media follows the image policy |
 | Completed tool calls | Restores known handles just before a trusted local tool runs |
 | Command output | Masks stdout and stderr before they return to the model |
 | Structured config | Uses field names and syntax to create useful labels |
 | UTF-8 uploads | Checks and rewrites supported Files API content |
 | Documents | Checks supported document formats sent in a request |
-| Images | Runs local OCR and covers sensitive areas |
+| Images | With OCR enabled, scans locally and covers detected areas; unchecked media follows `image.unscanned` |
 | QR codes and barcodes | Checks the text found in codes inside images |
-| Browser screenshots | Runs local OCR before supported screenshot results reach the provider |
+| Browser screenshots | Applies the configured OCR and unchecked-media policy before supported results reach the provider |
 | Unknown provider structures | Returns an error by default |
 
 Pentect checks for secrets and personal data. Supported config formats include

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -26,6 +26,7 @@ proxy for the whole system or replace the client UI.
 | Capability | Behavior |
 | --- | --- |
 | Prompts and tool results | Replaces sensitive text before supported requests are sent |
+| MCP and connector results | Checks supported text, structured values, clipboard text, and media |
 | Completed tool calls | Restores known handles just before a trusted local tool runs |
 | Command output | Masks stdout and stderr before they return to the model |
 | Structured config | Uses field names and syntax to create useful labels |
@@ -33,6 +34,7 @@ proxy for the whole system or replace the client UI.
 | Documents | Checks supported document formats sent in a request |
 | Images | Runs local OCR and covers sensitive areas |
 | QR codes and barcodes | Checks the text found in codes inside images |
+| Browser screenshots | Runs local OCR before supported screenshot results reach the provider |
 | Unknown provider structures | Returns an error by default |
 
 Pentect checks for secrets and personal data. Supported config formats include

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -18,8 +18,42 @@ cannot complete a requested change.
 | `pentect codex app` | Launch Codex App for this protected session |
 | `pentect claude app` | Launch Claude Desktop for this protected session |
 
+For Codex and Claude, `--set-default` adds a reviewed function to the current
+shell's user profile. The normal `codex` or `claude` command then launches
+through Pentect. `--unset-default` removes only the block Pentect added.
+
+```sh
+pentect codex --set-default
+pentect codex --unset-default
+```
+
+PowerShell, Bash, Zsh, and Fish are supported. Add `--yes` only in automation
+where you have already reviewed the profile change.
+
+### App launchers
+
+Add an optional clickable launcher for a desktop App:
+
+```sh
+pentect codex app --install-launcher
+pentect claude app --install-launcher
+```
+
+| Option | Result |
+| --- | --- |
+| `--install-launcher` | Add or refresh the current user's Pentect launcher |
+| `--remove-launcher` | Remove only the launcher owned by Pentect |
+| `--yes` | Skip the confirmation in reviewed automation |
+
+Windows and macOS are supported. Both commands show the exact target and ask
+before changing it. The launcher does not store a custom `--app`, `--upstream`,
+or `--plugins` value; use the normal terminal launch for those one-time options.
+
 Use `--upstream URL` to choose a compatible gateway for one launch. Use
-`--plugins SOURCE` to add a plugin for one launch. App commands also support
+`--upstream-header-env HEADER=ENV_NAME` to add a gateway credential without
+putting its value in command arguments. The source variable is removed from the
+launched client process. Use `--plugins SOURCE` to add a plugin for one launch.
+App commands also support
 `--app PATH` and `--check`.
 
 Codex and Claude arguments are forwarded directly:

--- a/website/src/content/docs/start/examples.md
+++ b/website/src/content/docs/start/examples.md
@@ -6,6 +6,52 @@ description: Copyable ways to use Pentect in everyday work.
 Each example uses fake data. Start a client through Pentect before you use a
 handle in that client.
 
+## Paste a secret into a prompt
+
+If you paste a credential into a protected client, Pentect checks it before the
+request leaves your computer:
+
+```text
+Use OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX to test the account.
+```
+
+The provider receives a handle instead of the detected value:
+
+```text
+Use OPENAI_API_KEY=<<OPENAI_API_KEY_...>> to test the account.
+```
+
+The original text can remain visible in the local client UI. This protection
+applies to requests sent through a supported Pentect launch.
+
+## Keep an accidental tool result local
+
+An agent may run a command that prints a token, read a sensitive log line, or
+receive a secret in clipboard text. Pentect checks supported tool output before
+the next provider request and replaces the value with a handle.
+
+The same rule applies to supported MCP results. Text, JSON fields, page
+snapshots, and clipboard data can be protected even when the agent did not know
+that the tool would return a secret.
+
+## Create an API key with a browser tool
+
+Suppose an MCP browser opens an admin page and creates a new key. The tool may
+return it as structured data:
+
+```json
+{"apiKey":"sk-ABCDEFGHIJKLMNOPQRSTUVWX"}
+```
+
+Before the result is sent back to the provider, Pentect changes the value to a
+handle such as `<<APIKEY_...>>`. A later local tool can use the known handle
+without the provider receiving the key.
+
+If the browser returns only a screenshot, Pentect uses local OCR and covers
+detected sensitive regions. Read
+[Prompts and tool results](/protection/prompts-and-tools/) for the full flow and
+[Files and images](/protection/files-and-images/) for OCR limits.
+
 ## Read a config file safely
 
 Ask a protected Codex or Claude session to read `.env`. The provider receives
@@ -43,34 +89,18 @@ Prefer this to `pentect resolve` when a command can accept the handle directly.
 
 ## Keep your normal client command
 
-Add a small function to your shell profile. Client arguments still pass
-through:
+Let Pentect add the shell function after showing it to you:
 
-::: code-group
-
-```powershell [PowerShell]
-function codex { & pentect codex @args }
-function claude { & pentect claude @args }
+```sh
+pentect codex --set-default
+pentect claude --set-default
 ```
-
-```sh [Bash / Zsh]
-codex() { command pentect codex "$@"; }
-claude() { command pentect claude "$@"; }
-```
-
-```fish [Fish]
-function codex
-    command pentect codex $argv
-end
-function claude
-    command pentect claude $argv
-end
-```
-
-:::
 
 Now commands such as `codex exec --full-auto` and `claude --model sonnet` use
 Pentect without changing their normal arguments.
+
+Undo the change with `pentect codex --unset-default` or `pentect claude
+--unset-default`.
 
 ## Use a local model or gateway
 

--- a/website/src/content/docs/start/how-it-works.md
+++ b/website/src/content/docs/start/how-it-works.md
@@ -8,8 +8,8 @@ requests and responses without changing the client UI.
 
 1. **Detect locally**
 
-   Pentect checks prompts, tool results, config files, uploads, and images
-   before they are sent to the provider.
+   Pentect checks text typed into a prompt, tool and MCP results, config files,
+   uploads, and images before they are sent to the provider.
 
 2. **Replace the value with a handle**
 
@@ -49,6 +49,10 @@ requests and responses without changing the client UI.
 | Local execution | Completed tool arguments | Known handles restored just before the tool runs |
 | Tool result | stdout, stderr, and supported data | Sensitive values replaced before the next request |
 
+A tool result can come from a shell, file reader, browser, connector, or MCP
+server. Supported text and structured fields are checked as they enter the
+next provider request. Supported screenshots use the image path instead.
+
 Pentect works with API fields instead of reading the terminal screen. Streaming
 and normal client controls continue to work.
 
@@ -70,6 +74,9 @@ Text can contain a reusable handle. Images need local OCR and visual masking.
 Unknown binary files follow the unscanned-content setting. See
 [Files and images](/protection/files-and-images/) for details. Plugins can add
 new checks without changing the client setup.
+
+See [Prompts and tool results](/protection/prompts-and-tools/) for examples of
+manual input, unexpected output, browser-created keys, and screenshots.
 
 ## Why handles instead of `[REDACTED]`?
 

--- a/website/src/content/docs/start/install.md
+++ b/website/src/content/docs/start/install.md
@@ -18,6 +18,37 @@ pentect doctor
 `doctor` checks Pentect and the AI clients installed on your machine. To apply
 a fix after reviewing it, run `pentect doctor --fix`.
 
+## Start a client
+
+Use Pentect for one session:
+
+```sh
+pentect codex
+# or
+pentect claude
+```
+
+To keep the shorter client command, ask Pentect to update your shell profile:
+
+```sh
+pentect codex --set-default
+pentect claude --set-default
+```
+
+The change is shown before approval and can be removed later with
+`--unset-default`. See [Quick start](/start/quick-start/) for the full flow.
+
+If you use a desktop App often, install a separate protected launcher:
+
+```sh
+pentect codex app --install-launcher
+pentect claude app --install-launcher
+```
+
+The launcher is optional. It appears as `Codex via Pentect` or `Claude via
+Pentect` and does not replace the official App. Quit the official App before
+opening the protected launcher.
+
 ## Install a specific version
 
 Use the same installer with a version number:
@@ -110,6 +141,15 @@ sudo nixos-rebuild switch --flake .#HOSTNAME
 ```
 
 ## Uninstall
+
+Remove any shell defaults or App launchers first:
+
+```sh
+pentect codex --unset-default
+pentect claude --unset-default
+pentect codex app --remove-launcher
+pentect claude app --remove-launcher
+```
 
 For a direct PowerShell or shell install:
 

--- a/website/src/content/docs/start/quick-start.md
+++ b/website/src/content/docs/start/quick-start.md
@@ -3,8 +3,15 @@ title: Quick start
 description: Protect a real Codex or Claude session in a few commands.
 ---
 
-Install Pentect first, then use one protected launch. You do not need to change
-the permanent settings of Codex or Claude.
+## Install
+
+New to Pentect? [Choose your OS and install method](/start/install/). The
+installation page covers Windows, macOS, Linux, npm, Homebrew, APT, and Nix.
+
+Already installed? Continue below. You do not need to change the permanent
+settings of Codex or Claude.
+
+## Start a protected session
 
 1. Check Pentect and the client.
 
@@ -39,6 +46,17 @@ the permanent settings of Codex or Claude.
 
 ## What success looks like
 
+You can test the request boundary with fake data. Paste this into the protected
+client:
+
+```text
+Remember OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX for this task.
+```
+
+The provider-bound prompt contains an `<<OPENAI_API_KEY_...>>` handle instead
+of the fake value. The same protection applies to supported text returned by a
+terminal, file tool, browser, or MCP server.
+
 If a file contains `DATABASE_URL=postgres://...`, the provider sees a handle
 instead of the credential:
 
@@ -66,34 +84,19 @@ pentect codex exec --full-auto
 pentect claude --model sonnet
 ```
 
-## Launch through Pentect by default
+## Use Pentect from your normal CLI command
 
-Add these functions to your shell profile, then restart the terminal. Existing
-Codex and Claude arguments continue to work normally.
+This step is optional. If you want `codex` or `claude` to use Pentect without
+typing the `pentect` prefix, run:
 
-::: code-group
-
-```powershell [PowerShell · $PROFILE]
-function codex { & pentect codex @args }
-function claude { & pentect claude @args }
+```sh
+pentect codex --set-default
+pentect claude --set-default
 ```
 
-```sh [Bash · ~/.bashrc or Zsh · ~/.zshrc]
-codex() { command pentect codex "$@"; }
-claude() { command pentect claude "$@"; }
-```
-
-```fish [Fish · ~/.config/fish/config.fish]
-function codex
-    command pentect codex $argv
-end
-
-function claude
-    command pentect claude $argv
-end
-```
-
-:::
+Pentect detects PowerShell, Bash, Zsh, or Fish. Before changing anything, it
+shows the profile path and the function it will add. It also backs up an
+existing profile. Restart the terminal after you approve the change.
 
 After that, launch either client as usual:
 
@@ -101,6 +104,45 @@ After that, launch either client as usual:
 codex exec --full-auto
 claude --model sonnet
 ```
+
+Remove only the profile block created by Pentect with:
+
+```sh
+pentect codex --unset-default
+pentect claude --unset-default
+```
+
+## Add a clickable App launcher
+
+This is also optional. Add a separate protected launcher for the desktop App:
+
+```sh
+pentect codex app --install-launcher
+pentect claude app --install-launcher
+```
+
+| System | Launcher location |
+| --- | --- |
+| Windows | Start menu → Pentect |
+| macOS | `~/Applications` |
+
+Pin `Codex via Pentect` or `Claude via Pentect` to the taskbar or Dock. The
+launcher starts the same local Pentect gateway as the terminal command, without
+leaving a terminal window open. The official App and its shortcut are not
+changed.
+
+Quit the official App before using the protected launcher. An App that is
+already running cannot inherit the temporary Pentect routing.
+
+Remove the launcher with:
+
+```sh
+pentect codex app --remove-launcher
+pentect claude app --remove-launcher
+```
+
+The remove command checks that Pentect created the launcher. It will not delete
+an unrelated shortcut or App with the same name.
 
 ## Try masking without an agent
 
@@ -118,8 +160,8 @@ Get-Content .env -Raw | pentect mask
 The output contains reusable handles. Pentect does not print the real values.
 
 ::: tip
-These functions affect only that shell. Pentect protects clients started by the
-functions. It does not create a proxy for the whole system.
+The default is optional. It affects only supported clients started from that
+shell; it does not create a proxy for the whole system.
 :::
 
 ## Next steps
@@ -128,5 +170,7 @@ functions. It does not create a proxy for the whole system.
 - See [Structured data](/protection/structured-data/) for dotenv, Terraform, Kubernetes, and JSON behavior.
 - Read [Handles](/start/handles/) before copying handles between sessions or scripts.
 - Review [Files and images](/protection/files-and-images/) before sending uploads.
+- See [Prompts and tool results](/protection/prompts-and-tools/) for pasted
+  secrets, accidental output, MCP browsers, and screenshots.
 - Run `pentect doctor` again after changing a client installation or provider.
 - Copy a complete task from [Examples](/start/examples/).

--- a/website/src/content/docs/start/what-is-pentect.md
+++ b/website/src/content/docs/start/what-is-pentect.md
@@ -62,10 +62,18 @@ Pentect fits work where an AI agent must read configuration, inspect logs, or
 call a local tool without sending every credential and private field to the
 model provider. Common examples are:
 
+- pasting a credential into a prompt by mistake;
+- masking a secret that appears in terminal output, logs, or clipboard text;
+- letting an MCP browser create a new API key without returning the real value
+  to the model provider;
+- covering sensitive text in a browser screenshot with local OCR;
 - coding with `.env`, Terraform, Kubernetes, cloud, npm, or PyPI settings;
 - letting an agent call an API with a credential already on the computer;
 - checking documents and screenshots before they enter a supported request;
 - adding a company-specific detector through a reviewed plugin.
+
+See [Prompts and tool results](/protection/prompts-and-tools/) for the complete
+flow from local input to provider request.
 
 It is less useful for a client that never exposes a supported local API route,
 or for a workflow that already sends the original value outside the protected


### PR DESCRIPTION
## Summary
- redesign the docs home, install flow, navigation, and client guidance
- add persistent CLI defaults and desktop App launchers
- add safe custom-upstream header injection from environment variables
- document prompts, MCP/browser tools, screenshots, OCR, files, and custom gateways

## Verification
- cargo check -p pentect-cli --tests
- npm --prefix website run build
- git diff --check

Antigravity CLI remains tracked in #203 until its model transport can be intercepted without relying on non-transforming hooks or an undocumented endpoint contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Set or remove default Codex and Claude shell integrations.
  - Install or remove protected clickable desktop launchers on Windows and macOS.
  - Configure custom upstream headers securely for Codex and Claude sessions.
  - Added automatic secret protection for prompts, tool results, screenshots, OCR text, QR codes, and barcodes.
  - Added platform-aware installation commands with copy-to-clipboard support.

- **Documentation**
  - Expanded installation, launcher, custom upstream, security, and protection guidance.
  - Added examples for masking credentials across prompts, tools, browsers, and images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->