### PR TITLE
Prepare v0.0.46 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.45"
+version = "0.0.46"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.45"
+version = "0.0.46"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump the Pentect CLI, npm package, and lockfile to v0.0.46
- release the four-client public surface and diagnostics/install fixes already merged to main

## Validation
- `cargo check -p pentect-cli`
- `npm pack --dry-run --json`
- built CLI reports `pentect 0.0.46`