### PR TITLE
Fix Codex App session routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   npm-package:
     name: npm package
+    needs: changes
+    if: needs.changes.outputs.npm == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -46,7 +48,22 @@ jobs:
       detector: ${{ steps.filter.outputs.detector }}
       ocr: ${{ steps.filter.outputs.ocr }}
       plugins: ${{ steps.filter.outputs.plugins }}
-      apps: ${{ steps.filter.outputs.apps }}
+      npm: ${{ steps.filter.outputs.npm }}
+      rust: ${{ steps.filter.outputs.rust }}
+      core_rust: ${{ steps.filter.outputs.core_rust }}
+      runtime_rust: ${{ steps.filter.outputs.runtime_rust }}
+      cli_rust: ${{ steps.filter.outputs.cli_rust }}
+      workspace_rust: ${{ steps.filter.outputs.workspace_rust }}
+      manifests: ${{ steps.filter.outputs.manifests }}
+      packaging: ${{ steps.filter.outputs.packaging }}
+      sdk: ${{ steps.filter.outputs.sdk }}
+      codex_app: ${{ steps.filter.outputs.codex_app }}
+      claude_app: ${{ steps.filter.outputs.claude_app }}
+      openai_proxy: ${{ steps.filter.outputs.openai_proxy }}
+      command_shims: ${{ steps.filter.outputs.command_shims }}
+      runtime_log: ${{ steps.filter.outputs.runtime_log }}
+      cli_general: ${{ steps.filter.outputs.cli_general }}
+      runtime_general: ${{ steps.filter.outputs.runtime_general }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -55,69 +72,113 @@ jobs:
         id: filter
         with:
           filters: |
-            detector:
+            npm:
+              - 'package.json'
+              - 'package-lock.json'
+              - 'packaging/npm/**'
+              - 'integrations/pi/**'
+            rust:
               - '.github/workflows/ci.yml'
               - '.github/actions/rust-toolchain/**'
-              - '.gitmodules'
               - '.cargo/**'
               - 'Cargo.lock'
               - 'Cargo.toml'
-              - 'crates/*/Cargo.toml'
+              - 'crates/**/Cargo.toml'
               - 'rust-toolchain*'
+              - 'crates/**/*.rs'
+            manifests:
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'crates/**/Cargo.toml'
+            core_rust:
+              - 'crates/pentect-core/**/*.rs'
+              - 'crates/pentect-core/Cargo.toml'
+            runtime_rust:
+              - 'crates/pentect-runtime/**/*.rs'
+              - 'crates/pentect-runtime/Cargo.toml'
+            cli_rust:
+              - 'crates/pentect-cli/**/*.rs'
+              - 'crates/pentect-cli/Cargo.toml'
+            workspace_rust:
+              - '.cargo/**'
+              - 'Cargo.toml'
+              - 'rust-toolchain*'
+            packaging:
+              - 'packaging/**'
+              - 'tools/install.ps1'
+              - 'tools/install.sh'
+              - 'tools/install-apt.sh'
+              - 'tools/package_deb.sh'
+              - 'tools/build_apt_repository.sh'
+              - 'tools/propose_automation_pr.sh'
+              - 'tools/test_propose_automation_pr.sh'
+              - 'tools/update_package_metadata.py'
+            sdk:
+              - 'sdk/**'
+            detector:
               - 'crates/pentect-core/**'
             ocr:
-              - '.github/workflows/ci.yml'
-              - '.github/actions/rust-toolchain/**'
-              - '.cargo/**'
-              - 'Cargo.lock'
-              - 'Cargo.toml'
-              - 'crates/*/Cargo.toml'
-              - 'rust-toolchain*'
               - 'crates/pentect-runtime/assets/ocr/**'
               - 'crates/pentect-runtime/src/image_ocr.rs'
+              - 'crates/pentect-runtime/src/image.rs'
             plugins:
-              - '.github/workflows/ci.yml'
-              - '.github/actions/rust-toolchain/**'
-              - '.cargo/**'
-              - 'Cargo.lock'
-              - 'Cargo.toml'
-              - 'crates/*/Cargo.toml'
-              - 'rust-toolchain*'
               - 'crates/pentect-cli/src/plugins.rs'
               - 'crates/pentect-cli/src/plugins_cmd.rs'
-              - 'crates/pentect-cli/src/main.rs'
-              - 'crates/pentect-cli/src/codex_app.rs'
-              - 'crates/pentect-cli/src/claude_app_proxy.rs'
-              - 'crates/pentect-cli/src/claude_http_proxy.rs'
               - 'crates/pentect-runtime/src/masking.rs'
               - 'crates/pentect-runtime/src/plugin_middleware.rs'
               - 'plugins/**'
               - 'protocol/**'
               - 'sdk/**'
-            apps:
-              - '.github/workflows/ci.yml'
-              - '.github/actions/rust-toolchain/**'
-              - '.cargo/**'
-              - 'Cargo.lock'
-              - 'Cargo.toml'
-              - 'crates/*/Cargo.toml'
-              - 'rust-toolchain*'
-              - 'crates/pentect-cli/src/claude_app_proxy.rs'
-              - 'crates/pentect-cli/src/claude_http_proxy.rs'
+            codex_app:
               - 'crates/pentect-cli/src/codex_app.rs'
-              - 'crates/pentect-cli/src/http_files.rs'
-              - 'crates/pentect-cli/src/main.rs'
               - 'crates/pentect-cli/src/openai_http_proxy.rs'
+              - 'crates/pentect-cli/src/http_files.rs'
               - 'crates/pentect-cli/src/remote_content.rs'
               - 'crates/pentect-cli/src/upstream.rs'
-              - 'crates/pentect-runtime/**'
-              - 'guides/apps.md'
-              - 'COMPATIBILITY.md'
+            claude_app:
+              - 'crates/pentect-cli/src/claude_app_proxy.rs'
+              - 'crates/pentect-cli/src/claude_http_proxy.rs'
+              - 'crates/pentect-cli/src/http_files.rs'
+              - 'crates/pentect-cli/src/remote_content.rs'
+              - 'crates/pentect-cli/src/upstream.rs'
+            openai_proxy:
+              - 'crates/pentect-cli/src/openai_http_proxy.rs'
+              - 'crates/pentect-cli/src/http_files.rs'
+              - 'crates/pentect-cli/src/remote_content.rs'
+              - 'crates/pentect-cli/src/upstream.rs'
+            command_shims:
+              - 'crates/pentect-cli/src/main.rs'
+            runtime_log:
+              - 'crates/pentect-runtime/src/activity_log.rs'
+              - 'crates/pentect-runtime/src/delegated_process_host.rs'
+              - 'crates/pentect-runtime/src/memory_store.rs'
+            cli_general:
+              - 'crates/pentect-cli/src/**'
+              - '!crates/pentect-cli/src/codex_app.rs'
+              - '!crates/pentect-cli/src/openai_http_proxy.rs'
+              - '!crates/pentect-cli/src/http_files.rs'
+              - '!crates/pentect-cli/src/remote_content.rs'
+              - '!crates/pentect-cli/src/upstream.rs'
+              - '!crates/pentect-cli/src/claude_app_proxy.rs'
+              - '!crates/pentect-cli/src/claude_http_proxy.rs'
+              - '!crates/pentect-cli/src/plugins.rs'
+              - '!crates/pentect-cli/src/plugins_cmd.rs'
+              - '!crates/pentect-cli/src/main.rs'
+            runtime_general:
+              - 'crates/pentect-runtime/src/**'
+              - '!crates/pentect-runtime/src/main.rs'
+              - '!crates/pentect-runtime/src/activity_log.rs'
+              - '!crates/pentect-runtime/src/delegated_process_host.rs'
+              - '!crates/pentect-runtime/src/memory_store.rs'
+              - '!crates/pentect-runtime/src/image_ocr.rs'
+              - '!crates/pentect-runtime/src/image.rs'
+              - '!crates/pentect-runtime/src/masking.rs'
+              - '!crates/pentect-runtime/src/plugin_middleware.rs'
 
   native-ocr:
     name: Native OCR (${{ matrix.os }})
     needs: changes
-    if: always()
+    if: needs.changes.result == 'success' && needs.changes.outputs.ocr == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -147,7 +208,7 @@ jobs:
   plugin-platform:
     name: Plugins (${{ matrix.os }})
     needs: changes
-    if: always()
+    if: needs.changes.result == 'success' && needs.changes.outputs.plugins == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -197,7 +258,7 @@ jobs:
   app-platform:
     name: Desktop app boundaries (${{ matrix.os }})
     needs: changes
-    if: always()
+    if: needs.changes.result == 'success' && (needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.command_shims == 'true')
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -209,30 +270,33 @@ jobs:
         if: needs.changes.result != 'success'
         run: exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        if: needs.changes.outputs.apps == 'true'
+        if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.command_shims == 'true'
         with:
           submodules: recursive
           persist-credentials: false
       - uses: ./.github/actions/rust-toolchain
-        if: needs.changes.outputs.apps == 'true'
+        if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.command_shims == 'true'
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: needs.changes.outputs.apps == 'true'
+        if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.command_shims == 'true'
       - name: Test Codex App launcher and recovery
-        if: needs.changes.outputs.apps == 'true'
+        if: needs.changes.outputs.codex_app == 'true'
         run: python tools/run_filtered_tests.py codex_app::tests
       - name: Test Claude Desktop gateway
-        if: needs.changes.outputs.apps == 'true'
+        if: needs.changes.outputs.claude_app == 'true'
         run: python tools/run_filtered_tests.py claude_app_proxy::tests
+      - name: Test OpenAI gateway
+        if: needs.changes.outputs.openai_proxy == 'true'
+        run: python tools/run_filtered_tests.py openai_http_proxy::tests
       - name: Test Windows npm command shims
-        if: needs.changes.outputs.apps == 'true' && runner.os == 'Windows'
+        if: needs.changes.outputs.command_shims == 'true' && runner.os == 'Windows'
         run: cargo test -p pentect-cli --no-default-features windows_npm_cmd_shim --locked
       - name: No app changes
-        if: needs.changes.outputs.apps != 'true'
+        if: needs.changes.outputs.codex_app != 'true' && needs.changes.outputs.claude_app != 'true' && needs.changes.outputs.command_shims != 'true'
         run: echo "No app changes"
 
   test:
     needs: changes
-    if: always()
+    if: needs.changes.result == 'success' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.manifests == 'true' || needs.changes.outputs.packaging == 'true' || needs.changes.outputs.sdk == 'true' || needs.changes.outputs.runtime_log == 'true' || needs.changes.outputs.cli_general == 'true' || needs.changes.outputs.runtime_general == 'true' || needs.changes.outputs.detector == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -246,21 +310,24 @@ jobs:
       - uses: ./.github/actions/rust-toolchain
         with:
           components: rustfmt, clippy
-          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Format
+        if: needs.changes.outputs.rust == 'true'
         run: cargo fmt --all --check
       - name: Verify third-party licenses
+        if: needs.changes.outputs.manifests == 'true'
         run: python tools/generate_licenses.py --check
       - name: Verify package metadata
+        if: needs.changes.outputs.packaging == 'true'
         run: |
           python tools/update_package_metadata.py --metadata-file packaging/release.json --check
           sh -n tools/install.sh tools/install-apt.sh tools/package_deb.sh tools/build_apt_repository.sh tools/propose_automation_pr.sh
           sh tools/test_propose_automation_pr.sh
       - name: Validate PowerShell tools
+        if: needs.changes.outputs.packaging == 'true'
         shell: pwsh
         run: |
           foreach ($path in @('tools/install.ps1', 'tools/release_live_e2e.ps1')) {
@@ -275,12 +342,35 @@ jobs:
               throw "$path`n$($errors | Out-String)"
             }
           }
-      - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Clippy core
+        if: needs.changes.outputs.core_rust == 'true'
+        run: cargo clippy -p pentect-core --all-targets --no-default-features -- -D warnings
+      - name: Clippy runtime
+        if: needs.changes.outputs.runtime_rust == 'true'
+        run: cargo clippy -p pentect-runtime --all-targets --no-default-features -- -D warnings
+      - name: Clippy CLI
+        if: needs.changes.outputs.cli_rust == 'true'
+        run: cargo clippy -p pentect-cli --all-targets --no-default-features -- -D warnings
+      - name: Clippy workspace configuration
+        if: needs.changes.outputs.workspace_rust == 'true'
+        run: cargo clippy -p pentect-core -p pentect-runtime -p pentect-cli --all-targets --no-default-features -- -D warnings
       - name: Check WebAssembly plugin SDK
-        run: cargo check --manifest-path sdk/rust/pentect-plugin/Cargo.toml --target wasm32-unknown-unknown --example wasm
-      - name: Test
-        run: cargo test --all-features
-      - name: Test (rules-only, no default features)
+        if: needs.changes.outputs.sdk == 'true'
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo check --manifest-path sdk/rust/pentect-plugin/Cargo.toml --target wasm32-unknown-unknown --example wasm
+      - name: Test runtime activity log
+        if: needs.changes.outputs.runtime_log == 'true'
+        run: cargo test -p pentect-runtime --no-default-features activity_log::tests --locked
+      - name: Test general CLI changes
+        if: needs.changes.outputs.cli_general == 'true'
+        run: cargo test -p pentect-cli --no-default-features --locked
+      - name: Test general runtime changes
+        if: needs.changes.outputs.runtime_general == 'true'
+        run: cargo test -p pentect-runtime --no-default-features --locked
+      - name: Test detector changes
         if: needs.changes.outputs.detector == 'true'
-        run: cargo test -p pentect-core --no-default-features
+        run: cargo test -p pentect-core --no-default-features --locked
+      - name: Full test on main
+        if: github.event_name == 'push'
+        run: cargo test --all-features --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
   native-ocr:
     name: Native OCR (${{ matrix.os }})
     needs: changes
-    if: needs.changes.result == 'success' && needs.changes.outputs.ocr == 'true'
+    if: always()
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -213,7 +213,7 @@ jobs:
   plugin-platform:
     name: Plugins (${{ matrix.os }})
     needs: changes
-    if: needs.changes.result == 'success' && needs.changes.outputs.plugins == 'true'
+    if: always()
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -263,7 +263,7 @@ jobs:
   app-platform:
     name: Desktop app boundaries (${{ matrix.os }})
     needs: changes
-    if: needs.changes.result == 'success' && (needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true')
+    if: always()
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -315,7 +315,7 @@ jobs:
 
   test:
     needs: changes
-    if: needs.changes.result == 'success' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.manifests == 'true' || needs.changes.outputs.packaging == 'true' || needs.changes.outputs.sdk == 'true' || needs.changes.outputs.runtime_log == 'true' || needs.changes.outputs.cli_general == 'true' || needs.changes.outputs.runtime_general == 'true' || needs.changes.outputs.runtime_main == 'true' || needs.changes.outputs.command_shims == 'true' || needs.changes.outputs.detector == 'true')
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       runtime_log: ${{ steps.filter.outputs.runtime_log }}
       cli_general: ${{ steps.filter.outputs.cli_general }}
       runtime_general: ${{ steps.filter.outputs.runtime_general }}
+      runtime_main: ${{ steps.filter.outputs.runtime_main }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -106,6 +107,8 @@ jobs:
             packaging:
               - 'packaging/**'
               - 'tools/install.ps1'
+              - 'tools/test_install.ps1'
+              - 'tools/release_live_e2e.ps1'
               - 'tools/install.sh'
               - 'tools/install-apt.sh'
               - 'tools/package_deb.sh'
@@ -174,6 +177,8 @@ jobs:
               - '!crates/pentect-runtime/src/image.rs'
               - '!crates/pentect-runtime/src/masking.rs'
               - '!crates/pentect-runtime/src/plugin_middleware.rs'
+            runtime_main:
+              - 'crates/pentect-runtime/src/main.rs'
 
   native-ocr:
     name: Native OCR (${{ matrix.os }})
@@ -258,7 +263,7 @@ jobs:
   app-platform:
     name: Desktop app boundaries (${{ matrix.os }})
     needs: changes
-    if: needs.changes.result == 'success' && (needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.command_shims == 'true')
+    if: needs.changes.result == 'success' && (needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true')
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -270,14 +275,14 @@ jobs:
         if: needs.changes.result != 'success'
         run: exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.command_shims == 'true'
+        if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true'
         with:
           submodules: recursive
           persist-credentials: false
       - uses: ./.github/actions/rust-toolchain
-        if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.command_shims == 'true'
+        if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true'
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.command_shims == 'true'
+        if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true'
       - name: Test Codex App launcher and recovery
         if: needs.changes.outputs.codex_app == 'true'
         run: python tools/run_filtered_tests.py codex_app::tests
@@ -291,12 +296,26 @@ jobs:
         if: needs.changes.outputs.command_shims == 'true' && runner.os == 'Windows'
         run: cargo test -p pentect-cli --no-default-features windows_npm_cmd_shim --locked
       - name: No app changes
-        if: needs.changes.outputs.codex_app != 'true' && needs.changes.outputs.claude_app != 'true' && needs.changes.outputs.command_shims != 'true'
+        if: needs.changes.outputs.codex_app != 'true' && needs.changes.outputs.claude_app != 'true' && needs.changes.outputs.openai_proxy != 'true' && needs.changes.outputs.command_shims != 'true'
         run: echo "No app changes"
+
+  windows-powershell-installer:
+    name: Windows PowerShell installer
+    needs: changes
+    if: needs.changes.result == 'success' && needs.changes.outputs.packaging == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Test Windows PowerShell 5.1 fallback
+        shell: powershell
+        run: ./tools/test_install.ps1
 
   test:
     needs: changes
-    if: needs.changes.result == 'success' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.manifests == 'true' || needs.changes.outputs.packaging == 'true' || needs.changes.outputs.sdk == 'true' || needs.changes.outputs.runtime_log == 'true' || needs.changes.outputs.cli_general == 'true' || needs.changes.outputs.runtime_general == 'true' || needs.changes.outputs.detector == 'true')
+    if: needs.changes.result == 'success' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.manifests == 'true' || needs.changes.outputs.packaging == 'true' || needs.changes.outputs.sdk == 'true' || needs.changes.outputs.runtime_log == 'true' || needs.changes.outputs.cli_general == 'true' || needs.changes.outputs.runtime_general == 'true' || needs.changes.outputs.runtime_main == 'true' || needs.changes.outputs.command_shims == 'true' || needs.changes.outputs.detector == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -342,6 +361,7 @@ jobs:
               throw "$path`n$($errors | Out-String)"
             }
           }
+          & ./tools/test_install.ps1
       - name: Clippy core
         if: needs.changes.outputs.core_rust == 'true'
         run: cargo clippy -p pentect-core --all-targets --no-default-features -- -D warnings
@@ -367,6 +387,9 @@ jobs:
         run: cargo test -p pentect-cli --no-default-features --locked
       - name: Test general runtime changes
         if: needs.changes.outputs.runtime_general == 'true'
+        run: cargo test -p pentect-runtime --no-default-features --locked
+      - name: Test runtime entrypoint changes
+        if: needs.changes.outputs.runtime_main == 'true'
         run: cargo test -p pentect-runtime --no-default-features --locked
       - name: Test detector changes
         if: needs.changes.outputs.detector == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
               throw "$path`n$($errors | Out-String)"
             }
           }
+          & ./tools/test_install.ps1
       - name: Verify third-party licenses
         run: python tools/generate_licenses.py --check
       - name: Verify package metadata generator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,22 +360,57 @@ jobs:
           dist/pentect-linux-x86_64 gemini -- --version
 
   lifecycle:
-    name: Lifecycle (${{ matrix.os }})
-    needs: publish
+    name: Installer smoke (${{ matrix.os }}, ${{ matrix.installer }})
+    needs: [publish, package-deb]
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-15]
+        include:
+          - os: windows-latest
+            installer: direct
+          - os: windows-latest
+            installer: npm
+          - os: ubuntu-22.04
+            installer: direct
+          - os: ubuntu-22.04
+            installer: npm
+          - os: ubuntu-22.04
+            installer: deb
+            artifact: pentect-deb-amd64
+          - os: ubuntu-22.04-arm
+            installer: direct
+          - os: ubuntu-22.04-arm
+            installer: npm
+          - os: ubuntu-22.04-arm
+            installer: deb
+            artifact: pentect-deb-arm64
+          - os: macos-15-intel
+            installer: direct
+          - os: macos-15-intel
+            installer: npm
+          - os: macos-15
+            installer: direct
+          - os: macos-15
+            installer: npm
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+      - name: Download Debian package
+        if: matrix.installer == 'deb'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist
       - name: Install, update, and uninstall (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.installer == 'direct'
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
@@ -406,13 +441,9 @@ jobs:
           } finally {
             Pop-Location
           }
-          & $binary uninstall
-          for ($attempt = 0; $attempt -lt 100 -and (Test-Path -LiteralPath $binary); $attempt++) {
-            Start-Sleep -Milliseconds 100
-          }
-          if (Test-Path -LiteralPath $binary) { throw 'uninstall did not remove the binary' }
+          "PENTECT_SMOKE_BINARY=$binary" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Install through npm (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.installer == 'npm'
         shell: pwsh
         run: |
           $env:PENTECT_VERSION = $env:GITHUB_REF_NAME.TrimStart('v')
@@ -420,8 +451,9 @@ jobs:
           npm install --global . --prefix $prefix
           $version = & (Join-Path $prefix 'pentect.cmd') version
           if ($version -ne "pentect $env:PENTECT_VERSION") { throw 'npm-installed version mismatch' }
+          "PENTECT_SMOKE_BINARY=$(Join-Path $prefix 'pentect.cmd')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Install, update, and uninstall (POSIX)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.installer == 'direct'
         shell: sh
         env:
           GH_TOKEN: ${{ github.token }}
@@ -444,10 +476,9 @@ jobs:
             "$binary" plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --yes
             "$binary" plugins inspect openai-privacy-filter | grep -F 'hooks: inspect'
           )
-          "$binary" uninstall
-          test ! -e "$binary"
+          printf 'PENTECT_SMOKE_BINARY=%s\n' "$binary" >> "$GITHUB_ENV"
       - name: Install through npm (POSIX)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.installer == 'npm'
         shell: sh
         run: |
           set -eu
@@ -455,6 +486,67 @@ jobs:
           prefix="$RUNNER_TEMP/pentect-npm"
           PENTECT_VERSION="$version" npm install --global . --prefix "$prefix"
           test "$("$prefix/bin/pentect" version)" = "pentect $version"
+          printf 'PENTECT_SMOKE_BINARY=%s\n' "$prefix/bin/pentect" >> "$GITHUB_ENV"
+      - name: Install Debian package
+        if: matrix.installer == 'deb'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo dpkg -i dist/pentect_*.deb
+          test "$(pentect version)" = "pentect ${GITHUB_REF_NAME#v}"
+          echo 'PENTECT_SMOKE_BINARY=/usr/bin/pentect' >> "$GITHUB_ENV"
+      - name: Verify Codex CLI and Codex App launch (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          npm install --global @openai/codex@0.147.0
+          & $env:PENTECT_SMOKE_BINARY codex -- --version
+          if ($LASTEXITCODE -ne 0) { throw 'pentect codex failed to launch' }
+          $node = (Get-Command node -ErrorAction Stop).Source
+          $fixture = Join-Path $env:RUNNER_TEMP 'codex-app-fixture.exe'
+          Copy-Item -LiteralPath $node -Destination $fixture
+          $env:CODEX_HOME = Join-Path $env:RUNNER_TEMP 'codex-home'
+          New-Item -ItemType Directory -Force $env:CODEX_HOME | Out-Null
+          $config = Join-Path $env:CODEX_HOME 'config.toml'
+          '# installer smoke sentinel' | Set-Content -Encoding utf8 $config
+          $before = (Get-FileHash -Algorithm SHA256 $config).Hash
+          & $env:PENTECT_SMOKE_BINARY codex app --app $fixture --upstream https://api.openai.com/v1
+          if ($LASTEXITCODE -ne 0) { throw 'pentect codex app failed to launch' }
+          if ((Get-FileHash -Algorithm SHA256 $config).Hash -ne $before) { throw 'Codex config was modified' }
+      - name: Verify Codex CLI and Codex App launch (POSIX)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --global @openai/codex@0.147.0
+          "$PENTECT_SMOKE_BINARY" codex -- --version
+          fixture="$RUNNER_TEMP/codex-app-fixture"
+          cp "$(command -v node)" "$fixture"
+          chmod +x "$fixture"
+          export CODEX_HOME="$RUNNER_TEMP/codex-home"
+          mkdir -p "$CODEX_HOME"
+          printf '%s\n' '# installer smoke sentinel' > "$CODEX_HOME/config.toml"
+          cp "$CODEX_HOME/config.toml" "$RUNNER_TEMP/config.before"
+          "$PENTECT_SMOKE_BINARY" codex app --app "$fixture" --upstream https://api.openai.com/v1
+          cmp "$RUNNER_TEMP/config.before" "$CODEX_HOME/config.toml"
+      - name: Uninstall direct installation (Windows)
+        if: runner.os == 'Windows' && matrix.installer == 'direct'
+        shell: pwsh
+        run: |
+          & $env:PENTECT_SMOKE_BINARY uninstall
+          for ($attempt = 0; $attempt -lt 100 -and (Test-Path -LiteralPath $env:PENTECT_SMOKE_BINARY); $attempt++) {
+            Start-Sleep -Milliseconds 100
+          }
+          if (Test-Path -LiteralPath $env:PENTECT_SMOKE_BINARY) { throw 'uninstall did not remove the binary' }
+      - name: Uninstall direct installation (POSIX)
+        if: runner.os != 'Windows' && matrix.installer == 'direct'
+        shell: sh
+        run: |
+          "$PENTECT_SMOKE_BINARY" uninstall
+          test ! -e "$PENTECT_SMOKE_BINARY"
+      - name: Remove Debian package
+        if: matrix.installer == 'deb'
+        run: sudo apt-get remove -y pentect
 
   promote:
     name: Publish stable release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,6 +2336,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "jiff",
  "junction",
  "libc",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,6 +1769,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "junction"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.35"
+version = "0.0.36"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -2326,6 +2336,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "junction",
  "libc",
  "memchr",
  "pdf-extract",

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -31,7 +31,7 @@ Pentect currently uses the upstream crate without source modifications.
 CARGO PACKAGES
 --------------
 
-502 non-workspace release dependency packages are covered below.
+503 non-workspace release dependency packages are covered below.
 Package labels show the license expression declared in Cargo metadata.
 
 DOCUMENT 1
@@ -9425,6 +9425,34 @@ SOFTWARE.
 DOCUMENT 147
 ~~~~~~~~~~~~
 Applies to:
+- junction 2.0.0 (MIT)
+
+MIT License
+
+Copyright (c) 2020 lzutao
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+DOCUMENT 148
+~~~~~~~~~~~~
+Applies to:
 - keccak 0.1.6 (Apache-2.0 OR MIT)
 
 Copyright (c) 2018-2022 RustCrypto Developers
@@ -9454,7 +9482,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 148
+DOCUMENT 149
 ~~~~~~~~~~~~
 Applies to:
 - lazy_static 1.5.0 (MIT OR Apache-2.0)
@@ -9488,7 +9516,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 149
+DOCUMENT 150
 ~~~~~~~~~~~~
 Applies to:
 - libc 0.2.186 (MIT OR Apache-2.0)
@@ -9520,7 +9548,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 150
+DOCUMENT 151
 ~~~~~~~~~~~~
 Applies to:
 - libm 0.2.16 (MIT)
@@ -9785,7 +9813,7 @@ have been licensed under extremely permissive terms.
 Copyright notices are retained in src/* files where relevant.
 
 
-DOCUMENT 151
+DOCUMENT 152
 ~~~~~~~~~~~~
 Applies to:
 - linux-raw-sys 0.12.1 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -9821,7 +9849,7 @@ is licensed under:
 at your option.
 
 
-DOCUMENT 152
+DOCUMENT 153
 ~~~~~~~~~~~~
 Applies to:
 - linux-raw-sys 0.12.1 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -10054,7 +10082,7 @@ the License, but only in their entirety and only with respect to the Combined
 Software.
 
 
-DOCUMENT 153
+DOCUMENT 154
 ~~~~~~~~~~~~
 Applies to:
 - lock_api 0.4.14 (MIT OR Apache-2.0)
@@ -10089,7 +10117,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 154
+DOCUMENT 155
 ~~~~~~~~~~~~
 Applies to:
 - lopdf 0.42.0 (MIT)
@@ -10118,7 +10146,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 155
+DOCUMENT 156
 ~~~~~~~~~~~~
 Applies to:
 - lru-slab 0.1.2 (MIT OR Apache-2.0 OR Zlib)
@@ -10132,7 +10160,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 156
+DOCUMENT 157
 ~~~~~~~~~~~~
 Applies to:
 - lru-slab 0.1.2 (MIT OR Apache-2.0 OR Zlib)
@@ -10158,7 +10186,7 @@ the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 157
+DOCUMENT 158
 ~~~~~~~~~~~~
 Applies to:
 - matrixmultiply 0.3.10 (MIT/Apache-2.0)
@@ -10192,7 +10220,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 158
+DOCUMENT 159
 ~~~~~~~~~~~~
 Applies to:
 - md-5 0.10.6 (MIT OR Apache-2.0)
@@ -10227,7 +10255,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 159
+DOCUMENT 160
 ~~~~~~~~~~~~
 Applies to:
 - memmap2 0.9.11 (MIT OR Apache-2.0)
@@ -10435,7 +10463,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 160
+DOCUMENT 161
 ~~~~~~~~~~~~
 Applies to:
 - memmap2 0.9.11 (MIT OR Apache-2.0)
@@ -10468,7 +10496,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 161
+DOCUMENT 162
 ~~~~~~~~~~~~
 Applies to:
 - minimal-lexical 0.2.1 (MIT/Apache-2.0)
@@ -10512,38 +10540,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 162
-~~~~~~~~~~~~
-Applies to:
-- miniz_oxide 0.8.9 (MIT OR Zlib OR Apache-2.0)
-
-MIT License
-
-Copyright 2013-2014 RAD Game Tools and Valve Software
-Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
-Copyright (c) 2017 Frommi
-Copyright (c) 2017-2024 oyvindln
-
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
 DOCUMENT 163
 ~~~~~~~~~~~~
 Applies to:
@@ -10555,6 +10551,7 @@ Copyright 2013-2014 RAD Game Tools and Valve Software
 Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
 Copyright (c) 2017 Frommi
 Copyright (c) 2017-2024 oyvindln
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10580,6 +10577,37 @@ DOCUMENT 164
 Applies to:
 - miniz_oxide 0.8.9 (MIT OR Zlib OR Apache-2.0)
 
+MIT License
+
+Copyright 2013-2014 RAD Game Tools and Valve Software
+Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
+Copyright (c) 2017 Frommi
+Copyright (c) 2017-2024 oyvindln
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+DOCUMENT 165
+~~~~~~~~~~~~
+Applies to:
+- miniz_oxide 0.8.9 (MIT OR Zlib OR Apache-2.0)
+
 Copyright 2013-2014 RAD Game Tools and Valve Software
 Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
 Copyright (c) 2020 Frommi
@@ -10596,7 +10624,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 165
+DOCUMENT 166
 ~~~~~~~~~~~~
 Applies to:
 - mio 1.2.1 (MIT)
@@ -10622,7 +10650,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 166
+DOCUMENT 167
 ~~~~~~~~~~~~
 Applies to:
 - moka 0.12.15 ((MIT OR Apache-2.0) AND Apache-2.0)
@@ -10830,7 +10858,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 167
+DOCUMENT 168
 ~~~~~~~~~~~~
 Applies to:
 - moka 0.12.15 ((MIT OR Apache-2.0) AND Apache-2.0)
@@ -10858,7 +10886,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 168
+DOCUMENT 169
 ~~~~~~~~~~~~
 Applies to:
 - moka 0.12.15 ((MIT OR Apache-2.0) AND Apache-2.0)
@@ -10879,7 +10907,7 @@ These files were ported from the Java Caffeine library and are not dual-licensed
 Please refer to the LICENSE-APACHE file for more details on the Apache License 2.0.
 
 
-DOCUMENT 169
+DOCUMENT 170
 ~~~~~~~~~~~~
 Applies to:
 - moxcms 0.8.1 (BSD-3-Clause OR Apache-2.0)
@@ -11088,7 +11116,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 170
+DOCUMENT 171
 ~~~~~~~~~~~~
 Applies to:
 - moxcms 0.8.1 (BSD-3-Clause OR Apache-2.0)
@@ -11122,7 +11150,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 171
+DOCUMENT 172
 ~~~~~~~~~~~~
 Applies to:
 - ndarray 0.17.2 (MIT OR Apache-2.0)
@@ -11156,7 +11184,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 172
+DOCUMENT 173
 ~~~~~~~~~~~~
 Applies to:
 - ndk-context 0.1.1 (MIT OR Apache-2.0)
@@ -11188,7 +11216,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 173
+DOCUMENT 174
 ~~~~~~~~~~~~
 Applies to:
 - nix 0.28.0 (MIT)
@@ -11217,7 +11245,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 174
+DOCUMENT 175
 ~~~~~~~~~~~~
 Applies to:
 - nom 7.1.3 (MIT)
@@ -11245,7 +11273,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 175
+DOCUMENT 176
 ~~~~~~~~~~~~
 Applies to:
 - nom-language 0.1.0 (MIT)
@@ -11277,7 +11305,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 176
+DOCUMENT 177
 ~~~~~~~~~~~~
 Applies to:
 - ntapi 0.4.3 (Apache-2.0 OR MIT)
@@ -11301,7 +11329,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 177
+DOCUMENT 178
 ~~~~~~~~~~~~
 Applies to:
 - num-conv 0.2.2 (MIT OR Apache-2.0)
@@ -11327,7 +11355,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 178
+DOCUMENT 179
 ~~~~~~~~~~~~
 Applies to:
 - objc2 0.6.4 (MIT)
@@ -11359,7 +11387,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 179
+DOCUMENT 180
 ~~~~~~~~~~~~
 Applies to:
 - objc2-core-foundation 0.3.2 (Zlib OR Apache-2.0 OR MIT)
@@ -11391,7 +11419,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 180
+DOCUMENT 181
 ~~~~~~~~~~~~
 Applies to:
 - objc2-encode 4.1.0 (MIT)
@@ -11423,7 +11451,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 181
+DOCUMENT 182
 ~~~~~~~~~~~~
 Applies to:
 - objc2-foundation 0.3.2 (MIT)
@@ -11455,7 +11483,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 182
+DOCUMENT 183
 ~~~~~~~~~~~~
 Applies to:
 - objc2-io-kit 0.3.2 (Zlib OR Apache-2.0 OR MIT)
@@ -11487,7 +11515,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 183
+DOCUMENT 184
 ~~~~~~~~~~~~
 Applies to:
 - objc2-vision 0.3.2 (Zlib OR Apache-2.0 OR MIT)
@@ -11519,7 +11547,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 184
+DOCUMENT 185
 ~~~~~~~~~~~~
 Applies to:
 - ocrs 0.12.2 (MIT OR Apache-2.0)
@@ -11551,7 +11579,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 185
+DOCUMENT 186
 ~~~~~~~~~~~~
 Applies to:
 - Ocrs bundled RTen models (CC-BY-SA-4.0 attribution)
@@ -11572,7 +11600,7 @@ Files:
   SHA-256: e484866d4cce403175bd8d00b128feb08ab42e208de30e42cd9889d8f1735a6e
 
 
-DOCUMENT 186
+DOCUMENT 187
 ~~~~~~~~~~~~
 Applies to:
 - oncemutex 0.1.1 (MIT/Apache-2.0)
@@ -11604,7 +11632,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 187
+DOCUMENT 188
 ~~~~~~~~~~~~
 Applies to:
 - pdf-extract 0.12.0 (MIT)
@@ -11636,7 +11664,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 188
+DOCUMENT 189
 ~~~~~~~~~~~~
 Applies to:
 - png 0.18.1 (MIT OR Apache-2.0)
@@ -11668,7 +11696,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 189
+DOCUMENT 190
 ~~~~~~~~~~~~
 Applies to:
 - postcard 1.1.3 (MIT OR Apache-2.0)
@@ -11700,7 +11728,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 190
+DOCUMENT 191
 ~~~~~~~~~~~~
 Applies to:
 - postscript 0.14.1 (Apache-2.0/MIT)
@@ -11756,7 +11784,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 
-DOCUMENT 191
+DOCUMENT 192
 ~~~~~~~~~~~~
 Applies to:
 - powerfmt 0.2.0 (MIT OR Apache-2.0)
@@ -11964,7 +11992,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 192
+DOCUMENT 193
 ~~~~~~~~~~~~
 Applies to:
 - powerfmt 0.2.0 (MIT OR Apache-2.0)
@@ -11990,7 +12018,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 193
+DOCUMENT 194
 ~~~~~~~~~~~~
 Applies to:
 - prefix-trie 0.8.4 (MIT OR Apache-2.0)
@@ -12004,7 +12032,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 194
+DOCUMENT 195
 ~~~~~~~~~~~~
 Applies to:
 - primal-check 0.3.4 (MIT OR Apache-2.0)
@@ -12036,7 +12064,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 195
+DOCUMENT 196
 ~~~~~~~~~~~~
 Applies to:
 - proc-macro-error-attr2 2.0.0 (MIT OR Apache-2.0)
@@ -12245,7 +12273,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 196
+DOCUMENT 197
 ~~~~~~~~~~~~
 Applies to:
 - proc-macro-error-attr2 2.0.0 (MIT OR Apache-2.0)
@@ -12274,7 +12302,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 197
+DOCUMENT 198
 ~~~~~~~~~~~~
 Applies to:
 - quick-error 2.0.1 (MIT/Apache-2.0)
@@ -12300,7 +12328,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 198
+DOCUMENT 199
 ~~~~~~~~~~~~
 Applies to:
 - quick-xml 0.41.0 (MIT)
@@ -12330,7 +12358,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 199
+DOCUMENT 200
 ~~~~~~~~~~~~
 Applies to:
 - quinn 0.11.11 (MIT OR Apache-2.0)
@@ -12346,7 +12374,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 200
+DOCUMENT 201
 ~~~~~~~~~~~~
 Applies to:
 - r-efi 6.0.0 (MIT OR Apache-2.0 OR LGPL-2.1-or-later)
@@ -12378,7 +12406,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 201
+DOCUMENT 202
 ~~~~~~~~~~~~
 Applies to:
 - rand 0.10.1 (MIT OR Apache-2.0)
@@ -12400,7 +12428,7 @@ The Rand project includes code from the Rust project
 published under these same licenses.
 
 
-DOCUMENT 202
+DOCUMENT 203
 ~~~~~~~~~~~~
 Applies to:
 - rand 0.10.1 (MIT OR Apache-2.0)
@@ -12583,7 +12611,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 203
+DOCUMENT 204
 ~~~~~~~~~~~~
 Applies to:
 - rand 0.10.1 (MIT OR Apache-2.0)
@@ -12617,7 +12645,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 204
+DOCUMENT 205
 ~~~~~~~~~~~~
 Applies to:
 - rand_core 0.10.1 (MIT OR Apache-2.0)
@@ -12633,7 +12661,7 @@ licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
 <LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
 
 
-DOCUMENT 205
+DOCUMENT 206
 ~~~~~~~~~~~~
 Applies to:
 - rand_core 0.10.1 (MIT OR Apache-2.0)
@@ -12830,7 +12858,7 @@ APPENDIX: How to apply the Apache License to your work.
    identification within third-party archives.
 
 
-DOCUMENT 206
+DOCUMENT 207
 ~~~~~~~~~~~~
 Applies to:
 - rand_core 0.10.1 (MIT OR Apache-2.0)
@@ -12862,7 +12890,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 207
+DOCUMENT 208
 ~~~~~~~~~~~~
 Applies to:
 - rand_distr 0.6.0 (MIT OR Apache-2.0)
@@ -12894,7 +12922,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 208
+DOCUMENT 209
 ~~~~~~~~~~~~
 Applies to:
 - rand_pcg 0.10.2 (MIT OR Apache-2.0)
@@ -12927,7 +12955,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 209
+DOCUMENT 210
 ~~~~~~~~~~~~
 Applies to:
 - rangemap 1.7.1 (MIT/Apache-2.0)
@@ -13124,7 +13152,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 210
+DOCUMENT 211
 ~~~~~~~~~~~~
 Applies to:
 - rangemap 1.7.1 (MIT/Apache-2.0)
@@ -13138,7 +13166,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 211
+DOCUMENT 212
 ~~~~~~~~~~~~
 Applies to:
 - rcgen 0.14.8 (MIT OR Apache-2.0)
@@ -13359,7 +13387,7 @@ Apache License, version 2.0
    END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 212
+DOCUMENT 213
 ~~~~~~~~~~~~
 Applies to:
 - redox_syscall 0.5.18 (MIT)
@@ -13388,7 +13416,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 213
+DOCUMENT 214
 ~~~~~~~~~~~~
 Applies to:
 - regex-cache 0.2.1 (MIT)
@@ -13414,7 +13442,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 214
+DOCUMENT 215
 ~~~~~~~~~~~~
 Applies to:
 - reqwest 0.12.28 (MIT OR Apache-2.0)
@@ -13622,7 +13650,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 215
+DOCUMENT 216
 ~~~~~~~~~~~~
 Applies to:
 - reqwest 0.12.28 (MIT OR Apache-2.0)
@@ -13648,7 +13676,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 216
+DOCUMENT 217
 ~~~~~~~~~~~~
 Applies to:
 - resolv-conf 0.7.6 (MIT OR Apache-2.0)
@@ -13674,7 +13702,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 217
+DOCUMENT 218
 ~~~~~~~~~~~~
 Applies to:
 - ring 0.17.14 (Apache-2.0 AND ISC)
@@ -13690,7 +13718,7 @@ See src/polyfill/once_cell/LICENSE-APACHE and src/polyfill/once_cell/LICENSE-MIT
 for the license to code that was sourced from the once_cell project.
 
 
-DOCUMENT 218
+DOCUMENT 219
 ~~~~~~~~~~~~
 Applies to:
 - ring 0.17.14 (Apache-2.0 AND ISC)
@@ -13968,7 +13996,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 219
+DOCUMENT 220
 ~~~~~~~~~~~~
 Applies to:
 - ring 0.17.14 (Apache-2.0 AND ISC)
@@ -13988,7 +14016,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-DOCUMENT 220
+DOCUMENT 221
 ~~~~~~~~~~~~
 Applies to:
 - rten 0.24.0 (MIT OR Apache-2.0)
@@ -14020,7 +14048,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 221
+DOCUMENT 222
 ~~~~~~~~~~~~
 Applies to:
 - rten-base 0.24.0 (MIT OR Apache-2.0)
@@ -14052,7 +14080,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 222
+DOCUMENT 223
 ~~~~~~~~~~~~
 Applies to:
 - rten-gemm 0.24.0 (MIT OR Apache-2.0)
@@ -14084,7 +14112,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 223
+DOCUMENT 224
 ~~~~~~~~~~~~
 Applies to:
 - rten-imageproc 0.24.0 (MIT OR Apache-2.0)
@@ -14116,7 +14144,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 224
+DOCUMENT 225
 ~~~~~~~~~~~~
 Applies to:
 - rten-model-file 0.24.0 (MIT OR Apache-2.0)
@@ -14148,7 +14176,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 225
+DOCUMENT 226
 ~~~~~~~~~~~~
 Applies to:
 - rten-shape-inference 0.24.0 (MIT OR Apache-2.0)
@@ -14180,7 +14208,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 226
+DOCUMENT 227
 ~~~~~~~~~~~~
 Applies to:
 - rten-simd 0.24.0 (MIT OR Apache-2.0)
@@ -14212,7 +14240,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 227
+DOCUMENT 228
 ~~~~~~~~~~~~
 Applies to:
 - rten-tensor 0.24.0 (MIT OR Apache-2.0)
@@ -14244,7 +14272,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 228
+DOCUMENT 229
 ~~~~~~~~~~~~
 Applies to:
 - rten-vecmath 0.24.0 (MIT OR Apache-2.0)
@@ -14276,7 +14304,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 229
+DOCUMENT 230
 ~~~~~~~~~~~~
 Applies to:
 - rustfft 6.4.1 (MIT OR Apache-2.0)
@@ -14303,7 +14331,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 230
+DOCUMENT 231
 ~~~~~~~~~~~~
 Applies to:
 - rustix 1.1.4 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -14339,7 +14367,7 @@ is licensed under:
 at your option.
 
 
-DOCUMENT 231
+DOCUMENT 232
 ~~~~~~~~~~~~
 Applies to:
 - rustls-native-certs 0.8.4 (Apache-2.0 OR ISC OR MIT)
@@ -14355,7 +14383,7 @@ respectively.  You may use this software under the terms of any
 of these licenses, at your option.
 
 
-DOCUMENT 232
+DOCUMENT 233
 ~~~~~~~~~~~~
 Applies to:
 - rustls-pki-types 1.15.0 (MIT OR Apache-2.0)
@@ -14563,7 +14591,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 233
+DOCUMENT 234
 ~~~~~~~~~~~~
 Applies to:
 - rustls-pki-types 1.15.0 (MIT OR Apache-2.0)
@@ -14595,7 +14623,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 234
+DOCUMENT 235
 ~~~~~~~~~~~~
 Applies to:
 - rustls-webpki 0.103.13 (ISC)
@@ -14621,7 +14649,7 @@ The files under third-party/chromium are licensed as described in
 third-party/chromium/LICENSE.
 
 
-DOCUMENT 235
+DOCUMENT 236
 ~~~~~~~~~~~~
 Applies to:
 - rxing 0.9.1 (Apache-2.0)
@@ -14829,7 +14857,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 236
+DOCUMENT 237
 ~~~~~~~~~~~~
 Applies to:
 - ryu 1.0.23 (Apache-2.0 OR BSL-1.0)
@@ -14859,7 +14887,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 237
+DOCUMENT 238
 ~~~~~~~~~~~~
 Applies to:
 - same-file 1.0.6 (Unlicense/MIT)
@@ -14888,7 +14916,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 238
+DOCUMENT 239
 ~~~~~~~~~~~~
 Applies to:
 - scan_fmt 0.2.6 (MIT)
@@ -14916,7 +14944,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 239
+DOCUMENT 240
 ~~~~~~~~~~~~
 Applies to:
 - schannel 0.1.29 (MIT)
@@ -14930,7 +14958,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 240
+DOCUMENT 241
 ~~~~~~~~~~~~
 Applies to:
 - scopeguard 1.2.0 (MIT OR Apache-2.0)
@@ -14962,7 +14990,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 241
+DOCUMENT 242
 ~~~~~~~~~~~~
 Applies to:
 - security-framework 3.7.0 (MIT OR Apache-2.0)
@@ -14990,7 +15018,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 242
+DOCUMENT 243
 ~~~~~~~~~~~~
 Applies to:
 - serde_urlencoded 0.7.1 (MIT/Apache-2.0)
@@ -15022,7 +15050,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 243
+DOCUMENT 244
 ~~~~~~~~~~~~
 Applies to:
 - serial2 0.2.37 (BSD-2-Clause OR Apache-2.0)
@@ -15042,7 +15070,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 244
+DOCUMENT 245
 ~~~~~~~~~~~~
 Applies to:
 - serial2 0.2.37 (BSD-2-Clause OR Apache-2.0)
@@ -15073,7 +15101,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 245
+DOCUMENT 246
 ~~~~~~~~~~~~
 Applies to:
 - sha3 0.10.9 (MIT OR Apache-2.0)
@@ -15108,7 +15136,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 246
+DOCUMENT 247
 ~~~~~~~~~~~~
 Applies to:
 - shared_library 0.1.9 (Apache-2.0/MIT)
@@ -15140,7 +15168,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 247
+DOCUMENT 248
 ~~~~~~~~~~~~
 Applies to:
 - shell-words 1.1.1 (MIT/Apache-2.0)
@@ -15348,7 +15376,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 248
+DOCUMENT 249
 ~~~~~~~~~~~~
 Applies to:
 - shell-words 1.1.1 (MIT/Apache-2.0)
@@ -15380,7 +15408,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 249
+DOCUMENT 250
 ~~~~~~~~~~~~
 Applies to:
 - shlex 2.0.1 (MIT OR Apache-2.0)
@@ -15400,7 +15428,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 250
+DOCUMENT 251
 ~~~~~~~~~~~~
 Applies to:
 - shlex 2.0.1 (MIT OR Apache-2.0)
@@ -15428,7 +15456,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 251
+DOCUMENT 252
 ~~~~~~~~~~~~
 Applies to:
 - signal-hook-registry 1.4.8 (MIT OR Apache-2.0)
@@ -15460,7 +15488,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 252
+DOCUMENT 253
 ~~~~~~~~~~~~
 Applies to:
 - simd-adler32 0.3.9 (MIT)
@@ -15488,7 +15516,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 253
+DOCUMENT 254
 ~~~~~~~~~~~~
 Applies to:
 - slab 0.4.12 (MIT)
@@ -15520,7 +15548,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 254
+DOCUMENT 255
 ~~~~~~~~~~~~
 Applies to:
 - smallvec 1.15.2 (MIT OR Apache-2.0)
@@ -15552,7 +15580,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 255
+DOCUMENT 256
 ~~~~~~~~~~~~
 Applies to:
 - spin 0.9.8 (MIT)
@@ -15580,7 +15608,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 256
+DOCUMENT 257
 ~~~~~~~~~~~~
 Applies to:
 - spki 0.7.3 (Apache-2.0 OR MIT)
@@ -15612,7 +15640,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 257
+DOCUMENT 258
 ~~~~~~~~~~~~
 Applies to:
 - stable_deref_trait 1.2.1 (MIT OR Apache-2.0)
@@ -15644,7 +15672,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 258
+DOCUMENT 259
 ~~~~~~~~~~~~
 Applies to:
 - string-interner 0.19.0 (MIT/Apache-2.0)
@@ -15667,7 +15695,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 259
+DOCUMENT 260
 ~~~~~~~~~~~~
 Applies to:
 - string-interner 0.19.0 (MIT/Apache-2.0)
@@ -15696,7 +15724,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 260
+DOCUMENT 261
 ~~~~~~~~~~~~
 Applies to:
 - stringprep 0.1.5 (MIT/Apache-2.0)
@@ -15722,7 +15750,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 261
+DOCUMENT 262
 ~~~~~~~~~~~~
 Applies to:
 - strum 0.27.2 (MIT)
@@ -15751,7 +15779,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 262
+DOCUMENT 263
 ~~~~~~~~~~~~
 Applies to:
 - subtle 2.6.1 (BSD-3-Clause)
@@ -15787,7 +15815,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 263
+DOCUMENT 264
 ~~~~~~~~~~~~
 Applies to:
 - synstructure 0.13.2 (MIT)
@@ -15801,7 +15829,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 264
+DOCUMENT 265
 ~~~~~~~~~~~~
 Applies to:
 - sysinfo 0.37.2 (MIT)
@@ -15829,7 +15857,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 265
+DOCUMENT 266
 ~~~~~~~~~~~~
 Applies to:
 - system-configuration 0.7.0 (MIT OR Apache-2.0)
@@ -15862,7 +15890,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 266
+DOCUMENT 267
 ~~~~~~~~~~~~
 Applies to:
 - tagptr 0.2.0 (MIT/Apache-2.0)
@@ -15882,7 +15910,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 267
+DOCUMENT 268
 ~~~~~~~~~~~~
 Applies to:
 - tagptr 0.2.0 (MIT/Apache-2.0)
@@ -15910,7 +15938,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 268
+DOCUMENT 269
 ~~~~~~~~~~~~
 Applies to:
 - tar 0.4.46 (MIT OR Apache-2.0)
@@ -15942,7 +15970,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 269
+DOCUMENT 270
 ~~~~~~~~~~~~
 Applies to:
 - time 0.3.54 (MIT OR Apache-2.0)
@@ -15970,7 +15998,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 270
+DOCUMENT 271
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec 1.11.0 (Zlib OR Apache-2.0 OR MIT)
@@ -15982,7 +16010,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 271
+DOCUMENT 272
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec_macros 0.1.1 (MIT OR Apache-2.0 OR Zlib)
@@ -16190,7 +16218,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 272
+DOCUMENT 273
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec_macros 0.1.1 (MIT OR Apache-2.0 OR Zlib)
@@ -16218,7 +16246,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 273
+DOCUMENT 274
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec_macros 0.1.1 (MIT OR Apache-2.0 OR Zlib)
@@ -16244,7 +16272,7 @@ freely, subject to the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 274
+DOCUMENT 275
 ~~~~~~~~~~~~
 Applies to:
 - tokio 1.52.3 (MIT)
@@ -16273,7 +16301,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 275
+DOCUMENT 276
 ~~~~~~~~~~~~
 Applies to:
 - tokio-macros 2.7.0 (MIT)
@@ -16302,7 +16330,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 276
+DOCUMENT 277
 ~~~~~~~~~~~~
 Applies to:
 - tokio-rustls 0.26.4 (MIT OR Apache-2.0)
@@ -16510,7 +16538,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 277
+DOCUMENT 278
 ~~~~~~~~~~~~
 Applies to:
 - tokio-rustls 0.26.4 (MIT OR Apache-2.0)
@@ -16542,7 +16570,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 278
+DOCUMENT 279
 ~~~~~~~~~~~~
 Applies to:
 - tower 0.5.3 (MIT)
@@ -16576,7 +16604,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 279
+DOCUMENT 280
 ~~~~~~~~~~~~
 Applies to:
 - tower-http 0.6.11 (MIT)
@@ -16608,7 +16636,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 280
+DOCUMENT 281
 ~~~~~~~~~~~~
 Applies to:
 - tracing 0.1.44 (MIT)
@@ -16641,7 +16669,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 281
+DOCUMENT 282
 ~~~~~~~~~~~~
 Applies to:
 - tract-core 0.23.3 (MIT OR Apache-2.0)
@@ -16668,7 +16696,7 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
 
 
-DOCUMENT 282
+DOCUMENT 283
 ~~~~~~~~~~~~
 Applies to:
 - tract-extra 0.23.3 (MIT OR Apache-2.0)
@@ -16700,7 +16728,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 283
+DOCUMENT 284
 ~~~~~~~~~~~~
 Applies to:
 - tract-transformers 0.23.3 (MIT OR Apache-2.0)
@@ -16732,7 +16760,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 284
+DOCUMENT 285
 ~~~~~~~~~~~~
 Applies to:
 - transpose 0.2.3 (MIT OR Apache-2.0)
@@ -16940,7 +16968,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 285
+DOCUMENT 286
 ~~~~~~~~~~~~
 Applies to:
 - transpose 0.2.3 (MIT OR Apache-2.0)
@@ -16972,7 +17000,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 286
+DOCUMENT 287
 ~~~~~~~~~~~~
 Applies to:
 - try-lock 0.2.5 (MIT)
@@ -16999,7 +17027,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 287
+DOCUMENT 288
 ~~~~~~~~~~~~
 Applies to:
 - type1-encoding-parser 0.1.1 (MIT)
@@ -17031,7 +17059,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 288
+DOCUMENT 289
 ~~~~~~~~~~~~
 Applies to:
 - typenum 1.20.1 (MIT OR Apache-2.0)
@@ -17039,7 +17067,7 @@ Applies to:
 MIT OR Apache-2.0
 
 
-DOCUMENT 289
+DOCUMENT 290
 ~~~~~~~~~~~~
 Applies to:
 - typenum 1.20.1 (MIT OR Apache-2.0)
@@ -17247,7 +17275,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 290
+DOCUMENT 291
 ~~~~~~~~~~~~
 Applies to:
 - typenum 1.20.1 (MIT OR Apache-2.0)
@@ -17275,7 +17303,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 291
+DOCUMENT 292
 ~~~~~~~~~~~~
 Applies to:
 - unicode-bidi 0.3.18 (MIT OR Apache-2.0)
@@ -17290,7 +17318,7 @@ carrying such notice may not be copied, modified, or distributed except
 according to those terms.
 
 
-DOCUMENT 292
+DOCUMENT 293
 ~~~~~~~~~~~~
 Applies to:
 - unicode-ident 1.0.24 ((MIT OR Apache-2.0) AND Unicode-3.0)
@@ -17336,7 +17364,7 @@ dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
 
 
-DOCUMENT 293
+DOCUMENT 294
 ~~~~~~~~~~~~
 Applies to:
 - unicode-normalization 0.1.25 (MIT OR Apache-2.0)
@@ -17353,7 +17381,7 @@ notice may not be copied, modified, or distributed except
 according to those terms.
 
 
-DOCUMENT 294
+DOCUMENT 295
 ~~~~~~~~~~~~
 Applies to:
 - untrusted 0.9.0 (ISC)
@@ -17373,7 +17401,7 @@ Applies to:
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-DOCUMENT 295
+DOCUMENT 296
 ~~~~~~~~~~~~
 Applies to:
 - utf8_iter 1.0.4 (Apache-2.0 OR MIT)
@@ -17422,7 +17450,7 @@ licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
 <LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
 
 
-DOCUMENT 296
+DOCUMENT 297
 ~~~~~~~~~~~~
 Applies to:
 - utf8parse 0.2.2 (Apache-2.0 OR MIT)
@@ -17454,7 +17482,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 297
+DOCUMENT 298
 ~~~~~~~~~~~~
 Applies to:
 - uuid 1.24.0 (Apache-2.0 OR MIT)
@@ -17487,7 +17515,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 298
+DOCUMENT 299
 ~~~~~~~~~~~~
 Applies to:
 - version_check 0.9.5 (MIT/Apache-2.0)
@@ -17513,7 +17541,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 299
+DOCUMENT 300
 ~~~~~~~~~~~~
 Applies to:
 - want 0.3.1 (MIT)
@@ -17539,7 +17567,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 300
+DOCUMENT 301
 ~~~~~~~~~~~~
 Applies to:
 - wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17571,7 +17599,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 301
+DOCUMENT 302
 ~~~~~~~~~~~~
 Applies to:
 - wasm-encoder 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17603,7 +17631,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 302
+DOCUMENT 303
 ~~~~~~~~~~~~
 Applies to:
 - wasm-metadata 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17635,7 +17663,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 303
+DOCUMENT 304
 ~~~~~~~~~~~~
 Applies to:
 - wasmi 1.1.0 (MIT/Apache-2.0)
@@ -17667,7 +17695,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 304
+DOCUMENT 305
 ~~~~~~~~~~~~
 Applies to:
 - wasmi_collections 1.1.0 (MIT/Apache-2.0)
@@ -17699,7 +17727,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 305
+DOCUMENT 306
 ~~~~~~~~~~~~
 Applies to:
 - wasmi_core 1.1.0 (MIT/Apache-2.0)
@@ -17731,7 +17759,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 306
+DOCUMENT 307
 ~~~~~~~~~~~~
 Applies to:
 - wasmi_ir 1.1.0 (MIT/Apache-2.0)
@@ -17763,7 +17791,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 307
+DOCUMENT 308
 ~~~~~~~~~~~~
 Applies to:
 - wasmparser 0.239.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17795,7 +17823,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 308
+DOCUMENT 309
 ~~~~~~~~~~~~
 Applies to:
 - wasmparser 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17827,7 +17855,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 309
+DOCUMENT 310
 ~~~~~~~~~~~~
 Applies to:
 - web-time 1.1.0 (MIT OR Apache-2.0)
@@ -18035,7 +18063,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 310
+DOCUMENT 311
 ~~~~~~~~~~~~
 Applies to:
 - web-time 1.1.0 (MIT OR Apache-2.0)
@@ -18063,7 +18091,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 311
+DOCUMENT 312
 ~~~~~~~~~~~~
 Applies to:
 - weezl 0.1.12 (MIT OR Apache-2.0)
@@ -18091,7 +18119,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 312
+DOCUMENT 313
 ~~~~~~~~~~~~
 Applies to:
 - winapi 0.3.9 (MIT/Apache-2.0)
@@ -18117,7 +18145,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 313
+DOCUMENT 314
 ~~~~~~~~~~~~
 Applies to:
 - winapi-i686-pc-windows-gnu 0.4.0 (MIT/Apache-2.0)
@@ -18149,7 +18177,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 314
+DOCUMENT 315
 ~~~~~~~~~~~~
 Applies to:
 - winapi-x86_64-pc-windows-gnu 0.4.0 (MIT/Apache-2.0)
@@ -18181,7 +18209,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 315
+DOCUMENT 316
 ~~~~~~~~~~~~
 Applies to:
 - windows 0.61.3 (MIT OR Apache-2.0)
@@ -18420,7 +18448,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 316
+DOCUMENT 317
 ~~~~~~~~~~~~
 Applies to:
 - windows 0.61.3 (MIT OR Apache-2.0)
@@ -18479,7 +18507,7 @@ MIT License
     SOFTWARE
 
 
-DOCUMENT 317
+DOCUMENT 318
 ~~~~~~~~~~~~
 Applies to:
 - winnow 0.7.15 (MIT)
@@ -18504,7 +18532,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 318
+DOCUMENT 319
 ~~~~~~~~~~~~
 Applies to:
 - winreg 0.10.1 (MIT)
@@ -18530,7 +18558,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 319
+DOCUMENT 320
 ~~~~~~~~~~~~
 Applies to:
 - wit-component 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -18562,7 +18590,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 320
+DOCUMENT 321
 ~~~~~~~~~~~~
 Applies to:
 - wit-parser 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -18594,7 +18622,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 321
+DOCUMENT 322
 ~~~~~~~~~~~~
 Applies to:
 - xattr 1.6.1 (MIT OR Apache-2.0)
@@ -18626,7 +18654,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 322
+DOCUMENT 323
 ~~~~~~~~~~~~
 Applies to:
 - yasna 0.6.0 (MIT OR Apache-2.0)
@@ -18640,7 +18668,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 323
+DOCUMENT 324
 ~~~~~~~~~~~~
 Applies to:
 - zerocopy 0.8.52 (BSD-2-Clause OR Apache-2.0 OR MIT)
@@ -18849,7 +18877,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 324
+DOCUMENT 325
 ~~~~~~~~~~~~
 Applies to:
 - zerocopy 0.8.52 (BSD-2-Clause OR Apache-2.0 OR MIT)
@@ -18881,7 +18909,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 325
+DOCUMENT 326
 ~~~~~~~~~~~~
 Applies to:
 - zerocopy 0.8.52 (BSD-2-Clause OR Apache-2.0 OR MIT)
@@ -18914,7 +18942,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 326
+DOCUMENT 327
 ~~~~~~~~~~~~
 Applies to:
 - zeroize 1.8.2 (Apache-2.0 OR MIT)
@@ -18942,7 +18970,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 327
+DOCUMENT 328
 ~~~~~~~~~~~~
 Applies to:
 - zune-core 0.5.1 (MIT OR Apache-2.0 OR Zlib)
@@ -18971,7 +18999,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 328
+DOCUMENT 329
 ~~~~~~~~~~~~
 Applies to:
 - zune-core 0.5.1 (MIT OR Apache-2.0 OR Zlib)

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.35"
+version = "0.0.36"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true
@@ -43,6 +43,7 @@ rcgen = { version = "0.14", default-features = false, features = ["ring"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
 
 [target.'cfg(windows)'.dependencies]
+junction = "2.0.0"
 windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -37,6 +37,7 @@ ctrlc.workspace = true
 reqwest.workspace = true
 toml_edit.workspace = true
 futures-util = { workspace = true }
+jiff = { workspace = true }
 pdf-extract = "0.12"
 sysinfo = { version = "0.37.2", default-features = false, features = ["system"] }
 rcgen = { version = "0.14", default-features = false, features = ["ring"] }

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -8,7 +8,11 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
-use std::{fs::OpenOptions, io::Write};
+use std::{fs::OpenOptions, io::Write, thread, time::Duration};
+
+const APP_START_GRACE: Duration = Duration::from_secs(15);
+const APP_EXIT_GRACE: Duration = Duration::from_secs(3);
+const APP_MONITOR_INTERVAL: Duration = Duration::from_millis(500);
 
 pub(crate) fn cmd_codex_app(args: &[String]) -> i32 {
     match run_codex_app(args) {
@@ -66,6 +70,19 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         &routing.provider,
         proxy.base_url(),
     )?);
+    let lifecycle_log = match CodexAppLifecycleLog::open(
+        session_home
+            .as_ref()
+            .expect("Codex session home exists")
+            .source_home(),
+    ) {
+        Ok(log) => Some(log),
+        Err(error) => {
+            eprintln!("[pentect] warning: Codex App lifecycle log is unavailable: {error}");
+            None
+        }
+    };
+    record_lifecycle(&lifecycle_log, "gateway-started", "loopback");
     eprintln!("[pentect] Codex App gateway ready at {}", proxy.base_url());
     eprintln!(
         "[pentect] Codex provider '{}' is routed through the gateway for this App session",
@@ -100,6 +117,11 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     let mut child = command
         .spawn()
         .map_err(|error| format!("could not start Codex App: {error}"))?;
+    record_lifecycle(
+        &lifecycle_log,
+        "launcher-started",
+        &format!("pid={}", child.id()),
+    );
     let session_cleanup = Arc::new(Mutex::new(session_home));
     let signal_cleanup = Arc::clone(&session_cleanup);
     let signal_lock = Arc::clone(&config_lock);
@@ -126,9 +148,7 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
             "could not install Codex App session cleanup handler: {error}"
         ));
     }
-    let status = child
-        .wait()
-        .map_err(|error| format!("could not wait for Codex App: {error}"))?;
+    let status = monitor_codex_app(&mut child, &app, &proxy, &lifecycle_log)?;
     session_cleanup
         .lock()
         .map_err(|_| "Codex App session cleanup lock is unavailable".to_string())?
@@ -138,7 +158,141 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         .map_err(|_| "Codex App session lock is unavailable".to_string())?
         .take();
     drop(proxy);
+    record_lifecycle(&lifecycle_log, "session-finished", "app-exited");
     Ok(status)
+}
+
+fn monitor_codex_app(
+    child: &mut std::process::Child,
+    app: &Path,
+    proxy: &crate::openai_http_proxy::OpenAiHttpProxyGuard,
+    lifecycle_log: &Option<CodexAppLifecycleLog>,
+) -> Result<std::process::ExitStatus, String> {
+    loop {
+        if !proxy.is_running() {
+            let reason = proxy
+                .failure_reason()
+                .unwrap_or_else(|| "gateway thread exited unexpectedly".to_string());
+            record_lifecycle(lifecycle_log, "gateway-stopped", &reason);
+            terminate_child_process(child.id());
+            let _ = child.wait();
+            return Err(format!(
+                "Codex App gateway stopped: {reason}; inspect the lifecycle entries with `pentect log`"
+            ));
+        }
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| format!("could not monitor Codex App launcher: {error}"))?
+        {
+            record_lifecycle(
+                lifecycle_log,
+                "launcher-exited",
+                &format!("status={}", status.code().unwrap_or(-1)),
+            );
+            return monitor_handed_off_app(app, proxy, lifecycle_log, status);
+        }
+        thread::sleep(APP_MONITOR_INTERVAL);
+    }
+}
+
+fn monitor_handed_off_app(
+    app: &Path,
+    proxy: &crate::openai_http_proxy::OpenAiHttpProxyGuard,
+    lifecycle_log: &Option<CodexAppLifecycleLog>,
+    launcher_status: std::process::ExitStatus,
+) -> Result<std::process::ExitStatus, String> {
+    let mut process_probe = CodexAppProcessProbe::new(app);
+    let started = std::time::Instant::now();
+    while started.elapsed() < APP_START_GRACE {
+        ensure_gateway_running(proxy, lifecycle_log)?;
+        if process_probe.is_running() {
+            record_lifecycle(lifecycle_log, "app-process-observed", "running");
+            let mut absent_since = None;
+            loop {
+                ensure_gateway_running(proxy, lifecycle_log)?;
+                if process_probe.is_running() {
+                    absent_since = None;
+                } else {
+                    let since = absent_since.get_or_insert_with(std::time::Instant::now);
+                    if since.elapsed() >= APP_EXIT_GRACE {
+                        return Ok(launcher_status);
+                    }
+                }
+                thread::sleep(APP_MONITOR_INTERVAL);
+            }
+        }
+        thread::sleep(APP_MONITOR_INTERVAL);
+    }
+    Ok(launcher_status)
+}
+
+fn ensure_gateway_running(
+    proxy: &crate::openai_http_proxy::OpenAiHttpProxyGuard,
+    lifecycle_log: &Option<CodexAppLifecycleLog>,
+) -> Result<(), String> {
+    if proxy.is_running() {
+        return Ok(());
+    }
+    let reason = proxy
+        .failure_reason()
+        .unwrap_or_else(|| "gateway thread exited unexpectedly".to_string());
+    record_lifecycle(lifecycle_log, "gateway-stopped", &reason);
+    Err(format!(
+        "Codex App gateway stopped: {reason}; inspect the lifecycle entries with `pentect log`"
+    ))
+}
+
+struct CodexAppLifecycleLog {
+    file: Mutex<std::fs::File>,
+}
+
+impl CodexAppLifecycleLog {
+    fn open(codex_home: &Path) -> Result<Self, String> {
+        let directory = codex_home.join(".pentect").join("logs");
+        std::fs::create_dir_all(&directory)
+            .map_err(|error| format!("could not create '{}': {error}", directory.display()))?;
+        reject_directory_link(&directory, "Codex App log directory")?;
+        let path = directory.join("codex-app.log");
+        reject_symlink(&path, "Codex App lifecycle log")?;
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|error| format!("could not open '{}': {error}", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+        }
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+
+    fn record(&self, event: &str, detail: &str) {
+        let detail = detail
+            .chars()
+            .filter(|character| !matches!(character, '\r' | '\n'))
+            .take(512)
+            .collect::<String>();
+        if let Ok(mut file) = self.file.lock() {
+            let entry = serde_json::json!({
+                "time": jiff::Timestamp::now().to_string(),
+                "action": "lifecycle",
+                "surface": "codex-app",
+                "event": event,
+                "detail": detail,
+            });
+            let _ = writeln!(file, "{entry}");
+            let _ = file.flush();
+        }
+    }
+}
+
+fn record_lifecycle(log: &Option<CodexAppLifecycleLog>, event: &str, detail: &str) {
+    if let Some(log) = log {
+        log.record(event, detail);
+    }
 }
 
 fn codex_app_not_found(app: &Path, app_was_explicit: bool) -> String {
@@ -895,41 +1049,59 @@ fn version_components(value: &str) -> Vec<u64> {
 }
 
 fn codex_app_is_running(app: &Path) -> bool {
-    let expected = app
-        .canonicalize()
-        .unwrap_or_else(|_| app.to_path_buf())
-        .to_string_lossy()
-        .to_ascii_lowercase();
-    let install_root = app
-        .parent()
-        .map(|path| {
-            path.canonicalize()
-                .unwrap_or_else(|_| path.to_path_buf())
+    CodexAppProcessProbe::new(app).is_running()
+}
+
+struct CodexAppProcessProbe {
+    expected: String,
+    install_root: String,
+    system: sysinfo::System,
+}
+
+impl CodexAppProcessProbe {
+    fn new(app: &Path) -> Self {
+        Self {
+            expected: app
+                .canonicalize()
+                .unwrap_or_else(|_| app.to_path_buf())
                 .to_string_lossy()
-                .to_ascii_lowercase()
+                .to_ascii_lowercase(),
+            install_root: app
+                .parent()
+                .map(|path| {
+                    path.canonicalize()
+                        .unwrap_or_else(|_| path.to_path_buf())
+                        .to_string_lossy()
+                        .to_ascii_lowercase()
+                })
+                .unwrap_or_default(),
+            system: sysinfo::System::new(),
+        }
+    }
+
+    fn is_running(&mut self) -> bool {
+        self.system
+            .refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+        self.system.processes().values().any(|process| {
+            process
+                .exe()
+                .and_then(|path| path.canonicalize().ok())
+                .map(|path| path.to_string_lossy().to_ascii_lowercase())
+                .is_some_and(|path| {
+                    path == self.expected
+                        || (!self.install_root.is_empty()
+                            && path.starts_with(&self.install_root)
+                            && matches!(
+                                process
+                                    .name()
+                                    .to_string_lossy()
+                                    .to_ascii_lowercase()
+                                    .as_str(),
+                                "codex.exe" | "chatgpt.exe"
+                            ))
+                })
         })
-        .unwrap_or_default();
-    let mut system = sysinfo::System::new();
-    system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
-    system.processes().values().any(|process| {
-        process
-            .exe()
-            .and_then(|path| path.canonicalize().ok())
-            .map(|path| path.to_string_lossy().to_ascii_lowercase())
-            .is_some_and(|path| {
-                path == expected
-                    || (!install_root.is_empty()
-                        && path.starts_with(&install_root)
-                        && matches!(
-                            process
-                                .name()
-                                .to_string_lossy()
-                                .to_ascii_lowercase()
-                                .as_str(),
-                            "codex.exe" | "chatgpt.exe"
-                        ))
-            })
-    })
+    }
 }
 
 #[cfg(windows)]
@@ -1042,6 +1214,35 @@ mod tests {
                 "ChatGPT_1.0.0.0_x64__id"
             }
         ));
+    }
+
+    #[test]
+    fn lifecycle_log_is_value_free_jsonl() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-codex-lifecycle-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let log = CodexAppLifecycleLog::open(&root).unwrap();
+        log.record("gateway-stopped", "gateway thread exited unexpectedly");
+        let payload =
+            std::fs::read_to_string(root.join(".pentect").join("logs").join("codex-app.log"))
+                .unwrap();
+        let value: serde_json::Value = serde_json::from_str(payload.trim()).unwrap();
+        assert_eq!(value["action"], "lifecycle");
+        assert_eq!(value["surface"], "codex-app");
+        assert_eq!(value["event"], "gateway-stopped");
+        assert_eq!(value["detail"], "gateway thread exited unexpectedly");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn process_probe_observes_the_current_executable() {
+        let executable = std::env::current_exe().unwrap();
+        assert!(CodexAppProcessProbe::new(&executable).is_running());
     }
 
     #[cfg(windows)]

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use std::{fs::OpenOptions, io::Write, thread, time::Duration};
 
 const APP_START_GRACE: Duration = Duration::from_secs(15);
-const APP_EXIT_GRACE: Duration = Duration::from_secs(3);
+const APP_EXIT_GRACE: Duration = Duration::from_secs(30);
 const APP_MONITOR_INTERVAL: Duration = Duration::from_millis(500);
 const MAX_LIFECYCLE_LOG_BYTES: u64 = 1024 * 1024;
 
@@ -179,6 +179,9 @@ fn monitor_codex_app(
                 "launcher-exited",
                 &format!("status={}", status.code().unwrap_or(-1)),
             );
+            if !status.success() {
+                return Ok(status);
+            }
             return monitor_handed_off_app(app, proxy, lifecycle_log, status);
         }
         thread::sleep(APP_MONITOR_INTERVAL);
@@ -193,27 +196,35 @@ fn monitor_handed_off_app(
 ) -> Result<std::process::ExitStatus, String> {
     let mut process_probe = CodexAppProcessProbe::new(app);
     let started = std::time::Instant::now();
-    while started.elapsed() < APP_START_GRACE {
+    let mut observed = false;
+    let mut warned_unobservable = false;
+    let mut absent_since = None;
+    loop {
         ensure_gateway_running(proxy, lifecycle_log)?;
         if process_probe.is_running() {
-            record_lifecycle(lifecycle_log, "app-process-observed", "running");
-            let mut absent_since = None;
-            loop {
-                ensure_gateway_running(proxy, lifecycle_log)?;
-                if process_probe.is_running() {
-                    absent_since = None;
-                } else {
-                    let since = absent_since.get_or_insert_with(std::time::Instant::now);
-                    if since.elapsed() >= APP_EXIT_GRACE {
-                        return Ok(launcher_status);
-                    }
-                }
-                thread::sleep(APP_MONITOR_INTERVAL);
+            if !observed {
+                record_lifecycle(lifecycle_log, "app-process-observed", "running");
+                observed = true;
             }
+            absent_since = None;
+        } else if observed {
+            let since = absent_since.get_or_insert_with(std::time::Instant::now);
+            if since.elapsed() >= APP_EXIT_GRACE {
+                record_lifecycle(lifecycle_log, "app-process-exited", "confirmed");
+                return Ok(launcher_status);
+            }
+        } else if started.elapsed() >= APP_START_GRACE && !warned_unobservable {
+            // Packaged Windows apps can hide their executable path from normal
+            // process enumeration. Never drop the gateway merely because the
+            // process cannot be observed: remain in the foreground until Ctrl+C.
+            record_lifecycle(lifecycle_log, "app-process-unobservable", "gateway-kept-alive");
+            eprintln!(
+                "[pentect] Codex App process could not be observed; the gateway will stay active until Ctrl+C"
+            );
+            warned_unobservable = true;
         }
         thread::sleep(APP_MONITOR_INTERVAL);
     }
-    Ok(launcher_status)
 }
 
 fn ensure_gateway_running(
@@ -1124,7 +1135,7 @@ impl CodexAppProcessProbe {
     fn matches(&self, process: &sysinfo::Process) -> bool {
         process
             .exe()
-            .and_then(|path| path.canonicalize().ok())
+            .map(|path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf()))
             .map(|path| path.to_string_lossy().to_ascii_lowercase())
             .is_some_and(|path| {
                 path == self.expected

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -13,6 +13,7 @@ use std::{fs::OpenOptions, io::Write, thread, time::Duration};
 const APP_START_GRACE: Duration = Duration::from_secs(15);
 const APP_EXIT_GRACE: Duration = Duration::from_secs(3);
 const APP_MONITOR_INTERVAL: Duration = Duration::from_millis(500);
+const MAX_LIFECYCLE_LOG_BYTES: u64 = 1024 * 1024;
 
 pub(crate) fn cmd_codex_app(args: &[String]) -> i32 {
     match run_codex_app(args) {
@@ -26,7 +27,7 @@ pub(crate) fn cmd_codex_app(args: &[String]) -> i32 {
 
 fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     let options = CodexAppOptions::parse(args)?;
-    recover_legacy_config()?;
+    let recovered_legacy_config = recover_legacy_config()?;
     let app_was_explicit = options.app.is_some();
     let app = options.app.unwrap_or_else(default_codex_app_path);
     if options.check {
@@ -82,6 +83,9 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
             None
         }
     };
+    if recovered_legacy_config {
+        record_lifecycle(&lifecycle_log, "legacy-config-restored", "completed");
+    }
     record_lifecycle(&lifecycle_log, "gateway-started", "loopback");
     eprintln!("[pentect] Codex App gateway ready at {}", proxy.base_url());
     eprintln!(
@@ -114,9 +118,13 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         );
     }
     configure_child_process(&mut command);
-    let mut child = command
-        .spawn()
-        .map_err(|error| format!("could not start Codex App: {error}"))?;
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            record_lifecycle(&lifecycle_log, "launcher-failed", &error.to_string());
+            return Err(format!("could not start Codex App: {error}"));
+        }
+    };
     record_lifecycle(
         &lifecycle_log,
         "launcher-started",
@@ -126,8 +134,10 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     let signal_cleanup = Arc::clone(&session_cleanup);
     let signal_lock = Arc::clone(&config_lock);
     let child_id = child.id();
+    let signal_app = app.clone();
     if let Err(error) = ctrlc::set_handler(move || {
         terminate_child_process(child_id);
+        terminate_codex_app_processes(&signal_app);
         if let Ok(mut cleanup) = signal_cleanup.lock() {
             cleanup.take();
         }
@@ -254,6 +264,16 @@ impl CodexAppLifecycleLog {
         reject_directory_link(&directory, "Codex App log directory")?;
         let path = directory.join("codex-app.log");
         reject_symlink(&path, "Codex App lifecycle log")?;
+        if path
+            .metadata()
+            .is_ok_and(|metadata| metadata.len() > MAX_LIFECYCLE_LOG_BYTES)
+        {
+            OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(&path)
+                .map_err(|error| format!("could not rotate '{}': {error}", path.display()))?;
+        }
         let file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -319,6 +339,29 @@ fn terminate_child_process(pid: u32) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
+}
+
+fn terminate_codex_app_processes(app: &Path) {
+    for pid in CodexAppProcessProbe::new(app).matching_pids() {
+        terminate_process(pid);
+    }
+}
+
+#[cfg(windows)]
+fn terminate_process(pid: u32) {
+    let _ = Command::new(crate::windows_system_executable("taskkill.exe"))
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+#[cfg(unix)]
+fn terminate_process(pid: u32) {
+    unsafe {
+        libc::kill(pid as i32, libc::SIGTERM);
+    }
 }
 
 #[cfg(unix)]
@@ -644,11 +687,11 @@ fn cleanup_session_home(path: &Path) {
     let _ = std::fs::remove_dir(path);
 }
 
-pub(crate) fn recover_legacy_config() -> Result<(), String> {
+pub(crate) fn recover_legacy_config() -> Result<bool, String> {
     recover_legacy_config_in(&crate::codex_home_dir()?)
 }
 
-fn recover_legacy_config_in(home: &Path) -> Result<(), String> {
+fn recover_legacy_config_in(home: &Path) -> Result<bool, String> {
     let config = home.join("config.toml");
     let backup = home.join("config.toml.pentect-backup");
     let no_original_marker = home.join("config.toml.pentect-no-original");
@@ -677,10 +720,10 @@ fn recover_legacy_config_in(home: &Path) -> Result<(), String> {
         }
         let _ = std::fs::remove_file(&no_original_marker);
         eprintln!("[pentect] restored Codex config left by an older interrupted App session");
-        return Ok(());
+        return Ok(true);
     }
     if !config.is_file() {
-        return Ok(());
+        return Ok(false);
     }
     let original = std::fs::read_to_string(&config)
         .map_err(|error| format!("could not read '{}': {error}", config.display()))?;
@@ -688,7 +731,7 @@ fn recover_legacy_config_in(home: &Path) -> Result<(), String> {
         .parse::<toml_edit::DocumentMut>()
         .map_err(|error| format!("could not parse '{}': {error}", config.display()))?;
     if !is_orphaned_legacy_gateway(&parsed) {
-        return Ok(());
+        return Ok(false);
     }
     parsed.remove("model_provider");
     if let Some(providers) = parsed
@@ -712,7 +755,7 @@ fn recover_legacy_config_in(home: &Path) -> Result<(), String> {
     std::fs::rename(&temporary, &config)
         .map_err(|error| format!("could not recover '{}': {error}", config.display()))?;
     eprintln!("[pentect] removed a stale Codex gateway left by an older release");
-    Ok(())
+    Ok(true)
 }
 
 fn is_orphaned_legacy_gateway(config: &toml_edit::DocumentMut) -> bool {
@@ -1080,27 +1123,36 @@ impl CodexAppProcessProbe {
     }
 
     fn is_running(&mut self) -> bool {
+        !self.matching_pids().is_empty()
+    }
+
+    fn matching_pids(&mut self) -> Vec<u32> {
         self.system
             .refresh_processes(sysinfo::ProcessesToUpdate::All, true);
-        self.system.processes().values().any(|process| {
-            process
-                .exe()
-                .and_then(|path| path.canonicalize().ok())
-                .map(|path| path.to_string_lossy().to_ascii_lowercase())
-                .is_some_and(|path| {
-                    path == self.expected
-                        || (!self.install_root.is_empty()
-                            && path.starts_with(&self.install_root)
-                            && matches!(
-                                process
-                                    .name()
-                                    .to_string_lossy()
-                                    .to_ascii_lowercase()
-                                    .as_str(),
-                                "codex.exe" | "chatgpt.exe"
-                            ))
-                })
-        })
+        self.system
+            .processes()
+            .iter()
+            .filter_map(|(pid, process)| {
+                process
+                    .exe()
+                    .and_then(|path| path.canonicalize().ok())
+                    .map(|path| path.to_string_lossy().to_ascii_lowercase())
+                    .is_some_and(|path| {
+                        path == self.expected
+                            || (!self.install_root.is_empty()
+                                && path.starts_with(&self.install_root)
+                                && matches!(
+                                    process
+                                        .name()
+                                        .to_string_lossy()
+                                        .to_ascii_lowercase()
+                                        .as_str(),
+                                    "codex.exe" | "chatgpt.exe"
+                                ))
+                    })
+                    .then(|| pid.as_u32())
+            })
+            .collect()
     }
 }
 
@@ -1236,6 +1288,28 @@ mod tests {
         assert_eq!(value["surface"], "codex-app");
         assert_eq!(value["event"], "gateway-stopped");
         assert_eq!(value["detail"], "gateway thread exited unexpectedly");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lifecycle_log_is_truncated_before_it_grows_without_bound() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-codex-lifecycle-rotation-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let path = root.join(".pentect").join("logs").join("codex-app.log");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, vec![b'x'; MAX_LIFECYCLE_LOG_BYTES as usize + 1]).unwrap();
+
+        let log = CodexAppLifecycleLog::open(&root).unwrap();
+        log.record("gateway-started", "loopback");
+        let payload = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(payload.lines().count(), 1);
+        assert!(payload.contains("gateway-started"));
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -1,9 +1,9 @@
 //! Launcher for the unmodified Codex desktop application.
 //!
 //! The app and its bundled Codex process use a loopback-only Responses API
-//! gateway. Pentect temporarily overrides the selected provider in the user's
-//! Codex configuration, restores the exact original when the App exits, and
-//! refuses to launch while another Codex App process is running.
+//! gateway. The App gets a session-only `CODEX_HOME`; Pentect never changes the
+//! user's shared Codex configuration and refuses to launch while another Codex
+//! App process is running.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -22,6 +22,7 @@ pub(crate) fn cmd_codex_app(args: &[String]) -> i32 {
 
 fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     let options = CodexAppOptions::parse(args)?;
+    recover_legacy_config()?;
     let app_was_explicit = options.app.is_some();
     let app = options.app.unwrap_or_else(default_codex_app_path);
     if options.check {
@@ -61,32 +62,46 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         &options.upstream_header_env,
     )?;
     let config_lock = Arc::new(Mutex::new(Some(CodexConfigLock::acquire()?)));
-    let config_override = Some(CodexConfigOverride::install(
+    let session_home = Some(CodexSessionHome::create(
         &routing.provider,
         proxy.base_url(),
     )?);
     eprintln!("[pentect] Codex App gateway ready at {}", proxy.base_url());
-    if config_override.is_some() {
-        eprintln!(
-            "[pentect] Codex provider '{}' is routed through the gateway for this App session",
-            routing.provider
-        );
-    }
+    eprintln!(
+        "[pentect] Codex provider '{}' is routed through the gateway for this App session",
+        routing.provider
+    );
     eprintln!("[pentect] Responses API prompts, files, and completed tool calls are protected");
 
     let mut command = Command::new(&app);
     crate::upstream::hide_header_source_env(&mut command, &options.upstream_header_env);
     command
+        .env(
+            "CODEX_HOME",
+            session_home
+                .as_ref()
+                .expect("Codex session home exists")
+                .path(),
+        )
         .env("OPENAI_BASE_URL", proxy.base_url())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    if std::env::var_os("CODEX_SQLITE_HOME").is_none() {
+        command.env(
+            "CODEX_SQLITE_HOME",
+            session_home
+                .as_ref()
+                .expect("Codex session home exists")
+                .source_home(),
+        );
+    }
     configure_child_process(&mut command);
     let mut child = command
         .spawn()
         .map_err(|error| format!("could not start Codex App: {error}"))?;
-    let config_cleanup = Arc::new(Mutex::new(config_override));
-    let signal_cleanup = Arc::clone(&config_cleanup);
+    let session_cleanup = Arc::new(Mutex::new(session_home));
+    let signal_cleanup = Arc::clone(&session_cleanup);
     let signal_lock = Arc::clone(&config_lock);
     let child_id = child.id();
     if let Err(error) = ctrlc::set_handler(move || {
@@ -101,22 +116,22 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     }) {
         terminate_child_process(child_id);
         let _ = child.wait();
-        if let Ok(mut cleanup) = config_cleanup.lock() {
+        if let Ok(mut cleanup) = session_cleanup.lock() {
             cleanup.take();
         }
         if let Ok(mut lock) = config_lock.lock() {
             lock.take();
         }
         return Err(format!(
-            "could not install Codex App config recovery handler: {error}"
+            "could not install Codex App session cleanup handler: {error}"
         ));
     }
     let status = child
         .wait()
         .map_err(|error| format!("could not wait for Codex App: {error}"))?;
-    config_cleanup
+    session_cleanup
         .lock()
-        .map_err(|_| "Codex App config recovery lock is unavailable".to_string())?
+        .map_err(|_| "Codex App session cleanup lock is unavailable".to_string())?
         .take();
     config_lock
         .lock()
@@ -168,10 +183,9 @@ fn configure_child_process(command: &mut Command) {
     command.process_group(0);
 }
 
-struct CodexConfigOverride {
-    config: PathBuf,
-    backup: PathBuf,
-    no_original_marker: PathBuf,
+struct CodexSessionHome {
+    path: PathBuf,
+    source_home: PathBuf,
 }
 
 #[derive(Debug)]
@@ -210,7 +224,7 @@ impl CodexConfigLock {
             }
             Err(std::fs::TryLockError::Error(error)) => {
                 return Err(format!(
-                    "could not lock Codex App configuration '{}': {error}",
+                    "could not lock Codex App session '{}': {error}",
                     path.display()
                 ));
             }
@@ -234,124 +248,342 @@ impl Drop for CodexConfigLock {
     }
 }
 
-impl CodexConfigOverride {
-    fn install(provider: &str, gateway: &str) -> Result<Self, String> {
-        let home = crate::codex_home_dir()?;
-        Self::install_in(&home, provider, gateway)
+impl CodexSessionHome {
+    fn create(provider: &str, gateway: &str) -> Result<Self, String> {
+        Self::create_in(&crate::codex_home_dir()?, provider, gateway)
     }
 
-    fn install_in(home: &Path, provider: &str, gateway: &str) -> Result<Self, String> {
-        std::fs::create_dir_all(home)
-            .map_err(|error| format!("could not create '{}': {error}", home.display()))?;
-        let config = home.join("config.toml");
-        let backup = home.join("config.toml.pentect-backup");
-        let no_original_marker = home.join("config.toml.pentect-no-original");
-        reject_symlink(&config, "Codex config")?;
-        reject_symlink(&backup, "Codex recovery backup")?;
-        reject_symlink(&no_original_marker, "Codex recovery marker")?;
-        if backup.is_file() {
-            if config.is_file() {
-                std::fs::remove_file(&config).map_err(|error| {
-                    format!(
-                        "could not recover Codex config '{}': {error}",
-                        config.display()
-                    )
-                })?;
-            }
-            if no_original_marker.is_file() {
-                std::fs::remove_file(&backup).map_err(|error| {
-                    format!("could not clear interrupted Codex backup: {error}")
-                })?;
-                let _ = std::fs::remove_file(&no_original_marker);
-            } else {
-                std::fs::rename(&backup, &config).map_err(|error| {
-                    format!(
-                        "could not restore interrupted Codex config override '{}': {error}",
-                        backup.display()
-                    )
-                })?;
-            }
-            eprintln!("[pentect] restored Codex config left by an interrupted App session");
-        }
+    fn create_in(source_home: &Path, provider: &str, gateway: &str) -> Result<Self, String> {
+        std::fs::create_dir_all(source_home)
+            .map_err(|error| format!("could not create '{}': {error}", source_home.display()))?;
+        let pentect_state = source_home.join(".pentect");
+        reject_directory_link(&pentect_state, "Pentect Codex state directory")?;
+        std::fs::create_dir_all(&pentect_state).map_err(|error| {
+            format!(
+                "could not create Pentect Codex state directory '{}': {error}",
+                pentect_state.display()
+            )
+        })?;
+        let sessions = pentect_state.join("codex-app-sessions");
+        reject_directory_link(&sessions, "Codex App sessions directory")?;
+        std::fs::create_dir_all(&sessions).map_err(|error| {
+            format!(
+                "could not create Codex App session directory '{}': {error}",
+                sessions.display()
+            )
+        })?;
+        cleanup_stale_session_homes(&sessions);
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos());
+        let path = sessions.join(format!("{}-{suffix}", std::process::id()));
+        std::fs::create_dir(&path).map_err(|error| {
+            format!(
+                "could not create Codex App session home '{}': {error}",
+                path.display()
+            )
+        })?;
+        #[cfg(unix)]
+        std::fs::set_permissions(&path, std::os::unix::fs::PermissionsExt::from_mode(0o700))
+            .map_err(|error| {
+                format!(
+                    "could not protect Codex App session home '{}': {error}",
+                    path.display()
+                )
+            })?;
 
-        let had_original = config.is_file();
-        let original = if had_original {
-            std::fs::read_to_string(&config)
-                .map_err(|error| format!("could not read '{}': {error}", config.display()))?
-        } else {
-            String::new()
-        };
-        let mut parsed = if original.trim().is_empty() {
-            toml_edit::DocumentMut::new()
-        } else {
-            original
-                .parse::<toml_edit::DocumentMut>()
-                .map_err(|error| format!("could not parse '{}': {error}", config.display()))?
-        };
-        set_provider_gateway(&mut parsed, provider, gateway)?;
-
-        write_new_private_file(&backup, original.as_bytes())
-            .map_err(|error| format!("could not back up '{}': {error}", config.display()))?;
-        if !had_original {
-            write_new_private_file(&no_original_marker, b"")
-                .map_err(|error| format!("could not create Codex recovery marker: {error}"))?;
-        }
-        let temporary = home.join(format!("config.toml.pentect-{}.tmp", std::process::id()));
-        reject_symlink(&temporary, "Codex temporary config")?;
-        write_new_private_file(&temporary, parsed.to_string().as_bytes())
-            .map_err(|error| format!("could not write '{}': {error}", temporary.display()))?;
-        if config.is_file() {
-            std::fs::remove_file(&config)
-                .map_err(|error| format!("could not replace '{}': {error}", config.display()))?;
-        }
-        if let Err(error) = std::fs::rename(&temporary, &config) {
-            if had_original {
-                let _ = std::fs::rename(&backup, &config);
-            } else {
-                let _ = std::fs::remove_file(&backup);
-                let _ = std::fs::remove_file(&no_original_marker);
+        let result = (|| {
+            for entry in std::fs::read_dir(source_home).map_err(|error| {
+                format!(
+                    "could not inspect Codex home '{}': {error}",
+                    source_home.display()
+                )
+            })? {
+                let entry = entry
+                    .map_err(|error| format!("could not inspect Codex home entry: {error}"))?;
+                let name = entry.file_name();
+                if session_home_excludes(&name) {
+                    continue;
+                }
+                link_session_entry(&entry.path(), &path.join(&name))?;
             }
-            return Err(format!(
-                "could not activate Codex config override '{}': {error}",
-                config.display()
-            ));
+
+            let source_config = source_home.join("config.toml");
+            reject_symlink(&source_config, "Codex config")?;
+            let original = match std::fs::read_to_string(&source_config) {
+                Ok(value) => value,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+                Err(error) => {
+                    return Err(format!(
+                        "could not read '{}': {error}",
+                        source_config.display()
+                    ));
+                }
+            };
+            let mut config = if original.trim().is_empty() {
+                toml_edit::DocumentMut::new()
+            } else {
+                original
+                    .parse::<toml_edit::DocumentMut>()
+                    .map_err(|error| {
+                        format!("could not parse '{}': {error}", source_config.display())
+                    })?
+            };
+            set_provider_gateway(&mut config, provider, gateway)?;
+            write_new_private_file(&path.join("config.toml"), config.to_string().as_bytes())
+                .map_err(|error| format!("could not write Codex App session config: {error}"))?;
+            Ok(())
+        })();
+        if let Err(error) = result {
+            cleanup_session_home(&path);
+            return Err(error);
         }
         Ok(Self {
-            config,
-            backup,
-            no_original_marker,
+            path,
+            source_home: source_home.to_path_buf(),
         })
     }
 
-    fn restore(&self) -> Result<(), String> {
-        reject_symlink(&self.config, "Codex config")?;
-        reject_symlink(&self.backup, "Codex recovery backup")?;
-        reject_symlink(&self.no_original_marker, "Codex recovery marker")?;
-        if !self.backup.is_file() {
-            return Ok(());
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn source_home(&self) -> &Path {
+        &self.source_home
+    }
+}
+
+impl Drop for CodexSessionHome {
+    fn drop(&mut self) {
+        cleanup_session_home(&self.path);
+    }
+}
+
+fn session_home_excludes(name: &std::ffi::OsStr) -> bool {
+    let name = name.to_string_lossy();
+    name == ".pentect"
+        || name == "config.toml"
+        || name == "config.toml.pentect-backup"
+        || name == "config.toml.pentect-no-original"
+        || name == "pentect-codex-app.lock"
+        || (name.starts_with("config.toml.pentect-") && name.ends_with(".tmp"))
+}
+
+#[cfg(unix)]
+fn link_session_entry(source: &Path, destination: &Path) -> Result<(), String> {
+    std::os::unix::fs::symlink(source, destination).map_err(|error| {
+        format!(
+            "could not link Codex state '{}' into the App session: {error}",
+            source.display()
+        )
+    })
+}
+
+#[cfg(windows)]
+fn link_session_entry(source: &Path, destination: &Path) -> Result<(), String> {
+    let metadata = std::fs::metadata(source).map_err(|error| {
+        format!(
+            "could not inspect Codex state '{}': {error}",
+            source.display()
+        )
+    })?;
+    if metadata.is_dir() {
+        match junction::create(source, destination) {
+            Ok(()) => Ok(()),
+            Err(junction_error) => {
+                // `junction::create` may leave an empty directory behind when
+                // the volume does not support junctions.
+                let _ = std::fs::remove_dir(destination);
+                std::os::windows::fs::symlink_dir(source, destination).map_err(|symlink_error| {
+                    format!(
+                        "could not link Codex state directory '{}' into the App session: junction failed ({junction_error}); directory symlink failed ({symlink_error})",
+                        source.display()
+                    )
+                })
+            }
         }
-        if self.config.is_file() {
-            std::fs::remove_file(&self.config).map_err(|error| {
+    } else if metadata.is_file() {
+        std::fs::hard_link(source, destination)
+            .or_else(|hard_link_error| {
+                std::os::windows::fs::symlink_file(source, destination).map_err(|symlink_error| {
+                    std::io::Error::new(
+                        symlink_error.kind(),
+                        format!(
+                            "hard link failed ({hard_link_error}); file symlink failed ({symlink_error})"
+                        ),
+                    )
+                })
+            })
+            .map_err(|error| {
                 format!(
-                    "could not remove temporary Codex config '{}': {error}",
-                    self.config.display()
+                    "could not link Codex state file '{}' into the App session: {error}",
+                    source.display()
+                )
+            })
+    } else {
+        Err(format!(
+            "Codex state entry '{}' has an unsupported file type",
+            source.display()
+        ))
+    }
+}
+
+fn cleanup_stale_session_homes(sessions: &Path) {
+    let Ok(entries) = std::fs::read_dir(sessions) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if generated_session_name(&entry.file_name()) {
+            cleanup_session_home(&entry.path());
+        }
+    }
+}
+
+fn generated_session_name(name: &std::ffi::OsStr) -> bool {
+    let name = name.to_string_lossy();
+    let Some((pid, suffix)) = name.split_once('-') else {
+        return false;
+    };
+    !pid.is_empty()
+        && !suffix.is_empty()
+        && pid.bytes().all(|byte| byte.is_ascii_digit())
+        && suffix.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn cleanup_session_home(path: &Path) {
+    #[cfg(windows)]
+    if junction::exists(path).unwrap_or(false) {
+        let _ = junction::delete(path);
+        let _ = std::fs::remove_dir(path);
+        return;
+    }
+    let Ok(root_metadata) = std::fs::symlink_metadata(path) else {
+        return;
+    };
+    if root_metadata.file_type().is_symlink() || root_metadata.is_file() {
+        let _ = std::fs::remove_file(path);
+        return;
+    }
+    if !root_metadata.is_dir() {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        #[cfg(windows)]
+        if junction::exists(&entry_path).unwrap_or(false) {
+            let _ = junction::delete(&entry_path);
+            let _ = std::fs::remove_dir(&entry_path);
+            continue;
+        }
+        let Ok(metadata) = std::fs::symlink_metadata(&entry_path) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() || metadata.is_file() {
+            let _ = std::fs::remove_file(&entry_path);
+        } else if metadata.is_dir() {
+            let _ = std::fs::remove_dir_all(&entry_path);
+        }
+    }
+    let _ = std::fs::remove_dir(path);
+}
+
+pub(crate) fn recover_legacy_config() -> Result<(), String> {
+    recover_legacy_config_in(&crate::codex_home_dir()?)
+}
+
+fn recover_legacy_config_in(home: &Path) -> Result<(), String> {
+    let config = home.join("config.toml");
+    let backup = home.join("config.toml.pentect-backup");
+    let no_original_marker = home.join("config.toml.pentect-no-original");
+    reject_symlink(&config, "Codex config")?;
+    reject_symlink(&backup, "Codex recovery backup")?;
+    reject_symlink(&no_original_marker, "Codex recovery marker")?;
+    if backup.is_file() {
+        if config.is_file() {
+            std::fs::remove_file(&config).map_err(|error| {
+                format!(
+                    "could not recover Codex config '{}': {error}",
+                    config.display()
                 )
             })?;
         }
-        if self.no_original_marker.is_file() {
-            std::fs::remove_file(&self.backup)
-                .map_err(|error| format!("could not remove Codex backup: {error}"))?;
-            std::fs::remove_file(&self.no_original_marker)
-                .map_err(|error| format!("could not remove Codex recovery marker: {error}"))
+        if no_original_marker.is_file() {
+            std::fs::remove_file(&backup)
+                .map_err(|error| format!("could not clear interrupted Codex backup: {error}"))?;
         } else {
-            std::fs::rename(&self.backup, &self.config).map_err(|error| {
+            std::fs::rename(&backup, &config).map_err(|error| {
                 format!(
-                    "could not restore Codex config '{}': {error}",
-                    self.config.display()
+                    "could not restore interrupted Codex config '{}': {error}",
+                    backup.display()
                 )
-            })
+            })?;
+        }
+        let _ = std::fs::remove_file(&no_original_marker);
+        eprintln!("[pentect] restored Codex config left by an older interrupted App session");
+        return Ok(());
+    }
+    if !config.is_file() {
+        return Ok(());
+    }
+    let original = std::fs::read_to_string(&config)
+        .map_err(|error| format!("could not read '{}': {error}", config.display()))?;
+    let mut parsed = original
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|error| format!("could not parse '{}': {error}", config.display()))?;
+    if !is_orphaned_legacy_gateway(&parsed) {
+        return Ok(());
+    }
+    parsed.remove("model_provider");
+    if let Some(providers) = parsed
+        .get_mut("model_providers")
+        .and_then(toml_edit::Item::as_table_mut)
+    {
+        providers.remove(crate::CODEX_GATEWAY_PROVIDER);
+        if providers.is_empty() {
+            parsed.remove("model_providers");
         }
     }
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let temporary = home.join(format!(
+        "config.toml.pentect-recovery-{}-{suffix}.tmp",
+        std::process::id()
+    ));
+    write_new_private_file(&temporary, parsed.to_string().as_bytes())
+        .map_err(|error| format!("could not write Codex recovery config: {error}"))?;
+    std::fs::rename(&temporary, &config)
+        .map_err(|error| format!("could not recover '{}': {error}", config.display()))?;
+    eprintln!("[pentect] removed a stale Codex gateway left by an older release");
+    Ok(())
+}
+
+fn is_orphaned_legacy_gateway(config: &toml_edit::DocumentMut) -> bool {
+    if config
+        .get("model_provider")
+        .and_then(toml_edit::Item::as_str)
+        != Some(crate::CODEX_GATEWAY_PROVIDER)
+    {
+        return false;
+    }
+    let Some(provider) = config
+        .get("model_providers")
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|providers| providers.get(crate::CODEX_GATEWAY_PROVIDER))
+        .and_then(toml_edit::Item::as_table)
+    else {
+        return false;
+    };
+    let base_url = provider
+        .get("base_url")
+        .and_then(toml_edit::Item::as_str)
+        .unwrap_or_default();
+    provider.get("name").and_then(toml_edit::Item::as_str) == Some("OpenAI through Pentect")
+        && provider.get("wire_api").and_then(toml_edit::Item::as_str) == Some("responses")
+        && (base_url.starts_with("http://127.0.0.1:") || base_url.starts_with("http://localhost:"))
 }
 
 fn reject_symlink(path: &Path, label: &str) -> Result<(), String> {
@@ -362,6 +594,17 @@ fn reject_symlink(path: &Path, label: &str) -> Result<(), String> {
         )),
         Ok(_) | Err(_) => Ok(()),
     }
+}
+
+fn reject_directory_link(path: &Path, label: &str) -> Result<(), String> {
+    #[cfg(windows)]
+    if junction::exists(path).unwrap_or(false) {
+        return Err(format!(
+            "{label} '{}' is a junction; Pentect will not use it",
+            path.display()
+        ));
+    }
+    reject_symlink(path, label)
 }
 
 fn write_new_private_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
@@ -375,14 +618,6 @@ fn write_new_private_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let mut file = options.open(path)?;
     file.write_all(bytes)?;
     file.sync_all()
-}
-
-impl Drop for CodexConfigOverride {
-    fn drop(&mut self) {
-        if let Err(error) = self.restore() {
-            eprintln!("[pentect] {error}");
-        }
-    }
 }
 
 fn set_provider_gateway(
@@ -896,52 +1131,69 @@ base_url = "https://other.example/v1"
     }
 
     #[test]
-    fn temporary_config_override_restores_the_exact_original() {
+    fn stale_cleanup_only_accepts_generated_session_names() {
+        assert!(generated_session_name(std::ffi::OsStr::new("123-456")));
+        assert!(!generated_session_name(std::ffi::OsStr::new("123")));
+        assert!(!generated_session_name(std::ffi::OsStr::new("../outside")));
+        assert!(!generated_session_name(std::ffi::OsStr::new("123-current")));
+    }
+
+    fn test_home(label: &str) -> PathBuf {
         let root = std::env::temp_dir().join(format!(
-            "pentect-codex-config-{}-{}",
+            "pentect-{label}-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos()
         ));
-        let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn session_home_routes_only_the_app_and_keeps_shared_state_linked() {
+        let root = test_home("codex-session-home");
         let original = "# keep this comment\nopenai_base_url = \"https://example.test/v1\"\n";
         std::fs::write(root.join("config.toml"), original).unwrap();
-        {
-            let guard =
-                CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").unwrap();
-            let active = std::fs::read_to_string(root.join("config.toml")).unwrap();
-            assert!(active.contains("http://127.0.0.1:47781"));
-            assert!(root.join("config.toml.pentect-backup").is_file());
-            drop(guard);
-        }
+        std::fs::write(root.join("auth.json"), "{\"token\":\"local\"}").unwrap();
+        std::fs::create_dir(root.join("sessions")).unwrap();
+        std::fs::write(root.join("sessions").join("thread.jsonl"), "thread").unwrap();
+
+        let session =
+            CodexSessionHome::create_in(&root, "openai", "http://127.0.0.1:47781").unwrap();
+        let session_path = session.path().to_path_buf();
         assert_eq!(
             std::fs::read_to_string(root.join("config.toml")).unwrap(),
             original
         );
         assert!(!root.join("config.toml.pentect-backup").exists());
+        let session_config = std::fs::read_to_string(session.path().join("config.toml")).unwrap();
+        assert!(session_config.contains("http://127.0.0.1:47781"));
+        assert_eq!(
+            std::fs::read_to_string(session.path().join("auth.json")).unwrap(),
+            "{\"token\":\"local\"}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(session.path().join("sessions").join("thread.jsonl")).unwrap(),
+            "thread"
+        );
+        drop(session);
+        assert!(!session_path.exists());
+        assert_eq!(
+            std::fs::read_to_string(root.join("config.toml")).unwrap(),
+            original
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
-    fn interrupted_config_override_is_recovered_before_reinstall() {
-        let root = std::env::temp_dir().join(format!(
-            "pentect-codex-recovery-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&root).unwrap();
+    fn legacy_backup_is_restored_before_a_new_session() {
+        let root = test_home("codex-legacy-backup");
         let original = "model = \"original\"\n";
         std::fs::write(root.join("config.toml"), "model = \"interrupted\"\n").unwrap();
         std::fs::write(root.join("config.toml.pentect-backup"), original).unwrap();
-        let guard =
-            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").unwrap();
-        drop(guard);
+        recover_legacy_config_in(&root).unwrap();
         assert_eq!(
             std::fs::read_to_string(root.join("config.toml")).unwrap(),
             original
@@ -951,22 +1203,12 @@ base_url = "https://other.example/v1"
     }
 
     #[test]
-    fn interrupted_override_without_an_original_remains_absent_after_recovery() {
-        let root = std::env::temp_dir().join(format!(
-            "pentect-codex-no-original-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&root).unwrap();
+    fn legacy_override_without_an_original_is_removed() {
+        let root = test_home("codex-legacy-no-original");
         std::fs::write(root.join("config.toml"), "model = \"interrupted\"\n").unwrap();
         std::fs::write(root.join("config.toml.pentect-backup"), b"").unwrap();
         std::fs::write(root.join("config.toml.pentect-no-original"), b"").unwrap();
-        let guard =
-            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").unwrap();
-        drop(guard);
+        recover_legacy_config_in(&root).unwrap();
         assert!(!root.join("config.toml").exists());
         assert!(!root.join("config.toml.pentect-backup").exists());
         assert!(!root.join("config.toml.pentect-no-original").exists());
@@ -974,21 +1216,39 @@ base_url = "https://other.example/v1"
     }
 
     #[test]
-    fn malformed_config_does_not_create_recovery_artifacts() {
-        let root = std::env::temp_dir().join(format!(
-            "pentect-codex-malformed-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&root).unwrap();
+    fn orphaned_generated_gateway_is_removed_without_touching_other_settings() {
+        let root = test_home("codex-orphaned-gateway");
+        std::fs::write(
+            root.join("config.toml"),
+            r#"model = "gpt-5"
+model_provider = "pentect-openai-gateway"
+
+[model_providers.pentect-openai-gateway]
+name = "OpenAI through Pentect"
+base_url = "http://127.0.0.1:40495/v1"
+wire_api = "responses"
+requires_openai_auth = true
+supports_websockets = false
+
+[desktop]
+theme = "dark"
+"#,
+        )
+        .unwrap();
+        recover_legacy_config_in(&root).unwrap();
+        let recovered = std::fs::read_to_string(root.join("config.toml")).unwrap();
+        assert!(!recovered.contains("pentect-openai-gateway"));
+        assert!(recovered.contains("model = \"gpt-5\""));
+        assert!(recovered.contains("theme = \"dark\""));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn malformed_config_is_never_replaced() {
+        let root = test_home("codex-malformed-config");
         let malformed = "[not valid";
         std::fs::write(root.join("config.toml"), malformed).unwrap();
-        assert!(
-            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").is_err()
-        );
+        assert!(CodexSessionHome::create_in(&root, "openai", "http://127.0.0.1:47781").is_err());
         assert_eq!(
             std::fs::read_to_string(root.join("config.toml")).unwrap(),
             malformed
@@ -1014,9 +1274,7 @@ base_url = "https://other.example/v1"
         let target = root.join("outside.toml");
         std::fs::write(&target, "model = \"untouched\"\n").unwrap();
         symlink(&target, root.join("config.toml")).unwrap();
-        assert!(
-            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").is_err()
-        );
+        assert!(CodexSessionHome::create_in(&root, "openai", "http://127.0.0.1:47781").is_err());
         assert_eq!(
             std::fs::read_to_string(&target).unwrap(),
             "model = \"untouched\"\n"
@@ -1026,7 +1284,7 @@ base_url = "https://other.example/v1"
 
     #[cfg(unix)]
     #[test]
-    fn active_config_and_recovery_files_are_private() {
+    fn session_config_is_private() {
         use std::os::unix::fs::PermissionsExt;
 
         let root = std::env::temp_dir().join(format!(
@@ -1039,17 +1297,15 @@ base_url = "https://other.example/v1"
         ));
         std::fs::create_dir_all(&root).unwrap();
         std::fs::write(root.join("config.toml"), "model = \"original\"\n").unwrap();
-        let guard =
-            CodexConfigOverride::install_in(&root, "openai", "http://127.0.0.1:47781").unwrap();
-        for path in [
-            root.join("config.toml"),
-            root.join("config.toml.pentect-backup"),
-        ] {
-            assert_eq!(
-                std::fs::metadata(path).unwrap().permissions().mode() & 0o077,
-                0
-            );
-        }
+        let guard = CodexSessionHome::create_in(&root, "openai", "http://127.0.0.1:47781").unwrap();
+        assert_eq!(
+            std::fs::metadata(guard.path().join("config.toml"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o077,
+            0
+        );
         drop(guard);
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -67,16 +67,8 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         &options.upstream_header_env,
     )?;
     let config_lock = Arc::new(Mutex::new(Some(CodexConfigLock::acquire()?)));
-    let session_home = Some(CodexSessionHome::create(
-        &routing.provider,
-        proxy.base_url(),
-    )?);
-    let lifecycle_log = match CodexAppLifecycleLog::open(
-        session_home
-            .as_ref()
-            .expect("Codex session home exists")
-            .source_home(),
-    ) {
+    let session_home = CodexSessionHome::create(&routing.provider, proxy.base_url())?;
+    let lifecycle_log = match CodexAppLifecycleLog::open(session_home.source_home()) {
         Ok(log) => Some(log),
         Err(error) => {
             eprintln!("[pentect] warning: Codex App lifecycle log is unavailable: {error}");
@@ -97,25 +89,13 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     let mut command = Command::new(&app);
     crate::upstream::hide_header_source_env(&mut command, &options.upstream_header_env);
     command
-        .env(
-            "CODEX_HOME",
-            session_home
-                .as_ref()
-                .expect("Codex session home exists")
-                .path(),
-        )
+        .env("CODEX_HOME", session_home.path())
         .env("OPENAI_BASE_URL", proxy.base_url())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
     if std::env::var_os("CODEX_SQLITE_HOME").is_none() {
-        command.env(
-            "CODEX_SQLITE_HOME",
-            session_home
-                .as_ref()
-                .expect("Codex session home exists")
-                .source_home(),
-        );
+        command.env("CODEX_SQLITE_HOME", session_home.source_home());
     }
     configure_child_process(&mut command);
     let mut child = match command.spawn() {
@@ -130,7 +110,7 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         "launcher-started",
         &format!("pid={}", child.id()),
     );
-    let session_cleanup = Arc::new(Mutex::new(session_home));
+    let session_cleanup = Arc::new(Mutex::new(Some(session_home)));
     let signal_cleanup = Arc::clone(&session_cleanup);
     let signal_lock = Arc::clone(&config_lock);
     let child_id = child.id();
@@ -600,13 +580,13 @@ fn link_session_entry(source: &Path, destination: &Path) -> Result<(), String> {
             }
         }
     } else if metadata.is_file() {
-        std::fs::hard_link(source, destination)
-            .or_else(|hard_link_error| {
-                std::os::windows::fs::symlink_file(source, destination).map_err(|symlink_error| {
+        std::os::windows::fs::symlink_file(source, destination)
+            .or_else(|symlink_error| {
+                std::fs::hard_link(source, destination).map_err(|hard_link_error| {
                     std::io::Error::new(
-                        symlink_error.kind(),
+                        hard_link_error.kind(),
                         format!(
-                            "hard link failed ({hard_link_error}); file symlink failed ({symlink_error})"
+                            "file symlink failed ({symlink_error}); hard link failed ({hard_link_error})"
                         ),
                     )
                 })
@@ -629,22 +609,36 @@ fn cleanup_stale_session_homes(sessions: &Path) {
     let Ok(entries) = std::fs::read_dir(sessions) else {
         return;
     };
+    let mut system = sysinfo::System::new();
+    system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
     for entry in entries.flatten() {
-        if generated_session_name(&entry.file_name()) {
+        let Some(pid) = generated_session_pid(&entry.file_name()) else {
+            continue;
+        };
+        if system.process(sysinfo::Pid::from_u32(pid)).is_none() {
             cleanup_session_home(&entry.path());
         }
     }
 }
 
+#[cfg(test)]
 fn generated_session_name(name: &std::ffi::OsStr) -> bool {
+    generated_session_pid(name).is_some()
+}
+
+fn generated_session_pid(name: &std::ffi::OsStr) -> Option<u32> {
     let name = name.to_string_lossy();
     let Some((pid, suffix)) = name.split_once('-') else {
-        return false;
+        return None;
     };
-    !pid.is_empty()
-        && !suffix.is_empty()
-        && pid.bytes().all(|byte| byte.is_ascii_digit())
-        && suffix.bytes().all(|byte| byte.is_ascii_digit())
+    if pid.is_empty()
+        || suffix.is_empty()
+        || !pid.bytes().all(|byte| byte.is_ascii_digit())
+        || !suffix.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+    pid.parse().ok()
 }
 
 fn cleanup_session_home(path: &Path) {
@@ -679,7 +673,10 @@ fn cleanup_session_home(path: &Path) {
             continue;
         };
         if metadata.file_type().is_symlink() || metadata.is_file() {
-            let _ = std::fs::remove_file(&entry_path);
+            if std::fs::remove_file(&entry_path).is_err() {
+                // Windows directory symlinks require directory removal.
+                let _ = std::fs::remove_dir(&entry_path);
+            }
         } else if metadata.is_dir() {
             let _ = std::fs::remove_dir_all(&entry_path);
         }
@@ -699,15 +696,15 @@ fn recover_legacy_config_in(home: &Path) -> Result<bool, String> {
     reject_symlink(&backup, "Codex recovery backup")?;
     reject_symlink(&no_original_marker, "Codex recovery marker")?;
     if backup.is_file() {
-        if config.is_file() {
-            std::fs::remove_file(&config).map_err(|error| {
-                format!(
-                    "could not recover Codex config '{}': {error}",
-                    config.display()
-                )
-            })?;
-        }
         if no_original_marker.is_file() {
+            if config.is_file() {
+                std::fs::remove_file(&config).map_err(|error| {
+                    format!(
+                        "could not recover Codex config '{}': {error}",
+                        config.display()
+                    )
+                })?;
+            }
             std::fs::remove_file(&backup)
                 .map_err(|error| format!("could not clear interrupted Codex backup: {error}"))?;
         } else {
@@ -725,11 +722,12 @@ fn recover_legacy_config_in(home: &Path) -> Result<bool, String> {
     if !config.is_file() {
         return Ok(false);
     }
-    let original = std::fs::read_to_string(&config)
-        .map_err(|error| format!("could not read '{}': {error}", config.display()))?;
-    let mut parsed = original
-        .parse::<toml_edit::DocumentMut>()
-        .map_err(|error| format!("could not parse '{}': {error}", config.display()))?;
+    let Ok(original) = std::fs::read_to_string(&config) else {
+        return Ok(false);
+    };
+    let Ok(mut parsed) = original.parse::<toml_edit::DocumentMut>() else {
+        return Ok(false);
+    };
     if !is_orphaned_legacy_gateway(&parsed) {
         return Ok(false);
     }
@@ -1413,6 +1411,26 @@ base_url = "https://other.example/v1"
         assert!(!generated_session_name(std::ffi::OsStr::new("123-current")));
     }
 
+    #[test]
+    fn stale_cleanup_keeps_live_sessions_and_removes_dead_ones() {
+        let root = test_home("codex-stale-session-cleanup");
+        let sessions = root.join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        let live = sessions.join(format!("{}-1", std::process::id()));
+        let stale = sessions.join(format!("{}-2", u32::MAX));
+        let unrelated = sessions.join("keep-me");
+        std::fs::create_dir(&live).unwrap();
+        std::fs::create_dir(&stale).unwrap();
+        std::fs::create_dir(&unrelated).unwrap();
+
+        cleanup_stale_session_homes(&sessions);
+
+        assert!(live.exists());
+        assert!(!stale.exists());
+        assert!(unrelated.exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
     fn test_home(label: &str) -> PathBuf {
         let root = std::env::temp_dir().join(format!(
             "pentect-{label}-{}-{}",
@@ -1524,6 +1542,7 @@ theme = "dark"
         let malformed = "[not valid";
         std::fs::write(root.join("config.toml"), malformed).unwrap();
         assert!(CodexSessionHome::create_in(&root, "openai", "http://127.0.0.1:47781").is_err());
+        assert!(!recover_legacy_config_in(&root).unwrap());
         assert_eq!(
             std::fs::read_to_string(root.join("config.toml")).unwrap(),
             malformed

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -200,7 +200,10 @@ fn monitor_handed_off_app(
     let mut warned_unobservable = false;
     let mut absent_since = None;
     loop {
-        ensure_gateway_running(proxy, lifecycle_log)?;
+        if let Err(error) = ensure_gateway_running(proxy, lifecycle_log) {
+            terminate_codex_app_processes(app);
+            return Err(error);
+        }
         if process_probe.is_running() {
             if !observed {
                 record_lifecycle(lifecycle_log, "app-process-observed", "running");
@@ -217,7 +220,11 @@ fn monitor_handed_off_app(
             // Packaged Windows apps can hide their executable path from normal
             // process enumeration. Never drop the gateway merely because the
             // process cannot be observed: remain in the foreground until Ctrl+C.
-            record_lifecycle(lifecycle_log, "app-process-unobservable", "gateway-kept-alive");
+            record_lifecycle(
+                lifecycle_log,
+                "app-process-unobservable",
+                "gateway-kept-alive",
+            );
             eprintln!(
                 "[pentect] Codex App process could not be observed; the gateway will stay active until Ctrl+C"
             );
@@ -265,16 +272,16 @@ impl CodexAppLifecycleLog {
                 .open(&path)
                 .map_err(|error| format!("could not rotate '{}': {error}", path.display()))?;
         }
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .map_err(|error| format!("could not open '{}': {error}", path.display()))?;
+        let mut options = OpenOptions::new();
+        options.create(true).append(true);
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
         }
+        let file = options
+            .open(&path)
+            .map_err(|error| format!("could not open '{}': {error}", path.display()))?;
         Ok(Self {
             file: Mutex::new(file),
         })
@@ -1091,28 +1098,16 @@ fn codex_app_is_running(app: &Path) -> bool {
 }
 
 struct CodexAppProcessProbe {
-    expected: String,
-    install_root: String,
+    expected: PathBuf,
+    install_root: Option<PathBuf>,
     system: sysinfo::System,
 }
 
 impl CodexAppProcessProbe {
     fn new(app: &Path) -> Self {
         Self {
-            expected: app
-                .canonicalize()
-                .unwrap_or_else(|_| app.to_path_buf())
-                .to_string_lossy()
-                .to_ascii_lowercase(),
-            install_root: app
-                .parent()
-                .map(|path| {
-                    path.canonicalize()
-                        .unwrap_or_else(|_| path.to_path_buf())
-                        .to_string_lossy()
-                        .to_ascii_lowercase()
-                })
-                .unwrap_or_default(),
+            expected: comparable_process_path(app),
+            install_root: app.parent().map(comparable_process_path),
             system: sysinfo::System::new(),
         }
     }
@@ -1133,7 +1128,7 @@ impl CodexAppProcessProbe {
     }
 
     fn matches(&self, process: &sysinfo::Process) -> bool {
-        let process_name = process.name().to_string_lossy().to_ascii_lowercase();
+        let process_name = comparable_process_name(&process.name().to_string_lossy());
         // Windows packaged ChatGPT/Codex processes may not expose their image
         // path to a non-elevated caller. Treat ChatGPT.exe as the App in that
         // case so an already-running process is never mistaken for a protected
@@ -1145,30 +1140,49 @@ impl CodexAppProcessProbe {
 
         let executable_matches = process
             .exe()
-            .map(|path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf()))
-            .map(|path| path.to_string_lossy().to_ascii_lowercase())
-            .is_some_and(|path| {
-                path == self.expected
-                    || (!self.install_root.is_empty()
-                        && path.starts_with(&self.install_root)
-                        && matches!(
-                            process_name.as_str(),
-                            "codex.exe" | "chatgpt.exe"
-                        ))
-            });
+            .map(comparable_process_path)
+            .is_some_and(|path| self.path_matches(&path, &process_name));
         if executable_matches {
             return true;
         }
 
         process.cmd().first().is_some_and(|command| {
             let path = PathBuf::from(command.as_os_str());
-            let path = path.canonicalize().unwrap_or(path);
-            let path = path.to_string_lossy().to_ascii_lowercase();
-            path == self.expected
-                || (!self.install_root.is_empty()
-                    && path.starts_with(&self.install_root)
-                    && matches!(process_name.as_str(), "codex.exe" | "chatgpt.exe"))
+            let path = comparable_process_path(&path);
+            self.path_matches(&path, &process_name)
         })
+    }
+
+    fn path_matches(&self, path: &Path, process_name: &str) -> bool {
+        path == self.expected
+            || (self
+                .install_root
+                .as_ref()
+                .is_some_and(|root| path.starts_with(root))
+                && matches!(process_name, "codex.exe" | "chatgpt.exe"))
+    }
+}
+
+fn comparable_process_path(path: &Path) -> PathBuf {
+    let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    #[cfg(windows)]
+    {
+        PathBuf::from(path.to_string_lossy().to_ascii_lowercase())
+    }
+    #[cfg(not(windows))]
+    {
+        path
+    }
+}
+
+fn comparable_process_name(name: &str) -> String {
+    #[cfg(windows)]
+    {
+        name.to_ascii_lowercase()
+    }
+    #[cfg(not(windows))]
+    {
+        name.to_string()
     }
 }
 
@@ -1187,6 +1201,23 @@ fn success_status() -> std::process::ExitStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn process_matching_requires_install_root_component_boundary() {
+        let probe = CodexAppProcessProbe {
+            expected: PathBuf::from("/opt/Codex/app/ChatGPT.exe"),
+            install_root: Some(PathBuf::from("/opt/Codex/app")),
+            system: sysinfo::System::new(),
+        };
+        assert!(probe.path_matches(
+            Path::new("/opt/Codex/app/helper/ChatGPT.exe"),
+            "chatgpt.exe",
+        ));
+        assert!(!probe.path_matches(
+            Path::new("/opt/Codex/app-nightly/ChatGPT.exe"),
+            "chatgpt.exe",
+        ));
+    }
 
     #[test]
     fn parses_launcher_options() {

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -628,9 +628,7 @@ fn generated_session_name(name: &std::ffi::OsStr) -> bool {
 
 fn generated_session_pid(name: &std::ffi::OsStr) -> Option<u32> {
     let name = name.to_string_lossy();
-    let Some((pid, suffix)) = name.split_once('-') else {
-        return None;
-    };
+    let (pid, suffix) = name.split_once('-')?;
     if pid.is_empty()
         || suffix.is_empty()
         || !pid.bytes().all(|byte| byte.is_ascii_digit())

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -819,22 +819,10 @@ fn set_provider_gateway(
     gateway: &str,
 ) -> Result<(), String> {
     if provider == "openai" {
-        config["model_provider"] = toml_edit::value(crate::CODEX_GATEWAY_PROVIDER);
-        let providers = config
-            .entry("model_providers")
-            .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()))
-            .as_table_mut()
-            .ok_or_else(|| "model_providers is not a TOML table".to_string())?;
-        let mut gateway_provider = toml_edit::Table::new();
-        gateway_provider.insert("name", toml_edit::value("OpenAI through Pentect"));
-        gateway_provider.insert("base_url", toml_edit::value(gateway));
-        gateway_provider.insert("wire_api", toml_edit::value("responses"));
-        gateway_provider.insert("requires_openai_auth", toml_edit::value(true));
-        gateway_provider.insert("supports_websockets", toml_edit::value(false));
-        providers.insert(
-            crate::CODEX_GATEWAY_PROVIDER,
-            toml_edit::Item::Table(gateway_provider),
-        );
+        // Preserve the built-in provider ID in Codex's thread metadata. The
+        // gateway answers WebSocket upgrades with 426 so Codex falls back to
+        // the protected HTTP Responses path for this session.
+        config["openai_base_url"] = toml_edit::value(gateway);
         return Ok(());
     }
     let providers = config
@@ -1380,7 +1368,7 @@ base_url = "https://other.example/v1"
     #[test]
     fn provider_override_preserves_comments_and_valid_toml() {
         let mut config =
-            "# keep this comment\n[model_providers.proxy]\nbase_url = \"https://old.example/v1\"\n"
+            "# keep this comment\nmodel_provider = \"openai\"\n[model_providers.proxy]\nbase_url = \"https://old.example/v1\"\n"
                 .parse::<toml_edit::DocumentMut>()
                 .unwrap();
         set_provider_gateway(&mut config, "openai", "http://127.0.0.1:47781").unwrap();
@@ -1389,18 +1377,13 @@ base_url = "https://other.example/v1"
         assert!(encoded.contains("# keep this comment"), "{encoded}");
         let parsed = encoded.parse::<toml::Value>().unwrap();
         assert_eq!(
-            parsed["model_provider"].as_str(),
-            Some(crate::CODEX_GATEWAY_PROVIDER)
-        );
-        assert_eq!(
-            parsed["model_providers"][crate::CODEX_GATEWAY_PROVIDER]["base_url"].as_str(),
+            parsed["openai_base_url"].as_str(),
             Some("http://127.0.0.1:47781")
         );
-        assert_eq!(
-            parsed["model_providers"][crate::CODEX_GATEWAY_PROVIDER]["supports_websockets"]
-                .as_bool(),
-            Some(false)
-        );
+        assert_eq!(parsed["model_provider"].as_str(), Some("openai"));
+        assert!(parsed["model_providers"]
+            .get(crate::CODEX_GATEWAY_PROVIDER)
+            .is_none());
     }
 
     #[test]

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -1130,27 +1130,29 @@ impl CodexAppProcessProbe {
         self.system
             .processes()
             .iter()
-            .filter_map(|(pid, process)| {
-                process
-                    .exe()
-                    .and_then(|path| path.canonicalize().ok())
-                    .map(|path| path.to_string_lossy().to_ascii_lowercase())
-                    .is_some_and(|path| {
-                        path == self.expected
-                            || (!self.install_root.is_empty()
-                                && path.starts_with(&self.install_root)
-                                && matches!(
-                                    process
-                                        .name()
-                                        .to_string_lossy()
-                                        .to_ascii_lowercase()
-                                        .as_str(),
-                                    "codex.exe" | "chatgpt.exe"
-                                ))
-                    })
-                    .then(|| pid.as_u32())
-            })
+            .filter(|(_, process)| self.matches(process))
+            .map(|(pid, _)| pid.as_u32())
             .collect()
+    }
+
+    fn matches(&self, process: &sysinfo::Process) -> bool {
+        process
+            .exe()
+            .and_then(|path| path.canonicalize().ok())
+            .map(|path| path.to_string_lossy().to_ascii_lowercase())
+            .is_some_and(|path| {
+                path == self.expected
+                    || (!self.install_root.is_empty()
+                        && path.starts_with(&self.install_root)
+                        && matches!(
+                            process
+                                .name()
+                                .to_string_lossy()
+                                .to_ascii_lowercase()
+                                .as_str(),
+                            "codex.exe" | "chatgpt.exe"
+                        ))
+            })
     }
 }
 

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -1133,7 +1133,17 @@ impl CodexAppProcessProbe {
     }
 
     fn matches(&self, process: &sysinfo::Process) -> bool {
-        process
+        let process_name = process.name().to_string_lossy().to_ascii_lowercase();
+        // Windows packaged ChatGPT/Codex processes may not expose their image
+        // path to a non-elevated caller. Treat ChatGPT.exe as the App in that
+        // case so an already-running process is never mistaken for a protected
+        // launch. Do not do this for a bare codex.exe name because that can be
+        // the unrelated CLI.
+        if cfg!(windows) && process_name == "chatgpt.exe" {
+            return true;
+        }
+
+        let executable_matches = process
             .exe()
             .map(|path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf()))
             .map(|path| path.to_string_lossy().to_ascii_lowercase())
@@ -1142,14 +1152,23 @@ impl CodexAppProcessProbe {
                     || (!self.install_root.is_empty()
                         && path.starts_with(&self.install_root)
                         && matches!(
-                            process
-                                .name()
-                                .to_string_lossy()
-                                .to_ascii_lowercase()
-                                .as_str(),
+                            process_name.as_str(),
                             "codex.exe" | "chatgpt.exe"
                         ))
-            })
+            });
+        if executable_matches {
+            return true;
+        }
+
+        process.cmd().first().is_some_and(|command| {
+            let path = PathBuf::from(command.as_os_str());
+            let path = path.canonicalize().unwrap_or(path);
+            let path = path.to_string_lossy().to_ascii_lowercase();
+            path == self.expected
+                || (!self.install_root.is_empty()
+                    && path.starts_with(&self.install_root)
+                    && matches!(process_name.as_str(), "codex.exe" | "chatgpt.exe"))
+        })
     }
 }
 

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -143,7 +143,7 @@ const COMMANDS: &[CommandSpec] = &[
     CommandSpec {
         name: "log",
         usage: "pentect log [--json]",
-        summary: "Follow local protection events",
+        summary: "Show gateway history and follow protection events",
         audience: CommandAudience::Public,
     },
     CommandSpec {

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1150,7 +1150,9 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
     // Releases before 0.0.36 could leave an App-only loopback provider in the
     // shared config after an interrupted launch. Repair that exact generated
     // shape before resolving the real upstream.
-    codex_app::recover_legacy_config()?;
+    if let Err(error) = codex_app::recover_legacy_config() {
+        eprintln!("[pentect] warning: could not recover legacy Codex App config: {error}");
+    }
     let routing = codex_effective_routing(opts)?;
     let mut args = opts.tool_args.clone();
     if opts.dry_run {

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -530,11 +530,32 @@ fn resolve_agent_command(program: &Path) -> Result<PathBuf, String> {
 #[cfg(any(windows, test))]
 fn resolve_windows_command_from(program: &Path, path: &OsStr, pathext: &OsStr) -> Option<PathBuf> {
     let names = if program.extension().is_none() {
-        let mut names = pathext
+        let mut extensions = pathext
             .to_string_lossy()
             .split(';')
             .map(str::trim)
             .filter(|extension| !extension.is_empty())
+            // Command::new can launch PE binaries and cmd/bat shims. A
+            // PowerShell .ps1 entry may appear in PATHEXT but cannot be
+            // executed directly through CreateProcess.
+            .filter(|extension| {
+                matches!(
+                    extension.to_ascii_uppercase().as_str(),
+                    ".COM" | ".EXE" | ".BAT" | ".CMD"
+                )
+            })
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        for fallback in [".COM", ".EXE", ".BAT", ".CMD"] {
+            if !extensions
+                .iter()
+                .any(|extension| extension.eq_ignore_ascii_case(fallback))
+            {
+                extensions.push(fallback.to_string());
+            }
+        }
+        let mut names = extensions
+            .into_iter()
             .map(|extension| {
                 let mut name = program.as_os_str().to_os_string();
                 name.push(extension);
@@ -2741,6 +2762,30 @@ mod tests {
             resolve_windows_command_from(Path::new("codex"), &path, OsStr::new(".EXE;.CMD"))
                 .unwrap();
         assert_eq!(resolved.parent(), Some(directory.as_path()));
+        assert!(resolved
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .eq_ignore_ascii_case("codex.cmd"));
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn windows_command_resolution_skips_powershell_only_pathext_entries() {
+        let directory = command_test_directory("npm-shim-powershell-pathext");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join("codex.ps1"), b"Write-Output codex\n").unwrap();
+        let cmd = if cfg!(windows) {
+            directory.join("codex.cmd")
+        } else {
+            directory.join("codex.CMD")
+        };
+        std::fs::write(&cmd, b"@echo off\r\n").unwrap();
+
+        let path = std::env::join_paths([&directory]).unwrap();
+        let resolved =
+            resolve_windows_command_from(Path::new("codex"), &path, OsStr::new(".PS1;.CMD"))
+                .unwrap();
         assert!(resolved
             .file_name()
             .unwrap()

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -2129,23 +2129,10 @@ const CODEX_GATEWAY_PROVIDER: &str = "pentect-openai-gateway";
 impl CodexHttpRouting {
     fn gateway_args(&self, gateway: &str) -> Vec<String> {
         let entries = if self.provider == "openai" {
-            vec![
-                format!("model_provider={}", toml_string(CODEX_GATEWAY_PROVIDER)),
-                format!(
-                    "model_providers.{CODEX_GATEWAY_PROVIDER}.name={}",
-                    toml_string("OpenAI through Pentect")
-                ),
-                format!(
-                    "model_providers.{CODEX_GATEWAY_PROVIDER}.base_url={}",
-                    toml_string(gateway)
-                ),
-                format!(
-                    "model_providers.{CODEX_GATEWAY_PROVIDER}.wire_api={}",
-                    toml_string("responses")
-                ),
-                format!("model_providers.{CODEX_GATEWAY_PROVIDER}.requires_openai_auth=true"),
-                format!("model_providers.{CODEX_GATEWAY_PROVIDER}.supports_websockets=false"),
-            ]
+            // Keep the built-in provider ID so Codex can resume this thread without
+            // Pentect. The gateway rejects the WebSocket upgrade with 426, which is
+            // Codex's supported signal to fall back to protected HTTP Responses.
+            vec![format!("openai_base_url={}", toml_string(gateway))]
         } else {
             let provider = codex_toml_key_segment(&self.provider);
             vec![

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -518,8 +518,8 @@ fn resolve_agent_command(program: &Path) -> Result<PathBuf, String> {
         let path = std::env::var_os("PATH").unwrap_or_default();
         let pathext =
             std::env::var_os("PATHEXT").unwrap_or_else(|| OsString::from(".COM;.EXE;.BAT;.CMD"));
-        return resolve_windows_command_from(program, &path, &pathext)
-            .ok_or_else(|| format!("could not run '{}': program not found", program.display()));
+        resolve_windows_command_from(program, &path, &pathext)
+            .ok_or_else(|| format!("could not run '{}': program not found", program.display()))
     }
     #[cfg(not(windows))]
     {
@@ -1142,6 +1142,10 @@ impl AgentToolOpts {
 }
 
 fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
+    // Releases before 0.0.36 could leave an App-only loopback provider in the
+    // shared config after an interrupted launch. Repair that exact generated
+    // shape before resolving the real upstream.
+    codex_app::recover_legacy_config()?;
     let routing = codex_effective_routing(opts)?;
     let mut args = opts.tool_args.clone();
     if opts.dry_run {

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -529,21 +529,26 @@ fn resolve_agent_command(program: &Path) -> Result<PathBuf, String> {
 
 #[cfg(any(windows, test))]
 fn resolve_windows_command_from(program: &Path, path: &OsStr, pathext: &OsStr) -> Option<PathBuf> {
-    let mut names = vec![program.to_path_buf()];
-    if program.extension().is_none() {
-        names.extend(
-            pathext
-                .to_string_lossy()
-                .split(';')
-                .map(str::trim)
-                .filter(|extension| !extension.is_empty())
-                .map(|extension| {
-                    let mut name = program.as_os_str().to_os_string();
-                    name.push(extension);
-                    PathBuf::from(name)
-                }),
-        );
-    }
+    let names = if program.extension().is_none() {
+        let mut names = pathext
+            .to_string_lossy()
+            .split(';')
+            .map(str::trim)
+            .filter(|extension| !extension.is_empty())
+            .map(|extension| {
+                let mut name = program.as_os_str().to_os_string();
+                name.push(extension);
+                PathBuf::from(name)
+            })
+            .collect::<Vec<_>>();
+        // npm installs a POSIX shim without an extension beside the Windows
+        // .cmd/.ps1 shims. It is a file, but Windows cannot execute it. Keep
+        // the raw name only as a final fallback after PATHEXT candidates.
+        names.push(program.to_path_buf());
+        names
+    } else {
+        vec![program.to_path_buf()]
+    };
 
     let explicit_path = program.is_absolute() || program.components().count() > 1;
     if explicit_path {
@@ -2726,6 +2731,32 @@ mod tests {
             resolve_windows_command_from(Path::new("codex"), &path, OsStr::new(".EXE;.CMD"))
                 .unwrap();
         assert_eq!(resolved.file_name().unwrap().to_string_lossy(), "codex.CMD");
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn windows_npm_cmd_shim_wins_over_posix_and_powershell_shims() {
+        let directory = command_test_directory("npm-shim-precedence");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join("codex"), b"#!/bin/sh\n").unwrap();
+        let cmd = if cfg!(windows) {
+            directory.join("codex.cmd")
+        } else {
+            directory.join("codex.CMD")
+        };
+        std::fs::write(&cmd, b"@echo off\r\n").unwrap();
+        std::fs::write(directory.join("codex.ps1"), b"Write-Output codex\n").unwrap();
+
+        let path = std::env::join_paths([&directory]).unwrap();
+        let resolved =
+            resolve_windows_command_from(Path::new("codex"), &path, OsStr::new(".EXE;.CMD"))
+                .unwrap();
+        assert_eq!(resolved.parent(), Some(directory.as_path()));
+        assert!(resolved
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .eq_ignore_ascii_case("codex.cmd"));
         std::fs::remove_dir_all(directory).unwrap();
     }
 

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -262,6 +262,21 @@ async fn proxy_request_inner(
     let method = request.method().clone();
     let endpoint = classify_openai_endpoint(path_and_query);
     enforce_known_openai_endpoint(endpoint, state.block_unknown_formats)?;
+    if method == hyper::Method::GET
+        && endpoint == OpenAiEndpoint::Responses
+        && request
+            .headers()
+            .get(hyper::header::UPGRADE)
+            .is_some_and(|value| value.as_bytes().eq_ignore_ascii_case(b"websocket"))
+    {
+        // Codex treats 426 as the supported signal to disable Responses
+        // WebSockets for this session and retry through HTTP/SSE. Pentect then
+        // protects the ordinary POST /responses request below.
+        return Ok(text_response(
+            StatusCode::UPGRADE_REQUIRED,
+            "Pentect uses protected HTTP Responses",
+        ));
+    }
     let responses_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::Responses;
     let chat_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::ChatCompletions;
     let responses_response = matches!(
@@ -2472,6 +2487,23 @@ mod tests {
             socket.flush().unwrap();
         });
         (format!("http://{address}"), body_rx, thread)
+    }
+
+    #[test]
+    fn codex_websocket_upgrade_falls_back_to_protected_http() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = ProviderBoundaryTestEnv::install(&store);
+        let proxy = OpenAiHttpProxyGuard::start("http://127.0.0.1:9".to_string()).unwrap();
+
+        let response = reqwest::blocking::Client::new()
+            .get(format!("{}/responses", proxy.base_url()))
+            .header(reqwest::header::CONNECTION, "Upgrade")
+            .header(reqwest::header::UPGRADE, "websocket")
+            .send()
+            .unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::UPGRADE_REQUIRED);
     }
 
     #[test]

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -45,6 +45,7 @@ pub(crate) struct OpenAiHttpProxyGuard {
     base_url: String,
     shutdown: Option<oneshot::Sender<()>>,
     thread: Option<thread::JoinHandle<()>>,
+    failure: Arc<Mutex<Option<String>>>,
 }
 
 impl OpenAiHttpProxyGuard {
@@ -63,6 +64,8 @@ impl OpenAiHttpProxyGuard {
         let (ready_tx, ready_rx) = mpsc::channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let thread_auth = auth.clone();
+        let failure = Arc::new(Mutex::new(None));
+        let thread_failure = Arc::clone(&failure);
         let thread = thread::spawn(move || {
             let runtime = match tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(2)
@@ -71,6 +74,9 @@ impl OpenAiHttpProxyGuard {
             {
                 Ok(runtime) => runtime,
                 Err(error) => {
+                    if let Ok(mut failure) = thread_failure.lock() {
+                        *failure = Some(format!("runtime initialization failed: {error}"));
+                    }
                     let _ = ready_tx.send(Err(format!(
                         "could not start OpenAI HTTP gateway runtime: {error}"
                     )));
@@ -81,7 +87,9 @@ impl OpenAiHttpProxyGuard {
                 if let Err(error) =
                     run_proxy(upstream, headers, thread_auth, ready_tx, shutdown_rx).await
                 {
-                    let _ = error;
+                    if let Ok(mut failure) = thread_failure.lock() {
+                        *failure = Some(error);
+                    }
                     proxy_diagnostic("gateway-stopped");
                 }
             });
@@ -93,11 +101,22 @@ impl OpenAiHttpProxyGuard {
             base_url,
             shutdown: Some(shutdown_tx),
             thread: Some(thread),
+            failure,
         })
     }
 
     pub(crate) fn base_url(&self) -> &str {
         &self.base_url
+    }
+
+    pub(crate) fn failure_reason(&self) -> Option<String> {
+        self.failure.lock().ok().and_then(|failure| failure.clone())
+    }
+
+    pub(crate) fn is_running(&self) -> bool {
+        self.thread
+            .as_ref()
+            .is_some_and(|thread| !thread.is_finished())
     }
 }
 

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -158,28 +158,14 @@ async fn run_proxy(
     ready_tx: mpsc::Sender<Result<String, String>>,
     mut shutdown_rx: oneshot::Receiver<()>,
 ) -> Result<(), String> {
-    let listener = TcpListener::bind(("127.0.0.1", 0))
-        .await
-        .map_err(|error| format!("could not bind OpenAI HTTP gateway: {error}"))?;
-    let address = listener
-        .local_addr()
-        .map_err(|error| format!("could not read OpenAI HTTP gateway address: {error}"))?;
-    let local_base_url = format!("http://{address}/{auth}");
-    let plugins = pentect_agent::PluginMiddleware::from_env()?;
-    let state = Arc::new(ProxyState {
-        upstream,
-        auth,
-        client: build_upstream_client()?,
-        masker: Arc::new(Mutex::new(
-            pentect_agent::ActiveToolOutputMasker::new_with_plugins(plugins.clone())?,
-        )),
-        plugins: Arc::new(Mutex::new(plugins)),
-        files: Mutex::new(HashMap::new()),
-        file_attestations: crate::http_files::FileAttestationStore::open_default()?,
-        requests: Arc::new(Semaphore::new(32)),
-        block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
-        headers,
-    });
+    let initialized = initialize_proxy(upstream, headers, auth).await;
+    let (listener, state, local_base_url) = match initialized {
+        Ok(initialized) => initialized,
+        Err(error) => {
+            let _ = ready_tx.send(Err(error));
+            return Err("gateway initialization failed".to_string());
+        }
+    };
     let _ = ready_tx.send(Ok(local_base_url));
 
     loop {
@@ -187,7 +173,7 @@ async fn run_proxy(
             _ = &mut shutdown_rx => break,
             accepted = listener.accept() => {
                 let (socket, _) = accepted
-                    .map_err(|error| format!("OpenAI HTTP gateway accept failed: {error}"))?;
+                    .map_err(|_| "gateway listener failed".to_string())?;
                 let state = Arc::clone(&state);
                 tokio::spawn(async move {
                     let io = hyper_util::rt::TokioIo::new(socket);
@@ -210,6 +196,36 @@ async fn run_proxy(
         }
     }
     Ok(())
+}
+
+async fn initialize_proxy(
+    upstream: reqwest::Url,
+    headers: crate::upstream::HeaderOverrides,
+    auth: String,
+) -> Result<(TcpListener, Arc<ProxyState>, String), String> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .map_err(|error| format!("could not bind OpenAI HTTP gateway: {error}"))?;
+    let address = listener
+        .local_addr()
+        .map_err(|error| format!("could not read OpenAI HTTP gateway address: {error}"))?;
+    let local_base_url = format!("http://{address}/{auth}");
+    let plugins = pentect_agent::PluginMiddleware::from_env()?;
+    let state = Arc::new(ProxyState {
+        upstream,
+        auth,
+        client: build_upstream_client()?,
+        masker: Arc::new(Mutex::new(
+            pentect_agent::ActiveToolOutputMasker::new_with_plugins(plugins.clone())?,
+        )),
+        plugins: Arc::new(Mutex::new(plugins)),
+        files: Mutex::new(HashMap::new()),
+        file_attestations: crate::http_files::FileAttestationStore::open_default()?,
+        requests: Arc::new(Semaphore::new(32)),
+        block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
+        headers,
+    });
+    Ok((listener, state, local_base_url))
 }
 
 fn build_upstream_client() -> Result<reqwest::Client, String> {
@@ -2407,6 +2423,38 @@ mod tests {
             offset = end;
         }
         None
+    }
+
+    #[test]
+    fn startup_reports_pre_ready_plugin_failure_without_timeout() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let name = "PENTECT_PLUGIN_BINARIES";
+        let previous = std::env::var_os(name);
+        let missing = std::env::temp_dir().join(format!(
+            "pentect-missing-plugin-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var(name, &missing);
+        let started = std::time::Instant::now();
+        let result = OpenAiHttpProxyGuard::start("https://example.test/v1".to_string());
+        match previous {
+            Some(value) => std::env::set_var(name, value),
+            None => std::env::remove_var(name),
+        }
+
+        let error = match result {
+            Ok(_) => panic!("missing plugin must fail gateway startup"),
+            Err(error) => error,
+        };
+        assert!(started.elapsed() < std::time::Duration::from_secs(4));
+        assert!(
+            error.contains("plugin") || error.contains("WebAssembly"),
+            "{error}"
+        );
     }
 
     fn mock_chat_upstream() -> (

--- a/crates/pentect-cli/src/uninstall.rs
+++ b/crates/pentect-cli/src/uninstall.rs
@@ -10,6 +10,7 @@ fn uninstall(args: &[String]) -> Result<(), String> {
     if args.len() != 2 {
         return Err("usage: pentect uninstall".to_string());
     }
+    crate::codex_app::recover_legacy_config()?;
     let executable = std::env::current_exe()
         .map_err(|error| format!("could not locate the installed executable: {error}"))?;
     if let Some(installation) = crate::installation::installation_for_executable(&executable)? {

--- a/crates/pentect-cli/src/uninstall.rs
+++ b/crates/pentect-cli/src/uninstall.rs
@@ -10,7 +10,9 @@ fn uninstall(args: &[String]) -> Result<(), String> {
     if args.len() != 2 {
         return Err("usage: pentect uninstall".to_string());
     }
-    crate::codex_app::recover_legacy_config()?;
+    if let Err(error) = crate::codex_app::recover_legacy_config() {
+        eprintln!("pentect: warning: could not recover legacy Codex App config: {error}");
+    }
     let executable = std::env::current_exe()
         .map_err(|error| format!("could not locate the installed executable: {error}"))?;
     if let Some(installation) = crate::installation::installation_for_executable(&executable)? {

--- a/crates/pentect-cli/tests/process_host.rs
+++ b/crates/pentect-cli/tests/process_host.rs
@@ -47,8 +47,8 @@ fn codex_dry_run_routes_through_the_http_gateway() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(rendered.contains("pentect-openai-gateway"), "{rendered}");
-    assert!(rendered.contains("supports_websockets=false"), "{rendered}");
+    assert!(rendered.contains("openai_base_url"), "{rendered}");
+    assert!(!rendered.contains("pentect-openai-gateway"), "{rendered}");
     assert!(rendered.contains("<pentect-gateway>"), "{rendered}");
     assert!(!rendered.contains("PENTECT_KEY_hash"), "{rendered}");
 }

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -4,7 +4,7 @@ use pentect_core::MaskResult;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashSet, VecDeque};
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -36,6 +36,11 @@ struct ActivitySource {
     client: MemoryStoreClient,
     cursor: u64,
     endpoint: ProcessHostEndpoint,
+}
+
+struct LifecycleSource {
+    file: Option<std::fs::File>,
+    offset: u64,
 }
 
 #[derive(Default)]
@@ -157,12 +162,29 @@ pub(crate) fn record_image(secret_images: usize, notes: &[String]) {
 
 pub(crate) fn follow(json: bool) -> Result<(), String> {
     let mut source = activity_source()?;
+    let mut lifecycle = LifecycleSource::open();
     let mut seen = SeenActivity::default();
 
     let stdout = std::io::stdout();
     let mut output = stdout.lock();
     loop {
         let mut wrote = false;
+        for payload in lifecycle.read_new()? {
+            if json {
+                writeln!(output, "{payload}")
+                    .map_err(|error| format!("could not write lifecycle log: {error}"))?;
+            } else if let Ok(entry) = serde_json::from_str::<serde_json::Value>(&payload) {
+                writeln!(
+                    output,
+                    "{}  lifecycle/codex-app  {}  {}",
+                    entry["time"].as_str().unwrap_or("unknown"),
+                    entry["event"].as_str().unwrap_or("event"),
+                    entry["detail"].as_str().unwrap_or_default(),
+                )
+                .map_err(|error| format!("could not write lifecycle log: {error}"))?;
+            }
+            wrote = true;
+        }
         match source.client.poll_activity(source.cursor) {
             Ok(records) => {
                 for (id, payload) in records {
@@ -195,6 +217,53 @@ pub(crate) fn follow(json: bool) -> Result<(), String> {
         }
         std::thread::sleep(POLL_INTERVAL);
     }
+}
+
+impl LifecycleSource {
+    fn open() -> Self {
+        Self::open_at(codex_lifecycle_log_path())
+    }
+
+    fn open_at(path: PathBuf) -> Self {
+        let file = std::fs::OpenOptions::new().read(true).open(path).ok();
+        Self { file, offset: 0 }
+    }
+
+    fn read_new(&mut self) -> Result<Vec<String>, String> {
+        if self.file.is_none() {
+            self.file = std::fs::OpenOptions::new()
+                .read(true)
+                .open(codex_lifecycle_log_path())
+                .ok();
+        }
+        let Some(file) = self.file.as_mut() else {
+            return Ok(Vec::new());
+        };
+        file.seek(SeekFrom::Start(self.offset))
+            .map_err(|error| format!("could not seek Codex App lifecycle log: {error}"))?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)
+            .map_err(|error| format!("could not read Codex App lifecycle log: {error}"))?;
+        self.offset += bytes.len() as u64;
+        Ok(String::from_utf8_lossy(&bytes)
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(str::to_string)
+            .collect())
+    }
+}
+
+fn codex_lifecycle_log_path() -> PathBuf {
+    let home = std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("USERPROFILE")
+                .or_else(|| std::env::var_os("HOME"))
+                .map(PathBuf::from)
+                .map(|home| home.join(".codex"))
+        })
+        .unwrap_or_else(|| PathBuf::from(".codex"));
+    home.join(".pentect").join("logs").join("codex-app.log")
 }
 
 fn record(event: ActivityEvent) {
@@ -304,5 +373,30 @@ mod tests {
         assert!(seen.insert(event));
         assert!(!seen.insert(event));
         assert!(seen.insert(r#"{"action":"resolve","count":1}"#));
+    }
+
+    #[test]
+    fn lifecycle_source_reads_only_appended_records_after_the_first_poll() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-lifecycle-source-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("codex-app.log");
+        std::fs::write(&path, "{\"event\":\"gateway-started\"}\n").unwrap();
+        let mut source = LifecycleSource::open_at(path.clone());
+        assert_eq!(source.read_new().unwrap().len(), 1);
+        assert!(source.read_new().unwrap().is_empty());
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(file, "{{\"event\":\"session-finished\"}}").unwrap();
+        assert_eq!(source.read_new().unwrap().len(), 1);
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -39,8 +39,10 @@ struct ActivitySource {
 }
 
 struct LifecycleSource {
+    path: PathBuf,
     file: Option<std::fs::File>,
     offset: u64,
+    pending: Vec<u8>,
 }
 
 #[derive(Default)]
@@ -225,27 +227,45 @@ impl LifecycleSource {
     }
 
     fn open_at(path: PathBuf) -> Self {
-        let file = std::fs::OpenOptions::new().read(true).open(path).ok();
-        Self { file, offset: 0 }
+        let file = std::fs::OpenOptions::new().read(true).open(&path).ok();
+        Self {
+            path,
+            file,
+            offset: 0,
+            pending: Vec::new(),
+        }
     }
 
     fn read_new(&mut self) -> Result<Vec<String>, String> {
         if self.file.is_none() {
-            self.file = std::fs::OpenOptions::new()
-                .read(true)
-                .open(codex_lifecycle_log_path())
-                .ok();
+            self.file = std::fs::OpenOptions::new().read(true).open(&self.path).ok();
         }
         let Some(file) = self.file.as_mut() else {
             return Ok(Vec::new());
         };
+        let length = file
+            .metadata()
+            .map_err(|error| format!("could not inspect Codex App lifecycle log: {error}"))?
+            .len();
+        if length < self.offset {
+            self.offset = 0;
+            self.pending.clear();
+        }
         file.seek(SeekFrom::Start(self.offset))
             .map_err(|error| format!("could not seek Codex App lifecycle log: {error}"))?;
         let mut bytes = Vec::new();
         file.read_to_end(&mut bytes)
             .map_err(|error| format!("could not read Codex App lifecycle log: {error}"))?;
         self.offset += bytes.len() as u64;
-        Ok(String::from_utf8_lossy(&bytes)
+        self.pending.extend_from_slice(&bytes);
+
+        let complete = self
+            .pending
+            .iter()
+            .rposition(|byte| *byte == b'\n')
+            .map(|index| self.pending.drain(..=index).collect::<Vec<_>>())
+            .unwrap_or_default();
+        Ok(String::from_utf8_lossy(&complete)
             .lines()
             .filter(|line| !line.trim().is_empty())
             .map(str::to_string)
@@ -397,6 +417,38 @@ mod tests {
             .unwrap();
         writeln!(file, "{{\"event\":\"session-finished\"}}").unwrap();
         assert_eq!(source.read_new().unwrap().len(), 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lifecycle_source_waits_for_complete_lines_and_recovers_after_truncation() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-lifecycle-partial-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("codex-app.log");
+        std::fs::write(&path, "{\"event\":\"gateway").unwrap();
+        let mut source = LifecycleSource::open_at(path.clone());
+        assert!(source.read_new().unwrap().is_empty());
+
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(file, "-started\"}}").unwrap();
+        assert_eq!(
+            source.read_new().unwrap(),
+            ["{\"event\":\"gateway-started\"}"]
+        );
+
+        drop(file);
+        std::fs::write(&path, "{\"event\":\"rotated\"}\n").unwrap();
+        assert_eq!(source.read_new().unwrap(), ["{\"event\":\"rotated\"}"]);
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -240,6 +240,17 @@ impl LifecycleSource {
         if self.file.is_none() {
             self.file = std::fs::OpenOptions::new().read(true).open(&self.path).ok();
         }
+        let path_replaced = self
+            .file
+            .as_ref()
+            .and_then(|file| file.metadata().ok())
+            .zip(std::fs::metadata(&self.path).ok())
+            .is_some_and(|(open, current)| !same_file_identity(&open, &current));
+        if path_replaced {
+            self.file = std::fs::OpenOptions::new().read(true).open(&self.path).ok();
+            self.offset = 0;
+            self.pending.clear();
+        }
         let Some(file) = self.file.as_mut() else {
             return Ok(Vec::new());
         };
@@ -271,6 +282,25 @@ impl LifecycleSource {
             .map(str::to_string)
             .collect())
     }
+}
+
+#[cfg(unix)]
+fn same_file_identity(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(windows)]
+fn same_file_identity(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    // Stable Rust does not expose the Windows file index. Pentect creates the
+    // replacement log itself, so its creation timestamp changes on rotation.
+    left.creation_time() == right.creation_time()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_file_identity(_left: &std::fs::Metadata, _right: &std::fs::Metadata) -> bool {
+    true
 }
 
 fn codex_lifecycle_log_path() -> PathBuf {
@@ -449,6 +479,35 @@ mod tests {
         drop(file);
         std::fs::write(&path, "{\"event\":\"rotated\"}\n").unwrap();
         assert_eq!(source.read_new().unwrap(), ["{\"event\":\"rotated\"}"]);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lifecycle_source_follows_path_replacement_rotation() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-lifecycle-rotation-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("codex-app.log");
+        let rotated = root.join("codex-app.log.1");
+        std::fs::write(&path, "{\"event\":\"before-rotation\"}\n").unwrap();
+        let mut source = LifecycleSource::open_at(path.clone());
+        assert_eq!(
+            source.read_new().unwrap(),
+            ["{\"event\":\"before-rotation\"}"]
+        );
+
+        std::fs::rename(&path, &rotated).unwrap();
+        std::fs::write(&path, "{\"event\":\"after-rotation\"}\n").unwrap();
+        assert_eq!(
+            source.read_new().unwrap(),
+            ["{\"event\":\"after-rotation\"}"]
+        );
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -697,7 +697,7 @@ fn usage() {
          exec: masked output\n\
          view: handle\n\
          resolve: write handles\n\
-         log: live events"
+         log: gateway history and live events"
     );
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -4,6 +4,45 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 Set-StrictMode -Version Latest
 
+function ConvertTo-PentectArchitecture {
+    param([Parameter(Mandatory = $true)][string]$Value)
+
+    switch ($Value.Trim().ToUpperInvariant()) {
+        { $_ -in @('X64', 'AMD64', 'X86_64') } { return 'X64' }
+        { $_ -in @('ARM64', 'AARCH64') } { return 'Arm64' }
+        { $_ -in @('X86', 'I386', 'I486', 'I586', 'I686') } { return 'X86' }
+        default { return $Value.Trim() }
+    }
+}
+
+function Get-PentectOsArchitecture {
+    param(
+        [scriptblock]$RuntimeArchitecture = { [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString() },
+        [AllowEmptyString()][string]$ProcessorArchitecture = $env:PROCESSOR_ARCHITECTURE,
+        [AllowEmptyString()][string]$ProcessorArchitectureW6432 = $env:PROCESSOR_ARCHITEW6432
+    )
+
+    try {
+        $runtimeValue = & $RuntimeArchitecture
+        if (-not [string]::IsNullOrWhiteSpace([string]$runtimeValue)) {
+            return ConvertTo-PentectArchitecture ([string]$runtimeValue)
+        }
+    } catch {
+        # Windows PowerShell 5.1 can expose RuntimeInformation without the
+        # OSArchitecture property. Fall back to the native process variables.
+    }
+
+    $environmentValue = if (-not [string]::IsNullOrWhiteSpace($ProcessorArchitectureW6432)) {
+        $ProcessorArchitectureW6432
+    } else {
+        $ProcessorArchitecture
+    }
+    if ([string]::IsNullOrWhiteSpace($environmentValue)) {
+        throw 'pentect: could not determine Windows architecture'
+    }
+    return ConvertTo-PentectArchitecture $environmentValue
+}
+
 $repository = 'EdamAme-x/pentect'
 $requestedVersion = $Version
 if ($requestedVersion) {
@@ -17,7 +56,7 @@ if ($requestedVersion) {
     $releaseTag = 'latest'
     $baseUrl = "https://github.com/$repository/releases/latest/download"
 }
-$architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+$architecture = Get-PentectOsArchitecture
 if ($architecture -ne 'X64') {
     throw "pentect: unsupported Windows architecture: $architecture"
 }

--- a/tools/test_install.ps1
+++ b/tools/test_install.ps1
@@ -3,9 +3,11 @@ Set-StrictMode -Version Latest
 
 $savedDryRun = $env:PENTECT_INSTALL_DRY_RUN
 $savedSkipPath = $env:PENTECT_INSTALL_SKIP_PATH
+$savedInstallDir = $env:PENTECT_INSTALL_DIR
 try {
     $env:PENTECT_INSTALL_DRY_RUN = '1'
     $env:PENTECT_INSTALL_SKIP_PATH = '1'
+    $env:PENTECT_INSTALL_DIR = Join-Path ([System.IO.Path]::GetTempPath()) 'pentect-installer-test'
     . (Join-Path $PSScriptRoot 'install.ps1') | Out-Null
 
     $missingRuntimeProperty = { throw 'OSArchitecture property is unavailable' }
@@ -26,4 +28,5 @@ try {
 } finally {
     $env:PENTECT_INSTALL_DRY_RUN = $savedDryRun
     $env:PENTECT_INSTALL_SKIP_PATH = $savedSkipPath
+    $env:PENTECT_INSTALL_DIR = $savedInstallDir
 }

--- a/tools/test_install.ps1
+++ b/tools/test_install.ps1
@@ -1,0 +1,29 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$savedDryRun = $env:PENTECT_INSTALL_DRY_RUN
+$savedSkipPath = $env:PENTECT_INSTALL_SKIP_PATH
+try {
+    $env:PENTECT_INSTALL_DRY_RUN = '1'
+    $env:PENTECT_INSTALL_SKIP_PATH = '1'
+    . (Join-Path $PSScriptRoot 'install.ps1') | Out-Null
+
+    $missingRuntimeProperty = { throw 'OSArchitecture property is unavailable' }
+    $x64 = Get-PentectOsArchitecture $missingRuntimeProperty 'x86' 'AMD64'
+    if ($x64 -ne 'X64') {
+        throw "expected X64 from PROCESSOR_ARCHITEW6432, received $x64"
+    }
+
+    $nativeX64 = Get-PentectOsArchitecture $missingRuntimeProperty 'AMD64' ''
+    if ($nativeX64 -ne 'X64') {
+        throw "expected X64 from PROCESSOR_ARCHITECTURE, received $nativeX64"
+    }
+
+    $arm64 = Get-PentectOsArchitecture $missingRuntimeProperty 'x86' 'ARM64'
+    if ($arm64 -ne 'Arm64') {
+        throw "expected Arm64 fallback result, received $arm64"
+    }
+} finally {
+    $env:PENTECT_INSTALL_DRY_RUN = $savedDryRun
+    $env:PENTECT_INSTALL_SKIP_PATH = $savedSkipPath
+}

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -108,6 +108,11 @@ uses your normal provider, even while the protected App is open.
 
 `--check` exercises discovery and routing without sending a model prompt.
 
+`pentect codex app` stays attached for the full App session. If the launcher
+hands off to another App process, Pentect keeps the gateway alive until that
+process exits. `pentect log` includes value-free Codex App lifecycle and crash
+events from previous sessions as well as live protection events.
+
 ## Verify protection
 
 Run `pentect log` in another terminal. Then ask Codex to read a test dotenv

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -101,7 +101,10 @@ pentect codex app --app /path/to/codex
 ```
 
 This affects only the launch started by Pentect. Opening Codex App normally
-does not use Pentect or change other ChatGPT traffic.
+does not use Pentect or change other ChatGPT traffic. Pentect gives the child
+App a session-only Codex configuration; it never points your shared
+`~/.codex/config.toml` at the temporary gateway. Running `codex` directly still
+uses your normal provider, even while the protected App is open.
 
 `--check` exercises discovery and routing without sending a model prompt.
 

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -77,7 +77,7 @@ unknown-handle behavior.
 | `pentect exec --live "COMMAND"` | Stream masked output while the command runs |
 | `pentect view HANDLE` | Show handle details without revealing the real value |
 | `pentect resolve [PATH...]` | Restore known handles from stdin or selected files |
-| `pentect log [--json]` | Follow local protection events without secret values |
+| `pentect log [--json]` | Show gateway history and follow protection events without secret values |
 | `pentect doctor [--json]` | Check the installation and supported clients |
 | `pentect doctor --fix` | Offer repairable configuration changes |
 | `pentect update [VERSION]` | Install a checksummed GitHub Release binary |

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -92,7 +92,7 @@ pentect gemini --model gemini-2.5-pro
 | `pentect read PATH` | Print a masked preview of a file |
 | `pentect exec "COMMAND"` | Restore known handles, run the command, and mask its output |
 | `pentect view HANDLE` | Show handle details without revealing its value |
-| `pentect log [--json]` | Follow local protection events |
+| `pentect log [--json]` | Show gateway history and follow protection events |
 
 ### `mask`
 

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -184,6 +184,10 @@ pentect log
 pentect log --json
 ```
 
+Codex App gateway lifecycle and crash entries are persisted locally, so this
+also shows why a previous protected App session ended. The entries contain
+event types and process status only, never request bodies or secret values.
+
 Logs show actions and counts, not real protected values.
 
 ::: warning


### PR DESCRIPTION
## Summary

- keep the shared Codex configuration unchanged by using an isolated session-only `CODEX_HOME`
- recover legacy interrupted App configuration without deleting valid user settings
- preserve provider identity and session resumability
- keep the gateway alive across Windows packaged-app handoff and terminate the App if protection fails
- prefer executable Windows npm shims and reject PowerShell-only PATHEXT candidates
- persist value-free lifecycle diagnostics and follow rotated logs
- support the official installer on Windows PowerShell 5.1 when `OSArchitecture` is unavailable
- add Windows PowerShell 5.1, npm-shim, configuration recovery, process lifecycle, and log-rotation regression tests

## Validation

- CI: success
- Security audit: success
- Windows PowerShell 5.1 installer: success
- Windows and macOS desktop boundaries: success
- rustfmt and Clippy: success
- Rust, npm, packaging, and lifecycle tests: success

Fixes #252
Fixes #258
Fixes #261
Fixes #262
Fixes #263
Fixes #264
Fixes #265