### PR TITLE
ci: recover empty stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,8 +280,15 @@ jobs:
               --json isDraft,isPrerelease,assets)
             test "$(jq -r .isDraft <<<"$release")" = false
             if test "$(jq -r .isPrerelease <<<"$release")" != true; then
-              echo "refusing to replace assets on an existing stable release" >&2
-              exit 1
+              asset_count=$(jq '.assets | length' <<<"$release")
+              if test "$asset_count" != 0; then
+                echo "refusing to replace assets on an existing stable release" >&2
+                exit 1
+              fi
+              echo "existing stable release has no uploaded assets; returning it to prerelease validation"
+              gh release edit "$GITHUB_REF_NAME" --prerelease --repo "$GITHUB_REPOSITORY"
+              release=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+                --json isDraft,isPrerelease,assets)
             fi
 
             find dist -maxdepth 1 -type f -printf '%f\n' | sort > "$RUNNER_TEMP/local-assets"


### PR DESCRIPTION
## Summary

- recover a manually-created Stable release when it has no uploaded assets
- return it to Prerelease before uploading and running the installer matrix
- keep refusing to replace any Stable release that already contains uploaded assets

## Incident

Fixes the release-path failure behind #267. The v0.0.36 release was created as Stable before the workflow reached its staging job, so the safety check stopped publication and every installer smoke job was skipped.

The current v0.0.36 run still needs the release changed to Prerelease and the failed jobs rerun; workflow files are fixed to their tag commit.