### PR TITLE
ci: unblock validated automation pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -709,6 +709,7 @@ jobs:
       actions: write
       contents: write
       pull-requests: write
+      statuses: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/tools/propose_automation_pr.sh
+++ b/tools/propose_automation_pr.sh
@@ -39,11 +39,60 @@ if [ -z "$pull" ]; then
     --body "$body")
 fi
 
-# Pushes authenticated with GITHUB_TOKEN do not trigger other workflows. Start
-# the required branch checks explicitly so automation PRs can actually merge.
+# Pushes authenticated with GITHUB_TOKEN do not trigger pull_request workflows.
+# Validate the exact automation commit through workflow_dispatch, then publish
+# the three required commit statuses only after both workflows succeed.
+head=$(git rev-parse HEAD)
+latest_run() {
+  gh run list \
+    --repo "$GITHUB_REPOSITORY" \
+    --workflow "$1" \
+    --branch "$branch" \
+    --event workflow_dispatch \
+    --limit 10 \
+    --json databaseId,headSha \
+    --jq ".[] | select(.headSha == \"$head\") | .databaseId" \
+    | head -n 1
+}
+
+previous_ci=$(latest_run ci.yml)
+previous_nix=$(latest_run nix.yml)
 gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
 gh workflow run nix.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
 
+new_run() {
+  workflow=$1
+  previous=$2
+  for attempt in $(seq 1 30); do
+    run_id=$(latest_run "$workflow")
+    if [ -n "$run_id" ] && [ "$run_id" != "$previous" ]; then
+      printf '%s\n' "$run_id"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "could not find dispatched $workflow run for $head" >&2
+  return 1
+}
+
+ci_run=$(new_run ci.yml "$previous_ci")
+nix_run=$(new_run nix.yml "$previous_nix")
+gh run watch "$ci_run" --repo "$GITHUB_REPOSITORY" --exit-status >&2
+gh run watch "$nix_run" --repo "$GITHUB_REPOSITORY" --exit-status >&2
+
+ci_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$ci_run"
+for context in \
+  test \
+  'Native OCR (windows-latest)' \
+  'Native OCR (macos-latest)'
+do
+  gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head" \
+    -f state=success \
+    -f context="$context" \
+    -f description='Validated by the automation PR CI workflow' \
+    -f target_url="$ci_url" >/dev/null
+done
+
 gh pr merge "$pull" --repo "$GITHUB_REPOSITORY" --auto --merge --delete-branch \
-  --match-head-commit "$(git rev-parse HEAD)" >&2
+  --match-head-commit "$head" >&2
 printf '%s\n' "$pull"

--- a/tools/test_propose_automation_pr.sh
+++ b/tools/test_propose_automation_pr.sh
@@ -47,4 +47,12 @@ output=$(
 )
 test "$output" = https://github.com/example/project/pull/1
 test "$(wc -l < "$tmp/state/watch")" -eq 2
+grep -Fx 'run watch 101 --repo example/project --exit-status' "$tmp/state/watch"
+grep -Fx 'run watch 102 --repo example/project --exit-status' "$tmp/state/watch"
 test "$(wc -l < "$tmp/state/api")" -eq 3
+status_endpoint='api --method POST repos/example/project/statuses/0123456789abcdef'
+test "$(grep -Fc "$status_endpoint" "$tmp/state/api")" -eq 3
+grep -F 'context=test' "$tmp/state/api"
+grep -F 'context=Native OCR (windows-latest)' "$tmp/state/api"
+grep -F 'context=Native OCR (macos-latest)' "$tmp/state/api"
+test "$(grep -Fc 'target_url=https://github.com/example/project/actions/runs/101' "$tmp/state/api")" -eq 3

--- a/tools/test_propose_automation_pr.sh
+++ b/tools/test_propose_automation_pr.sh
@@ -17,17 +17,34 @@ case "$1 $2" in
   "pr list") exit 0 ;;
   "pr create") printf '%s\n' https://github.com/example/project/pull/1 ;;
   "pr merge") printf '%s\n' 'merge scheduled' ;;
-  "workflow run") exit 0 ;;
+  "workflow run")
+    case "$*" in
+      *ci.yml*) touch "$MOCK_STATE/ci" ;;
+      *nix.yml*) touch "$MOCK_STATE/nix" ;;
+    esac
+    ;;
+  "run list")
+    case "$*" in
+      *ci.yml*) test ! -e "$MOCK_STATE/ci" || printf '%s\n' 101 ;;
+      *nix.yml*) test ! -e "$MOCK_STATE/nix" || printf '%s\n' 102 ;;
+    esac
+    ;;
+  "run watch") printf '%s\n' "$*" >> "$MOCK_STATE/watch" ;;
+  "api --method") printf '%s\n' "$*" >> "$MOCK_STATE/api" ;;
   *) echo "unexpected gh invocation: $*" >&2; exit 1 ;;
 esac
 EOF
 chmod +x "$tmp/git" "$tmp/gh"
+mkdir "$tmp/state"
 
 output=$(
   PATH="$tmp:$PATH" \
+  MOCK_STATE="$tmp/state" \
   GH_TOKEN=test-token \
   GITHUB_REPOSITORY=example/project \
     sh "$root/tools/propose_automation_pr.sh" \
       automation/test "test automation" "test body" 2>/dev/null
 )
 test "$output" = https://github.com/example/project/pull/1
+test "$(wc -l < "$tmp/state/watch")" -eq 2
+test "$(wc -l < "$tmp/state/api")" -eq 3


### PR DESCRIPTION
## Summary
- wait for CI and Nix workflow_dispatch runs on the exact automation PR head
- publish the three branch-protection statuses only after both validation workflows succeed
- grant the release metadata job narrowly scoped `statuses: write`
- cover run discovery, watches, and status publication in the shell regression test

This prevents future package-metadata releases from waiting forever because pushes made with `GITHUB_TOKEN` do not emit recursive `pull_request` workflow events.

## Validation
- `sh -n tools/propose_automation_pr.sh tools/test_propose_automation_pr.sh`
- `sh tools/test_propose_automation_pr.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automated pull request handling by tracking the exact commit and waiting for required CI and Nix workflows to complete successfully.
  * Added automatic success statuses and enabled auto-merge only after all checks pass.

* **Bug Fixes**
  * Added the permissions needed to publish workflow status updates.

* **Tests**
  * Expanded automation coverage for workflow dispatching, monitoring, completion checks, and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->