### PR TITLE
chore: release v0.0.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.34"
+version = "0.0.35"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- release current Microsoft Store Codex App discovery on Windows
- release the simplified bug-report attachment field
- bump CLI and npm package versions to v0.0.35

## Validation

- PR #255 passed the full CI matrix
- Windows Codex App tests passed with current and legacy Store package names