### PR TITLE
fix(docs): restore install platform selector

### DIFF
--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -5,7 +5,7 @@ pageClass: docs-hub
 aside: false
 ---
 
-<QuickInstall />
+<HomeInstall />
 
 ## Clients
 


### PR DESCRIPTION
## Summary
- restore the full install selector on the docs homepage
- keep OS detection only as the initial selection
- let visitors switch between Windows, macOS, and Linux regardless of the viewing device

## Verification
- npm --prefix website run build