### PR TITLE
docs: refine quick start link

### DIFF
--- a/website/.vitepress/theme/HomeInstall.vue
+++ b/website/.vitepress/theme/HomeInstall.vue
@@ -310,10 +310,12 @@ onMounted(() => {
     <p v-if="copyState === 'failed'" class="home-install__status" role="status">
       Select the command and copy it manually.
     </p>
-    <a class="home-install__next" href="/start/quick-start/">
-      <span>Installed?</span>
-      <strong>Continue to Quick start</strong>
-      <span aria-hidden="true">→</span>
-    </a>
+    <div class="home-install__next">
+      <span class="home-install__next-label">Installed?</span>
+      <a class="home-install__next-link" href="/start/quick-start/">
+        <span>Continue to Quick start</span>
+        <span aria-hidden="true">→</span>
+      </a>
+    </div>
   </section>
 </template>

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -448,28 +448,42 @@ body {
   align-items: center;
   gap: 8px;
   padding: 18px 0;
-  color: var(--vp-c-text-1);
   font-size: 14px;
-  text-decoration: none;
 }
 
-.home-install__next span:first-child {
+.home-install__next-label {
+  color: var(--vp-c-text-3);
+}
+
+.vp-doc .home-install__next-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   color: var(--vp-c-text-2);
-}
-
-.home-install__next strong {
   font-weight: 600;
+  text-decoration: none;
+  transition: color 140ms ease;
 }
 
-.home-install__next span:last-child {
+.home-install__next-link span:first-child {
+  border-bottom: 1px solid color-mix(in srgb, currentcolor 45%, transparent);
+  line-height: 1.35;
+}
+
+.home-install__next-link span:last-child {
+  color: var(--vp-c-text-3);
   transition: transform 140ms ease;
 }
 
-.home-install__next:hover {
-  color: var(--vp-c-brand-1);
+.vp-doc .home-install__next-link:hover {
+  color: var(--vp-c-text-1);
 }
 
-.home-install__next:hover span:last-child {
+.home-install__next-link:hover span:first-child {
+  border-bottom-color: var(--vp-c-brand-1);
+}
+
+.home-install__next-link:hover span:last-child {
   transform: translateX(3px);
 }
 


### PR DESCRIPTION
## What changed

- separate the non-link Installed? label from the Quick start link
- limit the underline to the linked text
- use neutral colors by default and the Pentect accent only on hover

## Why

The previous single-anchor layout made both phrases look linked and the red treatment was too strong.

## Validation

- npm --prefix website run build
- 30 generated pages and 82 internal links checked
- Playwright visual check in light and dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the Quick start navigation layout by separating the “Installed?” label from the link.
  * Added clearer link, underline, arrow, spacing, and hover styling for improved visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->