### PR TITLE
Prepare v0.0.45 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.44"
+version = "0.0.45"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
Bump the Rust CLI and npm package versions to v0.0.45 after the logging, OCR, fail-closed, and documentation fixes merged in #292.\n\nValidation:\n- cargo fmt --all --check\n- cargo check --locked -p pentect-cli\n- npm pack --dry-run --json