### PR TITLE
ci: test Claude and OpenCode launchers in release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,13 +495,17 @@ jobs:
           sudo dpkg -i dist/pentect_*.deb
           test "$(pentect version)" = "pentect ${GITHUB_REF_NAME#v}"
           echo 'PENTECT_SMOKE_BINARY=/usr/bin/pentect' >> "$GITHUB_ENV"
-      - name: Verify Codex CLI and Codex App launch (Windows)
+      - name: Verify agent CLI and Codex App launch (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          npm install --global @openai/codex@0.147.0
+          npm install --global @openai/codex@0.147.0 @anthropic-ai/claude-code@2.1.227 opencode-ai@1.18.16
           & $env:PENTECT_SMOKE_BINARY codex -- --version
           if ($LASTEXITCODE -ne 0) { throw 'pentect codex failed to launch' }
+          & $env:PENTECT_SMOKE_BINARY claude -- --version
+          if ($LASTEXITCODE -ne 0) { throw 'pentect claude failed to launch' }
+          & $env:PENTECT_SMOKE_BINARY opencode -- --version
+          if ($LASTEXITCODE -ne 0) { throw 'pentect opencode failed to launch' }
           $node = (Get-Command node -ErrorAction Stop).Source
           $fixture = Join-Path $env:RUNNER_TEMP 'codex-app-fixture.exe'
           Copy-Item -LiteralPath $node -Destination $fixture
@@ -513,13 +517,15 @@ jobs:
           & $env:PENTECT_SMOKE_BINARY codex app --app $fixture --upstream https://api.openai.com/v1
           if ($LASTEXITCODE -ne 0) { throw 'pentect codex app failed to launch' }
           if ((Get-FileHash -Algorithm SHA256 $config).Hash -ne $before) { throw 'Codex config was modified' }
-      - name: Verify Codex CLI and Codex App launch (POSIX)
+      - name: Verify agent CLI and Codex App launch (POSIX)
         if: runner.os != 'Windows'
         shell: bash
         run: |
           set -euo pipefail
-          npm install --global @openai/codex@0.147.0
+          npm install --global @openai/codex@0.147.0 @anthropic-ai/claude-code@2.1.227 opencode-ai@1.18.16
           "$PENTECT_SMOKE_BINARY" codex -- --version
+          "$PENTECT_SMOKE_BINARY" claude -- --version
+          "$PENTECT_SMOKE_BINARY" opencode -- --version
           fixture="$RUNNER_TEMP/codex-app-fixture"
           cp "$(command -v node)" "$fixture"
           chmod +x "$fixture"


### PR DESCRIPTION
## Summary

- install the pinned Claude Code and OpenCode CLIs in every release installer smoke case
- verify `pentect claude -- --version` and `pentect opencode -- --version` on Windows, Linux x64/ARM64, and macOS Intel/ARM64
- keep the existing Codex CLI, Codex App, and configuration-integrity checks

This applies to releases after v0.0.36 because that tag already points to the previous workflow commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded release lifecycle smoke tests to verify Claude Code and OpenCode installation across Windows and POSIX systems.
  * Continued validating Codex app launch and configuration integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->