### PR TITLE
Keep release verification platform neutral

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,6 @@ jobs:
               throw "$path`n$($errors | Out-String)"
             }
           }
-          $fixture = "$env:RUNNER_TEMP/claude-app-smoke-fixture.exe"
-          $csc = Join-Path $env:WINDIR 'Microsoft.NET\Framework64\v4.0.30319\csc.exe'
-          if (-not (Test-Path -LiteralPath $csc)) { throw 'Framework C# compiler is unavailable' }
-          $source = (Resolve-Path 'tools/claude-app-smoke-fixture.cs').Path
-          & $csc /nologo /target:exe "/out:$fixture" $source
-          if ($LASTEXITCODE -ne 0) { throw 'Claude fixture compilation failed' }
           & ./tools/test_install.ps1
       - name: Verify third-party licenses
         run: python tools/generate_licenses.py --check


### PR DESCRIPTION
## Summary
- keep the Ubuntu release verification job focused on cross-platform PowerShell parsing and installer tests
- leave Windows C# fixture compilation covered by Windows CI and the Windows release lifecycle jobs

## Validation
- release failure was isolated to the Windows-only `WINDIR` compiler lookup running on Ubuntu
- final PR #277 CI and Windows fixture compilation passed before this release attempt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified Windows installer validation by removing an unnecessary compilation step.
  * Continued PowerShell syntax checks and installer test execution unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->