### PR TITLE
Fix Codex prompt masking and release v0.0.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.43"
+version = "0.0.44"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.43"
+version = "0.0.44"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -2752,8 +2752,14 @@ mod tests {
             !request.contains(&openrouter),
             "OpenRouter key reached upstream"
         );
-        assert!(request.contains("<<KEYED_SECRET_"), "{request}");
-        assert!(request.matches("<<").count() >= 2, "{request}");
+        assert!(
+            request.contains("<<KEYED_SECRET_"),
+            "keyed-secret handle did not reach upstream"
+        );
+        assert!(
+            request.matches("<<").count() >= 2,
+            "expected prompt handles did not reach upstream"
+        );
     }
 
     #[test]

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -2704,6 +2704,59 @@ mod tests {
     }
 
     #[test]
+    fn provider_boundary_masks_current_codex_prompt_shape_with_keyed_and_vendor_detectors() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = ProviderBoundaryTestEnv::install(&store);
+        let password = ["test-pentect", "-password-284-provider"].concat();
+        let openrouter = [
+            "sk-or-v1-",
+            "fedcba9876543210fedcba9876543210",
+            "fedcba9876543210fedcba9876543210",
+        ]
+        .concat();
+        let (upstream, captured, thread) = mock_chat_upstream();
+        let proxy = OpenAiHttpProxyGuard::start(upstream).unwrap();
+
+        reqwest::blocking::Client::new()
+            .post(format!("{}/responses", proxy.base_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(
+                serde_json::to_vec(&serde_json::json!({
+                    "model": "test",
+                    "input": [{
+                        "type": "message",
+                        "role": "user",
+                        "content": [{
+                            "type": "input_text",
+                            "text": format!(
+                                "Audit fixture: sudo password is {password} and OPENROUTER_API_KEY={openrouter}."
+                            )
+                        }]
+                    }],
+                    "stream": false
+                }))
+                .unwrap(),
+            )
+            .send()
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+
+        let (_, request) = captured
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .unwrap();
+        thread.join().unwrap();
+        assert!(!request.contains(&password), "password reached upstream");
+        assert!(
+            !request.contains(&openrouter),
+            "OpenRouter key reached upstream"
+        );
+        assert!(request.contains("<<KEYED_SECRET_"), "{request}");
+        assert!(request.matches("<<").count() >= 2, "{request}");
+    }
+
+    #[test]
     fn provider_boundary_decodes_codex_zstd_requests_before_protection() {
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let store = pentect_agent::start_in_process_memory_store().unwrap();

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -6,8 +6,8 @@ use crate::session::Session;
 use pentect_core::placeholder::{identity_hash, render_placeholder};
 use pentect_core::{
     load_pack, ByteRange, Category, Config, Context, CredSweeperNativeDetector, Engine,
-    EntropyDetector, EnvParser, EnvValueDetector, Input, JsonParser, Kind, MaskResult,
-    NdjsonParser, PemDetector, Profile, ProfilePolicy, Recovery, Region, RegionKind,
+    EntropyDetector, EnvParser, EnvValueDetector, Input, JsonParser, KeyValueDetector, Kind,
+    MaskResult, NdjsonParser, PemDetector, Profile, ProfilePolicy, Recovery, Region, RegionKind,
     SensitiveKeyDetector, ShapeGuard, ToolResultParser,
 };
 use std::collections::{BTreeMap, HashMap};
@@ -17,6 +17,7 @@ const ENV_ALIAS_LABEL: &str = "PENTECT_ENV_ALIAS";
 const ENV_ALIAS_RECORD_PREFIX: &str = "\u{1f}pentect-env\0";
 const PLUGIN_CONFIGS_ENV: &str = "PENTECT_PLUGIN_CONFIGS";
 static PENTECT_ENGINE: OnceLock<Result<Engine, String>> = OnceLock::new();
+static PENTECT_PROMPT_ENGINE: OnceLock<Result<Engine, String>> = OnceLock::new();
 const BATCH_DELIMITERS: [&str; 4] = [
     "\u{1f}pentect-batch-0\u{1e}",
     "\u{1f}pentect-batch-1\u{1d}",
@@ -35,6 +36,7 @@ pub(crate) struct ToolScalarInput {
 pub(crate) struct OutputMasker {
     store: MemoryStore,
     engine: &'static Engine,
+    prompt_engine: &'static Engine,
     plugin_middleware: PluginMiddleware,
     environment_prefix: String,
     mode: OutputMaskerMode,
@@ -67,6 +69,7 @@ impl OutputMasker {
         Ok(Self {
             store,
             engine: pentect_engine()?,
+            prompt_engine: pentect_prompt_engine()?,
             plugin_middleware,
             environment_prefix: config::environment_variable_prefix()?,
             mode: OutputMaskerMode::Shared,
@@ -82,6 +85,7 @@ impl OutputMasker {
         Ok(Self {
             store,
             engine: pentect_engine()?,
+            prompt_engine: pentect_prompt_engine()?,
             plugin_middleware: PluginMiddleware::from_env()?,
             environment_prefix: config::environment_variable_prefix()?,
             mode: OutputMaskerMode::Deferred { remask_recoveries },
@@ -126,7 +130,7 @@ impl OutputMasker {
         // Prompt scalars are structurally text, but dotenv assignments can be
         // embedded in prose. Run the Env parser first so assignment labels are
         // preserved, then feed the result through the same cached text engine.
-        let env_result = self.engine.mask(
+        let env_result = self.prompt_engine.mask(
             Input {
                 kind: Kind::Env,
                 data: remasked,
@@ -141,7 +145,7 @@ impl OutputMasker {
         let mut result = mask_read_input_with_engine_plugins_and_identity(
             self.store.session.key,
             self.store.session.identity_key,
-            self.engine,
+            self.prompt_engine,
             &self.plugin_middleware,
             Input {
                 kind: Kind::Text,
@@ -155,7 +159,7 @@ impl OutputMasker {
             initially_masked,
             &Kind::Text,
         )?;
-        let final_result = self.engine.mask(
+        let final_result = self.prompt_engine.mask(
             Input {
                 kind: Kind::Text,
                 data: masked,
@@ -911,7 +915,22 @@ fn pentect_engine() -> Result<&'static Engine, String> {
     }
 }
 
+fn pentect_prompt_engine() -> Result<&'static Engine, String> {
+    match PENTECT_PROMPT_ENGINE.get_or_init(build_pentect_prompt_engine) {
+        Ok(engine) => Ok(engine),
+        Err(error) => Err(error.clone()),
+    }
+}
+
 fn build_pentect_engine() -> Result<Engine, String> {
+    build_pentect_engine_with_prompt_detectors(false)
+}
+
+fn build_pentect_prompt_engine() -> Result<Engine, String> {
+    build_pentect_engine_with_prompt_detectors(true)
+}
+
+fn build_pentect_engine_with_prompt_detectors(prompt: bool) -> Result<Engine, String> {
     let mut builder = Engine::builder()
         .parser(Kind::Json, Box::new(JsonParser))
         .parser(Kind::Ndjson, Box::new(NdjsonParser))
@@ -919,7 +938,11 @@ fn build_pentect_engine() -> Result<Engine, String> {
         .structured_parsers()
         .parser(Kind::Har, Box::new(JsonParser))
         .parser(Kind::ToolResult, Box::new(ToolResultParser))
-        .detector(Box::new(CredSweeperNativeDetector::builtin()))
+        .detector(Box::new(CredSweeperNativeDetector::builtin()));
+    if prompt {
+        builder = builder.detector(Box::new(KeyValueDetector));
+    }
+    builder = builder
         .detector(Box::new(EnvValueDetector))
         .detector(Box::new(PemDetector::default()))
         .detector(Box::new(EntropyDetector::default()))

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -588,10 +588,19 @@ fn active_prompt_masks_keyed_and_vendor_secrets_in_prose() {
     let mut masker = ActiveToolOutputMasker::new().unwrap();
     let masked = masker.mask_prompt_text(&prompt).unwrap().unwrap();
 
-    assert!(!masked.contains(&password), "{masked}");
-    assert!(!masked.contains(&openrouter), "{masked}");
-    assert!(masked.contains("<<KEYED_SECRET_"), "{masked}");
-    assert!(masked.matches("<<").count() >= 2, "{masked}");
+    assert!(!masked.contains(&password), "password was not masked");
+    assert!(
+        !masked.contains(&openrouter),
+        "OpenRouter key was not masked"
+    );
+    assert!(
+        masked.contains("<<KEYED_SECRET_"),
+        "keyed-secret handle was not emitted"
+    );
+    assert!(
+        masked.matches("<<").count() >= 2,
+        "expected prompt handles were not emitted"
+    );
 }
 
 #[test]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -572,6 +572,29 @@ fn active_tool_output_masker_reuses_in_memory_state() {
 }
 
 #[test]
+fn active_prompt_masks_keyed_and_vendor_secrets_in_prose() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-prompt-keyed-detector");
+
+    let password = ["test-pentect", "-password-284-regression"].concat();
+    let openrouter = [
+        "sk-or-v1-",
+        "0123456789abcdef0123456789abcdef",
+        "0123456789abcdef0123456789abcdef",
+    ]
+    .concat();
+    let prompt =
+        format!("Audit fixture: sudo password is {password} and OPENROUTER_API_KEY={openrouter}.");
+    let mut masker = ActiveToolOutputMasker::new().unwrap();
+    let masked = masker.mask_prompt_text(&prompt).unwrap().unwrap();
+
+    assert!(!masked.contains(&password), "{masked}");
+    assert!(!masked.contains(&openrouter), "{masked}");
+    assert!(masked.contains("<<KEYED_SECRET_"), "{masked}");
+    assert!(masked.matches("<<").count() >= 2, "{masked}");
+}
+
+#[test]
 fn bridge_masks_prompt_wraps_shell_and_masks_result() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (_active_store, _, _) = ActiveMemoryStoreEnv::start("bridge-mask");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- add a prompt-only keyed-secret detector without changing tool-output masking policy
- cover current Codex Responses `message/input_text` request shape end to end
- regress natural-language passwords and OpenRouter API-key assignments
- bump CLI/npm version to 0.0.44

Closes #284.

## Verification

- clean-environment `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- release build and `pentect 0.0.44` doctor/dry-run
- actual Codex CLI 0.149.0 request through the built gateway into a sanitized local upstream; neither synthetic raw fixture reached upstream
- npm tests and package dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt masking to reliably remove passwords and OpenRouter API keys from text before requests are forwarded.
  * Ensured sensitive values are replaced with masked handles while preserving required secret references.

* **Tests**
  * Added regression coverage for masking sensitive credentials in prompts and Codex Responses requests.

* **Chores**
  * Updated the package version to 0.0.44.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->