### PR TITLE
chore: simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,65 +1,11 @@
 name: Bug report
-description: Report reproducible incorrect behavior in Pentect.
-title: "[Bug]: "
+description: Tell us about something that is not working.
+title: ""
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for helping improve Pentect. Remove secrets, tokens, personal data, and private URLs from every field and attachment.
-
   - type: textarea
     id: problem
     attributes:
       label: What happened?
-      description: Describe the actual behavior and what you expected instead.
-      placeholder: Pentect did ...; I expected ...
+      placeholder: Tell us what happened. Add steps, commands, or screenshots only if useful. Never include secrets.
     validations:
       required: true
-
-  - type: textarea
-    id: reproduce
-    attributes:
-      label: How can we reproduce it?
-      description: Provide the smallest safe sequence of commands or actions that reproduces the problem.
-      placeholder: |
-        1. Run `pentect ...`
-        2. ...
-        3. Observe ...
-    validations:
-      required: true
-
-  - type: input
-    id: version
-    attributes:
-      label: Pentect version
-      placeholder: Output of `pentect --version`
-    validations:
-      required: true
-
-  - type: input
-    id: environment
-    attributes:
-      label: Environment
-      description: Operating system, architecture, terminal, and affected integration when relevant.
-      placeholder: Windows 11 x86_64, PowerShell 7, Claude Code
-    validations:
-      required: true
-
-  - type: textarea
-    id: diagnostics
-    attributes:
-      label: Sanitized diagnostics
-      description: Add minimal logs or screenshots after confirming they contain no sensitive data.
-      render: shell
-
-  - type: checkboxes
-    id: checks
-    attributes:
-      label: Before submitting
-      options:
-        - label: I searched for an existing issue.
-          required: true
-        - label: I removed secrets, personal data, and private infrastructure details.
-          required: true
-        - label: This is not a security vulnerability.
-          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability
     url: https://github.com/EdamAme-x/pentect/security/advisories/new

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,35 +1,11 @@
 name: Feature request
-description: Propose a focused improvement to Pentect.
-title: "[Feature]: "
+description: Suggest an improvement or a new feature.
+title: ""
 body:
   - type: textarea
-    id: problem
+    id: idea
     attributes:
-      label: What problem should this solve?
-      description: Explain the user need before describing an implementation.
+      label: What would you like?
+      placeholder: Describe the idea and why it would be useful.
     validations:
       required: true
-
-  - type: textarea
-    id: proposal
-    attributes:
-      label: Proposed behavior
-      description: Describe the smallest useful outcome and, if relevant, an example CLI or config shape.
-    validations:
-      required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: Optional. Note existing workarounds or other designs you considered.
-
-  - type: checkboxes
-    id: checks
-    attributes:
-      label: Before submitting
-      options:
-        - label: I searched for an existing issue or discussion.
-          required: true
-        - label: This request does not include secrets or private data.
-          required: true

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,11 @@
+name: Feedback ⭐
+description: Share anything about Pentect.
+title: ""
+body:
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Feedback
+      placeholder: Write anything you would like to share. Never include secrets.
+    validations:
+      required: true


### PR DESCRIPTION
## What

Make opening an issue take only a title and one required text field.

- reduce bug reports to one free-form field
- reduce feature requests to one free-form field
- add a one-field Feedback ⭐ template
- allow blank issues
- keep private security reporting available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified bug report and feature request forms to make submissions faster.
  * Added a dedicated feedback submission form with guidance not to include secrets or vulnerability details.
  * Enabled blank issue creation for requests that don’t fit the available templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->