### PR TITLE
docs: clarify README security scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ providers. Start with the [documentation](https://pentect.dev/).
 - [Contributing](CONTRIBUTING.md)
 - [Third-party notices](THIRD_PARTY_LICENSES.txt)
 
+> **Security scope:** Pentect does not protect a compromised operating system
+> from malware with administrator privileges or an attacker that can read local
+> process memory. It reduces unintended disclosure of sensitive data to AI
+> providers.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary`n- clarify that Pentect does not protect an already-compromised operating system`n- define its scope as reducing unintended disclosure to AI providers