### PR TITLE
fix: stabilize installers and release v0.0.38

### DIFF
--- a/.github/workflows/release-guard.yml
+++ b/.github/workflows/release-guard.yml
@@ -1,0 +1,63 @@
+name: Guard published releases
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  quarantine-incomplete-release:
+    if: github.repository == 'EdamAme-x/pentect' && github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Quarantine a stable release with missing assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          release=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")
+          version=${RELEASE_TAG#v}
+          required=(
+            LICENSE
+            THIRD_PARTY_LICENSES.txt
+            pentect-windows-x86_64.exe
+            pentect-windows-x86_64.exe.gz
+            pentect-windows-x86_64.exe.sha256
+            pentect-linux-x86_64
+            pentect-linux-x86_64.gz
+            pentect-linux-x86_64.sha256
+            pentect-linux-aarch64
+            pentect-linux-aarch64.gz
+            pentect-linux-aarch64.sha256
+            pentect-macos-x86_64
+            pentect-macos-x86_64.gz
+            pentect-macos-x86_64.sha256
+            pentect-macos-aarch64
+            pentect-macos-aarch64.gz
+            pentect-macos-aarch64.sha256
+            "pentect_${version}_amd64.deb"
+            "pentect_${version}_amd64.deb.sha256"
+            "pentect_${version}_arm64.deb"
+            "pentect_${version}_arm64.deb.sha256"
+          )
+          missing=()
+          for asset in "${required[@]}"; do
+            if ! jq -e --arg name "$asset" '.assets[] | select(.name == $name)' <<<"$release" >/dev/null; then
+              missing+=("$asset")
+            fi
+          done
+          if test "${#missing[@]}" -eq 0; then
+            exit 0
+          fi
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            -F prerelease=true \
+            -f make_latest=false >/dev/null
+          printf 'Incomplete release was changed back to prerelease. Missing assets:\n' >&2
+          printf '  %s\n' "${missing[@]}" >&2
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,5 +33,10 @@ package metadata through an auto-merge pull request, creates the matching
 `nix-vX.Y.Z` tag, and tests the Homebrew formula on Intel and Apple Silicon before
 publishing it.
 
+Do not create or publish the GitHub Release manually. Push only the matching tag;
+the release workflow creates a prerelease and promotes it after every installer
+and launcher check passes. A guard changes incomplete manually published releases
+back to prereleases so they cannot replace the last healthy `latest` release.
+
 Never reuse a release tag. A workflow retry may fill in a missing prerelease
 asset only when every already-published asset has the same SHA-256 digest.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.37"
+version = "0.0.38"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -50,27 +50,49 @@ async function packageVersion() {
   return metadata.version?.replace(/^v/, '');
 }
 
-async function download(url, signal) {
-  const response = await fetch(url, {
-    redirect: 'follow',
-    headers: { 'user-agent': 'pentect-npm-installer' },
-    signal,
-  });
+export function retryableStatus(status) {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+export async function fetchWithRetry(url, options = {}) {
+  const request = options.request || globalThis.fetch;
+  const wait = options.wait || ((milliseconds) => new Promise(
+    (resolveDelay) => setTimeout(resolveDelay, milliseconds),
+  ));
+  const timeout = options.timeout || (() => AbortSignal.timeout(90_000));
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const response = await request(url, {
+        redirect: 'follow',
+        headers: { 'user-agent': 'pentect-npm-installer' },
+        signal: timeout(),
+      });
+      if (!retryableStatus(response.status) || attempt === 3) return response;
+      await response.body?.cancel();
+      lastError = new Error(`Download failed (${response.status} ${response.statusText})`);
+    } catch (error) {
+      lastError = error;
+      if (attempt === 3) throw error;
+    }
+    await wait(attempt * 250);
+  }
+  throw lastError;
+}
+
+async function download(url) {
+  const response = await fetchWithRetry(url);
   if (!response.ok) throw new Error(`Download failed (${response.status} ${response.statusText})`);
   return Buffer.from(await response.arrayBuffer());
 }
 
-async function downloadBinary(base, asset, signal) {
-  const compressed = await fetch(`${base}/${asset}.gz`, {
-    redirect: 'follow',
-    headers: { 'user-agent': 'pentect-npm-installer' },
-    signal,
-  });
+async function downloadBinary(base, asset) {
+  const compressed = await fetchWithRetry(`${base}/${asset}.gz`);
   if (compressed.ok) return gunzipSync(Buffer.from(await compressed.arrayBuffer()));
   if (compressed.status !== 404) {
     throw new Error(`Download failed (${compressed.status} ${compressed.statusText})`);
   }
-  return download(`${base}/${asset}`, signal);
+  return download(`${base}/${asset}`);
 }
 
 export async function install(version) {
@@ -81,10 +103,9 @@ export async function install(version) {
   const base = tag === 'latest'
     ? `https://github.com/${repository}/releases/latest/download`
     : `https://github.com/${repository}/releases/download/${tag}`;
-  const signal = AbortSignal.timeout(90_000);
   const [binary, checksumFile] = await Promise.all([
-    downloadBinary(base, asset, signal),
-    download(`${base}/${asset}.sha256`, signal),
+    downloadBinary(base, asset),
+    download(`${base}/${asset}.sha256`),
   ]);
   const expected = expectedChecksum(checksumFile.toString('utf8'));
   const actual = createHash('sha256').update(binary).digest('hex');

--- a/packaging/npm/install.test.js
+++ b/packaging/npm/install.test.js
@@ -3,7 +3,13 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { expectedChecksum, installationPath, releaseAsset } from './install.js';
+import {
+  expectedChecksum,
+  fetchWithRetry,
+  installationPath,
+  releaseAsset,
+  retryableStatus,
+} from './install.js';
 
 test('maps supported npm platforms to release assets', () => {
   assert.equal(releaseAsset('win32', 'x64'), 'pentect-windows-x86_64.exe');
@@ -19,6 +25,26 @@ test('accepts only a complete SHA-256 checksum record', () => {
   const hash = 'a'.repeat(64);
   assert.equal(expectedChecksum(`${hash}  pentect-linux-x86_64\n`), hash);
   assert.throws(() => expectedChecksum('not-a-checksum'), /invalid/);
+});
+
+test('retries only transient download failures', () => {
+  assert.equal(retryableStatus(408), true);
+  assert.equal(retryableStatus(429), true);
+  assert.equal(retryableStatus(503), true);
+  assert.equal(retryableStatus(404), false);
+  assert.equal(retryableStatus(401), false);
+});
+
+test('retries transient responses before returning success', async () => {
+  const statuses = [503, 429, 200];
+  const waits = [];
+  const response = await fetchWithRetry('https://example.invalid/pentect', {
+    request: async () => new Response(null, { status: statuses.shift() }),
+    timeout: () => undefined,
+    wait: async (milliseconds) => waits.push(milliseconds),
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(waits, [250, 500]);
 });
 
 test('uses a user-writable versioned cache for the installed binary', () => {

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -43,6 +43,57 @@ function Get-PentectOsArchitecture {
     return ConvertTo-PentectArchitecture $environmentValue
 }
 
+function Invoke-PentectDownload {
+    param(
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [Parameter(Mandatory = $true)][string]$OutFile,
+        [switch]$AllowNotFound
+    )
+
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri $Uri -OutFile $OutFile
+            return $true
+        } catch {
+            $response = $_.Exception.Response
+            if ($AllowNotFound -and $null -ne $response -and [int]$response.StatusCode -eq 404) {
+                return $false
+            }
+            if ($attempt -eq 3) {
+                throw "pentect: could not download '$Uri' after 3 attempts: $($_.Exception.Message)"
+            }
+            Start-Sleep -Seconds $attempt
+        }
+    }
+}
+
+function Expand-PentectGzip {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $inputStream = [System.IO.File]::OpenRead($Source)
+    try {
+        $outputStream = [System.IO.File]::Create($Destination)
+        try {
+            $gzipStream = [System.IO.Compression.GzipStream]::new(
+                $inputStream,
+                [System.IO.Compression.CompressionMode]::Decompress
+            )
+            try {
+                $gzipStream.CopyTo($outputStream)
+            } finally {
+                $gzipStream.Dispose()
+            }
+        } finally {
+            $outputStream.Dispose()
+        }
+    } finally {
+        $inputStream.Dispose()
+    }
+}
+
 $repository = 'EdamAme-x/pentect'
 $requestedVersion = $Version
 if ($requestedVersion) {
@@ -80,16 +131,25 @@ if ($env:PENTECT_INSTALL_DRY_RUN -eq '1') {
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("pentect-install-" + [guid]::NewGuid())
 New-Item -ItemType Directory -Path $tempDir | Out-Null
 try {
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = `
+            [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+    } catch {}
     Write-Output 'Pentect installer'
     Write-Output "  Platform : Windows x64"
     Write-Output "  Version  : $releaseTag"
     Write-Output "  Install  : $destination"
     Write-Output ''
     $binaryPath = Join-Path $tempDir $asset
+    $compressedPath = "$binaryPath.gz"
     $checksumPath = "$binaryPath.sha256"
     Write-Output "[1/4] Downloading $releaseTag..."
-    Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/$asset" -OutFile $binaryPath
-    Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/$asset.sha256" -OutFile $checksumPath
+    if (Invoke-PentectDownload -Uri "$baseUrl/$asset.gz" -OutFile $compressedPath -AllowNotFound) {
+        Expand-PentectGzip -Source $compressedPath -Destination $binaryPath
+    } else {
+        Invoke-PentectDownload -Uri "$baseUrl/$asset" -OutFile $binaryPath | Out-Null
+    }
+    Invoke-PentectDownload -Uri "$baseUrl/$asset.sha256" -OutFile $checksumPath | Out-Null
 
     Write-Output '[2/4] Verifying SHA-256...'
     $expected = ((Get-Content -Raw -LiteralPath $checksumPath) -split '\s+')[0].ToLowerInvariant()

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -65,6 +65,12 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
+download() {
+  curl -fsSL --proto '=https' --tlsv1.2 \
+    --retry 3 --retry-delay 1 \
+    "$1" -o "$2"
+}
+
 temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/pentect-install.XXXXXX")
 cleanup() {
   rm -rf "$temp_dir"
@@ -77,12 +83,13 @@ printf '  Version  : %s\n' "$release_tag"
 printf '  Install  : %s\n\n' "$destination"
 
 printf '[1/4] Downloading %s...\n' "$release_tag"
-curl -fsSL --proto '=https' --tlsv1.2 \
-  "$base_url/$asset" \
-  -o "$temp_dir/$asset"
-curl -fsSL --proto '=https' --tlsv1.2 \
-  "$base_url/$asset.sha256" \
-  -o "$temp_dir/$asset.sha256"
+if command -v gzip >/dev/null 2>&1 && \
+  download "$base_url/$asset.gz" "$temp_dir/$asset.gz" 2>/dev/null; then
+  gzip -dc "$temp_dir/$asset.gz" > "$temp_dir/$asset"
+else
+  download "$base_url/$asset" "$temp_dir/$asset"
+fi
+download "$base_url/$asset.sha256" "$temp_dir/$asset.sha256"
 
 printf '[2/4] Verifying SHA-256...\n'
 expected=$(awk 'NR == 1 { print tolower($1) }' "$temp_dir/$asset.sha256")

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3093,9 +3093,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- publish the unreleased Codex and Windows launcher fixes as v0.0.38
- prefer compressed release assets and retry transient downloads in shell, PowerShell, and npm installers
- quarantine incomplete manually published stable releases before they can remain `latest`
- update the website lockfile to resolve the nanoid high-severity advisory

## Validation

- `cargo test -p pentect-cli --no-default-features --locked` (241 tests)
- `cargo build -p pentect-cli --locked`
- `target/debug/pentect codex -- --version`
- `npm test` and `npm pack --dry-run`
- Pi package check, tests, and pack dry-run
- direct Linux installer against v0.0.35 with Codex launch
- PowerShell installer download/decompression/checksum in a clean container
- APT installer in a clean Debian-derived container
- website build, link check, and zero high-severity npm audit findings
- release workflow and release guard checked with actionlint
