### PR TITLE
Fix OpenAI Privacy Filter venv startup

### DIFF
--- a/plugins/openai-privacy-filter/server.py
+++ b/plugins/openai-privacy-filter/server.py
@@ -29,7 +29,13 @@ def _use_managed_python() -> None:
     except OSError:
         return
     if current != managed:
-        os.execv(str(managed), [str(managed), str(Path(__file__).resolve()), *sys.argv[1:]])
+        # Execute through the venv path rather than its resolved interpreter.
+        # Python discovers pyvenv.cfg from the executable path; bypassing the
+        # symlink starts the base interpreter without the venv's packages.
+        os.execv(
+            str(candidate),
+            [str(candidate), str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
 
 
 def _byte_offset(text: str, character_offset: int) -> int:

--- a/plugins/openai-privacy-filter/tests/test_server.py
+++ b/plugins/openai-privacy-filter/tests/test_server.py
@@ -1,7 +1,10 @@
 import importlib.util
+import os
 from pathlib import Path
+import tempfile
 from types import SimpleNamespace
 import unittest
+from unittest import mock
 
 
 SERVER_PATH = Path(__file__).parents[1] / "server.py"
@@ -18,6 +21,35 @@ class Redactor:
 
 
 class ServerTests(unittest.TestCase):
+    @unittest.skipIf(os.name == "nt", "symlink behavior is covered on POSIX")
+    def test_managed_python_executes_through_venv_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            runtime = home / "runtime" / "python"
+            runtime.parent.mkdir()
+            runtime.touch()
+            candidate = (
+                home
+                / ".pentect"
+                / "openai-privacy-filter"
+                / "venv"
+                / "bin"
+                / "python"
+            )
+            candidate.parent.mkdir(parents=True)
+            candidate.symlink_to(runtime)
+
+            with (
+                mock.patch.object(SERVER.Path, "home", return_value=home),
+                mock.patch.object(SERVER.sys, "executable", "/usr/bin/python3"),
+                mock.patch.object(SERVER.os, "execv") as execv,
+            ):
+                SERVER._use_managed_python()
+
+            executable, arguments = execv.call_args.args
+            self.assertEqual(executable, str(candidate))
+            self.assertEqual(arguments[0], str(candidate))
+
     def test_offsets_are_utf8_bytes(self) -> None:
         result = SERVER.inspect_text(Redactor(), "AéZ")
         self.assertEqual(


### PR DESCRIPTION
## Summary
- execute the managed Python through its venv path instead of the resolved base interpreter
- add a symlink regression test for venv package discovery

## Validation
- `python3 -m unittest discover plugins/openai-privacy-filter/tests`
- real OPF model load and JSONL inference through system Python -> managed venv

The previous path resolution bypassed `pyvenv.cfg`, causing `ModuleNotFoundError: opf` after the documented installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed Python environment handling to preserve virtual-environment package discovery when launching the privacy filter.

* **Tests**
  * Added coverage verifying that the managed environment launches through the correct virtual-environment path on POSIX systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->