### PR TITLE
ci: recover stale v0.0.37 release automatically

### DIFF
--- a/.github/workflows/recover-v0.0.37.yml
+++ b/.github/workflows/recover-v0.0.37.yml
@@ -1,0 +1,37 @@
+name: Recover v0.0.37 release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/recover-v0.0.37.yml"
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  recover:
+    if: github.repository == 'EdamAme-x/pentect'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Replace stale release tag and dispatch release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag=v0.0.37
+          release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag" --jq .id 2>/dev/null || true)
+          if test -n "$release_id"; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id"
+          fi
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" >/dev/null 2>&1; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$tag"
+          fi
+          gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/$tag" \
+            -f sha="$GITHUB_SHA"
+          gh workflow run release.yml --ref "$tag" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- allow the release workflow to be dispatched against an explicit tag
- add a one-shot recovery workflow for the stale v0.0.37 tag
- delete the empty v0.0.37 release and old tag after merge
- recreate v0.0.37 at the merge commit and dispatch the full release pipeline

This avoids requiring an interactive GitHub login while the maintainer's PC is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for manually triggering the release process.
  * Added automated recovery for the `v0.0.37` release and tag when changes are pushed to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->