### PR TITLE
chore: bump Pentect to v0.0.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.36"
+version = "0.0.37"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the Rust CLI package to 0.0.37
- update Cargo.lock
- bump the npm package to 0.0.37

The existing v0.0.37 tag points to an older 0.0.36 commit and must be recreated from `main` after this PR merges.