### PR TITLE
Add actionable batched gateway and OCR diagnostics

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -41,6 +41,19 @@ static WARNED_UNKNOWN_CONTENT_BLOCK: AtomicBool = AtomicBool::new(false);
 static WARNED_UNKNOWN_ENDPOINT: AtomicBool = AtomicBool::new(false);
 static WARNED_PROVIDER_MCP_CREDENTIALS: AtomicBool = AtomicBool::new(false);
 
+fn diagnostic(event: &str, kind: &str, endpoint: &str, retryable: bool) {
+    pentect_agent::record_http_diagnostic_activity(
+        "claude",
+        event,
+        kind,
+        endpoint,
+        "HTTP",
+        None,
+        retryable,
+        env!("CARGO_PKG_VERSION"),
+    );
+}
+
 type ProxyBodyError = Box<dyn Error + Send + Sync>;
 type ProxyBody = UnsyncBoxBody<Bytes, ProxyBodyError>;
 
@@ -52,6 +65,19 @@ enum AnthropicEndpoint {
     Models,
     Health,
     Unknown,
+}
+
+impl AnthropicEndpoint {
+    fn diagnostic_name(self) -> &'static str {
+        match self {
+            Self::Messages => "messages",
+            Self::CountTokens => "count-tokens",
+            Self::Files => "files",
+            Self::Models => "models",
+            Self::Health => "health",
+            Self::Unknown => "unknown",
+        }
+    }
 }
 
 pub(crate) struct ClaudeHttpProxyGuard {
@@ -84,6 +110,17 @@ impl ClaudeHttpProxyGuard {
             {
                 Ok(runtime) => runtime,
                 Err(error) => {
+                    crate::gateway_diagnostics::record(
+                        "claude",
+                        "gateway-stopped",
+                        "runtime",
+                        crate::gateway_diagnostics::RequestContext {
+                            endpoint: "gateway",
+                            method: "HTTP",
+                        },
+                        None,
+                        false,
+                    );
                     let _ = ready_tx.send(Err(format!(
                         "could not start Claude HTTP proxy runtime: {error}"
                     )));
@@ -94,7 +131,18 @@ impl ClaudeHttpProxyGuard {
                 if let Err(error) =
                     run_proxy(upstream, headers, thread_auth, ready_tx, shutdown_rx).await
                 {
-                    eprintln!("[pentect] Claude HTTP proxy stopped: {error}");
+                    crate::gateway_diagnostics::record(
+                        "claude",
+                        "gateway-stopped",
+                        "runtime",
+                        crate::gateway_diagnostics::RequestContext {
+                            endpoint: "gateway",
+                            method: "HTTP",
+                        },
+                        None,
+                        false,
+                    );
+                    let _ = error;
                 }
             });
         });
@@ -194,7 +242,17 @@ async fn run_proxy(
                     builder.max_buf_size(64 * 1024).max_headers(128);
                     if let Err(error) = builder.serve_connection(io, service).await {
                         if !error.is_incomplete_message() {
-                            eprintln!("[pentect] Claude HTTP proxy connection failed: {error}");
+                            crate::gateway_diagnostics::record(
+                                "claude",
+                                "connection-failed",
+                                "client-connection",
+                                crate::gateway_diagnostics::RequestContext {
+                                    endpoint: "gateway",
+                                    method: "HTTP",
+                                },
+                                None,
+                                true,
+                            );
                         }
                     }
                 });
@@ -212,7 +270,26 @@ async fn proxy_request(
     request: Request<Incoming>,
     state: Arc<ProxyState>,
 ) -> Result<Response<ProxyBody>, Infallible> {
+    let context = crate::gateway_diagnostics::RequestContext {
+        endpoint: classify_anthropic_endpoint(
+            request
+                .uri()
+                .path_and_query()
+                .map(|value| value.as_str())
+                .unwrap_or("/"),
+        )
+        .diagnostic_name(),
+        method: crate::gateway_diagnostics::method_name(request.method()),
+    };
     let Ok(_permit) = Arc::clone(&state.requests).try_acquire_owned() else {
+        crate::gateway_diagnostics::record(
+            "claude",
+            "gateway-busy",
+            "capacity",
+            context,
+            Some(StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+            true,
+        );
         return Ok(text_response(
             StatusCode::SERVICE_UNAVAILABLE,
             "Pentect proxy is busy",
@@ -221,14 +298,18 @@ async fn proxy_request(
     match proxy_request_inner(request, &state).await {
         Ok(response) => Ok(response),
         Err(error) => {
-            eprintln!("[pentect] Claude HTTP proxy request failed: {error}");
-            let local_rejection = error.starts_with("image blocked:")
-                || error.starts_with("document blocked:")
-                || error.starts_with("remote ")
-                || error.starts_with("file upload blocked:")
-                || error.starts_with("Files API upload ")
-                || error.starts_with("plugin blocked:")
-                || error.starts_with("unknown format blocked:");
+            let local_rejection = crate::gateway_diagnostics::is_local_rejection(&error);
+            let response_status = if local_rejection {
+                StatusCode::UNPROCESSABLE_ENTITY
+            } else {
+                StatusCode::BAD_GATEWAY
+            };
+            crate::gateway_diagnostics::record_request_failure(
+                "claude",
+                context,
+                &error,
+                response_status.as_u16(),
+            );
             Ok(if local_rejection {
                 owned_text_response(StatusCode::UNPROCESSABLE_ENTITY, &error)
             } else {
@@ -352,7 +433,7 @@ async fn proxy_request_inner(
         reqwest::Body::wrap_stream(stream)
     };
 
-    let mut upstream_request = state.client.request(method, upstream_url);
+    let mut upstream_request = state.client.request(method.clone(), upstream_url);
     let connection_headers = connection_named_headers(&headers);
     for (name, value) in &headers {
         if state.headers.forward_incoming_header(name.as_str())
@@ -370,6 +451,14 @@ async fn proxy_request_inner(
         .await
         .map_err(|error| reqwest_error_message("could not reach Claude upstream", &error))?;
     let status = upstream_response.status();
+    crate::gateway_diagnostics::record_upstream_status(
+        "claude",
+        crate::gateway_diagnostics::RequestContext {
+            endpoint: endpoint.diagnostic_name(),
+            method: crate::gateway_diagnostics::method_name(&method),
+        },
+        status,
+    );
     let response_headers = upstream_response.headers().clone();
     if response_headers
         .get(hyper::header::CONTENT_ENCODING)
@@ -433,9 +522,7 @@ async fn proxy_request_inner(
                     .await
                     .is_err()
                 {
-                    eprintln!(
-                        "[pentect] file attestation unavailable; uploaded file remains untrusted"
-                    );
+                    diagnostic("file-attestation-unavailable", "storage", "files", true);
                 } else if let Ok(mut files) = state.files.lock() {
                     crate::http_files::remember_scoped_file_coverage(
                         &mut files,
@@ -444,7 +531,7 @@ async fn proxy_request_inner(
                         coverage,
                     );
                 } else {
-                    eprintln!("[pentect] uploaded file registry unavailable; persistent attestation retained");
+                    diagnostic("file-registry-unavailable", "storage", "files", true);
                 }
             }
         }
@@ -453,8 +540,8 @@ async fn proxy_request_inner(
         let response_body = run_response_plugins(response_body, &state.plugins)?;
         match rewrite_anthropic_json_response(&response_body) {
             Ok(rewritten) => Bytes::from(rewritten),
-            Err(error) => {
-                eprintln!("[pentect] Claude response restoration skipped: {error}");
+            Err(_error) => {
+                diagnostic("response-restore-skipped", "protection", "messages", false);
                 response_body
             }
         }
@@ -686,7 +773,7 @@ fn protect_anthropic_request_body(
                     "unknown format blocked: Anthropic request is not valid JSON ({error}); set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
                 ));
             }
-            eprintln!("[pentect] Claude request protection skipped: invalid JSON: {error}");
+            diagnostic("request-invalid-json", "protocol", "messages", false);
             return Ok(ProtectedJsonBody {
                 body: body.clone(),
                 coverage: crate::http_files::Coverage::Partial,
@@ -749,7 +836,12 @@ fn protect_anthropic_request_body(
                 "Anthropic request blocked: content inspection is unavailable ({error})"
             ));
         }
-        eprintln!("[pentect] Claude request protection skipped: {error}");
+        diagnostic(
+            "request-protection-skipped",
+            "protection",
+            "messages",
+            false,
+        );
         return Ok(ProtectedJsonBody {
             body: body.clone(),
             coverage: crate::http_files::Coverage::Partial,
@@ -767,8 +859,8 @@ fn protect_anthropic_request_body(
             },
             local_response: None,
         }),
-        Err(error) => {
-            eprintln!("[pentect] Claude request protection skipped: encode failed: {error}");
+        Err(_error) => {
+            diagnostic("request-encode-skipped", "protocol", "messages", false);
             Ok(ProtectedJsonBody {
                 body: body.clone(),
                 coverage: crate::http_files::Coverage::Partial,
@@ -849,8 +941,11 @@ fn warn_provider_mcp_credentials(value: &Value) {
         })
         && !WARNED_PROVIDER_MCP_CREDENTIALS.swap(true, Ordering::Relaxed)
     {
-        eprintln!(
-            "[pentect] provider-side MCP authorization token is sent to the configured upstream"
+        diagnostic(
+            "provider-mcp-credential-forwarded",
+            "credential-forwarding",
+            "messages",
+            false,
         );
     }
 }
@@ -1013,7 +1108,7 @@ where
             return Ok(vec![Bytes::copy_from_slice(chunk)]);
         }
         if self.pending.len().saturating_add(chunk.len()) > MAX_PENDING_SSE_BYTES {
-            eprintln!("[pentect] Claude SSE restoration disabled: pending event exceeded limit");
+            diagnostic("sse-event-limit", "limit", "messages", false);
             return Ok(self.fail_open_with(chunk));
         }
         self.pending.extend_from_slice(chunk);
@@ -1055,7 +1150,7 @@ where
                 SseControlEvent::Other => {}
             }
             if active.bytes.len().saturating_add(block.len()) > MAX_PENDING_SSE_BYTES {
-                eprintln!("[pentect] Claude SSE restoration disabled: tool input exceeded limit");
+                diagnostic("sse-tool-limit", "limit", "messages", false);
                 let active = self.active_tool.take().expect("active tool exists");
                 output.push(Bytes::from(active.bytes));
                 output.push(Bytes::from(block));
@@ -1081,7 +1176,7 @@ where
                         if error.starts_with("plugin middleware:") {
                             return Err(error);
                         }
-                        eprintln!("[pentect] Claude SSE restoration skipped: {error}");
+                        diagnostic("sse-restore-skipped", "protection", "messages", false);
                         output.push(Bytes::from(active.bytes));
                     }
                 }
@@ -1389,9 +1484,7 @@ fn mask_content(
                     | "fallback" => {}
                     _ => {
                         if !WARNED_UNKNOWN_CONTENT_BLOCK.swap(true, Ordering::Relaxed) {
-                            eprintln!(
-                                "[pentect] unknown Anthropic content block passed through without text inspection"
-                            );
+                            diagnostic("unknown-content-block", "protocol", "messages", false);
                         }
                     }
                 }
@@ -1863,9 +1956,7 @@ where
         } else if shell_safe_secret_token(&resolved) {
             out.push_str(&resolved);
         } else {
-            eprintln!(
-                "[pentect] shell tool secret reference left unresolved: represented value is not shell-safe"
-            );
+            diagnostic("shell-secret-unresolved", "resolution", "tool-input", false);
             out.push_str(reference);
         }
         rest = &rest[end..];
@@ -1941,7 +2032,7 @@ fn inject_shell_environment(
                     if shell_safe_secret_token(&value) {
                         Some(format!("set \"{name}={value}\" && "))
                     } else {
-                        eprintln!("[pentect] cmd binding '{name}' was not injected because its value is not cmd-safe");
+                        diagnostic("cmd-binding-skipped", "resolution", "tool-input", false);
                         None
                     }
                 })
@@ -2012,8 +2103,13 @@ fn resolve_known_text(text: &str) -> Result<String, String> {
     match pentect_agent::resolve_known_text_from_active_memory_store(text) {
         Ok(Some(resolved)) => Ok(resolved),
         Ok(None) => Ok(text.to_string()),
-        Err(error) => {
-            eprintln!("[pentect] Claude tool input restoration skipped: {error}");
+        Err(_error) => {
+            diagnostic(
+                "tool-input-restore-skipped",
+                "resolution",
+                "tool-input",
+                false,
+            );
             Ok(text.to_string())
         }
     }
@@ -2025,13 +2121,23 @@ pub(crate) fn request_scoped_resolver() -> impl FnMut(&str) -> Result<String, St
         Ok(resolver) => match resolver.resolve_known_text(text) {
             Ok(Some(resolved)) => Ok(resolved),
             Ok(None) => Ok(text.to_string()),
-            Err(error) => {
-                eprintln!("[pentect] Claude tool input restoration skipped: {error}");
+            Err(_error) => {
+                diagnostic(
+                    "tool-input-restore-skipped",
+                    "resolution",
+                    "tool-input",
+                    false,
+                );
                 Ok(text.to_string())
             }
         },
-        Err(error) => {
-            eprintln!("[pentect] Claude tool input restoration skipped: {error}");
+        Err(_error) => {
+            diagnostic(
+                "tool-input-restore-skipped",
+                "resolution",
+                "tool-input",
+                false,
+            );
             Ok(text.to_string())
         }
     }
@@ -2090,7 +2196,7 @@ fn enforce_known_anthropic_endpoint(
         return Err("unknown format blocked: Anthropic endpoint is not supported; set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through".to_string());
     }
     if !WARNED_UNKNOWN_ENDPOINT.swap(true, Ordering::Relaxed) {
-        eprintln!("[pentect] unknown Anthropic endpoint passed through without content inspection");
+        diagnostic("unknown-endpoint", "protocol", "unknown", false);
     }
     Ok(())
 }

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -36,7 +36,25 @@ type UpstreamByteStream =
     Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static>>;
 
 fn proxy_diagnostic(reason: &str) {
-    pentect_agent::record_diagnostic_activity("cloud-code", reason);
+    let (kind, retryable) = match reason {
+        "gateway-stopped" => ("runtime", false),
+        "connection-failed" => ("client-connection", true),
+        "request-invalid-json" | "unknown-endpoint" => ("protocol", false),
+        "request-protection-skipped"
+        | "response-protection-skipped"
+        | "stream-event-protection-skipped" => ("protection", false),
+        _ => ("unclassified", false),
+    };
+    pentect_agent::record_http_diagnostic_activity(
+        "cloud-code",
+        reason,
+        kind,
+        "gateway",
+        "HTTP",
+        None,
+        retryable,
+        env!("CARGO_PKG_VERSION"),
+    );
 }
 
 pub(crate) struct CloudCodeHttpProxyGuard {
@@ -190,7 +208,26 @@ async fn proxy_request(
     request: Request<Incoming>,
     state: Arc<ProxyState>,
 ) -> Result<Response<ProxyBody>, Infallible> {
+    let context = crate::gateway_diagnostics::RequestContext {
+        endpoint: classify_endpoint(
+            request
+                .uri()
+                .path_and_query()
+                .map(|value| value.as_str())
+                .unwrap_or("/"),
+        )
+        .diagnostic_name(),
+        method: crate::gateway_diagnostics::method_name(request.method()),
+    };
     let Ok(_permit) = Arc::clone(&state.requests).try_acquire_owned() else {
+        crate::gateway_diagnostics::record(
+            "cloud-code",
+            "gateway-busy",
+            "capacity",
+            context,
+            Some(StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+            true,
+        );
         return Ok(text_response(
             StatusCode::SERVICE_UNAVAILABLE,
             "Pentect gateway is busy",
@@ -199,11 +236,18 @@ async fn proxy_request(
     match proxy_request_inner(request, &state).await {
         Ok(response) => Ok(response),
         Err(error) => {
-            proxy_diagnostic("request-failed");
-            let local = error.starts_with("unknown format blocked:")
-                || error.starts_with("image blocked:")
-                || error.starts_with("document blocked:")
-                || error.starts_with("plugin blocked:");
+            let local = crate::gateway_diagnostics::is_local_rejection(&error);
+            let response_status = if local {
+                StatusCode::UNPROCESSABLE_ENTITY
+            } else {
+                StatusCode::BAD_GATEWAY
+            };
+            crate::gateway_diagnostics::record_request_failure(
+                "cloud-code",
+                context,
+                &error,
+                response_status.as_u16(),
+            );
             Ok(if local {
                 owned_text_response(StatusCode::UNPROCESSABLE_ENTITY, &error)
             } else {
@@ -272,7 +316,7 @@ async fn proxy_request_inner(
         reqwest::Body::wrap_stream(stream)
     };
 
-    let mut upstream_request = state.client.request(method, upstream_url);
+    let mut upstream_request = state.client.request(method.clone(), upstream_url);
     let connection_headers = connection_named_headers(&request_headers);
     for (name, value) in &request_headers {
         if state.headers.forward_incoming_header(name.as_str())
@@ -290,6 +334,14 @@ async fn proxy_request_inner(
         .await
         .map_err(|error| reqwest_error_message("could not reach Google Cloud Code", &error))?;
     let status = upstream.status();
+    crate::gateway_diagnostics::record_upstream_status(
+        "cloud-code",
+        crate::gateway_diagnostics::RequestContext {
+            endpoint: endpoint.diagnostic_name(),
+            method: crate::gateway_diagnostics::method_name(&method),
+        },
+        status,
+    );
     let response_headers = upstream.headers().clone();
     if response_headers
         .get(hyper::header::CONTENT_ENCODING)
@@ -425,6 +477,17 @@ enum CloudCodeEndpoint {
 }
 
 impl CloudCodeEndpoint {
+    fn diagnostic_name(self) -> &'static str {
+        match self {
+            Self::GenerateContent => "generate-content",
+            Self::StreamGenerateContent => "stream-generate-content",
+            Self::CountTokens => "count-tokens",
+            Self::Telemetry => "telemetry",
+            Self::Control => "control",
+            Self::Unknown => "unknown",
+        }
+    }
+
     fn is_protected(self) -> bool {
         matches!(
             self,

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -208,15 +208,13 @@ async fn proxy_request(
     request: Request<Incoming>,
     state: Arc<ProxyState>,
 ) -> Result<Response<ProxyBody>, Infallible> {
+    let request_path = request
+        .uri()
+        .path_and_query()
+        .map(|value| value.as_str())
+        .unwrap_or("/");
     let context = crate::gateway_diagnostics::RequestContext {
-        endpoint: classify_endpoint(
-            request
-                .uri()
-                .path_and_query()
-                .map(|value| value.as_str())
-                .unwrap_or("/"),
-        )
-        .diagnostic_name(),
+        endpoint: diagnostic_endpoint_name(request_path, &state.auth),
         method: crate::gateway_diagnostics::method_name(request.method()),
     };
     let Ok(_permit) = Arc::clone(&state.requests).try_acquire_owned() else {
@@ -531,6 +529,13 @@ fn classify_endpoint(path_and_query: &str) -> CloudCodeEndpoint {
         | "/v1internal:recordSmartchoicesFeedback" => CloudCodeEndpoint::Telemetry,
         _ => CloudCodeEndpoint::Unknown,
     }
+}
+
+fn diagnostic_endpoint_name(request_path: &str, auth: &str) -> &'static str {
+    authenticated_request_path(request_path, auth)
+        .map(classify_endpoint)
+        .unwrap_or(CloudCodeEndpoint::Unknown)
+        .diagnostic_name()
 }
 
 fn enforce_known_endpoint(
@@ -1625,6 +1630,14 @@ mod tests {
         assert_eq!(
             authenticated_request_path("/tokenx/v1internal:countTokens", "token"),
             None
+        );
+        assert_eq!(
+            diagnostic_endpoint_name("/token/v1internal:countTokens", "token"),
+            "count-tokens"
+        );
+        assert_eq!(
+            diagnostic_endpoint_name("/tokenx/v1internal:countTokens", "token"),
+            "unknown"
         );
     }
 

--- a/crates/pentect-cli/src/gateway_diagnostics.rs
+++ b/crates/pentect-cli/src/gateway_diagnostics.rs
@@ -1,0 +1,169 @@
+//! Value-free HTTP gateway diagnostics shared by provider adapters.
+//!
+//! Never pass request/response bodies, headers, URLs, credentials, or raw
+//! error messages to the persistent activity log. This module converts them
+//! into a fixed vocabulary before recording anything.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RequestContext {
+    pub(crate) endpoint: &'static str,
+    pub(crate) method: &'static str,
+}
+
+pub(crate) fn method_name(method: &hyper::Method) -> &'static str {
+    match *method {
+        hyper::Method::GET => "GET",
+        hyper::Method::POST => "POST",
+        hyper::Method::PUT => "PUT",
+        hyper::Method::PATCH => "PATCH",
+        hyper::Method::DELETE => "DELETE",
+        hyper::Method::HEAD => "HEAD",
+        hyper::Method::OPTIONS => "OPTIONS",
+        _ => "OTHER",
+    }
+}
+
+pub(crate) fn record_request_failure(
+    surface: &'static str,
+    context: RequestContext,
+    error: &str,
+    response_status: u16,
+) {
+    let local_rejection = is_local_rejection(error);
+    let (kind, retryable) = failure_kind(error);
+    record(
+        surface,
+        if local_rejection {
+            "request-rejected"
+        } else {
+            "request-failed"
+        },
+        kind,
+        context,
+        Some(response_status),
+        retryable,
+    );
+}
+
+pub(crate) fn record_upstream_status(
+    surface: &'static str,
+    context: RequestContext,
+    status: reqwest::StatusCode,
+) {
+    if status.is_success() {
+        return;
+    }
+    let (kind, retryable) = status_kind(status.as_u16());
+    record(
+        surface,
+        "upstream-response",
+        kind,
+        context,
+        Some(status.as_u16()),
+        retryable,
+    );
+}
+
+pub(crate) fn record(
+    surface: &'static str,
+    event: &'static str,
+    kind: &'static str,
+    context: RequestContext,
+    status: Option<u16>,
+    retryable: bool,
+) {
+    pentect_agent::record_http_diagnostic_activity(
+        surface,
+        event,
+        kind,
+        context.endpoint,
+        context.method,
+        status,
+        retryable,
+        env!("CARGO_PKG_VERSION"),
+    );
+}
+
+pub(crate) fn is_local_rejection(error: &str) -> bool {
+    error.starts_with("image blocked:")
+        || error.starts_with("document blocked:")
+        || error.starts_with("remote ")
+        || error.starts_with("OpenAI file ")
+        || error.starts_with("file upload blocked:")
+        || error.starts_with("Files API upload ")
+        || error.starts_with("plugin blocked:")
+        || error.starts_with("unknown format blocked:")
+}
+
+fn failure_kind(error: &str) -> (&'static str, bool) {
+    let lower = error.to_ascii_lowercase();
+    if lower.contains("timed out") || lower.contains("timeout") {
+        ("timeout", true)
+    } else if lower.contains("connection failed") || lower.contains("could not reach") {
+        ("connect", true)
+    } else if lower.contains("stream failed") {
+        ("stream", true)
+    } else if lower.contains("invalid response body")
+        || lower.contains("could not read") && lower.contains("response")
+    {
+        ("response-body", true)
+    } else if is_local_rejection(error) {
+        ("policy", false)
+    } else if lower.contains("too large") || lower.contains("exceeded limit") {
+        ("limit", false)
+    } else if lower.contains("plugin") {
+        ("plugin", false)
+    } else if lower.contains("invalid json")
+        || lower.contains("not valid json")
+        || lower.contains("unsupported content encoding")
+        || lower.contains("unsupported shape")
+    {
+        ("protocol", false)
+    } else if lower.contains("lock was poisoned") || lower.contains("task failed") {
+        ("internal", false)
+    } else {
+        ("unclassified", false)
+    }
+}
+
+fn status_kind(status: u16) -> (&'static str, bool) {
+    match status {
+        401 | 403 => ("authentication", false),
+        408 => ("timeout", true),
+        409 => ("conflict", false),
+        429 => ("rate-limit", true),
+        500..=599 => ("upstream-server", true),
+        400..=499 => ("upstream-client", false),
+        300..=399 => ("redirect", false),
+        _ => ("unexpected-status", false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failures_are_reduced_to_fixed_safe_categories() {
+        assert_eq!(
+            failure_kind("could not reach provider: timed out"),
+            ("timeout", true)
+        );
+        assert_eq!(
+            failure_kind("could not reach provider: connection failed"),
+            ("connect", true)
+        );
+        assert_eq!(failure_kind("plugin blocked: fixture"), ("policy", false));
+        assert_eq!(
+            failure_kind("arbitrary secret-bearing detail"),
+            ("unclassified", false)
+        );
+    }
+
+    #[test]
+    fn statuses_have_actionable_retry_classification() {
+        assert_eq!(status_kind(401), ("authentication", false));
+        assert_eq!(status_kind(429), ("rate-limit", true));
+        assert_eq!(status_kind(503), ("upstream-server", true));
+    }
+}

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -32,7 +32,23 @@ type UpstreamByteStream =
     Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static>>;
 
 fn diagnostic(reason: &str) {
-    pentect_agent::record_diagnostic_activity("gemini", reason);
+    let (kind, retryable) = match reason {
+        "gateway-stopped" => ("runtime", false),
+        "connection-failed" => ("client-connection", true),
+        "request-invalid-json" => ("protocol", false),
+        "request-protection-skipped" => ("protection", false),
+        _ => ("unclassified", false),
+    };
+    pentect_agent::record_http_diagnostic_activity(
+        "gemini",
+        reason,
+        kind,
+        "gateway",
+        "HTTP",
+        None,
+        retryable,
+        env!("CARGO_PKG_VERSION"),
+    );
 }
 
 pub(crate) struct GeminiHttpProxyGuard {
@@ -177,7 +193,26 @@ async fn proxy_request(
     request: Request<Incoming>,
     state: Arc<ProxyState>,
 ) -> Result<Response<ProxyBody>, Infallible> {
+    let context = crate::gateway_diagnostics::RequestContext {
+        endpoint: classify_endpoint(
+            request
+                .uri()
+                .path_and_query()
+                .map(|value| value.as_str())
+                .unwrap_or("/"),
+        )
+        .diagnostic_name(),
+        method: crate::gateway_diagnostics::method_name(request.method()),
+    };
     let Ok(_permit) = Arc::clone(&state.requests).try_acquire_owned() else {
+        crate::gateway_diagnostics::record(
+            "gemini",
+            "gateway-busy",
+            "capacity",
+            context,
+            Some(StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+            true,
+        );
         return Ok(text_response(
             StatusCode::SERVICE_UNAVAILABLE,
             "Pentect gateway is busy",
@@ -186,11 +221,18 @@ async fn proxy_request(
     match proxy_request_inner(request, &state).await {
         Ok(response) => Ok(response),
         Err(error) => {
-            diagnostic("request-failed");
-            let local = error.starts_with("unknown format blocked:")
-                || error.starts_with("image blocked:")
-                || error.starts_with("document blocked:")
-                || error.starts_with("plugin blocked:");
+            let local = crate::gateway_diagnostics::is_local_rejection(&error);
+            let response_status = if local {
+                StatusCode::UNPROCESSABLE_ENTITY
+            } else {
+                StatusCode::BAD_GATEWAY
+            };
+            crate::gateway_diagnostics::record_request_failure(
+                "gemini",
+                context,
+                &error,
+                response_status.as_u16(),
+            );
             Ok(if local {
                 owned_text_response(StatusCode::UNPROCESSABLE_ENTITY, &error)
             } else {
@@ -258,7 +300,7 @@ async fn proxy_request_inner(
         });
         reqwest::Body::wrap_stream(stream)
     };
-    let mut upstream_request = state.client.request(method, upstream_url);
+    let mut upstream_request = state.client.request(method.clone(), upstream_url);
     let connection_headers = connection_named_headers(&request_headers);
     for (name, value) in &request_headers {
         if state.headers.forward_incoming_header(name.as_str())
@@ -276,6 +318,14 @@ async fn proxy_request_inner(
         .await
         .map_err(|error| reqwest_error_message("could not reach Gemini upstream", &error))?;
     let status = upstream.status();
+    crate::gateway_diagnostics::record_upstream_status(
+        "gemini",
+        crate::gateway_diagnostics::RequestContext {
+            endpoint: endpoint.diagnostic_name(),
+            method: crate::gateway_diagnostics::method_name(&method),
+        },
+        status,
+    );
     let response_headers = upstream.headers().clone();
     if response_headers
         .get(hyper::header::CONTENT_ENCODING)
@@ -338,6 +388,16 @@ enum GeminiEndpoint {
 }
 
 impl GeminiEndpoint {
+    fn diagnostic_name(self) -> &'static str {
+        match self {
+            Self::GenerateContent => "generate-content",
+            Self::StreamGenerateContent => "stream-generate-content",
+            Self::CountTokens => "count-tokens",
+            Self::Models => "models",
+            Self::Unknown => "unknown",
+        }
+    }
+
     fn is_protected(self) -> bool {
         matches!(
             self,

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -193,15 +193,13 @@ async fn proxy_request(
     request: Request<Incoming>,
     state: Arc<ProxyState>,
 ) -> Result<Response<ProxyBody>, Infallible> {
+    let request_path = request
+        .uri()
+        .path_and_query()
+        .map(|value| value.as_str())
+        .unwrap_or("/");
     let context = crate::gateway_diagnostics::RequestContext {
-        endpoint: classify_endpoint(
-            request
-                .uri()
-                .path_and_query()
-                .map(|value| value.as_str())
-                .unwrap_or("/"),
-        )
-        .diagnostic_name(),
+        endpoint: diagnostic_endpoint_name(request_path, &state.auth),
         method: crate::gateway_diagnostics::method_name(request.method()),
     };
     let Ok(_permit) = Arc::clone(&state.requests).try_acquire_owned() else {
@@ -423,6 +421,13 @@ fn classify_endpoint(path_and_query: &str) -> GeminiEndpoint {
     } else {
         GeminiEndpoint::Unknown
     }
+}
+
+fn diagnostic_endpoint_name(request_path: &str, auth: &str) -> &'static str {
+    authenticated_request_path(request_path, auth)
+        .map(classify_endpoint)
+        .unwrap_or(GeminiEndpoint::Unknown)
+        .diagnostic_name()
 }
 
 struct ProtectedRequest {
@@ -1099,6 +1104,20 @@ mod tests {
         assert_eq!(
             classify_endpoint("/v1internal:generateContent"),
             GeminiEndpoint::Unknown
+        );
+        assert_eq!(
+            diagnostic_endpoint_name(
+                "/token/v1beta/models/gemini-2.5-pro:generateContent",
+                "token"
+            ),
+            "generate-content"
+        );
+        assert_eq!(
+            diagnostic_endpoint_name(
+                "/tokenx/v1beta/models/gemini-2.5-pro:generateContent",
+                "token"
+            ),
+            "unknown"
         );
     }
 

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -8,6 +8,7 @@ mod cloud_code_http_proxy;
 mod codex_app;
 mod default_launch;
 mod doctor;
+mod gateway_diagnostics;
 mod gemini_http_proxy;
 mod handle_contract;
 mod http_files;

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -33,7 +33,29 @@ const MAX_CHAT_TOOL_CALLS: usize = 1024;
 static WARNED_UNKNOWN_ENDPOINT: AtomicBool = AtomicBool::new(false);
 
 fn proxy_diagnostic(reason: &str) {
-    pentect_agent::record_diagnostic_activity("openai", reason);
+    let (kind, retryable) = match reason {
+        "gateway-stopped" => ("runtime", false),
+        "connection-failed" => ("client-connection", true),
+        "request-invalid-json" | "request-content-encoding-skipped" | "unknown-endpoint" => {
+            ("protocol", false)
+        }
+        "request-protection-skipped" | "response-restore-skipped" | "sse-restore-skipped" => {
+            ("protection", false)
+        }
+        "file-attestation-unavailable" | "file-registry-unavailable" => ("storage", true),
+        "sse-event-limit" => ("limit", false),
+        _ => ("unclassified", false),
+    };
+    pentect_agent::record_http_diagnostic_activity(
+        "openai",
+        reason,
+        kind,
+        "gateway",
+        "HTTP",
+        None,
+        retryable,
+        env!("CARGO_PKG_VERSION"),
+    );
 }
 
 type ProxyBodyError = Box<dyn Error + Send + Sync>;
@@ -236,7 +258,26 @@ async fn proxy_request(
     request: Request<Incoming>,
     state: Arc<ProxyState>,
 ) -> Result<Response<ProxyBody>, Infallible> {
+    let context = crate::gateway_diagnostics::RequestContext {
+        endpoint: classify_openai_endpoint(
+            request
+                .uri()
+                .path_and_query()
+                .map(|value| value.as_str())
+                .unwrap_or("/"),
+        )
+        .diagnostic_name(),
+        method: crate::gateway_diagnostics::method_name(request.method()),
+    };
     let Ok(_permit) = Arc::clone(&state.requests).try_acquire_owned() else {
+        crate::gateway_diagnostics::record(
+            "openai",
+            "gateway-busy",
+            "capacity",
+            context,
+            Some(StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+            true,
+        );
         return Ok(text_response(
             StatusCode::SERVICE_UNAVAILABLE,
             "Pentect gateway is busy",
@@ -245,15 +286,18 @@ async fn proxy_request(
     match proxy_request_inner(request, &state).await {
         Ok(response) => Ok(response),
         Err(error) => {
-            proxy_diagnostic("request-failed");
-            let local_rejection = error.starts_with("image blocked:")
-                || error.starts_with("document blocked:")
-                || error.starts_with("remote ")
-                || error.starts_with("OpenAI file ")
-                || error.starts_with("file upload blocked:")
-                || error.starts_with("Files API upload ")
-                || error.starts_with("plugin blocked:")
-                || error.starts_with("unknown format blocked:");
+            let local_rejection = crate::gateway_diagnostics::is_local_rejection(&error);
+            let response_status = if local_rejection {
+                StatusCode::UNPROCESSABLE_ENTITY
+            } else {
+                StatusCode::BAD_GATEWAY
+            };
+            crate::gateway_diagnostics::record_request_failure(
+                "openai",
+                context,
+                &error,
+                response_status.as_u16(),
+            );
             Ok(if local_rejection {
                 owned_text_response(StatusCode::UNPROCESSABLE_ENTITY, &error)
             } else {
@@ -436,7 +480,7 @@ async fn proxy_request_inner(
         reqwest::Body::wrap_stream(stream)
     };
 
-    let mut upstream_request = state.client.request(method, upstream_url);
+    let mut upstream_request = state.client.request(method.clone(), upstream_url);
     let connection_headers = connection_named_headers(&headers);
     for (name, value) in &headers {
         if state.headers.forward_incoming_header(name.as_str())
@@ -455,6 +499,14 @@ async fn proxy_request_inner(
         .await
         .map_err(|error| reqwest_error_message("could not reach OpenAI upstream", &error))?;
     let status = upstream.status();
+    crate::gateway_diagnostics::record_upstream_status(
+        "openai",
+        crate::gateway_diagnostics::RequestContext {
+            endpoint: endpoint.diagnostic_name(),
+            method: crate::gateway_diagnostics::method_name(&method),
+        },
+        status,
+    );
     let response_headers = upstream.headers().clone();
     if response_headers
         .get(hyper::header::CONTENT_ENCODING)
@@ -534,9 +586,7 @@ async fn proxy_request_inner(
                     .await
                     .is_err()
                 {
-                    eprintln!(
-                        "[pentect] file attestation unavailable; uploaded file remains untrusted"
-                    );
+                    proxy_diagnostic("file-attestation-unavailable");
                 } else if let Ok(mut files) = state.files.lock() {
                     crate::http_files::remember_scoped_file_coverage(
                         &mut files,
@@ -545,7 +595,7 @@ async fn proxy_request_inner(
                         coverage,
                     );
                 } else {
-                    eprintln!("[pentect] uploaded file registry unavailable; persistent attestation retained");
+                    proxy_diagnostic("file-registry-unavailable");
                 }
             }
         }
@@ -2250,6 +2300,22 @@ enum OpenAiEndpoint {
     Models,
     Health,
     Unknown,
+}
+
+impl OpenAiEndpoint {
+    fn diagnostic_name(self) -> &'static str {
+        match self {
+            Self::Responses => "responses",
+            Self::ResponsesResource => "responses-resource",
+            Self::InputTokens => "input-tokens",
+            Self::ChatCompletions => "chat-completions",
+            Self::FilesCollection => "files-collection",
+            Self::Files => "files",
+            Self::Models => "models",
+            Self::Health => "health",
+            Self::Unknown => "unknown",
+        }
+    }
 }
 
 fn classify_openai_endpoint(path_and_query: &str) -> OpenAiEndpoint {

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -3,13 +3,13 @@ use crate::memory_store::MemoryStoreClient;
 use pentect_core::MaskResult;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const MAX_LABELS_PER_EVENT: usize = 64;
 const MAX_SEEN_EVENTS: usize = 4_096;
@@ -20,8 +20,12 @@ const LOG_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 const LOG_CHANNEL_CAPACITY: usize = 1_024;
 const LOG_MAX_BYTES: u64 = 128 * 1024 * 1024;
 const LOG_ROTATIONS: usize = 31;
+const DIAGNOSTIC_BATCH_WINDOW: Duration = Duration::from_secs(5);
+const DIAGNOSTIC_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const DIAGNOSTIC_CHANNEL_CAPACITY: usize = 1_024;
 static LOG_SHARE: OnceLock<bool> = OnceLock::new();
 static PERSISTENT_LOG: OnceLock<Option<PersistentLogWriter>> = OnceLock::new();
+static DIAGNOSTIC_WRITER: OnceLock<Option<DiagnosticWriter>> = OnceLock::new();
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct ActivityEvent {
@@ -35,6 +39,20 @@ pub(crate) struct ActivityEvent {
     target: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     event: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    endpoint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    method: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    status: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retryable: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_time: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pid: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -73,6 +91,39 @@ struct LifecycleSource {
 struct PersistentLogWriter {
     sender: SyncSender<LogMessage>,
     dropped: Arc<AtomicU64>,
+}
+
+struct DiagnosticWriter {
+    sender: SyncSender<DiagnosticMessage>,
+    dropped: Arc<AtomicU64>,
+}
+
+enum DiagnosticMessage {
+    Entry(Box<ActivityEvent>),
+    Flush(mpsc::Sender<()>),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct DiagnosticKey {
+    action: String,
+    surface: String,
+    event: Option<String>,
+    kind: Option<String>,
+    endpoint: Option<String>,
+    method: Option<String>,
+    status: Option<u16>,
+    retryable: Option<bool>,
+    pid: Option<u32>,
+}
+
+struct PendingDiagnostic {
+    event: ActivityEvent,
+    first_seen: Instant,
+}
+
+#[derive(Default)]
+struct DiagnosticBatch {
+    pending: HashMap<DiagnosticKey, PendingDiagnostic>,
 }
 
 enum LogMessage {
@@ -122,6 +173,13 @@ impl ActivityEvent {
                 .collect(),
             target,
             event: None,
+            kind: None,
+            endpoint: None,
+            method: None,
+            status: None,
+            retryable: None,
+            last_time: None,
+            duration_ms: None,
             pid: None,
             version: None,
             os: None,
@@ -148,6 +206,13 @@ impl ActivityEvent {
             labels: Vec::new(),
             target: None,
             event: Some(safe_identifier(event)),
+            kind: None,
+            endpoint: None,
+            method: None,
+            status: None,
+            retryable: None,
+            last_time: None,
+            duration_ms: None,
             pid: Some(std::process::id()),
             version: Some(version.chars().take(64).collect()),
             os: Some(std::env::consts::OS.to_string()),
@@ -156,6 +221,65 @@ impl ActivityEvent {
             panic_location: panic_location.map(safe_panic_location),
             backtrace: backtrace.map(safe_backtrace),
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn diagnostic(
+        surface: &str,
+        event: &str,
+        kind: Option<&str>,
+        endpoint: Option<&str>,
+        method: Option<&str>,
+        status: Option<u16>,
+        retryable: Option<bool>,
+        version: Option<&str>,
+    ) -> Self {
+        Self {
+            time: jiff::Timestamp::now().to_string(),
+            action: "warning".to_string(),
+            surface: safe_identifier(surface),
+            count: 1,
+            labels: Vec::new(),
+            target: None,
+            event: Some(safe_identifier(event)),
+            kind: kind.map(safe_identifier),
+            endpoint: endpoint.map(safe_identifier),
+            method: method.map(safe_identifier),
+            status,
+            retryable,
+            last_time: None,
+            duration_ms: None,
+            pid: Some(std::process::id()),
+            version: version.map(|value| value.chars().take(64).collect()),
+            os: Some(std::env::consts::OS.to_string()),
+            arch: Some(std::env::consts::ARCH.to_string()),
+            exit_code: None,
+            panic_location: None,
+            backtrace: None,
+        }
+    }
+}
+
+impl ActivityEvent {
+    #[allow(clippy::too_many_arguments)]
+    fn diagnostic_counted(
+        action: &str,
+        surface: &str,
+        event: &str,
+        kind: Option<&str>,
+        endpoint: Option<&str>,
+        method: Option<&str>,
+        status: Option<u16>,
+        retryable: Option<bool>,
+        version: Option<&str>,
+        count: u64,
+    ) -> Self {
+        let mut out = Self::diagnostic(
+            surface, event, kind, endpoint, method, status, retryable, version,
+        );
+        out.action = safe_identifier(action);
+        out.count = count.max(1);
+        out
     }
 }
 
@@ -178,9 +302,46 @@ pub(crate) fn record_process(
 }
 
 pub(crate) fn flush_persistent() {
+    if let Some(writer) = diagnostic_writer() {
+        writer.flush();
+    }
     if let Some(writer) = persistent_log() {
         writer.flush();
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_diagnostic(
+    surface: &str,
+    event: &str,
+    kind: Option<&str>,
+    endpoint: Option<&str>,
+    method: Option<&str>,
+    status: Option<u16>,
+    retryable: Option<bool>,
+    version: Option<&str>,
+) {
+    record(ActivityEvent::diagnostic(
+        surface, event, kind, endpoint, method, status, retryable, version,
+    ));
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_structured(
+    action: &str,
+    surface: &str,
+    event: &str,
+    kind: Option<&str>,
+    endpoint: Option<&str>,
+    method: Option<&str>,
+    status: Option<u16>,
+    retryable: Option<bool>,
+    version: Option<&str>,
+    count: u64,
+) {
+    record(ActivityEvent::diagnostic_counted(
+        action, surface, event, kind, endpoint, method, status, retryable, version, count,
+    ));
 }
 
 pub(crate) fn persistent_log_path() -> PathBuf {
@@ -437,6 +598,16 @@ fn codex_lifecycle_log_path() -> PathBuf {
 }
 
 fn record(event: ActivityEvent) {
+    if matches!(event.action.as_str(), "warning" | "diagnostic") {
+        if let Some(writer) = diagnostic_writer() {
+            writer.enqueue(event);
+            return;
+        }
+    }
+    record_immediate(event);
+}
+
+fn record_immediate(event: ActivityEvent) {
     let Ok(json) = serde_json::to_string(&event) else {
         return;
     };
@@ -445,6 +616,134 @@ fn record(event: ActivityEvent) {
     }
     let share = *LOG_SHARE.get_or_init(|| crate::config::activity_share_enabled().unwrap_or(true));
     let _ = delegated_process_host::send_activity(&json, share);
+}
+
+fn diagnostic_writer() -> Option<&'static DiagnosticWriter> {
+    DIAGNOSTIC_WRITER
+        .get_or_init(|| DiagnosticWriter::spawn().ok())
+        .as_ref()
+}
+
+impl DiagnosticWriter {
+    fn spawn() -> Result<Self, String> {
+        let (sender, receiver) = mpsc::sync_channel(DIAGNOSTIC_CHANNEL_CAPACITY);
+        let dropped = Arc::new(AtomicU64::new(0));
+        let worker_dropped = Arc::clone(&dropped);
+        std::thread::Builder::new()
+            .name("pentect-diagnostic-writer".to_string())
+            .spawn(move || diagnostic_writer_loop(receiver, worker_dropped))
+            .map_err(|error| format!("could not start diagnostic writer: {error}"))?;
+        Ok(Self { sender, dropped })
+    }
+
+    fn enqueue(&self, event: ActivityEvent) {
+        match self
+            .sender
+            .try_send(DiagnosticMessage::Entry(Box::new(event)))
+        {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(TrySendError::Disconnected(_)) => {}
+        }
+    }
+
+    fn flush(&self) {
+        let (sender, receiver) = mpsc::channel();
+        if self.sender.send(DiagnosticMessage::Flush(sender)).is_ok() {
+            let _ = receiver.recv_timeout(Duration::from_secs(5));
+        }
+    }
+}
+
+impl DiagnosticBatch {
+    fn push(&mut self, event: ActivityEvent, now: Instant) {
+        let key = DiagnosticKey {
+            action: event.action.clone(),
+            surface: event.surface.clone(),
+            event: event.event.clone(),
+            kind: event.kind.clone(),
+            endpoint: event.endpoint.clone(),
+            method: event.method.clone(),
+            status: event.status,
+            retryable: event.retryable,
+            pid: event.pid,
+        };
+        match self.pending.entry(key) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let pending = entry.get_mut();
+                pending.event.count = pending.event.count.saturating_add(event.count);
+                pending.event.last_time = Some(event.time);
+                pending.event.duration_ms = Some(
+                    now.saturating_duration_since(pending.first_seen)
+                        .as_millis()
+                        .try_into()
+                        .unwrap_or(u64::MAX),
+                );
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(PendingDiagnostic {
+                    event,
+                    first_seen: now,
+                });
+            }
+        }
+    }
+
+    fn drain_expired(&mut self, now: Instant, force: bool) -> Vec<ActivityEvent> {
+        let keys = self
+            .pending
+            .iter()
+            .filter(|(_, pending)| {
+                force
+                    || now.saturating_duration_since(pending.first_seen) >= DIAGNOSTIC_BATCH_WINDOW
+            })
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        keys.into_iter()
+            .filter_map(|key| self.pending.remove(&key).map(|pending| pending.event))
+            .collect()
+    }
+}
+
+fn diagnostic_writer_loop(receiver: Receiver<DiagnosticMessage>, dropped: Arc<AtomicU64>) {
+    let mut batch = DiagnosticBatch::default();
+    loop {
+        match receiver.recv_timeout(DIAGNOSTIC_POLL_INTERVAL) {
+            Ok(DiagnosticMessage::Entry(event)) => batch.push(*event, Instant::now()),
+            Ok(DiagnosticMessage::Flush(acknowledge)) => {
+                flush_diagnostic_batch(&mut batch, &dropped, true);
+                let _ = acknowledge.send(());
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                flush_diagnostic_batch(&mut batch, &dropped, false);
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    flush_diagnostic_batch(&mut batch, &dropped, true);
+}
+
+fn flush_diagnostic_batch(batch: &mut DiagnosticBatch, dropped: &AtomicU64, force: bool) {
+    for event in batch.drain_expired(Instant::now(), force) {
+        record_immediate(event);
+    }
+    let lost = dropped.swap(0, Ordering::Relaxed);
+    if lost > 0 {
+        let mut event = ActivityEvent::diagnostic(
+            "logger",
+            "diagnostic-queue-overflow",
+            Some("capacity"),
+            None,
+            None,
+            None,
+            Some(true),
+            None,
+        );
+        event.count = lost;
+        record_immediate(event);
+    }
 }
 
 fn persistent_log() -> Option<&'static PersistentLogWriter> {
@@ -655,6 +954,49 @@ fn format_event(event: &ActivityEvent) -> String {
             event.arch.as_deref().unwrap_or("unknown"),
             exit,
             location,
+        );
+    }
+    if matches!(event.action.as_str(), "warning" | "diagnostic") && event.event.is_some() {
+        let mut details = Vec::new();
+        if let Some(kind) = &event.kind {
+            details.push(format!("kind={kind}"));
+        }
+        if let Some(endpoint) = &event.endpoint {
+            details.push(format!("endpoint={endpoint}"));
+        }
+        if let Some(method) = &event.method {
+            details.push(format!("method={method}"));
+        }
+        if let Some(status) = event.status {
+            details.push(format!("status={status}"));
+        }
+        if let Some(retryable) = event.retryable {
+            details.push(format!("retryable={retryable}"));
+        }
+        if let Some(duration_ms) = event.duration_ms {
+            details.push(format!("span_ms={duration_ms}"));
+        }
+        if let Some(pid) = event.pid {
+            details.push(format!("pid={pid}"));
+        }
+        let count = if event.count == 1 {
+            String::new()
+        } else {
+            format!(" x{}", event.count)
+        };
+        let details = if details.is_empty() {
+            String::new()
+        } else {
+            format!("  {}", details.join("  "))
+        };
+        return format!(
+            "{}  {}/{}  {}{}{}",
+            event.time,
+            event.action,
+            event.surface,
+            event.event.as_deref().unwrap_or("event"),
+            count,
+            details,
         );
     }
     let labels = event
@@ -929,5 +1271,61 @@ mod tests {
             .unwrap()
             .contains("after-rotation"));
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn diagnostic_batch_aggregates_repeats_and_flushes_from_first_seen() {
+        let start = Instant::now();
+        let mut batch = DiagnosticBatch::default();
+        let event = ActivityEvent::diagnostic_counted(
+            "warning",
+            "openai",
+            "request-failed",
+            Some("connect"),
+            Some("responses"),
+            Some("POST"),
+            Some(502),
+            Some(true),
+            Some("test"),
+            1,
+        );
+        batch.push(event.clone(), start);
+        batch.push(event, start + Duration::from_secs(4));
+
+        let drained = batch.drain_expired(start + DIAGNOSTIC_BATCH_WINDOW, false);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].count, 2);
+        assert_eq!(drained[0].duration_ms, Some(4_000));
+        assert!(batch.pending.is_empty());
+    }
+
+    #[test]
+    fn structured_diagnostics_keep_action_and_classifier_boundaries() {
+        let start = Instant::now();
+        let mut batch = DiagnosticBatch::default();
+        for action in ["diagnostic", "warning"] {
+            batch.push(
+                ActivityEvent::diagnostic_counted(
+                    action,
+                    "ocr",
+                    "scan-complete",
+                    Some("bundled"),
+                    Some("image"),
+                    Some("SCAN"),
+                    None,
+                    Some(false),
+                    None,
+                    3,
+                ),
+                start,
+            );
+        }
+        let drained = batch.drain_expired(start, true);
+        assert_eq!(drained.len(), 2);
+        assert!(drained.iter().any(|event| event.action == "diagnostic"));
+        assert!(drained.iter().any(|event| event.action == "warning"));
+        assert!(drained.iter().all(|event| !serde_json::to_string(event)
+            .unwrap()
+            .contains("image bytes")));
     }
 }

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -237,20 +237,20 @@ impl ActivityEvent {
         Self {
             time: jiff::Timestamp::now().to_string(),
             action: "warning".to_string(),
-            surface: safe_identifier(surface),
+            surface: diagnostic_surface(surface),
             count: 1,
             labels: Vec::new(),
             target: None,
-            event: Some(safe_identifier(event)),
-            kind: kind.map(safe_identifier),
-            endpoint: endpoint.map(safe_identifier),
-            method: method.map(safe_identifier),
+            event: Some(diagnostic_event(event)),
+            kind: kind.map(diagnostic_kind),
+            endpoint: endpoint.map(diagnostic_endpoint),
+            method: method.map(diagnostic_method),
             status,
             retryable,
             last_time: None,
             duration_ms: None,
             pid: Some(std::process::id()),
-            version: version.map(|value| value.chars().take(64).collect()),
+            version: version.and_then(diagnostic_version),
             os: Some(std::env::consts::OS.to_string()),
             arch: Some(std::env::consts::ARCH.to_string()),
             exit_code: None,
@@ -277,7 +277,11 @@ impl ActivityEvent {
         let mut out = Self::diagnostic(
             surface, event, kind, endpoint, method, status, retryable, version,
         );
-        out.action = safe_identifier(action);
+        out.action = match action {
+            "warning" => "warning",
+            _ => "diagnostic",
+        }
+        .to_string();
         out.count = count.max(1);
         out
     }
@@ -1046,6 +1050,153 @@ fn safe_identifier(value: &str) -> String {
     }
 }
 
+fn allowed_diagnostic_identifier(value: &str, allowed: &[&str]) -> String {
+    if allowed.contains(&value) {
+        value.to_string()
+    } else {
+        "unknown".to_string()
+    }
+}
+
+fn diagnostic_surface(value: &str) -> String {
+    allowed_diagnostic_identifier(
+        value,
+        &["claude", "cloud-code", "gemini", "logger", "ocr", "openai"],
+    )
+}
+
+fn diagnostic_event(value: &str) -> String {
+    allowed_diagnostic_identifier(
+        value,
+        &[
+            "cmd-binding-skipped",
+            "connection-failed",
+            "diagnostic-queue-overflow",
+            "file-attestation-unavailable",
+            "file-registry-unavailable",
+            "gateway-busy",
+            "gateway-stopped",
+            "provider-mcp-credential-forwarded",
+            "request-content-encoding-skipped",
+            "request-encode-skipped",
+            "request-failed",
+            "request-invalid-json",
+            "request-protection-skipped",
+            "request-rejected",
+            "response-protection-skipped",
+            "response-restore-skipped",
+            "scan-complete",
+            "scan-failed",
+            "scan-failure-allowed",
+            "scan-failure-blocked",
+            "scan-unavailable-allowed",
+            "scan-unavailable-blocked",
+            "shell-secret-unresolved",
+            "sse-event-limit",
+            "sse-restore-skipped",
+            "sse-tool-limit",
+            "stream-event-protection-skipped",
+            "tool-input-restore-skipped",
+            "unknown-content-block",
+            "unknown-endpoint",
+            "upstream-response",
+        ],
+    )
+}
+
+fn diagnostic_kind(value: &str) -> String {
+    allowed_diagnostic_identifier(
+        value,
+        &[
+            "authentication",
+            "bundled",
+            "capacity",
+            "client-connection",
+            "conflict",
+            "connect",
+            "credential-forwarding",
+            "decode",
+            "disabled",
+            "initialize",
+            "internal",
+            "limit",
+            "model-load",
+            "policy",
+            "preprocess",
+            "protection",
+            "protocol",
+            "rate-limit",
+            "recognition",
+            "redirect",
+            "resolution",
+            "response-body",
+            "runtime",
+            "source-or-limit",
+            "storage",
+            "stream",
+            "timeout",
+            "unclassified",
+            "unexpected-status",
+            "unsupported",
+            "upstream-client",
+            "upstream-server",
+            "windows",
+            "macos",
+        ],
+    )
+}
+
+fn diagnostic_endpoint(value: &str) -> String {
+    allowed_diagnostic_identifier(
+        value,
+        &[
+            "bundled",
+            "chat-completions",
+            "control",
+            "count-tokens",
+            "disabled",
+            "files",
+            "files-collection",
+            "gateway",
+            "generate-content",
+            "health",
+            "image",
+            "input-tokens",
+            "macos",
+            "messages",
+            "models",
+            "responses",
+            "responses-resource",
+            "stream-generate-content",
+            "telemetry",
+            "tool-input",
+            "unknown",
+            "unsupported",
+            "windows",
+        ],
+    )
+}
+
+fn diagnostic_method(value: &str) -> String {
+    allowed_diagnostic_identifier(
+        value,
+        &[
+            "DELETE", "GET", "HEAD", "HTTP", "OPTIONS", "OTHER", "PATCH", "POST", "PUT", "SCAN",
+        ],
+    )
+}
+
+fn diagnostic_version(value: &str) -> Option<String> {
+    let value = value.strip_prefix('v').unwrap_or(value);
+    let mut parts = value.split('.');
+    let valid = (0..3).all(|_| {
+        parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit()))
+    }) && parts.next().is_none();
+    valid.then(|| value.to_string())
+}
+
 fn safe_panic_location(value: &str) -> String {
     value
         .chars()
@@ -1327,5 +1478,37 @@ mod tests {
         assert!(drained.iter().all(|event| !serde_json::to_string(event)
             .unwrap()
             .contains("image bytes")));
+    }
+
+    #[test]
+    fn structured_diagnostics_reject_unlisted_identifier_shaped_input() {
+        let event = ActivityEvent::diagnostic(
+            "tenantCredential123",
+            "httpsApiExampleComPrivateRoute",
+            Some("apiKeyMaterial123"),
+            Some("accountIdentifier456"),
+            Some("SECRETVERB"),
+            Some(502),
+            Some(false),
+            Some("12345678901234567890"),
+        );
+        let json = serde_json::to_string(&event).unwrap();
+
+        for rejected in [
+            "tenantCredential123",
+            "httpsApiExampleComPrivateRoute",
+            "apiKeyMaterial123",
+            "accountIdentifier456",
+            "SECRETVERB",
+            "12345678901234567890",
+        ] {
+            assert!(!json.contains(rejected), "persisted rejected field: {json}");
+        }
+        assert_eq!(event.surface, "unknown");
+        assert_eq!(event.event.as_deref(), Some("unknown"));
+        assert_eq!(event.kind.as_deref(), Some("unknown"));
+        assert_eq!(event.endpoint.as_deref(), Some("unknown"));
+        assert_eq!(event.method.as_deref(), Some("unknown"));
+        assert_eq!(event.version, None);
     }
 }

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -718,19 +718,12 @@ fn union_region_rects(regions: &[ImageTextRegion]) -> Option<NormalizedImageRect
 fn image_secret_findings(
     _bytes: &[u8],
     _key: &[u8; 32],
-    cfg: &ImageOcrConfig,
+    _cfg: &ImageOcrConfig,
 ) -> Result<ImageSecretFindings, String> {
-    if matches!(cfg.mode, crate::config::ImageOcrMode::Off) {
-        Ok(ImageSecretFindings {
-            findings: Vec::new(),
-            scan_failure: None,
-        })
-    } else {
-        Ok(ImageSecretFindings {
-            findings: Vec::new(),
-            scan_failure: Some("disabled"),
-        })
-    }
+    Ok(ImageSecretFindings {
+        findings: Vec::new(),
+        scan_failure: Some("disabled"),
+    })
 }
 
 fn ocr_failure_kind(error: &str) -> &'static str {
@@ -3036,6 +3029,16 @@ mod tests {
             fetch_seconds: 8,
             unscanned_images: UnscannedImagePolicy::Allow,
         }
+    }
+
+    #[cfg(not(feature = "ocr"))]
+    #[test]
+    fn disabled_build_never_reports_an_image_as_scanned() {
+        let mut cfg = test_config();
+        cfg.mode = ImageOcrMode::Off;
+        let findings = image_secret_findings(&[], &[7; 32], &cfg).unwrap();
+        assert_eq!(findings.scan_failure, Some("disabled"));
+        assert!(findings.is_empty());
     }
 
     #[cfg(feature = "ocr")]

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -1,8 +1,8 @@
 #[cfg(any(feature = "ocr", test))]
 use crate::config;
-use crate::config::ImageOcrConfig;
 #[cfg(feature = "ocr")]
 use crate::config::{image_ocr_config, ImageOcrMode, ImageRedactionStyle};
+use crate::config::{ImageOcrConfig, UnscannedImagePolicy};
 #[cfg(any(feature = "ocr", test))]
 use pentect_core::model::labels;
 #[cfg(any(feature = "ocr", test))]
@@ -98,6 +98,20 @@ struct ImageSecretFinding {
     redact_pixels: bool,
 }
 
+#[derive(Debug)]
+struct ImageSecretFindings {
+    findings: Vec<ImageSecretFinding>,
+    scan_failure: Option<&'static str>,
+}
+
+impl std::ops::Deref for ImageSecretFindings {
+    type Target = [ImageSecretFinding];
+
+    fn deref(&self) -> &Self::Target {
+        &self.findings
+    }
+}
+
 #[cfg(any(feature = "ocr", test))]
 #[derive(Clone, Debug)]
 struct ImageTextSecretHit {
@@ -184,6 +198,12 @@ pub(crate) fn inspect_tool_images_for_secrets(
         started_at: std::time::Instant::now(),
     };
     collect_image_inspection(value, key, cfg, &mut inspection)?;
+    record_ocr_outcomes(
+        inspection.scanned_images,
+        inspection.unscanned_images,
+        inspection.ocr_failures,
+        cfg,
+    );
     Ok(inspection)
 }
 
@@ -203,6 +223,12 @@ pub(crate) fn redact_tool_images_for_secrets(
         notes: Vec::new(),
     };
     let updated = redact_image_value(value, key, cfg, &mut state)?;
+    record_ocr_outcomes(
+        state.scanned_images,
+        state.unscanned_images,
+        state.ocr_failures,
+        cfg,
+    );
     Ok(ImageRedaction {
         changed: updated != *value,
         updated,
@@ -297,9 +323,19 @@ fn inspect_image_bytes(
     }
     inspection.scanned_images += 1;
     match image_secret_findings(bytes, key, cfg) {
-        Ok(findings) if !findings.is_empty() => inspection.secret_images += 1,
-        Ok(_) => {}
-        Err(_) => inspection.ocr_failures += 1,
+        Ok(findings) => {
+            if let Some(kind) = findings.scan_failure {
+                inspection.ocr_failures += 1;
+                record_ocr_failure(kind);
+            }
+            if !findings.is_empty() {
+                inspection.secret_images += 1;
+            }
+        }
+        Err(_) => {
+            inspection.ocr_failures += 1;
+            record_ocr_failure("protection");
+        }
     }
 }
 
@@ -548,9 +584,16 @@ fn redact_image_bytes(
     state.scanned_images += 1;
 
     let findings = match image_secret_findings(bytes, key, cfg) {
-        Ok(findings) => findings,
+        Ok(findings) => {
+            if let Some(kind) = findings.scan_failure {
+                state.ocr_failures += 1;
+                record_ocr_failure(kind);
+            }
+            findings.findings
+        }
         Err(_) => {
             state.ocr_failures += 1;
+            record_ocr_failure("protection");
             Vec::new()
         }
     };
@@ -574,7 +617,7 @@ fn image_secret_findings(
     bytes: &[u8],
     key: &[u8; 32],
     cfg: &ImageOcrConfig,
-) -> Result<Vec<ImageSecretFinding>, String> {
+) -> Result<ImageSecretFindings, String> {
     let mut findings = Vec::new();
     for region in image_metadata_regions(bytes) {
         for hit in image_text_secret_hits(&region.text, key)? {
@@ -613,8 +656,12 @@ fn image_secret_findings(
 
     let ocr_regions = match ocr_image_regions_with_config(bytes, cfg) {
         Ok(regions) => regions,
-        Err(err) if findings.is_empty() => return Err(err),
-        Err(_) => return Ok(findings),
+        Err(err) => {
+            return Ok(ImageSecretFindings {
+                findings,
+                scan_failure: Some(ocr_failure_kind(&err)),
+            });
+        }
     };
     for region in &ocr_regions {
         for hit in image_text_secret_hits(&region.text, key)? {
@@ -649,7 +696,10 @@ fn image_secret_findings(
             redact_pixels: true,
         });
     }
-    Ok(findings)
+    Ok(ImageSecretFindings {
+        findings,
+        scan_failure: None,
+    })
 }
 
 #[cfg(feature = "ocr")]
@@ -669,11 +719,127 @@ fn image_secret_findings(
     _bytes: &[u8],
     _key: &[u8; 32],
     cfg: &ImageOcrConfig,
-) -> Result<Vec<ImageSecretFinding>, String> {
+) -> Result<ImageSecretFindings, String> {
     if matches!(cfg.mode, crate::config::ImageOcrMode::Off) {
-        Ok(Vec::new())
+        Ok(ImageSecretFindings {
+            findings: Vec::new(),
+            scan_failure: None,
+        })
     } else {
-        Err("image OCR requires a build with `--features ocr`".to_string())
+        Ok(ImageSecretFindings {
+            findings: Vec::new(),
+            scan_failure: Some("disabled"),
+        })
+    }
+}
+
+fn ocr_failure_kind(error: &str) -> &'static str {
+    let error = error.to_ascii_lowercase();
+    if error.contains("disabled") || error.contains("requires a build") {
+        "disabled"
+    } else if error.contains("not supported") {
+        "unsupported"
+    } else if error.contains("decode") {
+        "decode"
+    } else if error.contains("pixels; limit") || error.contains("image limit") {
+        "limit"
+    } else if error.contains("load ocr") {
+        "model-load"
+    } else if error.contains("initialize") {
+        "initialize"
+    } else if error.contains("prepare") || error.contains("preprocess") {
+        "preprocess"
+    } else if error.contains("detect ocr") || error.contains("ocr image") {
+        "recognition"
+    } else {
+        "unclassified"
+    }
+}
+
+fn record_ocr_failure(kind: &'static str) {
+    crate::activity_log::record_structured(
+        "warning",
+        "ocr",
+        "scan-failed",
+        Some(kind),
+        Some(ocr_status()),
+        Some("SCAN"),
+        None,
+        Some(matches!(kind, "initialize" | "preprocess" | "recognition")),
+        None,
+        1,
+    );
+}
+
+pub(crate) fn record_direct_ocr_outcome(result: &Result<String, String>) {
+    match result {
+        Ok(_) => crate::activity_log::record_structured(
+            "diagnostic",
+            "ocr",
+            "scan-complete",
+            Some(ocr_status()),
+            Some("image"),
+            Some("SCAN"),
+            None,
+            Some(false),
+            None,
+            1,
+        ),
+        Err(error) => record_ocr_failure(ocr_failure_kind(error)),
+    }
+}
+
+fn record_ocr_outcomes(scanned: usize, unscanned: usize, failures: usize, cfg: &ImageOcrConfig) {
+    let completed = scanned.saturating_sub(failures);
+    if completed > 0 {
+        crate::activity_log::record_structured(
+            "diagnostic",
+            "ocr",
+            "scan-complete",
+            Some(ocr_status()),
+            Some("image"),
+            Some("SCAN"),
+            None,
+            Some(false),
+            None,
+            completed as u64,
+        );
+    }
+    if unscanned > 0 {
+        let event = match cfg.unscanned_images {
+            UnscannedImagePolicy::Block => "scan-unavailable-blocked",
+            UnscannedImagePolicy::Allow => "scan-unavailable-allowed",
+        };
+        crate::activity_log::record_structured(
+            "warning",
+            "ocr",
+            event,
+            Some("source-or-limit"),
+            Some(ocr_status()),
+            Some("SCAN"),
+            None,
+            Some(false),
+            None,
+            unscanned as u64,
+        );
+    }
+    if failures > 0 {
+        let event = match cfg.unscanned_images {
+            UnscannedImagePolicy::Block => "scan-failure-blocked",
+            UnscannedImagePolicy::Allow => "scan-failure-allowed",
+        };
+        crate::activity_log::record_structured(
+            "warning",
+            "ocr",
+            event,
+            Some("policy"),
+            Some(ocr_status()),
+            Some("SCAN"),
+            None,
+            Some(false),
+            None,
+            failures as u64,
+        );
     }
 }
 
@@ -3095,6 +3261,22 @@ mod tests {
             .find(|finding| finding.labels.iter().any(|label| label == "OPENAI_API_KEY"))
             .unwrap_or_else(|| panic!("missing EXIF secret finding: {findings:?}"));
         assert!(!exif_finding.redact_pixels);
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn metadata_finding_does_not_hide_an_ocr_failure() {
+        let app1 = exif_text_payload("OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX");
+        let jpeg = solid_jpeg_with_app1(&app1);
+        let mut cfg = metadata_test_config();
+        cfg.max_pixels = 1;
+
+        let findings = image_secret_findings(&jpeg, &[7; 32], &cfg).unwrap();
+
+        assert!(findings
+            .iter()
+            .any(|finding| finding.labels.iter().any(|label| label == "OPENAI_API_KEY")));
+        assert_eq!(findings.scan_failure, Some("limit"));
     }
 
     #[cfg(feature = "ocr")]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -168,12 +168,32 @@ pub fn record_read_activity(result: &MaskResult, path: &Path) {
 }
 
 pub fn record_diagnostic_activity(surface: &str, reason: &str) {
-    activity_log::record_summary(
-        "warning",
+    activity_log::record_diagnostic(surface, reason, None, None, None, None, None, None);
+}
+
+/// Persist a value-free, structured HTTP gateway diagnostic. Every text field
+/// must be a fixed classifier, never a URL, header, request body, response
+/// body, command argument, or raw error message.
+#[allow(clippy::too_many_arguments)]
+pub fn record_http_diagnostic_activity(
+    surface: &str,
+    event: &str,
+    kind: &str,
+    endpoint: &str,
+    method: &str,
+    status: Option<u16>,
+    retryable: bool,
+    version: &str,
+) {
+    activity_log::record_diagnostic(
         surface,
-        1,
-        BTreeMap::from([(reason.to_string(), 1)]),
-        None,
+        event,
+        Some(kind),
+        Some(endpoint),
+        Some(method),
+        status,
+        Some(retryable),
+        Some(version),
     );
 }
 
@@ -228,7 +248,9 @@ fn mask_input_into_memory_store_client(
 }
 
 pub fn ocr_image_bytes(bytes: &[u8]) -> Result<String, String> {
-    image_ocr::ocr_image_bytes(bytes)
+    let result = image_ocr::ocr_image_bytes(bytes);
+    image_ocr::record_direct_ocr_outcome(&result);
+    result
 }
 
 pub fn ocr_status() -> &'static str {

--- a/tools/install_portable_client_smoke.py
+++ b/tools/install_portable_client_smoke.py
@@ -30,11 +30,11 @@ LATEST_CLIENTS = (
 )
 
 RELEASE_CLIENTS = (
-    "@anthropic-ai/claude-code@2.1.237",
-    "opencode-ai@1.18.19",
+    "@anthropic-ai/claude-code@2.1.238",
+    "opencode-ai@1.18.20",
     "@earendil-works/pi-coding-agent@0.84.2",
     "@continuedev/cli@1.5.47",
-    "cline@3.0.55",
+    "cline@3.0.56",
     "@google/gemini-cli@0.56.0",
 )
 
@@ -131,7 +131,7 @@ def main() -> int:
     parser.add_argument("--only", choices=("codex",), help=argparse.SUPPRESS)
     args = parser.parse_args()
 
-    codex = latest_installable_codex() if args.mode == "latest" else "@openai/codex@0.148.0"
+    codex = latest_installable_codex() if args.mode == "latest" else "@openai/codex@0.149.0"
     install(codex)
     if args.only != "codex":
         for client in LATEST_CLIENTS if args.mode == "latest" else RELEASE_CLIENTS:

--- a/website/src/content/docs/protection/files-and-images.md
+++ b/website/src/content/docs/protection/files-and-images.md
@@ -59,6 +59,11 @@ When OCR is enabled, it runs on your computer and Pentect covers detected
 sensitive areas before sending the image. Limits control the number of images,
 file size, image size, download time, and total check time.
 
+Windows uses Windows OCR, macOS uses Vision, and Linux uses Pentect's bundled
+local OCR engine and model files. Linux does not require a separately installed
+Tesseract service. `pentect doctor` reports the selected backend as `windows`,
+`macos`, or `bundled`.
+
 This also applies when a supported browser or MCP tool returns a screenshot as
 part of a tool result. Pentect applies the configured image policy before that
 result enters the next provider request. If the tool also returns page text, HTML, clipboard

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -10,14 +10,14 @@ drift is visible before the next release.
 
 | Client | Test | Protected launch |
 | --- | --- | --- |
-| Codex CLI `0.148.0` | Real launch on Linux and all installer platforms | `pentect codex` |
-| Claude Code `2.1.237` | Real launch on Linux and all installer platforms | `pentect claude` |
-| OpenCode `1.18.19` | Real launch on Linux and all installer platforms | `pentect opencode` |
+| Codex CLI `0.149.0` | Real launch on Linux and all installer platforms | `pentect codex` |
+| Claude Code `2.1.238` | Real launch on Linux and all installer platforms | `pentect claude` |
+| OpenCode `1.18.20` | Real launch on Linux and all installer platforms | `pentect opencode` |
 | Pi `0.84.2` | Real launch, npm extension, and provider discovery | `pentect pi` or `@pentect/pi` |
 | Antigravity CLI `1.1.17` | Real launch plus Cloud Code protocol tests | `pentect antigravity` |
 | Aider `0.86.2` | Real launch and OpenAI-compatible route tests | `pentect aider` |
 | Continue CLI `1.5.47` | Real launch and Chat/Edit/Apply route tests | `pentect continue` |
-| Cline CLI `3.0.55` | Real launch, isolated provider registry, streaming, and tools | `pentect cline` |
+| Cline CLI `3.0.56` | Real launch, isolated provider registry, streaming, and tools | `pentect cline` |
 | Roo Code `3.54.0` | Real VS Code extension launch and built-in Roo modes | `pentect roo` |
 | Zed `1.16.1` | Real launch and isolated Agent/Inline Assistant settings | `pentect zed` |
 | Goose CLI `1.46.0` | Real launch and main/fast/planner model routing | `pentect goose` |

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -192,6 +192,17 @@ before following live events, `--json` keeps the JSONL representation, and
 version, OS, architecture, PID, source location, and a backtrace so a crash can
 be investigated after the process exits.
 
+Gateway warnings include a fixed endpoint class, HTTP method, status, retry
+hint, PID, OS, and architecture. OCR entries report the backend and a fixed
+outcome such as `scan-complete`, `scan-failed kind=decode`, or
+`scan-unavailable-blocked`. They never include URLs, image bytes, recognized
+text, or raw provider/OCR errors.
+
+Repeated diagnostics with the same safe fields are combined into one entry
+every five seconds. The entry's count and `span_ms` show how many times it
+occurred and over what interval, so a retry loop remains visible without
+writing one line per attempt.
+
 Writes are handled by a bounded background queue and flushed in batches of up
 to 64 events, 64 KiB, or 250 ms. The file rotates at 128 MiB and keeps 31
 older generations (`pentect.log.1` through `pentect.log.31`), for a maximum of

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -59,9 +59,9 @@ Use the complete name from the current handle. For example:
 PENTECT_KAGGLE_API_TOKEN_b818890b85f7482a
 ```
 
-In PowerShell, reference it as
-`$env:PENTECT_KAGGLE_API_TOKEN_b818890b85f7482a`. In Bash or Zsh, use
-`$PENTECT_KAGGLE_API_TOKEN_b818890b85f7482a`.
+For a handle written as `<<LABEL_ID>>`, reference `$env:PENTECT_LABEL_ID` in
+PowerShell or `${PENTECT_LABEL_ID}` in Bash and Zsh. The angle brackets belong
+only to the handle, not to the environment variable name.
 
 If the command output shows another handle instead of the value, masking worked.
 Do not use `echo` as a test. Test the intended API call with a fake credential
@@ -192,10 +192,10 @@ before following live events, `--json` keeps the JSONL representation, and
 version, OS, architecture, PID, source location, and a backtrace so a crash can
 be investigated after the process exits.
 
-Gateway warnings include a fixed endpoint class, HTTP method, status, retry
-hint, PID, OS, and architecture. OCR entries report the backend and a fixed
-outcome such as `scan-complete`, `scan-failed kind=decode`, or
-`scan-unavailable-blocked`. They never include URLs, image bytes, recognized
+Gateway warnings include a fixed endpoint class, HTTP method, retry hint, PID,
+OS, and architecture, and can include an HTTP status. OCR entries report the
+backend and a fixed outcome such as `scan-complete`, `scan-failed kind=decode`,
+or `scan-unavailable-blocked`. They never include URLs, image bytes, recognized
 text, or raw provider/OCR errors.
 
 Repeated diagnostics with the same safe fields are combined into one entry

--- a/website/src/content/docs/start/handles.md
+++ b/website/src/content/docs/start/handles.md
@@ -29,21 +29,22 @@ identity key stays on the local device.
 
 ## How a tool uses a handle
 
-Protected launches provide an environment binding for each handle. The binding
-name is `PENTECT_` followed by the text inside the handle:
+Protected launches provide an environment binding for each handle. Remove the
+angle brackets and add `PENTECT_` to the handle's label and ID. For example,
+`<<DATABASE_URL_ID>>` maps to `PENTECT_DATABASE_URL_ID`:
 
 ::: code-group
 
 ```powershell [PowerShell]
-# Handle: <<DATABASE_URL_4ce8a3b0a6f64e12>>
+# Handle: <<DATABASE_URL_ID>>
 irm https://api.example.test/status `
-  -Headers @{ Authorization = "Bearer $env:PENTECT_DATABASE_URL_4ce8a3b0a6f64e12" }
+  -Headers @{ Authorization = "Bearer $env:PENTECT_DATABASE_URL_ID" }
 ```
 
 ```sh [Bash / Zsh]
-# Handle: <<DATABASE_URL_4ce8a3b0a6f64e12>>
+# Handle: <<DATABASE_URL_ID>>
 curl https://api.example.test/status \
-  -H "Authorization: Bearer $PENTECT_DATABASE_URL_4ce8a3b0a6f64e12"
+  -H "Authorization: Bearer ${PENTECT_DATABASE_URL_ID}"
 ```
 
 :::
@@ -54,7 +55,8 @@ placing the real value in the command text.
 
 Do not assign the binding to a normal variable in one tool call and expect a
 later tool call to keep it. Agent shells may be separate processes. Reference
-the binding in each command that needs it.
+the complete binding literally in each command that needs it; do not construct
+its name dynamically or print it first.
 
 ## Lifetime and stability
 

--- a/website/src/content/docs/start/how-it-works.md
+++ b/website/src/content/docs/start/how-it-works.md
@@ -28,7 +28,7 @@ requests and responses without changing the client UI.
    does not need the real value. Protected launches also provide a local
    environment binding such as
    `$env:PENTECT_KAGGLE_API_TOKEN_85268c441f88c284` in PowerShell or
-   `$PENTECT_KAGGLE_API_TOKEN_85268c441f88c284` in a POSIX shell.
+   `${PENTECT_KAGGLE_API_TOKEN_85268c441f88c284}` in a POSIX shell.
 
 4. **Restore only before a local tool runs**
 

--- a/website/src/content/docs/start/quick-start.md
+++ b/website/src/content/docs/start/quick-start.md
@@ -34,9 +34,10 @@ settings of Codex or Claude.
    `<<DATABASE_URL_4ce8a3b0a6f64e12>>` instead of the real value.
 
    When the agent needs the value in a shell command, it can use the matching
-   `PENTECT_DATABASE_URL_4ce8a3b0a6f64e12` environment binding. Pentect adds
-   the binding to the protected tool process; it is not a permanent user
-   environment variable.
+   `$env:PENTECT_LABEL_ID` PowerShell binding or `${PENTECT_LABEL_ID}` POSIX
+   binding for a `<<LABEL_ID>>` handle. Pentect adds the binding to the
+   protected tool process; it is not a permanent user environment variable.
+   See [Handles](/start/handles/) for the exact syntax.
 
 4. Watch local protection events when you need to verify a flow.
 
@@ -84,15 +85,22 @@ pentect codex exec --full-auto
 pentect claude --model sonnet
 ```
 
-The same launch pattern works for other supported clients:
+The same launch pattern works for other supported clients. The complete,
+release-tested matrix is on the [Compatibility](/reference/compatibility/) page:
 
 | Client | Command |
 | --- | --- |
+| OpenCode | `pentect opencode` |
+| Pi | `pentect pi` |
+| Antigravity CLI | `pentect antigravity` |
+| Aider | `pentect aider` |
 | Continue CLI | `pentect continue` |
 | Cline CLI | `pentect cline` |
+| Roo Code | `pentect roo` |
 | Zed | `pentect zed` |
 | Goose CLI | `pentect goose` |
 | Junie CLI | `pentect junie` |
+| Gemini CLI | `pentect gemini` |
 
 Each command protects a specific surface. Check the client page before you
 use desktop, autocomplete, or external-agent features.

--- a/website/src/content/docs/start/what-is-pentect.md
+++ b/website/src/content/docs/start/what-is-pentect.md
@@ -51,9 +51,10 @@ that process only.
 ## Supported surfaces
 
 Pentect supports named CLI, editor, and desktop surfaces. These include Codex,
-Claude, OpenCode, Pi, Antigravity, Aider, Continue, Cline, Zed,
-Goose and Junie. It also offers local
-masking commands, custom gateways, and safe plugins.
+Claude, OpenCode, Pi, Antigravity, Aider, Continue, Cline, Roo Code, Zed,
+Goose, Junie, and Gemini CLI, plus supported Codex App and Claude Desktop
+routes. It also offers local masking commands, custom gateways, and safe
+plugins.
 
 See [Compatibility](/reference/compatibility/) for the release-tested matrix.
 


### PR DESCRIPTION
## Summary
- replace repeated value-free gateway warnings with structured endpoint/method/status/retry diagnostics aggregated every five seconds
- persist provider/OCR failure categories without URLs, bodies, recognized text, credentials, or raw errors
- log OCR backend/outcomes and preserve OCR failures even when metadata or barcode findings already exist, keeping the default fail-closed policy effective
- refresh current client compatibility pins, supported-client docs, handle environment-binding syntax, Linux OCR behavior, and diagnostic retention/batching documentation

Closes #289
Closes #293

## Validation
- `env -u PENTECT_MEMORY_STORE_ADDR -u PENTECT_MEMORY_STORE_TOKEN cargo test --workspace --all-targets`
- `cargo test -p pentect-runtime --no-default-features --lib`
- `cargo check -p pentect-cli --no-default-features`
- `cargo clippy -p pentect-cli --all-targets -- -D warnings`
- `npm --prefix website run build`
- `python tools/test_client_smoke_coverage.py`
- real Linux bundled OCR against `website/public/pentect-logo.png`, including persisted success and invalid-image failure diagnostics