### PR TITLE
fix: support npm installs with lifecycle scripts disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "node packaging/npm/install.js",
     "test": "node --test packaging/npm/*.test.js"
   },
   "engines": {

--- a/packaging/npm/bin/pentect.js
+++ b/packaging/npm/bin/pentect.js
@@ -1,8 +1,15 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { ensureInstalled } from '../install.js';
 
-const executable = fileURLToPath(new URL(`../vendor/${process.platform === 'win32' ? 'pentect.exe' : 'pentect'}`, import.meta.url));
+let executable;
+try {
+  executable = await ensureInstalled();
+} catch (error) {
+  console.error(`pentect: ${error.message}`);
+  process.exit(1);
+}
+
 const result = spawnSync(executable, process.argv.slice(2), { stdio: 'inherit' });
 if (result.error) {
   console.error(`pentect: ${result.error.message}`);

--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -73,7 +73,8 @@ async function downloadBinary(base, asset, signal) {
   return download(`${base}/${asset}`, signal);
 }
 
-export async function install(version = await packageVersion()) {
+export async function install(version) {
+  version ||= await packageVersion();
   const asset = releaseAsset();
   const destination = installationPath(version);
   const tag = version ? `v${version}` : 'latest';

--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -1,12 +1,30 @@
 import { createHash } from 'node:crypto';
-import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { gunzipSync } from 'node:zlib';
 
 const repository = 'EdamAme-x/pentect';
 const packageRoot = fileURLToPath(new URL('../..', import.meta.url));
-const destination = join(packageRoot, 'packaging', 'npm', 'vendor', process.platform === 'win32' ? 'pentect.exe' : 'pentect');
+
+function cacheBase(environment = process.env, platform = process.platform, home = homedir()) {
+  if (environment.PENTECT_NPM_CACHE) return resolve(environment.PENTECT_NPM_CACHE);
+  if (platform === 'win32') {
+    return resolve(environment.LOCALAPPDATA || join(home, 'AppData', 'Local'), 'Pentect', 'npm');
+  }
+  if (platform === 'darwin') return resolve(home, 'Library', 'Caches', 'Pentect', 'npm');
+  return resolve(environment.XDG_CACHE_HOME || join(home, '.cache'), 'pentect', 'npm');
+}
+
+export function installationPath(version, options = {}) {
+  if (!/^[0-9A-Za-z][0-9A-Za-z._+-]{0,63}$/.test(version) || version === '..') {
+    throw new Error('The Pentect package version is invalid');
+  }
+  const platform = options.platform || process.platform;
+  const base = cacheBase(options.environment, platform, options.home);
+  return join(base, version, platform === 'win32' ? 'pentect.exe' : 'pentect');
+}
 
 export function releaseAsset(platform = process.platform, architecture = process.arch) {
   const assets = {
@@ -54,6 +72,7 @@ export async function install() {
   const asset = releaseAsset();
   const metadata = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
   const version = (process.env.PENTECT_VERSION || metadata.version)?.replace(/^v/, '');
+  const destination = installationPath(version);
   const tag = version ? `v${version}` : 'latest';
   const base = tag === 'latest'
     ? `https://github.com/${repository}/releases/latest/download`
@@ -74,9 +93,29 @@ export async function install() {
     await rm(destination, { force: true });
     await rename(temporary, destination);
     if (process.platform !== 'win32') await chmod(destination, 0o755);
+    await writeFile(join(dirname(destination), '.pentect-managed-install.json'), JSON.stringify({
+      version: 1,
+      manager: 'npm',
+      update: 'npm update -g pentect',
+      uninstall: 'npm uninstall -g pentect',
+    }), { mode: 0o600 });
   } finally {
     await rm(temporary, { force: true });
   }
+  return destination;
+}
+
+export async function ensureInstalled() {
+  const metadata = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+  const version = (process.env.PENTECT_VERSION || metadata.version)?.replace(/^v/, '');
+  const destination = installationPath(version);
+  try {
+    await access(destination);
+    return destination;
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  return install();
 }
 
 const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);

--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -45,6 +45,11 @@ export function expectedChecksum(text) {
   return match[1].toLowerCase();
 }
 
+async function packageVersion() {
+  const metadata = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+  return metadata.version?.replace(/^v/, '');
+}
+
 async function download(url, signal) {
   const response = await fetch(url, {
     redirect: 'follow',
@@ -68,10 +73,8 @@ async function downloadBinary(base, asset, signal) {
   return download(`${base}/${asset}`, signal);
 }
 
-export async function install() {
+export async function install(version = await packageVersion()) {
   const asset = releaseAsset();
-  const metadata = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
-  const version = (process.env.PENTECT_VERSION || metadata.version)?.replace(/^v/, '');
   const destination = installationPath(version);
   const tag = version ? `v${version}` : 'latest';
   const base = tag === 'latest'
@@ -106,8 +109,7 @@ export async function install() {
 }
 
 export async function ensureInstalled() {
-  const metadata = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
-  const version = (process.env.PENTECT_VERSION || metadata.version)?.replace(/^v/, '');
+  const version = await packageVersion();
   const destination = installationPath(version);
   try {
     await access(destination);
@@ -115,7 +117,7 @@ export async function ensureInstalled() {
   } catch (error) {
     if (error?.code !== 'ENOENT') throw error;
   }
-  return install();
+  return install(version);
 }
 
 const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);

--- a/packaging/npm/install.test.js
+++ b/packaging/npm/install.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { expectedChecksum, releaseAsset } from './install.js';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expectedChecksum, installationPath, releaseAsset } from './install.js';
 
 test('maps supported npm platforms to release assets', () => {
   assert.equal(releaseAsset('win32', 'x64'), 'pentect-windows-x86_64.exe');
@@ -16,4 +19,22 @@ test('accepts only a complete SHA-256 checksum record', () => {
   const hash = 'a'.repeat(64);
   assert.equal(expectedChecksum(`${hash}  pentect-linux-x86_64\n`), hash);
   assert.throws(() => expectedChecksum('not-a-checksum'), /invalid/);
+});
+
+test('uses a user-writable versioned cache for the installed binary', () => {
+  const cache = join(tmpdir(), 'pentect-test-cache');
+  assert.equal(
+    installationPath('0.0.33', {
+      platform: 'linux',
+      environment: { XDG_CACHE_HOME: cache },
+      home: join(tmpdir(), 'pentect-test-home'),
+    }),
+    join(cache, 'pentect', 'npm', '0.0.33', 'pentect'),
+  );
+  assert.throws(() => installationPath('../escape'), /version is invalid/);
+});
+
+test('does not rely on npm lifecycle scripts', async () => {
+  const metadata = JSON.parse(await readFile(new URL('../../package.json', import.meta.url), 'utf8'));
+  assert.equal(metadata.scripts.postinstall, undefined);
 });


### PR DESCRIPTION
## What

- remove the npm postinstall dependency
- download and checksum-verify the release binary on first invocation
- store it in a user-writable, versioned cache
- mark the binary as npm-managed

## Validation

- npm test
- npm pack --dry-run
- node --check packaging/npm/install.js
- node --check packaging/npm/bin/pentect.js

Closes #246