### PR TITLE
Fix quick client compatibility gaps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,10 +410,10 @@ jobs:
       - name: Install supported agent CLIs
         run: >-
           npm install --global
-          @openai/codex@0.146.0
-          @anthropic-ai/claude-code@2.1.220
-          opencode-ai@1.18.14
-          @mariozechner/pi-coding-agent@0.73.1
+          @openai/codex@0.147.0
+          @anthropic-ai/claude-code@2.1.227
+          opencode-ai@1.18.16
+          @earendil-works/pi-coding-agent@0.84.1
           @continuedev/cli@1.5.47
           cline@3.0.52
           @google/gemini-cli@0.54.4

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,10 +6,10 @@ through the release binary:
 
 | Client | Release gate | Protected mode |
 | --- | --- | --- |
-| Codex CLI `0.146.0` | automated on Linux | `pentect codex` |
-| Claude Code `2.1.220` | automated on Linux | `pentect claude` |
-| OpenCode `1.18.14` | provider registration and model discovery on Windows | `pentect opencode` |
-| Pi `0.73.1` and `0.83.0` | provider registration and model discovery on Windows | `pentect pi` |
+| Codex CLI `0.147.0` | automated on Linux | `pentect codex` |
+| Claude Code `2.1.227` | automated on Linux | `pentect claude` |
+| OpenCode `1.18.16` | automated on Linux | `pentect opencode` |
+| Pi `0.84.1` | launcher and published extension discovery | `pentect pi` or `@pentect/pi` |
 | ChatGPT desktop app (Codex mode) | launcher and Responses protocol tests | `pentect codex app` |
 | Claude Desktop (supported Chat, attachment, and Claude Code routes) | launcher and protocol tests | `pentect claude app` |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.29"
+version = "0.0.30"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -202,8 +202,8 @@ enum ClientApi {
 impl ClientApi {
     fn parse(value: Option<&str>) -> Result<Self, String> {
         match value.unwrap_or("chat") {
-            "chat" | "chat-completions" => Ok(Self::ChatCompletions),
-            "responses" => Ok(Self::Responses),
+            "chat" | "chat-completions" | "openai-completions" => Ok(Self::ChatCompletions),
+            "responses" | "openai-responses" => Ok(Self::Responses),
             value => Err(format!(
                 "unsupported API format '{value}'; use --api chat or --api responses"
             )),
@@ -324,13 +324,36 @@ const PI_PROVIDER: &str = r#"export default function (pi) {
     models: [{
       id: model,
       name: model,
-      reasoning: api === "openai-responses",
-      input: ["text", "image"],
+      reasoning: piBoolean("PENTECT_PI_REASONING", api === "openai-responses"),
+      input: piInputs(),
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 128000,
-      maxTokens: 32768
+      contextWindow: piPositiveInteger("PENTECT_PI_CONTEXT_WINDOW", 128000),
+      maxTokens: piPositiveInteger("PENTECT_PI_MAX_TOKENS", 32768)
     }]
   });
+}
+
+function piPositiveInteger(name, fallback) {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${name} must be a positive integer`);
+  return value;
+}
+
+function piBoolean(name, fallback) {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (!value || value === "auto") return fallback;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`${name} must be auto, true, or false`);
+}
+
+function piInputs() {
+  const value = process.env.PENTECT_PI_INPUTS?.trim().toLowerCase();
+  if (!value || value === "text,image" || value === "image,text") return ["text", "image"];
+  if (value === "text") return ["text"];
+  throw new Error("PENTECT_PI_INPUTS must be text or text,image");
 }
 "#;
 
@@ -406,6 +429,14 @@ mod tests {
             "openai-responses"
         );
         assert!(ClientApi::parse(Some("anthropic")).is_err());
+        assert_eq!(
+            ClientApi::parse(Some("openai-completions")).unwrap(),
+            ClientApi::ChatCompletions
+        );
+        assert_eq!(
+            ClientApi::parse(Some("openai-responses")).unwrap(),
+            ClientApi::Responses
+        );
     }
 
     #[test]

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -19,5 +19,10 @@ Set `PENTECT_PI_MODEL` before Pi starts to expose a different model. Set
 `PENTECT_PI_API=responses` for the OpenAI Responses API. `OPENAI_BASE_URL` and
 `OPENAI_API_KEY` configure the upstream.
 
+For a custom upstream whose model limits differ from the defaults, set
+`PENTECT_PI_CONTEXT_WINDOW`, `PENTECT_PI_MAX_TOKENS`,
+`PENTECT_PI_INPUTS=text`, or `PENTECT_PI_REASONING=true|false`. Invalid values
+stop startup instead of advertising incorrect capabilities to Pi.
+
 The JavaScript extension only manages Pi's provider lifecycle. Detection,
 handles, plugins, and network forwarding remain inside the Pentect binary.

--- a/integrations/pi/extensions/pentect.js
+++ b/integrations/pi/extensions/pentect.js
@@ -6,6 +6,8 @@ const require = createRequire(import.meta.url);
 const STATE = Symbol.for("@pentect/pi/provider-state");
 const MAX_READY_BYTES = 16 * 1024;
 const START_TIMEOUT_MS = 10_000;
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 32_768;
 
 function sharedState() {
   if (!globalThis[STATE]) {
@@ -43,7 +45,34 @@ export function parseReady(line) {
   return ready;
 }
 
-export function providerDefinition(ready) {
+function positiveInteger(env, name, fallback) {
+  const raw = env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function reasoningSupport(env, api) {
+  const value = env.PENTECT_PI_REASONING?.trim().toLowerCase();
+  if (!value || value === "auto") return api === "openai-responses";
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error("PENTECT_PI_REASONING must be auto, true, or false");
+}
+
+function inputSupport(env) {
+  const value = env.PENTECT_PI_INPUTS?.trim().toLowerCase();
+  if (!value || value === "text,image" || value === "image,text") {
+    return ["text", "image"];
+  }
+  if (value === "text") return ["text"];
+  throw new Error("PENTECT_PI_INPUTS must be text or text,image");
+}
+
+export function providerDefinition(ready, env = process.env) {
   return {
     name: "Pentect",
     baseUrl: ready.baseUrl,
@@ -54,11 +83,19 @@ export function providerDefinition(ready) {
       {
         id: ready.model,
         name: ready.model,
-        reasoning: ready.api === "openai-responses",
-        input: ["text", "image"],
+        reasoning: reasoningSupport(env, ready.api),
+        input: inputSupport(env),
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 128000,
-        maxTokens: 32768,
+        contextWindow: positiveInteger(
+          env,
+          "PENTECT_PI_CONTEXT_WINDOW",
+          DEFAULT_CONTEXT_WINDOW,
+        ),
+        maxTokens: positiveInteger(
+          env,
+          "PENTECT_PI_MAX_TOKENS",
+          DEFAULT_MAX_TOKENS,
+        ),
       },
     ],
   };
@@ -101,8 +138,19 @@ async function startProvider() {
     return { child, ready: parseReady(line) };
   } catch (error) {
     child.kill();
+    restoreProviderCredentials(state, process.env);
     const detail = errors.trim();
     throw new Error(detail || error.message, { cause: error });
+  }
+}
+
+export function restoreProviderCredentials(state, env) {
+  if (state.openaiApiKey === undefined) delete env.OPENAI_API_KEY;
+  else env.OPENAI_API_KEY = state.openaiApiKey;
+  if (state.upstreamAuthorization === undefined) {
+    delete env.PENTECT_UPSTREAM_AUTHORIZATION;
+  } else {
+    env.PENTECT_UPSTREAM_AUTHORIZATION = state.upstreamAuthorization;
   }
 }
 
@@ -149,7 +197,14 @@ function stopProvider(child) {
 }
 
 export default async function pentect(pi) {
+  const state = sharedState();
   const { child, ready } = await startProvider();
-  pi.registerProvider("pentect", providerDefinition(ready));
+  try {
+    pi.registerProvider("pentect", providerDefinition(ready));
+  } catch (error) {
+    stopProvider(child);
+    restoreProviderCredentials(state, process.env);
+    throw error;
+  }
   pi.on("session_shutdown", () => stopProvider(child));
 }

--- a/integrations/pi/test/extension.test.js
+++ b/integrations/pi/test/extension.test.js
@@ -4,6 +4,7 @@ import {
   parseReady,
   providerArguments,
   providerDefinition,
+  restoreProviderCredentials,
 } from "../extensions/pentect.js";
 
 const baseUrl = `http://127.0.0.1:43123/${"a".repeat(64)}`;
@@ -61,4 +62,49 @@ test("registers one Pentect provider and one selected model", () => {
   assert.equal(provider.apiKey, "pentect-local");
   assert.equal(provider.models.length, 1);
   assert.equal(provider.models[0].id, "gpt-5");
+});
+
+test("allows truthful model limits and capabilities for custom upstreams", () => {
+  const provider = providerDefinition(
+    { baseUrl, model: "local-model", api: "openai-completions" },
+    {
+      PENTECT_PI_CONTEXT_WINDOW: "65536",
+      PENTECT_PI_MAX_TOKENS: "8192",
+      PENTECT_PI_INPUTS: "text",
+      PENTECT_PI_REASONING: "true",
+    },
+  );
+  assert.equal(provider.models[0].contextWindow, 65536);
+  assert.equal(provider.models[0].maxTokens, 8192);
+  assert.deepEqual(provider.models[0].input, ["text"]);
+  assert.equal(provider.models[0].reasoning, true);
+
+  assert.throws(() =>
+    providerDefinition(
+      { baseUrl, model: "bad", api: "openai-completions" },
+      { PENTECT_PI_CONTEXT_WINDOW: "unknown" },
+    ),
+  );
+});
+
+test("restores credentials when provider startup fails", () => {
+  const env = {
+    OPENAI_API_KEY: "pentect-local",
+  };
+  restoreProviderCredentials(
+    {
+      openaiApiKey: "original-key",
+      upstreamAuthorization: "Bearer original",
+    },
+    env,
+  );
+  assert.equal(env.OPENAI_API_KEY, "original-key");
+  assert.equal(env.PENTECT_UPSTREAM_AUTHORIZATION, "Bearer original");
+
+  restoreProviderCredentials(
+    { openaiApiKey: undefined, upstreamAuthorization: undefined },
+    env,
+  );
+  assert.equal(env.OPENAI_API_KEY, undefined);
+  assert.equal(env.PENTECT_UPSTREAM_AUTHORIZATION, undefined);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/website/src/content/docs/clients/pi.md
+++ b/website/src/content/docs/clients/pi.md
@@ -44,6 +44,11 @@ pentect pi --api responses --model gpt-5
 With the extension, set `PENTECT_PI_API=responses` and `PENTECT_PI_MODEL=gpt-5`
 before Pi starts, then select `pentect/gpt-5`.
 
+If a custom model has different limits, set `PENTECT_PI_CONTEXT_WINDOW` and
+`PENTECT_PI_MAX_TOKENS`. Use `PENTECT_PI_INPUTS=text` for a text-only model and
+`PENTECT_PI_REASONING=true` or `false` when API type alone cannot describe it.
+Pentect rejects invalid values instead of telling Pi the wrong capabilities.
+
 ## Custom gateways
 
 Custom and local providers can be reached through an OpenAI-compatible

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -8,9 +8,9 @@ specific public CLI versions with the release binary.
 
 | Client | Test | Protected launch |
 | --- | --- | --- |
-| Codex CLI `0.146.0` | Automatic test on Linux | `pentect codex` |
-| Claude Code `2.1.220` | Automatic test on Linux | `pentect claude` |
-| OpenCode `1.18.14` | Provider registration and model discovery on Windows | `pentect opencode` |
+| Codex CLI `0.147.0` | Automatic test on Linux | `pentect codex` |
+| Claude Code `2.1.227` | Automatic test on Linux | `pentect claude` |
+| OpenCode `1.18.16` | Automatic test on Linux | `pentect opencode` |
 | Pi `0.84.1` | Launcher and npm extension provider discovery | `pentect pi` or `@pentect/pi` |
 | Antigravity CLI `1.1.11` | Cloud Code JSON, SSE, function calls, and endpoint override | `pentect antigravity` |
 | Aider | OpenAI-compatible launch and route override | `pentect aider` |


### PR DESCRIPTION
## What changed

- accept Pi/OpenAI wire API aliases such as `openai-completions` and `openai-responses`
- restore original provider credentials when the published Pi extension cannot start or register
- let custom Pi upstreams declare truthful context, output, image, and reasoning capabilities
- update release compatibility pins and public evidence to current client versions
- bump Pentect to 0.0.30

## Why

The published Pi extension and the one-shot launcher could disagree on accepted API names and model metadata. A failed extension startup could also leave Pi's process environment set to the local dummy credential. Release compatibility evidence still exercised an obsolete Pi package.

## Validation

Local work was limited to formatting, JavaScript syntax checks, and `git diff --check`. Full builds and tests run in GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `openai-completions` and `openai-responses` API aliases.
  * Added configurable Pi model context limits, token limits, input modalities, and reasoning support.
  * Added safeguards to restore credentials when Pi startup or provider registration fails.

* **Bug Fixes**
  * Invalid capability settings are now rejected instead of being passed to Pi.

* **Documentation**
  * Updated Pi configuration guidance and compatibility information for supported CLI versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->