### PR TITLE
chore: update CredSweeper to v1.17.4

### DIFF
--- a/.github/workflows/update-credsweeper.yml
+++ b/.github/workflows/update-credsweeper.yml
@@ -45,11 +45,13 @@ jobs:
           git add -- \
             crates/pentect-core/vendors/CredSweeper \
             crates/pentect-core/vendors/credsweeper-assets \
-            tools/credsweeper-sidecar/runtime-requirements.txt
+            tools/credsweeper-sidecar/runtime-requirements.txt \
+            tools/credsweeper-sidecar/patches/lazy-imports.patch \
+            THIRD_PARTY_LICENSES.txt
           git commit -m "chore: update CredSweeper to $version"
           git push --force-with-lease origin "HEAD:$branch"
 
-          if ! gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          if [ "$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$branch" --json number --jq 'length')" -eq 0 ]; then
             gh pr create \
               --repo "$GITHUB_REPOSITORY" \
               --base "$BASE_BRANCH" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -9,7 +9,7 @@ BUNDLED DATA AND MODELS
 
 CredSweeper detection assets
 Source: https://github.com/Samsung/CredSweeper
-Version: v1.17.1 (commit 1064da2a54b4e3e4671e229eb2f7ba2ceb0bf629)
+Version: v1.17.4 (commit c7ad63b95ce0941954465a3b759046b14b88807b)
 Copyright (c) 2021 SAMSUNG
 License: MIT. The full MIT text appears below in the Cargo license documents.
 
@@ -3394,7 +3394,7 @@ SOFTWARE.
 DOCUMENT 56
 ~~~~~~~~~~~
 Applies to:
-- CredSweeper v1.17.1 detection assets (MIT)
+- CredSweeper v1.17.4 detection assets (MIT)
 
 Copyright (c) 2021 SAMSUNG
 

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.30"
+version = "0.0.31"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -133,6 +133,7 @@ enum CompiledRegex {
 #[derive(Clone)]
 enum SpecialMatcher {
     AwsMulti,
+    AlibabaMulti,
     GoogleMulti,
     Jwk,
     PemPrivateKey,
@@ -649,7 +650,7 @@ struct CandidateLineData<'a> {
 impl SpecialMatcher {
     fn find<'a>(&self, line: &'a str) -> Vec<Candidate<'a>> {
         match self {
-            Self::AwsMulti | Self::GoogleMulti | Self::Jwk => Vec::new(),
+            Self::AwsMulti | Self::AlibabaMulti | Self::GoogleMulti | Self::Jwk => Vec::new(),
             Self::PemPrivateKey => pem_private_key_candidates(line),
             Self::Base64PrivateKey => base64_private_key_candidates(line),
         }
@@ -658,13 +659,18 @@ impl SpecialMatcher {
     fn is_whole_text(&self) -> bool {
         matches!(
             self,
-            Self::AwsMulti | Self::GoogleMulti | Self::Jwk | Self::PemPrivateKey
+            Self::AwsMulti
+                | Self::AlibabaMulti
+                | Self::GoogleMulti
+                | Self::Jwk
+                | Self::PemPrivateKey
         )
     }
 
     fn find_whole_text<'a>(&self, text: &'a str) -> Vec<Candidate<'a>> {
         match self {
             Self::AwsMulti => aws_multi_candidates(text),
+            Self::AlibabaMulti => alibaba_multi_candidates(text),
             Self::GoogleMulti => google_multi_candidates(text),
             Self::Jwk => jwk_multi_candidates(text),
             Self::PemPrivateKey => pem_private_key_block_candidates(text),
@@ -702,6 +708,7 @@ fn translated_rule(raw: &RawRule) -> Option<SpecialMatcher> {
     match raw.kind.as_deref()? {
         "multi" => match raw.name.as_str() {
             "AWS Multi" => Some(SpecialMatcher::AwsMulti),
+            "Alibaba Multi" => Some(SpecialMatcher::AlibabaMulti),
             "Google Multi" => Some(SpecialMatcher::GoogleMulti),
             "JWK" => Some(SpecialMatcher::Jwk),
             _ => None,
@@ -783,6 +790,49 @@ fn aws_multi_candidates(text: &str) -> Vec<Candidate<'_>> {
         },
         |line_start, line, anchor| {
             regex_line_data(line_start, line, &AWS_SECRET)
+                .into_iter()
+                .filter(|part| {
+                    let local_start = part.start - line_start;
+                    let local_end = part.end - line_start;
+                    has_upper_lower_digit_or_aws_symbol(part.value)
+                        && !line
+                            .as_bytes()
+                            .get(local_end)
+                            .is_some_and(|b| b.is_ascii_alphanumeric() || matches!(*b, b'/' | b'+'))
+                        && !multi_value_filtered(line, part, anchor.value, local_start, local_end)
+                        && !base64_part_filtered(line, part.value, local_start, local_end)
+                })
+                .collect()
+        },
+    )
+}
+
+fn alibaba_multi_candidates(text: &str) -> Vec<Candidate<'_>> {
+    static ALIBABA_ID: LazyLock<RustRegex> = LazyLock::new(|| {
+        RustRegex::new(
+            r"(?:^|/|[^\\0-9A-Za-z+_-]|\\[0abfnrtv]|(?:%|\\x)[0-9A-Fa-f]{2}|\\[0-7]{3}|\\[Uu][0-9A-Fa-f]{4}|\x1B\[[0-9;]{0,80}m)(?P<value>LTAI[0-9A-Za-z]{12,20})",
+        )
+        .expect("alibaba multi id regex")
+    });
+    static ALIBABA_SECRET: LazyLock<RustRegex> = LazyLock::new(|| {
+        RustRegex::new(
+            r"(?:^|/|[^\\0-9A-Za-z+_-]|\\[0abfnrtv]|(?:%|\\x)[0-9A-Fa-f]{2}|\\[0-7]{3}|\\[Uu][0-9A-Fa-f]{4}|\x1B\[[0-9;]{0,80}m)(?P<value>[0-9A-Za-z/+]{30})",
+        )
+        .expect("alibaba multi secret regex")
+    });
+
+    multi_pattern_candidates(
+        text,
+        &ALIBABA_ID,
+        |line_start, line, anchor| {
+            let local_end = anchor.end - line_start;
+            !line
+                .as_bytes()
+                .get(local_end)
+                .is_some_and(|b| b.is_ascii_alphanumeric() || matches!(*b, b'_' | b'+' | b'-'))
+        },
+        |line_start, line, anchor| {
+            regex_line_data(line_start, line, &ALIBABA_SECRET)
                 .into_iter()
                 .filter(|part| {
                     let local_start = part.start - line_start;
@@ -2582,6 +2632,23 @@ mod tests {
             stats.total_patterns,
             stats.compiled_patterns + stats.translated_patterns + stats.unsupported_patterns
         );
+    }
+
+    #[test]
+    fn alibaba_multi_reports_the_secret_paired_with_an_access_key_id() {
+        let raw = concat!(
+            "access_key_id = LTAI1234567890ABCDEF\n",
+            "access_key_secret = AbCdEfGhIjKlMnOpQrStUvWxYz1234\n",
+        );
+        let candidates = alibaba_multi_candidates(raw);
+
+        assert!(candidates.iter().any(|candidate| {
+            candidate.value == "AbCdEfGhIjKlMnOpQrStUvWxYz1234"
+                && candidate
+                    .line_data
+                    .iter()
+                    .any(|part| part.value == "LTAI1234567890ABCDEF")
+        }));
     }
 
     #[test]

--- a/crates/pentect-core/vendors/credsweeper-assets/SOURCE.json
+++ b/crates/pentect-core/vendors/credsweeper-assets/SOURCE.json
@@ -1,14 +1,14 @@
 {
   "upstream": "https://github.com/Samsung/CredSweeper.git",
-  "version": "v1.17.2",
-  "commit": "4d49de647456034175a848b527835d0b1f6c4121",
+  "version": "v1.17.4",
+  "commit": "c7ad63b95ce0941954465a3b759046b14b88807b",
   "assets": {
     "LICENSE": "694ee61a304a6e644734b5575f370f74a993b41c51c033ed8df95045f37b7c58",
     "common/keyword_checklist.txt": "6bc196fb017a0fcdee54563131612c50596d87a73507f283a45f3f5e98f4984f",
-    "common/morpheme_checklist.txt": "77b5f268868569d96f5c91b2a5aa9aa7dfc47f2177e24eed8fe57ba23c5b3cea",
+    "common/morpheme_checklist.txt": "e27dc638f4377826f13bacd150ab142e61d9c4bcba81c2d14d2dd4855e9cb30a",
     "ml_model/ml_config.json": "b8c76465f422420516f75b2607028d17dc3a1db82e2210d0785307e0140065b6",
     "ml_model/ml_model.onnx": "ae6155800a46c24c86b5d147c1214f775d047bc2f5c2f97b4640b8ee022fec28",
-    "rules/config.yaml": "1ab6e57c4554e9cef8a37ca61eb2a6cb57dca1ba96563e27771fa9b76ce3259c",
+    "rules/config.yaml": "4dcde79abae896ad3f8928b591bc78b91f8138454b86cedb703656625b3cc69b",
     "secret/config.json": "58b8512936b64e75bd94fe99a5a5f5e98402751a0fd7b2374a345bbab0c716d7"
   }
 }

--- a/crates/pentect-core/vendors/credsweeper-assets/common/morpheme_checklist.txt
+++ b/crates/pentect-core/vendors/credsweeper-assets/common/morpheme_checklist.txt
@@ -582,6 +582,7 @@ exynos
 face
 fact
 fail
+fake
 false
 famil
 far

--- a/crates/pentect-core/vendors/credsweeper-assets/rules/config.yaml
+++ b/crates/pentect-core/vendors/credsweeper-assets/rules/config.yaml
@@ -232,8 +232,22 @@
     - code
     - doc
 
-- name: AWS Client ID
+- name: AWS AppSync GraphQL API Key
   severity: high
+  confidence: moderate
+  type: pattern
+  values:
+    - (?:^|/|[^\\0-9A-Za-z+_-]|\\[0abfnrtv]|(?:%|\\x)[0-9A-Fa-f]{2}|\\[0-7]{3}|\\[Uu][0-9A-Fa-f]{4}|\x1B\[[0-9;]{0,80}m)(?P<value>da2-[a-z0-9]{26})(?![0-9A-Za-z/+])
+  filter_type: GeneralPattern
+  required_substrings:
+    - da2-
+  min_line_len: 40
+  target:
+    - code
+    - doc
+
+- name: AWS Client ID
+  severity: medium
   confidence: moderate
   type: pattern
   values:
@@ -280,6 +294,41 @@
     - code
     - doc
 
+- name: Alibaba Access Key ID
+  severity: medium
+  confidence: moderate
+  type: pattern
+  values:
+    - (?:^|/|[^\\0-9A-Za-z+_-]|\\[0abfnrtv]|(?:%|\\x)[0-9A-Fa-f]{2}|\\[0-7]{3}|\\[Uu][0-9A-Fa-f]{4}|\x1B\[[0-9;]{0,80}m)(?P<value>LTAI[0-9A-Za-z]{12,20})(?![0-9A-Za-z_+-])
+  filter_type: GeneralPattern
+  required_substrings:
+    - LTAI
+  min_line_len: 16
+  required_regex: "[0-9A-Za-z_/+-]{15}"
+  target:
+    - code
+    - doc
+
+- name: Alibaba Multi
+  severity: high
+  confidence: moderate
+  type: multi
+  values:
+    - (?:^|/|[^\\0-9A-Za-z+_-]|\\[0abfnrtv]|(?:%|\\x)[0-9A-Fa-f]{2}|\\[0-7]{3}|\\[Uu][0-9A-Fa-f]{4}|\x1B\[[0-9;]{0,80}m)(?P<value>LTAI[0-9A-Za-z]{12,20})(?![0-9A-Za-z_+-])
+    - (?:^|/|[^\\0-9A-Za-z+_-]|\\[0abfnrtv]|(?:%|\\x)[0-9A-Fa-f]{2}|\\[0-7]{3}|\\[Uu][0-9A-Fa-f]{4}|\x1B\[[0-9;]{0,80}m)(?P<value>((?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/+])){30}(?(a)(?(b)(?(c)\b|(?!x)x)|(?!x)x)|(?!x)x))(?![0-9A-Za-z/+])
+  filter_type:
+    - LineSpecificKeyCheck
+    - ValuePatternCheck
+    - ValueBase64PartCheck
+    - ValueMorphemesCheck
+  required_substrings:
+    - LTAI
+  min_line_len: 20
+  required_regex: "[0-9A-Za-z_/+-]{15}"
+  target:
+    - code
+    - doc
+
 - name: AWS MWS Key
   severity: high
   confidence: strong
@@ -294,16 +343,44 @@
     - code
     - doc
 
+- name: Defined Networking API Key
+  severity: high
+  confidence: strong
+  type: pattern
+  values:
+    - (?P<value>dnkey-[A-Z2-7]{26}-[A-Z2-7]{52})
+  filter_type: GeneralPattern
+  required_substrings:
+    - dnkey-
+  min_line_len: 85
+  target:
+    - code
+    - doc
+
 - name: Dynatrace API Token
   severity: high
   confidence: moderate
   type: pattern
   values:
-    - (?:^|/|[^\\0-9A-Za-z+_-]|\\[0abfnrtv]|(?:%|\\x)[0-9A-Fa-f]{2}|\\[0-7]{3}|\\[Uu][0-9A-Fa-f]{4}|\x1B\[[0-9;]{0,80}m)(?P<value>dt0[A-Za-z]{1}[0-9]{2}\.[0-9A-Z]{24}\.[0-9A-Z]{64})(?![0-9A-Za-z_-])
+    - (?:^|/|[^\\0-9A-Za-z+_-]|\\[0abfnrtv]|(?:%|\\x)[0-9A-Fa-f]{2}|\\[0-7]{3}|\\[Uu][0-9A-Fa-f]{4}|\x1B\[[0-9;]{0,80}m)(?P<value>dt0[a-z]{1}[0-9]{2}\.[0-9A-Z]{24}\.[0-9A-Z]{64})(?![0-9A-Za-z_-])
   filter_type: TokenPattern
   required_substrings:
     - dt0
   min_line_len: 90
+  target:
+    - code
+    - doc
+
+- name: Doppler API Key
+  severity: high
+  confidence: strong
+  type: pattern
+  values:
+    - (?P<value>dp\.pt\.[0-9A-Za-z]{43})
+  filter_type: GeneralPattern
+  required_substrings:
+    - dp.pt.
+  min_line_len: 49
   target:
     - code
     - doc
@@ -1155,6 +1232,21 @@
     - code
     - doc
 
+- name: PlanetScale Credentials
+  severity: high
+  confidence: moderate
+  type: pattern
+  values:
+    - (?P<value>pscale_(tkn|oauth|pw)_[.0-9A-Za-z_-]{32,64})
+  min_line_len: 42
+  filter_type:
+    - ValuePatternCheck
+  required_substrings:
+    - pscale_
+  target:
+    - code
+    - doc
+
 - name: NewRelic Credentials
   severity: high
   confidence: moderate
@@ -1767,6 +1859,20 @@
     - code
     - doc
 
+- name: Supabase Credentials
+  severity: medium
+  confidence: strong
+  type: pattern
+  values:
+    - (?P<value>sbp_(v0_)?[0-9a-f]{40})
+  min_line_len: 44
+  filter_type: TokenPattern
+  required_substrings:
+    - sbp_
+  target:
+    - code
+    - doc
+
 - name: Salesforce Credentials
   severity: medium
   confidence: weak
@@ -1779,8 +1885,8 @@
     - ValueNumberCheck
     - ValueBase64PartCheck
   required_substrings:
-    - 00D
-    - 3MVG
+    - "3MVG"
+    - "00D"
   target:
     - code
     - doc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/tools/credsweeper-sidecar/patches/lazy-imports.patch
+++ b/tools/credsweeper-sidecar/patches/lazy-imports.patch
@@ -20,7 +20,7 @@ index 1cedfcf..e339c82 100644
 @@ -25,3 +14,35 @@ __all__ = [
  ]
  
- __version__ = "1.17.0"
+ __version__ = "1.17.4"
 +
 +
 +def __getattr__(name):
@@ -116,10 +116,14 @@ index 77b72b2..b110d99 100644
  import ast
  import base64
  import contextlib
-@@ -14,20 +16,6 @@ from typing import Any, Dict, List, Tuple, Optional, Union
+@@ -14,23 +16,9 @@ from typing import Any, Dict, List, Tuple, Optional, Union
  
  import numpy as np
  import yaml
+ from cryptography.utils import CryptographyDeprecationWarning
+-
++
+ warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)  # TODO: remove with DH
 -from cryptography.hazmat.primitives import hashes
 -from cryptography.hazmat.primitives.asymmetric import padding
 -from cryptography.hazmat.primitives.asymmetric.dh import DHPrivateKey, DHPublicKey

--- a/tools/credsweeper-sidecar/runtime-requirements.txt
+++ b/tools/credsweeper-sidecar/runtime-requirements.txt
@@ -1,8 +1,8 @@
 base58==2.1.1
 beautifulsoup4==4.15.0
 colorama==0.4.6
-cryptography==49.0.0
-GitPython==3.1.57
+cryptography==50.0.0
+GitPython==3.1.59
 humanfriendly==10.0
 lxml==6.1.1
 numpy==2.2.6; python_version == '3.10'

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -199,9 +199,17 @@ def generate() -> str:
             documents[digest] = content
             document_packages[digest].add(label)
 
+    credsweeper_source = json.loads(
+        (ROOT / "crates/pentect-core/vendors/credsweeper-assets/SOURCE.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    credsweeper_version = credsweeper_source["version"]
+    credsweeper_commit = credsweeper_source["commit"]
+
     bundled_documents = [
         (
-            "CredSweeper v1.17.1 detection assets (MIT)",
+            f"CredSweeper {credsweeper_version} detection assets (MIT)",
             ROOT / "crates/pentect-core/vendors/credsweeper-assets/LICENSE",
         ),
         (
@@ -227,7 +235,7 @@ def generate() -> str:
         "",
         "CredSweeper detection assets",
         "Source: https://github.com/Samsung/CredSweeper",
-        "Version: v1.17.1 (commit 1064da2a54b4e3e4671e229eb2f7ba2ceb0bf629)",
+        f"Version: {credsweeper_version} (commit {credsweeper_commit})",
         "Copyright (c) 2021 SAMSUNG",
         "License: MIT. The full MIT text appears below in the Cargo license documents.",
         "",

--- a/tools/update_credsweeper.py
+++ b/tools/update_credsweeper.py
@@ -25,6 +25,7 @@ ASSETS = {
     "credsweeper/rules/config.yaml": "rules/config.yaml",
     "credsweeper/secret/config.json": "secret/config.json",
 }
+SIDECAR_PATCH = Path("tools/credsweeper-sidecar/patches/lazy-imports.patch")
 
 
 def run(*args: str, cwd: Path, capture: bool = False) -> str:
@@ -118,6 +119,27 @@ def sync_runtime_requirements(submodule: Path, destination: Path) -> None:
     os.replace(temporary, destination)
 
 
+def sync_sidecar_patch(repo: Path, tag: str) -> None:
+    patch = repo / SIDECAR_PATCH
+    text = patch.read_text(encoding="utf-8")
+    replacement = f' __version__ = "{tag.removeprefix("v")}"'
+    updated, count = re.subn(
+        r'^ __version__ = "[0-9]+\.[0-9]+\.[0-9]+"$',
+        replacement,
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise RuntimeError("CredSweeper sidecar patch has no unique version context")
+    patch.write_text(updated, encoding="utf-8", newline="\n")
+    run("git", "apply", "--check", str(patch.resolve()), cwd=repo / "crates/pentect-core/vendors/CredSweeper")
+
+
+def sync_license_bundle(repo: Path) -> None:
+    run(sys.executable, "tools/generate_licenses.py", cwd=repo)
+
+
 def validate(repo: Path) -> None:
     run("cargo", "check", "-p", "pentect-core", cwd=repo)
     run("cargo", "test", "-p", "pentect-core", "migration_coverage_is_explicit", cwd=repo)
@@ -192,6 +214,8 @@ def main() -> int:
     commit = run("git", "rev-parse", "HEAD", cwd=submodule, capture=True)
     sync_assets(submodule, assets, requested, commit)
     sync_runtime_requirements(submodule, runtime_requirements)
+    sync_sidecar_patch(repo, requested)
+    sync_license_bundle(repo)
     if not args.skip_validation:
         validate(repo)
     print(f"CredSweeper {requested} synced at {commit}")


### PR DESCRIPTION
## What changed
- sync embedded CredSweeper assets and the pinned submodule from v1.17.2 to v1.17.4
- include the new Alibaba, PlanetScale, Supabase, AWS AppSync, Doppler, and related detector updates
- update sidecar runtime dependencies and keep its lazy-import patch compatible with the pinned release
- derive third-party license attribution from SOURCE.json instead of a hard-coded CredSweeper version
- fix the weekly updater so a previously merged PR on its reusable branch does not prevent future PR creation
- bump Pentect to v0.0.31 for release

## Why
Pentect was two CredSweeper releases behind. The scheduled updater had produced a v1.17.3 branch but skipped opening a PR because it found an old merged PR with the same branch name.

## Impact
Pentect uses the v1.17.4 detection definitions and future scheduled updates can open a fresh PR correctly. Release artifacts identify the exact upstream version and commit.

## Validation
- `python tools/update_credsweeper.py latest --check`
- `python tools/generate_licenses.py --check`
- Python bytecode compilation for both update scripts
- sidecar patch `git apply --check` against CredSweeper v1.17.4
- `git diff --check`
- full Rust, parity, sidecar, and release validation delegated to GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection support for credentials from AWS AppSync, Alibaba, Defined Networking, Doppler, PlanetScale, and Supabase.
  * Improved credential pattern matching for Dynatrace and Salesforce tokens.
  * Added broader keyword coverage to reduce missed credential findings.

* **Bug Fixes**
  * Reduced false-positive severity for AWS Client IDs.
  * Improved startup efficiency by loading scanning components only when needed.

* **Chores**
  * Updated the CredSweeper scanning engine and bundled license information.
  * Released version 0.0.31.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->