### PR TITLE
docs: fix README logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://pentect.dev/">
-    <img src="website/public/pentect-logo-transparent.png" width="96" alt="Pentect">
+    <img src="https://pentect.dev/pentect-logo-transparent.png" width="96" alt="Pentect">
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- serve the README logo from the public Pentect site
- avoid GitHub README relative-image resolution failures

## Verification
- confirmed the image URL returns HTTP 200 with image/png