### PR TITLE
Speed up release builds with persistent Rust caches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,6 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-${{ matrix.asset }}
-          save-if: false
       - name: Build release binary
         run: cargo build --release --locked -p pentect-cli
       - name: Package binary and checksum


### PR DESCRIPTION
## Summary
- allow each release platform to save its dedicated Rust build cache
- retain the existing per-asset cache isolation

## Why
The v0.0.44 release showed the five cold release builds on the critical path, with Intel macOS taking about 30 minutes. The pinned rust-cache action documents `save-if: false` as restore-only, so the release-specific caches were never populated.

## Validation
- verified the pinned action input semantics at commit `e18b497796c12c097a38f9edb9d0641fb99eee32`
- one-line workflow change

Closes #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release build workflow’s caching behavior to support more efficient subsequent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->