### PR TITLE
Expand persistent log retention for v0.0.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.42"
+version = "0.0.43"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -18,8 +18,8 @@ const LOG_BATCH_EVENTS: usize = 64;
 const LOG_BATCH_BYTES: usize = 64 * 1024;
 const LOG_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 const LOG_CHANNEL_CAPACITY: usize = 1_024;
-const LOG_MAX_BYTES: u64 = 64 * 1024 * 1024;
-const LOG_ROTATIONS: usize = 15;
+const LOG_MAX_BYTES: u64 = 128 * 1024 * 1024;
+const LOG_ROTATIONS: usize = 31;
 static LOG_SHARE: OnceLock<bool> = OnceLock::new();
 static PERSISTENT_LOG: OnceLock<Option<PersistentLogWriter>> = OnceLock::new();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -193,9 +193,9 @@ version, OS, architecture, PID, source location, and a backtrace so a crash can
 be investigated after the process exits.
 
 Writes are handled by a bounded background queue and flushed in batches of up
-to 64 events, 64 KiB, or 250 ms. The file rotates at 64 MiB and keeps 15
-older generations (`pentect.log.1` through `pentect.log.15`), for a maximum of
-about 1 GiB. A saturated queue never blocks protection work; the log records
+to 64 events, 64 KiB, or 250 ms. The file rotates at 128 MiB and keeps 31
+older generations (`pentect.log.1` through `pentect.log.31`), for a maximum of
+about 4 GiB. A saturated queue never blocks protection work; the log records
 the number of dropped diagnostic events when writing catches up.
 
 The entries contain command categories and status metadata only. Pentect does


### PR DESCRIPTION
## Summary
- increase persistent diagnostic log files from 64 MiB to 128 MiB
- retain 31 rotated generations instead of 15 (about 4 GiB total including the active file)
- prepare v0.0.43 because the v0.0.42 release tag is immutable

## Validation
- `cargo fmt --check`
- `cargo test -p pentect-runtime activity_log --lib` (8 passed)
- `npm test` (7 passed)
- Pi integration checks/tests (5 passed)
- release metadata, licenses, and client coverage checks