### PR TITLE
ci: make Codex App release smoke finite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -518,6 +518,7 @@ jobs:
           $node = (Get-Command node -ErrorAction Stop).Source
           $fixture = Join-Path $env:RUNNER_TEMP 'codex-app-fixture.exe'
           Copy-Item -LiteralPath $node -Destination $fixture
+          $env:NODE_OPTIONS = "--require=$((Resolve-Path 'tools/codex-app-smoke-fixture.cjs').Path)"
           $env:CODEX_HOME = Join-Path $env:RUNNER_TEMP 'codex-home'
           New-Item -ItemType Directory -Force $env:CODEX_HOME | Out-Null
           $config = Join-Path $env:CODEX_HOME 'config.toml'
@@ -538,6 +539,7 @@ jobs:
           fixture="$RUNNER_TEMP/codex-app-fixture"
           cp "$(command -v node)" "$fixture"
           chmod +x "$fixture"
+          export NODE_OPTIONS="--require=$PWD/tools/codex-app-smoke-fixture.cjs"
           export CODEX_HOME="$RUNNER_TEMP/codex-home"
           mkdir -p "$CODEX_HOME"
           printf '%s\n' '# installer smoke sentinel' > "$CODEX_HOME/config.toml"

--- a/tools/codex-app-smoke-fixture.cjs
+++ b/tools/codex-app-smoke-fixture.cjs
@@ -1,0 +1,17 @@
+const { spawn } = require("node:child_process");
+
+const childMarker = "PENTECT_CODEX_APP_SMOKE_CHILD";
+
+if (process.env[childMarker] === "1") {
+  // Stay alive long enough for Pentect's process probe to observe this exact
+  // executable, then exit so the smoke test can verify session cleanup.
+  setTimeout(() => process.exit(0), 5_000);
+} else {
+  const child = spawn(process.execPath, [], {
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, [childMarker]: "1" },
+  });
+  child.unref();
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary
- replace the indefinitely waiting copied-Node Codex App smoke with a handoff fixture
- exercise process observation, gateway lifetime, child exit, and session cleanup on Windows, Linux, and macOS
- keep the real Codex/Claude/OpenCode launch checks intact

## Validation
- integrated `pentect codex app` fixture smoke exits successfully locally
- `node --check tools/codex-app-smoke-fixture.cjs`
- `git diff --check`

Fixes the release lifecycle timeout observed in run 32403861757.