### PR TITLE
Prepare v0.0.41 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,7 +325,11 @@ jobs:
               gh release upload "$GITHUB_REF_NAME" "${missing[@]}" --repo "$GITHUB_REPOSITORY"
             fi
           else
-            gh release create "$GITHUB_REF_NAME" dist/* \
+            mapfile -d '' -t release_assets < <(
+              find dist -maxdepth 1 -type f -print0 | sort -z
+            )
+            test "${#release_assets[@]}" -gt 0
+            gh release create "$GITHUB_REF_NAME" "${release_assets[@]}" \
               --verify-tag \
               --generate-notes \
               --prerelease \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.40"
+version = "0.0.41"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- upload only regular files when staging the GitHub prerelease, excluding the signed APT directory
- advance CLI/package metadata to 0.0.41 because failed release tags are protected and immutable

## Validation
- synthetic `dist` test confirmed the release asset array contains files only and is deterministic
- v0.0.40 failed before GitHub Release creation, npm publication, installer smoke, or stable promotion