### PR TITLE
docs: separate client basics from upstream setup

### DIFF
--- a/website/src/content/docs/clients/antigravity.md
+++ b/website/src/content/docs/clients/antigravity.md
@@ -3,11 +3,16 @@ title: Antigravity CLI
 description: Run the official Antigravity CLI through Pentect.
 ---
 
-Launch the official `agy` command through Pentect:
+Start a protected Antigravity CLI session:
 
 ```sh
 pentect antigravity
 ```
+
+Google sign-in works as usual. Pentect changes routing only for the launched
+process and does not edit Antigravity settings or install a certificate.
+
+## Pass Antigravity arguments
 
 `pentect agy` is a shorter alias. Normal Antigravity arguments pass through:
 
@@ -15,37 +20,13 @@ pentect antigravity
 pentect agy --print "Review this project"
 ```
 
-Pentect gives only the child process a temporary `CLOUD_CODE_URL`. The official
-CLI keeps its normal Google sign-in and sends Cloud Code model requests through
-the local Pentect gateway. Pentect does not edit Antigravity settings or install
-a certificate.
+## What Pentect protects
 
 Pentect checks prompts, function results, inline text and images, streaming
 responses, and function calls. A known handle stays visible to the model and is
 restored only inside a function call that returns to the local client. Unknown
 Cloud Code routes and content parts are blocked by default.
 
-## Existing Cloud Code endpoint
-
-If `CLOUD_CODE_URL` already points to a compatible endpoint, Pentect uses it as
-the upstream and places the local gateway in front of it. You can also select an
-endpoint for one launch:
-
-```sh
-pentect antigravity --upstream https://cloud-code.example
-```
-
-Add a gateway credential without putting its value in command history:
-
-```sh
-PENTECT_GATEWAY_AUTH="Bearer example" \
-  pentect antigravity \
-  --upstream https://cloud-code.example \
-  --upstream-header-env Authorization=PENTECT_GATEWAY_AUTH
-```
-
-The source environment variable is removed from the `agy` process. The header
-is added only by Pentect when it contacts the selected upstream.
-
-Pentect protects the Cloud Code model boundary. Google sign-in and unrelated
-Antigravity services continue to use their normal endpoints.
+Using another Cloud Code-compatible endpoint is optional. See
+[Custom upstreams](/clients/upstreams/#antigravity-and-cloud-code) for endpoint
+selection and gateway credentials.

--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -29,7 +29,6 @@ Prerequisites:
 | --- | --- |
 | `pentect claude` | One Claude Code process and its children |
 | `pentect claude app` | One supported Claude Desktop launch |
-| `pentect claude --upstream URL` | One CLI launch using a gateway that supports Messages |
 | `pentect claude --plugins NAME` | One launch with the selected plugin set |
 
 ## Use a clickable App launcher
@@ -52,9 +51,8 @@ to close it so the new process can receive the proxy settings.
 pentect claude app --remove-launcher
 ```
 
-The launcher uses normal App discovery and the default upstream. Use the
-terminal command when you need a one-time `--app`, `--upstream`, or `--plugins`
-option.
+The launcher uses normal App discovery and the default provider. Use the
+terminal command when you need a one-time `--app` or `--plugins` option.
 
 Normal Claude Code arguments pass through directly:
 
@@ -74,6 +72,8 @@ environment bindings. The instructions contain labels and syntax, not real
 secret values. Claude can use a binding directly in a tool call instead of
 rereading the source file.
 
+## Custom gateways
+
 ```sh
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 ```
@@ -85,6 +85,9 @@ and completed tool calls.
 An endpoint that accepts similar JSON but does not implement Anthropic Messages
 and its streaming events is not supported. Put a compatible adapter in front of
 that endpoint and pass the adapter base URL with `--upstream`.
+
+See [Custom upstreams](/clients/upstreams/) for compatible gateway setup,
+credentials, and troubleshooting.
 
 ## Claude Desktop
 

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -30,7 +30,6 @@ Prerequisites:
 | --- | --- |
 | `pentect codex` | One Codex CLI process and its children |
 | `pentect codex app` | One Codex App launch |
-| `pentect codex --upstream URL` | One CLI launch using a compatible gateway |
 | `pentect codex --plugins NAME` | One launch with the selected plugin set |
 
 ## Use a clickable App launcher
@@ -54,8 +53,7 @@ pentect codex app --remove-launcher
 ```
 
 The launcher uses normal App discovery and your current Codex provider. Use the
-terminal command when you need a one-time `--app`, `--upstream`, or `--plugins`
-option.
+terminal command when you need a one-time `--app` or `--plugins` option.
 
 Client flags do not need a separator:
 
@@ -75,7 +73,7 @@ Codex how to use handles and their local environment bindings. These
 instructions contain no real secret values. They prevent the agent from
 rereading a file only because it sees a handle.
 
-## Existing providers
+## Custom gateways
 
 Pentect keeps your current Codex provider when it uses a supported API format.
 You can also choose a provider or gateway for one launch:
@@ -89,7 +87,9 @@ selected provider still manage login details and credentials.
 
 An OpenAI Chat Completions endpoint is not enough. Codex needs the Responses
 request and streaming event format. Use an API adapter such as Bifrost when the
-model server exposes a different contract.
+model server exposes a different contract. See
+[Custom upstreams](/clients/upstreams/) for setup, credentials, and
+troubleshooting.
 
 ## Codex App
 

--- a/website/src/content/docs/clients/opencode.md
+++ b/website/src/content/docs/clients/opencode.md
@@ -7,11 +7,9 @@ description: Run OpenCode through a temporary Pentect provider.
 pentect opencode --model openai/gpt-5
 ```
 
-Pentect adds an OpenAI-compatible provider to `OPENCODE_CONFIG_CONTENT` for
-this process only. It does not edit `opencode.json` or change normal OpenCode
-launches. The main model, small model, and provider allowlist are fixed to the
-temporary provider for this launch, so background tasks and subagents cannot
-select an unprotected provider.
+Pentect protects this OpenCode launch only. It does not edit `opencode.json` or
+change normal OpenCode launches. Background tasks and subagents use the same
+protected provider during the session.
 
 Normal OpenCode arguments pass through. A model flag may appear anywhere:
 
@@ -26,6 +24,8 @@ it:
 pentect opencode --api responses --model gpt-5
 ```
 
+## Custom gateways
+
 For Bifrost or another compatible gateway, keep its complete base path:
 
 ```sh
@@ -33,6 +33,6 @@ pentect opencode --model anthropic/claude-sonnet \
   --upstream http://127.0.0.1:8080/openai/v1
 ```
 
-If no model is given, Pentect uses `gpt-5`. `OPENAI_BASE_URL` is used when
-`--upstream` is absent. Authentication still comes from the client environment
-or `PENTECT_UPSTREAM_AUTHORIZATION`.
+If no model is given, Pentect uses `gpt-5`. Custom endpoint variables and
+gateway credentials are advanced options; see
+[Custom upstreams](/clients/upstreams/).

--- a/website/src/content/docs/clients/pi.md
+++ b/website/src/content/docs/clients/pi.md
@@ -13,8 +13,8 @@ Or install Pi and the matching Pentect release together:
 npx @pentect/pi --model openai/gpt-5
 ```
 
-Pentect creates a small provider-only extension for this process and removes
-it when Pi exits. It does not install prompt hooks or edit Pi settings.
+Pentect protects this Pi launch only. It does not install prompt hooks or edit
+Pi settings.
 
 Normal Pi arguments pass through:
 
@@ -28,6 +28,8 @@ Chat Completions is the default. Responses can be selected explicitly:
 pentect pi --api responses --model gpt-5
 ```
 
+## Custom gateways
+
 Custom and local providers can be reached through an OpenAI-compatible
 gateway such as Bifrost:
 
@@ -36,5 +38,5 @@ pentect pi --model anthropic/claude-sonnet \
   --upstream http://127.0.0.1:8080/openai/v1
 ```
 
-The adapter contains no API key or gateway token. Those values remain in the
-child environment and the authenticated loopback URL.
+The temporary provider contains no API key or gateway token. See
+[Custom upstreams](/clients/upstreams/) for credentials and endpoint details.

--- a/website/src/content/docs/clients/upstreams.md
+++ b/website/src/content/docs/clients/upstreams.md
@@ -12,10 +12,14 @@ pentect codex --upstream http://127.0.0.1:8080/openai/v1
 pentect claude --upstream http://127.0.0.1:8080/anthropic
 pentect opencode --model anthropic/claude-sonnet --upstream http://127.0.0.1:8080/openai/v1
 pentect pi --model anthropic/claude-sonnet --upstream http://127.0.0.1:8080/openai/v1
+pentect antigravity --upstream https://cloud-code.example
 ```
 
 The URL applies to one launch. Pentect keeps its base path, masks the request,
 and then sends it to that gateway.
+
+You do not need a custom upstream for normal use. Each client keeps its usual
+provider and sign-in when `--upstream` is not supplied.
 
 ## Use Bifrost
 
@@ -91,6 +95,48 @@ and request logs remain available at `http://127.0.0.1:8080` and
 `http://127.0.0.1:8080/logs`. See the
 [Bifrost agent guide](https://docs.getbifrost.ai/cli-agents/overview) for
 provider setup, virtual keys, and model IDs.
+
+## Antigravity and Cloud Code
+
+Normal Antigravity use needs no endpoint setting:
+
+```sh
+pentect antigravity
+```
+
+If Antigravity already uses a compatible `CLOUD_CODE_URL`, Pentect keeps that
+endpoint behind its local gateway. You can override it for one launch with
+`--upstream`. This is for existing Cloud Code gateways, not normal Google
+sign-in.
+
+Add a custom gateway credential without placing its value in command history:
+
+::: code-group
+
+```powershell [PowerShell]
+$secret = Read-Host "Gateway token" -AsSecureString
+$env:PENTECT_GATEWAY_AUTH = [Net.NetworkCredential]::new('', $secret).Password
+pentect antigravity --upstream https://cloud-code.example `
+  --upstream-header-env Authorization=PENTECT_GATEWAY_AUTH
+```
+
+```sh [Shell]
+read -rsp "Gateway token: " PENTECT_GATEWAY_AUTH && echo
+export PENTECT_GATEWAY_AUTH
+pentect antigravity --upstream https://cloud-code.example \
+  --upstream-header-env Authorization=PENTECT_GATEWAY_AUTH
+```
+
+:::
+
+Pentect reads the credential, removes the source variable from `agy`, and adds
+the header only when contacting that upstream.
+
+## Existing endpoint settings
+
+Pentect also respects `OPENAI_BASE_URL` for OpenCode and `CLOUD_CODE_URL` for
+Antigravity when those variables already exist. You normally do not set them
+for Pentect. Use `--upstream` when you want an explicit one-launch override.
 
 ## Supported API formats
 


### PR DESCRIPTION
## What changed

- keep each client page focused on launch commands and protected behavior
- remove internal endpoint environment variables from client introductions
- move Cloud Code, existing endpoint variables, and gateway credentials to Custom upstreams
- add Antigravity to the shared upstream examples

## Why

Provider-specific routing details appeared to be required setup even though normal client launches need no endpoint configuration.

## Validation

- npm --prefix website run build
- generated 30 agent-readable pages
- checked 87 internal links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified protected launch behavior across Antigravity, Claude, Codex, OpenCode, and Pi.
  * Added guidance for configuring custom gateways, credentials, endpoints, and troubleshooting.
  * Documented Antigravity upstream usage, including endpoint overrides and secure credential handling.
  * Simplified provider and sign-in guidance while removing outdated or overly detailed configuration instructions.
  * Added links to advanced custom upstream documentation for setup and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->