### PR TITLE
feat: persist batched crash diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,6 +403,8 @@ jobs:
             installer: npm
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    env:
+      PENTECT_LOG_DIR: ${{ github.workspace }}/.pentect-test-logs
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -542,6 +544,63 @@ jobs:
           cp "$CODEX_HOME/config.toml" "$RUNNER_TEMP/config.before"
           "$PENTECT_SMOKE_BINARY" codex app --app "$fixture" --upstream https://api.openai.com/v1
           cmp "$RUNNER_TEMP/config.before" "$CODEX_HOME/config.toml"
+      - name: Verify persistent diagnostics (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $secret = 'sk-pentect-log-smoke-secret'
+          & $env:PENTECT_SMOKE_BINARY __unknown_command $secret *> $null
+          if ($LASTEXITCODE -ne 2) { throw 'diagnostic failure fixture returned the wrong status' }
+          $logPath = (& $env:PENTECT_SMOKE_BINARY log --path | Select-Object -Last 1)
+          $expected = Join-Path $env:PENTECT_LOG_DIR 'pentect.log'
+          if ([IO.Path]::GetFullPath($logPath) -ne [IO.Path]::GetFullPath($expected)) {
+            throw "unexpected persistent log path: $logPath"
+          }
+          $raw = Get-Content -LiteralPath $logPath -Raw
+          if ($raw.Contains($secret)) { throw 'persistent log captured a command argument' }
+          $events = $raw -split "`n" | Where-Object { $_.Trim() } | ForEach-Object { $_ | ConvertFrom-Json }
+          if (-not ($events | Where-Object { $_.event -eq 'finished' -and $_.surface -eq 'codex' -and $_.exit_code -eq 0 })) {
+            throw 'successful Codex lifecycle was not persisted'
+          }
+          if (-not ($events | Where-Object { $_.event -eq 'finished' -and $_.surface -eq 'unknown' -and $_.exit_code -eq 2 })) {
+            throw 'failed command lifecycle was not persisted'
+          }
+      - name: Verify persistent diagnostics (POSIX)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          secret='sk-pentect-log-smoke-secret'
+          set +e
+          "$PENTECT_SMOKE_BINARY" __unknown_command "$secret" >/dev/null 2>&1
+          status=$?
+          set -e
+          test "$status" -eq 2
+          log_path=$("$PENTECT_SMOKE_BINARY" log --path)
+          test "$log_path" = "$PENTECT_LOG_DIR/pentect.log"
+          python3 - "$log_path" "$secret" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          secret = sys.argv[2]
+          raw = path.read_text(encoding="utf-8")
+          assert secret not in raw, "persistent log captured a command argument"
+          events = [json.loads(line) for line in raw.splitlines() if line.strip()]
+          assert any(
+              event.get("event") == "finished"
+              and event.get("surface") == "codex"
+              and event.get("exit_code") == 0
+              for event in events
+          ), "successful Codex lifecycle was not persisted"
+          assert any(
+              event.get("event") == "finished"
+              and event.get("surface") == "unknown"
+              and event.get("exit_code") == 2
+              for event in events
+          ), "failed command lifecycle was not persisted"
+          PY
       - name: Uninstall direct installation (Windows)
         if: runner.os == 'Windows' && matrix.installer == 'direct'
         shell: pwsh

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -142,8 +142,8 @@ const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "log",
-        usage: "pentect log [--json]",
-        summary: "Show gateway history and follow protection events",
+        usage: "pentect log [--json | --path]",
+        summary: "Show persistent diagnostics and live protection events",
         audience: CommandAudience::Public,
     },
     CommandSpec {
@@ -222,12 +222,87 @@ const COMMANDS: &[CommandSpec] = &[
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    if let Some(code) = catch_cli_exit(|| run(args)) {
+    let surface = diagnostic_surface(&args);
+    install_panic_logger(surface.clone());
+    pentect_agent::record_process_activity(
+        "started",
+        &surface,
+        env!("CARGO_PKG_VERSION"),
+        None,
+        None,
+        None,
+    );
+    let code = catch_cli_exit(|| run(args));
+    let exit_code = code.unwrap_or(0);
+    pentect_agent::record_process_activity(
+        "finished",
+        &surface,
+        env!("CARGO_PKG_VERSION"),
+        Some(exit_code),
+        None,
+        None,
+    );
+    pentect_agent::flush_activity_log();
+    if let Some(code) = code {
         std::process::exit(code);
     }
 }
 
+fn diagnostic_surface(args: &[String]) -> String {
+    let candidate = match (
+        args.get(1).map(String::as_str),
+        args.get(2).map(String::as_str),
+    ) {
+        (Some("agent"), Some(command)) => command,
+        (Some("codex"), Some("app")) => return "codex-app".to_string(),
+        (Some("claude"), Some("app")) => return "claude-app".to_string(),
+        #[cfg(debug_assertions)]
+        (Some("__test-panic"), _) => return "test-panic".to_string(),
+        (Some("--version" | "-V"), _) => "version",
+        (Some("--help" | "-h"), _) | (None, _) => "help",
+        (Some(command), _) => command,
+    };
+    if COMMANDS.iter().any(|command| command.name == candidate)
+        || client_descriptor::find(candidate).is_some()
+    {
+        candidate.to_string()
+    } else {
+        "unknown".to_string()
+    }
+}
+
+fn install_panic_logger(surface: String) {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = info.location().map(|location| {
+            format!(
+                "{}:{}:{}",
+                location.file(),
+                location.line(),
+                location.column()
+            )
+        });
+        let backtrace = std::backtrace::Backtrace::force_capture().to_string();
+        pentect_agent::record_process_activity(
+            "panic",
+            &surface,
+            env!("CARGO_PKG_VERSION"),
+            None,
+            location.as_deref(),
+            Some(&backtrace),
+        );
+        pentect_agent::flush_activity_log();
+        previous(info);
+    }));
+}
+
 fn run(args: Vec<String>) -> Option<i32> {
+    #[cfg(debug_assertions)]
+    if args.get(1).map(String::as_str) == Some("__test-panic")
+        && std::env::var_os("PENTECT_INTERNAL_TEST_PANIC").is_some()
+    {
+        panic!("forced test panic with payload that must not be persisted");
+    }
     let inherited_env_is_trusted = pentect_agent::active_memory_store_ready();
     if is_memory_store_server(&args) || !supports_process_host(&args) {
         return dispatch(args, inherited_env_is_trusted);
@@ -310,6 +385,15 @@ fn is_memory_store_server(args: &[String]) -> bool {
 /// One-shot inspection commands would only add startup cost and disappear
 /// before a useful handoff can occur.
 fn supports_process_host(args: &[String]) -> bool {
+    if matches!(
+        (
+            args.get(1).map(String::as_str),
+            args.get(2).map(String::as_str),
+        ),
+        (Some("log"), Some("--path"))
+    ) {
+        return false;
+    }
     matches!(
         (
             args.get(1).map(String::as_str),
@@ -509,7 +593,29 @@ fn cmd_agent_tool(tool: &'static client_descriptor::ClientDescriptor, args: &[St
         client_descriptor::Launcher::Ide(client) => ide_clients::run(client, &opts, &pentect),
     }
     .unwrap_or_else(|e| die_with_issue(&e));
+    record_child_exit(tool.name, &status);
     status.code().unwrap_or(1)
+}
+
+fn record_child_exit(surface: &str, status: &std::process::ExitStatus) {
+    #[cfg(unix)]
+    let event = {
+        use std::os::unix::process::ExitStatusExt;
+        status
+            .signal()
+            .map(|signal| format!("child-signal-{signal}"))
+            .unwrap_or_else(|| "child-exited".to_string())
+    };
+    #[cfg(not(unix))]
+    let event = "child-exited".to_string();
+    pentect_agent::record_process_activity(
+        &event,
+        surface,
+        env!("CARGO_PKG_VERSION"),
+        status.code(),
+        None,
+        None,
+    );
 }
 
 fn resolve_agent_command(program: &Path) -> Result<PathBuf, String> {
@@ -3092,6 +3198,23 @@ mod tests {
             let args = vec!["pentect".to_string(), command.to_string()];
             assert!(!supports_process_host(&args));
         }
+        assert!(!supports_process_host(&[
+            "pentect".to_string(),
+            "log".to_string(),
+            "--path".to_string(),
+        ]));
+    }
+
+    #[test]
+    fn diagnostic_surface_never_persists_unknown_argument_text() {
+        assert_eq!(
+            diagnostic_surface(&["pentect".to_string(), "sk-secret-command".to_string(),]),
+            "unknown"
+        );
+        assert_eq!(
+            diagnostic_surface(&["pentect".to_string(), "codex".to_string()]),
+            "codex"
+        );
     }
 
     #[test]

--- a/crates/pentect-cli/tests/persistent_log.rs
+++ b/crates/pentect-cli/tests/persistent_log.rs
@@ -1,0 +1,77 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn temp_root(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "pentect-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+fn events(path: &std::path::Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+#[test]
+fn process_lifecycle_is_persisted_without_arguments_or_environment() {
+    let root = temp_root("persistent-log");
+    let secret = "sk-pentect-persistent-log-secret";
+    let output = Command::new(env!("CARGO_BIN_EXE_pentect"))
+        .arg("version")
+        .arg(secret)
+        .env("PENTECT_LOG_DIR", &root)
+        .env("PENTECT_TEST_SECRET", secret)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+
+    let path = root.join("pentect.log");
+    let raw = std::fs::read_to_string(&path).unwrap();
+    assert!(!raw.contains(secret));
+    let events = events(&path);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["event"], "started");
+    assert_eq!(events[1]["event"], "finished");
+    assert_eq!(events[1]["exit_code"], 0);
+    assert_eq!(events[1]["version"], env!("CARGO_PKG_VERSION"));
+    assert!(events.iter().all(|event| event["surface"] == "version"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn panic_is_flushed_with_location_and_backtrace_but_not_payload() {
+    let root = temp_root("panic-log");
+    let output = Command::new(env!("CARGO_BIN_EXE_pentect"))
+        .arg("__test-panic")
+        .env("PENTECT_LOG_DIR", &root)
+        .env("PENTECT_INTERNAL_TEST_PANIC", "1")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+
+    let path = root.join("pentect.log");
+    let raw = std::fs::read_to_string(&path).unwrap();
+    assert!(!raw.contains("payload that must not be persisted"));
+    let events = events(&path);
+    let panic = events
+        .iter()
+        .find(|event| event["event"] == "panic")
+        .expect("missing panic event");
+    assert_eq!(panic["surface"], "test-panic");
+    assert!(panic["panic_location"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+    assert!(panic["backtrace"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -6,13 +6,22 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 const MAX_LABELS_PER_EVENT: usize = 64;
 const MAX_SEEN_EVENTS: usize = 4_096;
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+const LOG_BATCH_EVENTS: usize = 64;
+const LOG_BATCH_BYTES: usize = 64 * 1024;
+const LOG_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
+const LOG_CHANNEL_CAPACITY: usize = 1_024;
+const LOG_MAX_BYTES: u64 = 32 * 1024 * 1024;
+const LOG_ROTATIONS: usize = 8;
 static LOG_SHARE: OnceLock<bool> = OnceLock::new();
+static PERSISTENT_LOG: OnceLock<Option<PersistentLogWriter>> = OnceLock::new();
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct ActivityEvent {
@@ -24,6 +33,22 @@ pub(crate) struct ActivityEvent {
     labels: Vec<LabelCount>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    event: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    os: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    arch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    panic_location: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    backtrace: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -43,6 +68,16 @@ struct LifecycleSource {
     file: Option<std::fs::File>,
     offset: u64,
     pending: Vec<u8>,
+}
+
+struct PersistentLogWriter {
+    sender: SyncSender<LogMessage>,
+    dropped: Arc<AtomicU64>,
+}
+
+enum LogMessage {
+    Entry(String),
+    Flush(mpsc::Sender<()>),
 }
 
 #[derive(Default)]
@@ -86,8 +121,77 @@ impl ActivityEvent {
                 .map(|(name, count)| LabelCount { name, count })
                 .collect(),
             target,
+            event: None,
+            pid: None,
+            version: None,
+            os: None,
+            arch: None,
+            exit_code: None,
+            panic_location: None,
+            backtrace: None,
         }
     }
+
+    fn process(
+        event: &str,
+        surface: &str,
+        version: &str,
+        exit_code: Option<i32>,
+        panic_location: Option<&str>,
+        backtrace: Option<&str>,
+    ) -> Self {
+        Self {
+            time: jiff::Timestamp::now().to_string(),
+            action: "process".to_string(),
+            surface: safe_identifier(surface),
+            count: 1,
+            labels: Vec::new(),
+            target: None,
+            event: Some(safe_identifier(event)),
+            pid: Some(std::process::id()),
+            version: Some(version.chars().take(64).collect()),
+            os: Some(std::env::consts::OS.to_string()),
+            arch: Some(std::env::consts::ARCH.to_string()),
+            exit_code,
+            panic_location: panic_location.map(safe_panic_location),
+            backtrace: backtrace.map(safe_backtrace),
+        }
+    }
+}
+
+pub(crate) fn record_process(
+    event: &str,
+    surface: &str,
+    version: &str,
+    exit_code: Option<i32>,
+    panic_location: Option<&str>,
+    backtrace: Option<&str>,
+) {
+    record(ActivityEvent::process(
+        event,
+        surface,
+        version,
+        exit_code,
+        panic_location,
+        backtrace,
+    ));
+}
+
+pub(crate) fn flush_persistent() {
+    if let Some(writer) = persistent_log() {
+        writer.flush();
+    }
+}
+
+pub(crate) fn persistent_log_path() -> PathBuf {
+    if let Some(directory) = std::env::var_os("PENTECT_LOG_DIR") {
+        return PathBuf::from(directory).join("pentect.log");
+    }
+    user_home()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".pentect")
+        .join("logs")
+        .join("pentect.log")
 }
 
 pub(crate) fn record_mask_result(surface: &str, result: &MaskResult, target: Option<&Path>) {
@@ -165,12 +269,28 @@ pub(crate) fn record_image(secret_images: usize, notes: &[String]) {
 pub(crate) fn follow(json: bool) -> Result<(), String> {
     let mut source = activity_source()?;
     let mut lifecycle = LifecycleSource::open();
+    let mut persistent = LifecycleSource::open_at(persistent_log_path());
     let mut seen = SeenActivity::default();
 
     let stdout = std::io::stdout();
     let mut output = stdout.lock();
     loop {
         let mut wrote = false;
+        for payload in persistent.read_new()? {
+            if !seen.insert(&payload) {
+                continue;
+            }
+            let event: ActivityEvent = serde_json::from_str(&payload)
+                .map_err(|error| format!("invalid persistent log event: {error}"))?;
+            if json {
+                writeln!(output, "{payload}")
+                    .map_err(|error| format!("could not write persistent log: {error}"))?;
+            } else {
+                writeln!(output, "{}", format_event(&event))
+                    .map_err(|error| format!("could not write persistent log: {error}"))?;
+            }
+            wrote = true;
+        }
         for payload in lifecycle.read_new()? {
             if json {
                 writeln!(output, "{payload}")
@@ -320,8 +440,187 @@ fn record(event: ActivityEvent) {
     let Ok(json) = serde_json::to_string(&event) else {
         return;
     };
+    if let Some(writer) = persistent_log() {
+        writer.enqueue(json.clone());
+    }
     let share = *LOG_SHARE.get_or_init(|| crate::config::activity_share_enabled().unwrap_or(true));
     let _ = delegated_process_host::send_activity(&json, share);
+}
+
+fn persistent_log() -> Option<&'static PersistentLogWriter> {
+    PERSISTENT_LOG
+        .get_or_init(|| PersistentLogWriter::spawn(persistent_log_path()).ok())
+        .as_ref()
+}
+
+impl PersistentLogWriter {
+    fn spawn(path: PathBuf) -> Result<Self, String> {
+        prepare_log_path(&path)?;
+        let (sender, receiver) = mpsc::sync_channel(LOG_CHANNEL_CAPACITY);
+        let dropped = Arc::new(AtomicU64::new(0));
+        let worker_dropped = Arc::clone(&dropped);
+        std::thread::Builder::new()
+            .name("pentect-log-writer".to_string())
+            .spawn(move || log_writer_loop(path, receiver, worker_dropped))
+            .map_err(|error| format!("could not start persistent log writer: {error}"))?;
+        Ok(Self { sender, dropped })
+    }
+
+    fn enqueue(&self, entry: String) {
+        match self.sender.try_send(LogMessage::Entry(entry)) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(TrySendError::Disconnected(_)) => {}
+        }
+    }
+
+    fn flush(&self) {
+        let (sender, receiver) = mpsc::channel();
+        if self.sender.send(LogMessage::Flush(sender)).is_ok() {
+            let _ = receiver.recv_timeout(Duration::from_secs(5));
+        }
+    }
+}
+
+fn log_writer_loop(path: PathBuf, receiver: Receiver<LogMessage>, dropped: Arc<AtomicU64>) {
+    let mut batch = Vec::with_capacity(LOG_BATCH_EVENTS);
+    let mut bytes = 0usize;
+    loop {
+        let message = if batch.is_empty() {
+            match receiver.recv() {
+                Ok(message) => message,
+                Err(_) => break,
+            }
+        } else {
+            match receiver.recv_timeout(LOG_FLUSH_INTERVAL) {
+                Ok(message) => message,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    flush_batch(&path, &mut batch, &dropped);
+                    bytes = 0;
+                    continue;
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        };
+        match message {
+            LogMessage::Entry(entry) => {
+                bytes = bytes.saturating_add(entry.len() + 1);
+                batch.push(entry);
+                if batch.len() >= LOG_BATCH_EVENTS || bytes >= LOG_BATCH_BYTES {
+                    flush_batch(&path, &mut batch, &dropped);
+                    bytes = 0;
+                }
+            }
+            LogMessage::Flush(acknowledge) => {
+                flush_batch(&path, &mut batch, &dropped);
+                bytes = 0;
+                let _ = acknowledge.send(());
+            }
+        }
+    }
+    flush_batch(&path, &mut batch, &dropped);
+}
+
+fn flush_batch(path: &Path, batch: &mut Vec<String>, dropped: &AtomicU64) {
+    let lost = dropped.swap(0, Ordering::Relaxed);
+    if lost > 0 {
+        batch.push(
+            serde_json::json!({
+                "time": jiff::Timestamp::now().to_string(),
+                "action": "process",
+                "surface": "logger",
+                "count": lost,
+                "event": "queue-overflow",
+                "pid": std::process::id(),
+                "os": std::env::consts::OS,
+                "arch": std::env::consts::ARCH,
+            })
+            .to_string(),
+        );
+    }
+    if batch.is_empty() {
+        return;
+    }
+    if write_batch(path, batch).is_err() {
+        dropped.fetch_add(batch.len() as u64, Ordering::Relaxed);
+    }
+    batch.clear();
+}
+
+fn write_batch(path: &Path, batch: &[String]) -> Result<(), String> {
+    prepare_log_path(path)?;
+    let payload = batch.join("\n") + "\n";
+    rotate_log_if_needed(path, payload.len() as u64);
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| format!("could not open persistent log: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+    }
+    file.write_all(payload.as_bytes())
+        .and_then(|()| file.flush())
+        .map_err(|error| format!("could not write persistent log: {error}"))
+}
+
+fn prepare_log_path(path: &Path) -> Result<(), String> {
+    let directory = path
+        .parent()
+        .ok_or_else(|| "persistent log path has no parent directory".to_string())?;
+    std::fs::create_dir_all(directory)
+        .map_err(|error| format!("could not create persistent log directory: {error}"))?;
+    if std::fs::symlink_metadata(directory).is_ok_and(|metadata| metadata.file_type().is_symlink())
+    {
+        return Err("persistent log directory must not be a symbolic link".to_string());
+    }
+    if std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return Err("persistent log must not be a symbolic link".to_string());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o700));
+    }
+    Ok(())
+}
+
+fn rotate_log_if_needed(path: &Path, incoming: u64) {
+    let current = std::fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    if current.saturating_add(incoming) <= LOG_MAX_BYTES {
+        return;
+    }
+    for generation in (1..=LOG_ROTATIONS).rev() {
+        let source = if generation == 1 {
+            path.to_path_buf()
+        } else {
+            rotated_log_path(path, generation - 1)
+        };
+        let destination = rotated_log_path(path, generation);
+        if generation == LOG_ROTATIONS {
+            let _ = std::fs::remove_file(&destination);
+        }
+        if source.exists() {
+            let _ = std::fs::rename(source, destination);
+        }
+    }
+}
+
+fn rotated_log_path(path: &Path, generation: usize) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(format!(".{generation}"));
+    PathBuf::from(name)
 }
 
 fn activity_source() -> Result<ActivitySource, String> {
@@ -334,6 +633,30 @@ fn activity_source() -> Result<ActivitySource, String> {
 }
 
 fn format_event(event: &ActivityEvent) -> String {
+    if event.action == "process" {
+        let event_name = event.event.as_deref().unwrap_or("event");
+        let exit = event
+            .exit_code
+            .map(|code| format!("  exit={code}"))
+            .unwrap_or_default();
+        let location = event
+            .panic_location
+            .as_deref()
+            .map(|location| format!("  at={location}"))
+            .unwrap_or_default();
+        return format!(
+            "{}  process/{}  {}  pid={}  version={}  {}/{}{}{}",
+            event.time,
+            event.surface,
+            event_name,
+            event.pid.unwrap_or_default(),
+            event.version.as_deref().unwrap_or("unknown"),
+            event.os.as_deref().unwrap_or("unknown"),
+            event.arch.as_deref().unwrap_or("unknown"),
+            exit,
+            location,
+        );
+    }
     let labels = event
         .labels
         .iter()
@@ -360,6 +683,41 @@ fn format_event(event: &ActivityEvent) -> String {
         "{}  {}/{}  {}{}{}",
         event.time, event.action, event.surface, event.count, labels, target
     )
+}
+
+fn user_home() -> Option<PathBuf> {
+    std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
+}
+
+fn safe_identifier(value: &str) -> String {
+    let value = value
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+        .take(64)
+        .collect::<String>();
+    if value.is_empty() {
+        "unknown".to_string()
+    } else {
+        value
+    }
+}
+
+fn safe_panic_location(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| !matches!(character, '\r' | '\n' | '\0'))
+        .take(512)
+        .collect()
+}
+
+fn safe_backtrace(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| *character != '\0')
+        .take(16 * 1024)
+        .collect()
 }
 
 fn safe_target(path: &Path) -> String {
@@ -508,6 +866,50 @@ mod tests {
             source.read_new().unwrap(),
             ["{\"event\":\"after-rotation\"}"]
         );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn persistent_writer_flushes_a_batch_on_the_interval() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-persistent-batch-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let path = root.join("pentect.log");
+        let writer = PersistentLogWriter::spawn(path.clone()).unwrap();
+        writer.enqueue("{\"event\":\"one\"}".to_string());
+        writer.enqueue("{\"event\":\"two\"}".to_string());
+        std::thread::sleep(LOG_FLUSH_INTERVAL + Duration::from_millis(100));
+        let payload = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(payload.lines().count(), 2);
+        drop(writer);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn persistent_log_rotates_and_keeps_the_current_file_bounded() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-persistent-rotation-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("pentect.log");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(LOG_MAX_BYTES + 1).unwrap();
+        write_batch(&path, &["{\"event\":\"after-rotation\"}".to_string()]).unwrap();
+        assert!(rotated_log_path(&path, 1).exists());
+        assert!(std::fs::metadata(&path).unwrap().len() < LOG_MAX_BYTES);
+        assert!(std::fs::read_to_string(&path)
+            .unwrap()
+            .contains("after-rotation"));
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -177,6 +177,30 @@ pub fn record_diagnostic_activity(surface: &str, reason: &str) {
     );
 }
 
+/// Persist value-free process lifecycle diagnostics without recording command
+/// arguments, environment variables, request bodies, or protected values.
+pub fn record_process_activity(
+    event: &str,
+    surface: &str,
+    version: &str,
+    exit_code: Option<i32>,
+    panic_location: Option<&str>,
+    backtrace: Option<&str>,
+) {
+    activity_log::record_process(
+        event,
+        surface,
+        version,
+        exit_code,
+        panic_location,
+        backtrace,
+    );
+}
+
+pub fn flush_activity_log() {
+    activity_log::flush_persistent();
+}
+
 fn mask_input_into_memory_store_client(
     client: &MemoryStoreClient,
     input: Input,
@@ -692,7 +716,7 @@ fn usage() {
          pentect exec \"<command>\"\n\
          pentect view <HANDLE>\n\
          pentect resolve [PATH...]\n\
-         pentect log [--json]\n\
+         pentect log [--json | --path]\n\
          \n\
          exec: masked output\n\
          view: handle\n\
@@ -702,10 +726,14 @@ fn usage() {
 }
 
 fn cmd_log(args: &[String]) -> i32 {
+    if args.get(2).map(String::as_str) == Some("--path") && args.len() == 3 {
+        println!("{}", activity_log::persistent_log_path().display());
+        return 0;
+    }
     let json = match args.get(2).map(String::as_str) {
         None => false,
         Some("--json") if args.len() == 3 => true,
-        _ => return die("log [--json]"),
+        _ => return die("log [--json | --path]"),
     };
     match activity_log::follow(json) {
         Ok(()) => 0,

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -77,7 +77,7 @@ unknown-handle behavior.
 | `pentect exec --live "COMMAND"` | Stream masked output while the command runs |
 | `pentect view HANDLE` | Show handle details without revealing the real value |
 | `pentect resolve [PATH...]` | Restore known handles from stdin or selected files |
-| `pentect log [--json]` | Show gateway history and follow protection events without secret values |
+| `pentect log [--json \| --path]` | Show persistent diagnostics and follow protection events without secret values |
 | `pentect doctor [--json]` | Check the installation and supported clients |
 | `pentect doctor --fix` | Offer repairable configuration changes |
 | `pentect update [VERSION]` | Install a checksummed GitHub Release binary |

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -92,7 +92,7 @@ pentect gemini --model gemini-2.5-pro
 | `pentect read PATH` | Print a masked preview of a file |
 | `pentect exec "COMMAND"` | Restore known handles, run the command, and mask its output |
 | `pentect view HANDLE` | Show handle details without revealing its value |
-| `pentect log [--json]` | Show gateway history and follow protection events |
+| `pentect log [--json \| --path]` | Show persistent diagnostics and follow protection events |
 
 ### `mask`
 

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -182,11 +182,27 @@ attach a request sample.
 ```sh
 pentect log
 pentect log --json
+pentect log --path
 ```
 
-Codex App gateway lifecycle and crash entries are persisted locally, so this
-also shows why a previous protected App session ended. The entries contain
-event types and process status only, never request bodies or secret values.
+Pentect persists process starts, exit codes, gateway activity, and panic
+diagnostics to `~/.pentect/logs/pentect.log`. `pentect log` reads that history
+before following live events, `--json` keeps the JSONL representation, and
+`--path` prints the exact file location. Panic entries include the Pentect
+version, OS, architecture, PID, source location, and a backtrace so a crash can
+be investigated after the process exits.
+
+Writes are handled by a bounded background queue and flushed in batches of up
+to 64 events, 64 KiB, or 250 ms. The file rotates at 32 MiB and keeps eight
+older generations (`pentect.log.1` through `pentect.log.8`), for a maximum of
+about 288 MiB. A saturated queue never blocks protection work; the log records
+the number of dropped diagnostic events when writing catches up.
+
+The entries contain command categories and status metadata only. Pentect does
+not persist command arguments, environment variables, request or response
+bodies, prompts, protected values, or panic payload text. Codex App also keeps
+its value-free lifecycle history, so the combined view shows why a previous
+protected App session ended.
 
 Logs show actions and counts, not real protected values.
 


### PR DESCRIPTION
## Summary
- persist value-free process, gateway, exit, signal, and panic diagnostics as JSONL
- batch writes through a bounded queue (64 events / 64 KiB / 250 ms) and rotate 32 MiB files across 8 generations
- add `pentect log --path` and include persistent history in `pentect log`
- verify logs from every release installer matrix while checking command arguments never enter the log

## Validation
- `cargo test -p pentect-cli --no-default-features --locked` (244 tests)
- `cargo test -p pentect-runtime --no-default-features --locked activity_log` (8 tests)
- `cargo clippy -p pentect-cli --no-default-features --locked -- -D warnings`
- release build: `pentect version`, `pentect codex -- --version`, normal/failure lifecycle JSONL and secret non-persistence
- npm tests/package dry-run, website build/link check, actionlint

This must merge before regenerating the v0.0.38 prerelease.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added persistent diagnostics for process startup, completion, failures, panics, and child-process exits.
  - Added `pentect log --path` to display the diagnostic log location.
  - Enhanced live log following with persistent event history and process details.
  - Sensitive command arguments and payloads are excluded from logs.

- **Bug Fixes**
  - Improved diagnostic log reliability through batching, flushing, rotation, and secure file handling.

- **Documentation**
  - Updated CLI, capability, and troubleshooting documentation for persistent diagnostics and log replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->