### PR TITLE
Default plugin installs to user scope

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -7,17 +7,19 @@ Use a regex plugin for a stable value pattern. Use Wasm when you need context,
 policy logic, provider JSON, or an approved HTTP call. Normal Pentect secret
 and structured-data checks are built in and cannot be disabled by a plugin.
 
-Install and enable a plugin for the current project:
+Install and enable a plugin for the current user on this computer:
 
 ```text
 pentect plugins add github:@owner/repository/path
 ```
 
-The same configured plugin set is used by `mask`, `read`, Codex,
+The user plugin set is stored in `~/.pentect/config.toml` and is used by
+`mask`, `read`, Codex,
 Claude Code, and their desktop-app launchers. Use `--plugins SOURCE` only for a
 one-off addition. A one-off remote source must use a full 40-character Git
-commit; tags require a project content lock because Git does not make tags
-immutable.
+commit; tags require a content lock because Git does not make tags immutable.
+Pass `--project` to `add`, `remove`, `config`, `setup`, or `update` when the
+plugin and its approval must be isolated to the current repository.
 
 ```text
 pentect plugins new NAME
@@ -48,8 +50,9 @@ First-party examples are listed by `pentect plugins search`:
 - `openai-privacy-filter` connects a sandboxed adapter to OpenAI Privacy Filter
   running on `127.0.0.1`. It is optional and is not enabled automatically.
 
-Remote manifests and detector files are pinned by content digest in the
-project's `pentect.plugins.lock`. Commit it. Prefer an explicit release such as
+Remote manifests and detector files are pinned by content digest in
+`~/.pentect/pentect.plugins.lock`. Project-scoped installs instead use the
+repository's `pentect.plugins.lock`, which should be committed. Prefer an explicit release such as
 `github:@owner/repository/path@v1.2.3`; an unversioned `main` source is never
 used as runtime identity. Sources change only through an explicit `add`,
 `setup`, or `update`, never merely because a cache timer expired.

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -2226,6 +2226,8 @@ mod tests {
                 ("PENTECT_HOME", Some(home.as_os_str().to_owned())),
                 (crate::plugins::CONFIGS_ENV, None),
                 (crate::plugins::BINARIES_ENV, None),
+                (crate::plugins::GLOBAL_BINARIES_ENV, None),
+                (crate::plugins::GLOBAL_BINARY_IDS_ENV, None),
             ]);
             let process_host_candidate = Some(
                 pentect_agent::register_process_host_candidate(

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -525,9 +525,29 @@ fn cmd_agent_from(start: usize, args: &[String], inherited_env_is_trusted: bool)
             .then(|| std::env::var_os(plugins::BINARIES_ENV))
             .flatten()
     });
+    let global_binary_env = match active_plugins.global_binary_env_value() {
+        Ok(value) => value,
+        Err(e) => die(&e),
+    }
+    .or_else(|| {
+        inherited_env_is_trusted
+            .then(|| std::env::var_os(plugins::GLOBAL_BINARIES_ENV))
+            .flatten()
+    });
+    let global_binary_ids_env = match active_plugins.global_binary_ids_env_value() {
+        Ok(value) => value,
+        Err(e) => die(&e),
+    }
+    .or_else(|| {
+        inherited_env_is_trusted
+            .then(|| std::env::var_os(plugins::GLOBAL_BINARY_IDS_ENV))
+            .flatten()
+    });
     let plugin_env = EnvVarGuard::set_optional([
         (plugins::CONFIGS_ENV, config_env),
         (plugins::BINARIES_ENV, binary_env),
+        (plugins::GLOBAL_BINARIES_ENV, global_binary_env),
+        (plugins::GLOBAL_BINARY_IDS_ENV, global_binary_ids_env),
     ]);
     let mut agent_args = Vec::with_capacity(forward_args.len() + 1);
     agent_args.push(
@@ -755,6 +775,18 @@ fn app_plugin_env_guard(args: &[String]) -> Result<EnvVarGuard, String> {
                 .binary_env_value()
                 .map_err(|error| error.to_string())?,
         ),
+        (
+            plugins::GLOBAL_BINARIES_ENV,
+            active
+                .global_binary_env_value()
+                .map_err(|error| error.to_string())?,
+        ),
+        (
+            plugins::GLOBAL_BINARY_IDS_ENV,
+            active
+                .global_binary_ids_env_value()
+                .map_err(|error| error.to_string())?,
+        ),
     ]))
 }
 
@@ -820,6 +852,18 @@ fn cmd_mask(args: &[String]) {
             plugins::BINARIES_ENV,
             active_plugins
                 .binary_env_value()
+                .unwrap_or_else(|error| die(error)),
+        ),
+        (
+            plugins::GLOBAL_BINARIES_ENV,
+            active_plugins
+                .global_binary_env_value()
+                .unwrap_or_else(|error| die(error)),
+        ),
+        (
+            plugins::GLOBAL_BINARY_IDS_ENV,
+            active_plugins
+                .global_binary_ids_env_value()
                 .unwrap_or_else(|error| die(error)),
         ),
     ]);
@@ -943,9 +987,19 @@ fn cmd_read(args: &[String]) {
         Ok(value) => value,
         Err(e) => die(&e),
     };
+    let global_binary_env = match active_plugins.global_binary_env_value() {
+        Ok(value) => value,
+        Err(e) => die(&e),
+    };
+    let global_binary_ids_env = match active_plugins.global_binary_ids_env_value() {
+        Ok(value) => value,
+        Err(e) => die(&e),
+    };
     let _plugin_env = EnvVarGuard::set_optional([
         (plugins::CONFIGS_ENV, config_env),
         (plugins::BINARIES_ENV, binary_env),
+        (plugins::GLOBAL_BINARIES_ENV, global_binary_env),
+        (plugins::GLOBAL_BINARY_IDS_ENV, global_binary_ids_env),
     ]);
     let input = Input { kind, data };
     match pentect_agent::mask_input_into_active_memory_store(
@@ -2138,6 +2192,12 @@ fn agent_parent_env_guard(
     let binary_env = active_plugins
         .binary_env_value()
         .map_err(|e| e.to_string())?;
+    let global_binary_env = active_plugins
+        .global_binary_env_value()
+        .map_err(|e| e.to_string())?;
+    let global_binary_ids_env = active_plugins
+        .global_binary_ids_env_value()
+        .map_err(|e| e.to_string())?;
     Ok(EnvVarGuard::set_optional([
         (
             PENTECT_MEMORY_STORE_ADDR_ENV,
@@ -2154,6 +2214,8 @@ fn agent_parent_env_guard(
         ),
         (plugins::CONFIGS_ENV, config_env),
         (plugins::BINARIES_ENV, binary_env),
+        (plugins::GLOBAL_BINARIES_ENV, global_binary_env),
+        (plugins::GLOBAL_BINARY_IDS_ENV, global_binary_ids_env),
     ]))
 }
 
@@ -2566,6 +2628,18 @@ fn apply_plugin_env(cmd: &mut Command, active: &plugins::ActivePlugins) -> Resul
     }
     if let Some(value) = active.binary_env_value().map_err(|e| e.to_string())? {
         cmd.env(plugins::BINARIES_ENV, value);
+    }
+    if let Some(value) = active
+        .global_binary_env_value()
+        .map_err(|e| e.to_string())?
+    {
+        cmd.env(plugins::GLOBAL_BINARIES_ENV, value);
+    }
+    if let Some(value) = active
+        .global_binary_ids_env_value()
+        .map_err(|e| e.to_string())?
+    {
+        cmd.env(plugins::GLOBAL_BINARY_IDS_ENV, value);
     }
     Ok(())
 }

--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, SystemTime};
 
 pub(crate) const CONFIGS_ENV: &str = "PENTECT_PLUGIN_CONFIGS";
 pub(crate) const BINARIES_ENV: &str = "PENTECT_PLUGIN_BINARIES";
+pub(crate) const GLOBAL_BINARIES_ENV: &str = "PENTECT_GLOBAL_PLUGIN_BINARIES";
+pub(crate) const GLOBAL_BINARY_IDS_ENV: &str = "PENTECT_GLOBAL_PLUGIN_IDS";
 pub(crate) const PLUGIN_MANIFEST_FILE: &str = "plugin.toml";
 
 const PENTECT_DIR: &str = ".pentect";
@@ -33,10 +35,18 @@ const MAX_REMOTE_PLUGIN_CACHE_ENTRIES: usize = 256;
 const MAX_PROJECT_PLUGIN_LOCK_BYTES: u64 = 1024 * 1024;
 static PROJECT_LOCK_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PluginScope {
+    User,
+    Project,
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct ActivePlugins {
     config_paths: Vec<PathBuf>,
     binary_paths: Vec<PathBuf>,
+    global_binary_paths: Vec<PathBuf>,
+    global_binary_ids: Vec<PathBuf>,
 }
 
 #[derive(Clone, Debug)]
@@ -45,6 +55,8 @@ pub(crate) struct PluginSource {
     pub(crate) manifest_path: Option<PathBuf>,
     pub(crate) repository: Option<String>,
     pub(crate) remote_base: Option<String>,
+    pub(crate) scope: PluginScope,
+    pub(crate) runtime_id: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -84,6 +96,10 @@ impl ActivePlugins {
         &self.binary_paths
     }
 
+    pub(crate) fn has_binary(&self) -> bool {
+        !self.binary_paths.is_empty() || !self.global_binary_paths.is_empty()
+    }
+
     pub(crate) fn config_env_value(&self) -> Result<Option<OsString>> {
         if self.config_paths.is_empty() {
             return Ok(None);
@@ -100,6 +116,24 @@ impl ActivePlugins {
         std::env::join_paths(&self.binary_paths)
             .map(Some)
             .context("could not encode plugin binary manifests")
+    }
+
+    pub(crate) fn global_binary_env_value(&self) -> Result<Option<OsString>> {
+        if self.global_binary_paths.is_empty() {
+            return Ok(None);
+        }
+        std::env::join_paths(&self.global_binary_paths)
+            .map(Some)
+            .context("could not encode global plugin paths")
+    }
+
+    pub(crate) fn global_binary_ids_env_value(&self) -> Result<Option<OsString>> {
+        if self.global_binary_ids.is_empty() {
+            return Ok(None);
+        }
+        std::env::join_paths(&self.global_binary_ids)
+            .map(Some)
+            .context("could not encode global plugin identities")
     }
 }
 
@@ -119,6 +153,23 @@ pub(crate) fn parse_plugin_value(value: &str) -> Result<Vec<String>> {
         bail!("--plugins requires at least one plugin");
     }
     Ok(specs)
+}
+
+pub(crate) fn plugin_spec_for_scope(spec: &str, scope: PluginScope) -> Result<String> {
+    validate_plugin_spec(spec)?;
+    if scope == PluginScope::User && is_path_spec(spec) {
+        if config_specs_scoped()?
+            .into_iter()
+            .any(|(configured_scope, configured)| configured_scope == scope && configured == spec)
+        {
+            return Ok(spec.to_string());
+        }
+        return Path::new(spec)
+            .canonicalize()
+            .with_context(|| format!("could not resolve plugin path '{spec}'"))
+            .map(|path| path.to_string_lossy().into_owned());
+    }
+    Ok(spec.to_string())
 }
 
 pub(crate) fn collect_from_args(args: &[String]) -> Result<Vec<String>> {
@@ -223,19 +274,38 @@ pub(crate) fn active_from_specs(
     explicit_specs: Vec<String>,
     create_named: bool,
 ) -> Result<ActivePlugins> {
-    let mut specs = config_specs()?;
-    extend_unique(&mut specs, explicit_specs);
-    active_from_explicit_specs(specs, create_named)
+    let mut specs = config_specs_scoped()?;
+    for spec in explicit_specs {
+        if !specs.iter().any(|(_, existing)| existing == &spec) {
+            specs.push((PluginScope::Project, spec));
+        }
+    }
+    active_from_scoped_specs(specs, create_named)
 }
 
 pub(crate) fn active_from_explicit_specs(
     specs: Vec<String>,
     create_named: bool,
 ) -> Result<ActivePlugins> {
-    let (config_paths, binary_paths) = plugin_paths_for_specs(&specs, create_named)?;
+    active_from_scoped_specs(
+        specs
+            .into_iter()
+            .map(|spec| (PluginScope::Project, spec))
+            .collect(),
+        create_named,
+    )
+}
+
+pub(crate) fn active_from_scoped_specs(
+    specs: Vec<(PluginScope, String)>,
+    create_named: bool,
+) -> Result<ActivePlugins> {
+    let paths = plugin_paths_for_scoped_specs(&specs, create_named)?;
     Ok(ActivePlugins {
-        config_paths,
-        binary_paths,
+        config_paths: paths.config_paths,
+        binary_paths: paths.binary_paths,
+        global_binary_paths: paths.global_binary_paths,
+        global_binary_ids: paths.global_binary_ids,
     })
 }
 
@@ -279,11 +349,34 @@ pub(crate) fn load_plugin_config(path: &Path, source: &str) -> Result<Pack, Stri
 }
 
 pub(crate) fn config_specs() -> Result<Vec<String>> {
-    let path = PathBuf::from(PENTECT_DIR).join(PENTECT_CONFIG_FILE);
+    Ok(config_specs_scoped()?
+        .into_iter()
+        .map(|(_, spec)| spec)
+        .collect())
+}
+
+pub(crate) fn config_specs_scoped() -> Result<Vec<(PluginScope, String)>> {
+    let mut specs = Vec::new();
+    for (scope, path) in [
+        (PluginScope::User, user_plugin_config_path()?),
+        (PluginScope::Project, project_plugin_config_path()),
+    ] {
+        for spec in config_specs_at(&path)? {
+            if let Some(existing) = specs.iter_mut().find(|(_, value)| value == &spec) {
+                *existing = (scope, spec);
+            } else {
+                specs.push((scope, spec));
+            }
+        }
+    }
+    Ok(specs)
+}
+
+fn config_specs_at(path: &Path) -> Result<Vec<String>> {
     if !path.exists() {
         return Ok(Vec::new());
     }
-    let src = std::fs::read_to_string(&path)
+    let src = std::fs::read_to_string(path)
         .with_context(|| format!("could not read '{}'", path.display()))?;
     let value = src
         .parse::<toml::Value>()
@@ -292,6 +385,23 @@ pub(crate) fn config_specs() -> Result<Vec<String>> {
         return Ok(Vec::new());
     };
     parse_config_plugins(raw_plugins)
+        .with_context(|| format!("invalid plugin config '{}'", path.display()))
+}
+
+pub(crate) fn project_plugin_config_path() -> PathBuf {
+    PathBuf::from(PENTECT_DIR).join(PENTECT_CONFIG_FILE)
+}
+
+pub(crate) fn user_plugin_config_path() -> Result<PathBuf> {
+    home_dir()
+        .map(|home| home.join(PENTECT_DIR).join(PENTECT_CONFIG_FILE))
+        .ok_or_else(|| anyhow!("could not find a home directory for global Pentect config"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
 }
 
 fn parse_config_plugins(value: &toml::Value) -> Result<Vec<String>> {
@@ -311,33 +421,71 @@ fn parse_config_plugins(value: &toml::Value) -> Result<Vec<String>> {
     }
 }
 
-fn plugin_paths_for_specs(
-    specs: &[String],
+struct ScopedPluginPaths {
+    config_paths: Vec<PathBuf>,
+    binary_paths: Vec<PathBuf>,
+    global_binary_paths: Vec<PathBuf>,
+    global_binary_ids: Vec<PathBuf>,
+}
+
+fn plugin_paths_for_scoped_specs(
+    specs: &[(PluginScope, String)],
     create_named: bool,
-) -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
+) -> Result<ScopedPluginPaths> {
     let mut configs = Vec::new();
     let mut binaries = Vec::new();
-    for spec in specs {
-        let resolved = resolve_configured_plugin_spec(spec)?;
+    let mut global_binaries = Vec::new();
+    let mut global_ids = Vec::new();
+    for (scope, spec) in specs {
+        let resolved = resolve_configured_plugin_spec_in_scope(spec, *scope)?;
         let spec = resolved.as_str();
-        if is_remote_spec(spec) {
+        let found = if is_remote_spec(spec) {
             let found = plugin_paths_for_url(spec)?;
-            verify_project_remote_plugin(spec, &normalize_github_plugin_url(spec)?)?;
-            configs.extend(found.config_paths);
-            binaries.extend(found.binary_paths);
+            verify_remote_plugin(*scope, spec, &normalize_github_plugin_url(spec)?)?;
+            found
         } else if is_path_spec(spec) {
-            let found = plugin_paths_for_path(Path::new(spec))?;
-            configs.extend(found.config_paths);
-            binaries.extend(found.binary_paths);
+            plugin_paths_for_path(Path::new(spec))?
         } else {
-            let found = plugin_paths_for_named(spec, create_named)?;
-            configs.extend(found.config_paths);
-            binaries.extend(found.binary_paths);
+            plugin_paths_for_named_scoped(spec, create_named, *scope)?
+        };
+        configs.extend(found.config_paths);
+        match scope {
+            PluginScope::Project => binaries.extend(found.binary_paths),
+            PluginScope::User => {
+                let runtime_id = plugin_runtime_id(spec);
+                for path in found.binary_paths {
+                    global_binaries.push(path);
+                    global_ids.push(PathBuf::from(&runtime_id));
+                }
+            }
         }
     }
     dedup_paths(&mut configs);
     dedup_paths(&mut binaries);
-    Ok((configs, binaries))
+    let mut seen = std::collections::HashSet::new();
+    let mut index = 0usize;
+    global_binaries.retain(|path| {
+        let keep = seen.insert(path.clone());
+        if !keep {
+            global_ids.remove(index);
+        } else {
+            index += 1;
+        }
+        keep
+    });
+    Ok(ScopedPluginPaths {
+        config_paths: configs,
+        binary_paths: binaries,
+        global_binary_paths: global_binaries,
+        global_binary_ids: global_ids,
+    })
+}
+
+fn plugin_runtime_id(spec: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"pentect-global-plugin-v1");
+    digest.update(spec.as_bytes());
+    data_encoding::HEXLOWER.encode(&digest.finalize()[..16])
 }
 
 fn dedup_paths(paths: &mut Vec<PathBuf>) {
@@ -351,29 +499,41 @@ struct PluginPaths {
     binary_paths: Vec<PathBuf>,
 }
 
+#[cfg(test)]
 fn plugin_paths_for_named(name: &str, _create: bool) -> Result<PluginPaths> {
+    plugin_paths_for_named_scoped(name, _create, PluginScope::Project)
+}
+
+fn plugin_paths_for_named_scoped(
+    name: &str,
+    _create: bool,
+    scope: PluginScope,
+) -> Result<PluginPaths> {
     validate_plugin_name(name)?;
     let project_dir = plugins_root().join(name);
     let official_dir = official_plugins_root().join(name);
 
-    if project_dir.is_dir() {
-        let paths = plugin_paths_in_dir(&project_dir)?;
-        if !paths.is_empty() {
-            return Ok(paths);
+    if scope == PluginScope::Project {
+        if project_dir.is_dir() {
+            let paths = plugin_paths_in_dir(&project_dir)?;
+            if !paths.is_empty() {
+                return Ok(paths);
+            }
         }
-    }
 
-    if official_dir.is_dir() {
-        let paths = plugin_paths_in_dir(&official_dir)?;
-        if !paths.is_empty() {
-            return Ok(paths);
+        if official_dir.is_dir() {
+            let paths = plugin_paths_in_dir(&official_dir)?;
+            if !paths.is_empty() {
+                return Ok(paths);
+            }
         }
     }
 
     let remote_error = if remote_plugins_enabled() {
         match remote_plugin_paths_for_name(name) {
             Ok(paths) if !paths.is_empty() => {
-                verify_project_remote_plugin(
+                verify_remote_plugin(
+                    scope,
                     name,
                     &format!("{DEFAULT_REMOTE_PLUGINS_BASE}/{name}"),
                 )?;
@@ -385,7 +545,7 @@ fn plugin_paths_for_named(name: &str, _create: bool) -> Result<PluginPaths> {
     } else {
         None
     };
-    if project_dir.is_dir() || official_dir.is_dir() {
+    if scope == PluginScope::Project && (project_dir.is_dir() || official_dir.is_dir()) {
         let suggestion_dir = if project_dir.is_dir() {
             &project_dir
         } else {
@@ -402,11 +562,14 @@ fn plugin_paths_for_named(name: &str, _create: bool) -> Result<PluginPaths> {
         bail!(message);
     }
 
-    let mut message = format!(
-        "plugin '{name}' was not found at '{}' or '{}'",
-        project_dir.display(),
-        official_dir.display()
-    );
+    let mut message = match scope {
+        PluginScope::User => format!("global plugin '{name}' was not found in the remote catalog"),
+        PluginScope::Project => format!(
+            "plugin '{name}' was not found at '{}' or '{}'",
+            project_dir.display(),
+            official_dir.display()
+        ),
+    };
     if let Some(error) = remote_error {
         message.push_str(&format!("; remote lookup failed: {error}"));
     }
@@ -537,12 +700,28 @@ fn official_plugins_root() -> PathBuf {
 
 pub(crate) fn plugin_source(spec: &str) -> Result<PluginSource> {
     let spec = resolve_configured_plugin_spec(spec)?;
-    plugin_source_with_refresh(&spec, false)
+    let scope = configured_scope(&spec).unwrap_or(PluginScope::Project);
+    plugin_source_with_refresh(&spec, false, scope)
 }
 
-pub(crate) fn refresh_plugin_source(spec: &str) -> Result<PluginSource> {
-    let spec = resolve_configured_plugin_spec(spec)?;
-    plugin_source_with_refresh(&spec, true)
+pub(crate) fn refresh_plugin_source_in_scope(
+    spec: &str,
+    scope: PluginScope,
+) -> Result<PluginSource> {
+    let spec = resolve_configured_plugin_spec_in_scope(spec, scope)?;
+    plugin_source_with_refresh(&spec, true, scope)
+}
+
+pub(crate) fn plugin_source_in_scope(spec: &str, scope: PluginScope) -> Result<PluginSource> {
+    let spec = resolve_configured_plugin_spec_in_scope(spec, scope)?;
+    plugin_source_with_refresh(&spec, false, scope)
+}
+
+pub(crate) fn configured_scope(spec: &str) -> Option<PluginScope> {
+    config_specs_scoped()
+        .ok()?
+        .into_iter()
+        .find_map(|(scope, configured)| (configured == spec).then_some(scope))
 }
 
 fn resolve_configured_plugin_spec(spec: &str) -> Result<String> {
@@ -555,7 +734,8 @@ fn resolve_configured_plugin_spec(spec: &str) -> Result<String> {
     }
     let mut matches = Vec::new();
     for configured in configured_specs {
-        let Ok(source) = plugin_source_with_refresh(&configured, false) else {
+        let scope = configured_scope(&configured).unwrap_or(PluginScope::Project);
+        let Ok(source) = plugin_source_with_refresh(&configured, false, scope) else {
             continue;
         };
         let manifest_name = source
@@ -592,7 +772,63 @@ fn resolve_configured_plugin_spec(spec: &str) -> Result<String> {
     }
 }
 
-fn plugin_source_with_refresh(spec: &str, refresh: bool) -> Result<PluginSource> {
+fn resolve_configured_plugin_spec_in_scope(spec: &str, scope: PluginScope) -> Result<String> {
+    if is_remote_spec(spec) || is_path_spec(spec) {
+        return Ok(spec.to_string());
+    }
+    let configured_specs = config_specs_scoped()?
+        .into_iter()
+        .filter_map(|(configured_scope, configured)| {
+            (configured_scope == scope).then_some(configured)
+        })
+        .collect::<Vec<_>>();
+    if configured_specs.iter().any(|configured| configured == spec) {
+        return Ok(spec.to_string());
+    }
+    let mut matches = Vec::new();
+    for configured in configured_specs {
+        let Ok(source) = plugin_source_with_refresh(&configured, false, scope) else {
+            continue;
+        };
+        let manifest_name = source
+            .manifest_path
+            .as_deref()
+            .and_then(|path| {
+                pentect_agent::read_bounded_utf8(
+                    path,
+                    MAX_REMOTE_PLUGIN_FILE_BYTES,
+                    "plugin manifest",
+                )
+                .ok()
+            })
+            .and_then(|text| text.parse::<toml::Value>().ok())
+            .and_then(|value| {
+                value
+                    .get("name")
+                    .and_then(toml::Value::as_str)
+                    .map(str::to_string)
+            });
+        if source.name == spec || manifest_name.as_deref() == Some(spec) {
+            matches.push(configured);
+        }
+    }
+    matches.sort();
+    matches.dedup();
+    match matches.as_slice() {
+        [] => Ok(spec.to_string()),
+        [resolved] => Ok(resolved.clone()),
+        _ => bail!(
+            "plugin name '{spec}' is ambiguous in the selected scope; use one exact source: {}",
+            matches.join(", ")
+        ),
+    }
+}
+
+fn plugin_source_with_refresh(
+    spec: &str,
+    refresh: bool,
+    scope: PluginScope,
+) -> Result<PluginSource> {
     validate_plugin_spec(spec)?;
     if is_remote_spec(spec) {
         let normalized = normalize_github_plugin_url(spec)?;
@@ -629,6 +865,8 @@ fn plugin_source_with_refresh(spec: &str, refresh: bool) -> Result<PluginSource>
             manifest_path,
             repository,
             remote_base: Some(remote_base),
+            scope,
+            runtime_id: plugin_runtime_id(spec),
         });
     }
     if is_path_spec(spec) {
@@ -661,28 +899,34 @@ fn plugin_source_with_refresh(spec: &str, refresh: bool) -> Result<PluginSource>
             manifest_path: manifest.is_file().then_some(manifest),
             repository: None,
             remote_base: None,
+            scope,
+            runtime_id: plugin_runtime_id(spec),
         });
     }
 
     validate_plugin_name(spec)?;
-    for (root, repository) in [
-        (plugins_root().join(spec), None),
-        (
-            official_plugins_root().join(spec),
-            Some(DEFAULT_PLUGIN_REPOSITORY.to_string()),
-        ),
-    ] {
-        if root.is_dir() {
-            let root = root
-                .canonicalize()
-                .with_context(|| format!("could not resolve '{}'", root.display()))?;
-            let manifest = root.join(PLUGIN_MANIFEST_FILE);
-            return Ok(PluginSource {
-                name: spec.to_string(),
-                manifest_path: manifest.is_file().then_some(manifest),
-                repository,
-                remote_base: None,
-            });
+    if scope == PluginScope::Project {
+        for (root, repository) in [
+            (plugins_root().join(spec), None),
+            (
+                official_plugins_root().join(spec),
+                Some(DEFAULT_PLUGIN_REPOSITORY.to_string()),
+            ),
+        ] {
+            if root.is_dir() {
+                let root = root
+                    .canonicalize()
+                    .with_context(|| format!("could not resolve '{}'", root.display()))?;
+                let manifest = root.join(PLUGIN_MANIFEST_FILE);
+                return Ok(PluginSource {
+                    name: spec.to_string(),
+                    manifest_path: manifest.is_file().then_some(manifest),
+                    repository,
+                    remote_base: None,
+                    scope,
+                    runtime_id: plugin_runtime_id(spec),
+                });
+            }
         }
     }
     let base = format!("{DEFAULT_REMOTE_PLUGINS_BASE}/{spec}");
@@ -697,6 +941,8 @@ fn plugin_source_with_refresh(spec: &str, refresh: bool) -> Result<PluginSource>
         manifest_path,
         repository: Some(DEFAULT_PLUGIN_REPOSITORY.to_string()),
         remote_base: Some(base),
+        scope,
+        runtime_id: plugin_runtime_id(spec),
     })
 }
 
@@ -806,6 +1052,19 @@ pub(crate) fn project_plugin_lock_path() -> PathBuf {
     PathBuf::from(PROJECT_PLUGIN_LOCK_FILE)
 }
 
+pub(crate) fn user_plugin_lock_path() -> Result<PathBuf> {
+    home_dir()
+        .map(|home| home.join(PENTECT_DIR).join(PROJECT_PLUGIN_LOCK_FILE))
+        .ok_or_else(|| anyhow!("could not find a home directory for global plugin lock"))
+}
+
+pub(crate) fn plugin_lock_path(scope: PluginScope) -> Result<PathBuf> {
+    match scope {
+        PluginScope::User => user_plugin_lock_path(),
+        PluginScope::Project => Ok(project_plugin_lock_path()),
+    }
+}
+
 pub(crate) fn remote_plugin_lock_entry(
     spec: &str,
     source: &PluginSource,
@@ -875,7 +1134,11 @@ pub(crate) fn remote_plugin_sources(source: &PluginSource) -> Result<BTreeMap<St
 pub(crate) fn snapshot_remote_plugin_cache(
     spec: &str,
 ) -> Result<Option<RemotePluginCacheSnapshot>> {
-    let source = plugin_source_with_refresh(spec, false)?;
+    let source = plugin_source_with_refresh(
+        spec,
+        false,
+        configured_scope(spec).unwrap_or(PluginScope::Project),
+    )?;
     let Some(resolved) = source.remote_base else {
         return Ok(None);
     };
@@ -941,18 +1204,19 @@ pub(crate) fn restore_remote_plugin_cache(snapshot: &RemotePluginCacheSnapshot) 
     Ok(())
 }
 
-pub(crate) fn lock_project_plugin_mutation() -> Result<ProjectPluginMutationGuard> {
-    ProjectPluginMutationGuard::acquire(&project_plugin_lock_path())
+pub(crate) fn lock_plugin_mutation(scope: PluginScope) -> Result<ProjectPluginMutationGuard> {
+    ProjectPluginMutationGuard::acquire(&plugin_lock_path(scope)?)
 }
 
-pub(crate) fn set_project_remote_plugin_lock_with_guard(
+pub(crate) fn set_remote_plugin_lock_with_guard(
+    scope: PluginScope,
     guard: &ProjectPluginMutationGuard,
     spec: &str,
     entry: Option<RemotePluginLockEntry>,
 ) -> Result<()> {
-    let path = project_plugin_lock_path();
+    let path = plugin_lock_path(scope)?;
     if guard.project_lock != path {
-        bail!("project plugin mutation guard does not match the project lock");
+        bail!("plugin mutation guard does not match the selected lock");
     }
     set_project_remote_plugin_lock_at_locked(&path, spec, entry)
 }
@@ -1019,14 +1283,24 @@ fn set_project_remote_plugin_lock_at_locked(
     Ok(())
 }
 
-fn verify_project_remote_plugin(spec: &str, resolved: &str) -> Result<()> {
-    let configured = config_specs()?.iter().any(|configured| configured == spec);
-    let path = project_plugin_lock_path();
+fn verify_remote_plugin(scope: PluginScope, spec: &str, resolved: &str) -> Result<()> {
+    let configured = config_specs_scoped()?
+        .iter()
+        .any(|(configured_scope, configured)| *configured_scope == scope && configured == spec);
+    let path = plugin_lock_path(scope)?;
+    let scope_name = match scope {
+        PluginScope::User => "user",
+        PluginScope::Project => "project",
+    };
+    let scope_flag = match scope {
+        PluginScope::User => "",
+        PluginScope::Project => " --project",
+    };
     if !path.is_file() {
         if remote_reference_may_run_without_lock(configured, resolved) {
             return Ok(());
         }
-        bail!("remote plugin is not locked for this project; run `pentect plugins add {spec}`");
+        bail!("remote plugin is not locked for this {scope_name} scope; run `pentect plugins add {spec}{scope_flag}`");
     }
     let source = pentect_agent::read_bounded_utf8(
         &path,
@@ -1049,7 +1323,7 @@ fn verify_project_remote_plugin(spec: &str, resolved: &str) -> Result<()> {
             if remote_reference_may_run_without_lock(configured, resolved) {
                 return Ok(());
             }
-            bail!("remote plugin is not locked; run `pentect plugins add {spec}`");
+            bail!("remote plugin is not locked; run `pentect plugins add {spec}{scope_flag}`");
         }
         bail!("remote plugin lock contains duplicate entries for {spec}");
     };

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -23,19 +23,35 @@ pub(crate) fn cmd_plugins(args: &[String]) {
     };
     let result = match opts.action {
         Action::List => list_plugins(opts.json),
-        Action::Add { spec, approved } => add_plugin(&spec, approved, opts.json),
-        Action::Remove { spec } => remove_plugin(&spec, opts.json),
+        Action::Add {
+            spec,
+            approved,
+            scope,
+        } => add_plugin(&spec, approved, scope, opts.json),
+        Action::Remove { spec, scope } => remove_plugin(&spec, scope, opts.json),
         Action::Search { query } => search_plugins(query.as_deref(), opts.json),
         Action::Inspect { spec } => inspect_plugin(&spec, opts.json),
         Action::Test { spec } => test_plugin(&spec, opts.json),
         Action::New { name, form } => new_plugin(&name, form, opts.json),
         Action::Dev { spec, approved } => dev_plugin(&spec, approved, opts.json),
         Action::Publish { spec } => publish_plugin(&spec, opts.json),
-        Action::Config { spec, change } => config_plugin(&spec, change, opts.json),
-        Action::Setup { spec, approved } => setup_plugin(&spec, approved, opts.json),
-        Action::Update { spec, approved } => match spec {
-            Some(spec) => update_plugin(&spec, approved, opts.json),
-            None => update_all_plugins(approved, opts.json),
+        Action::Config {
+            spec,
+            change,
+            scope,
+        } => config_plugin(&spec, change, scope, opts.json),
+        Action::Setup {
+            spec,
+            approved,
+            scope,
+        } => setup_plugin(&spec, approved, scope, opts.json),
+        Action::Update {
+            spec,
+            approved,
+            scope,
+        } => match spec {
+            Some(spec) => update_plugin(&spec, approved, scope, opts.json),
+            None => update_all_plugins(approved, scope, opts.json),
         },
     };
     if let Err(e) = result {
@@ -55,9 +71,11 @@ enum Action {
     Add {
         spec: String,
         approved: bool,
+        scope: plugins::PluginScope,
     },
     Remove {
         spec: String,
+        scope: plugins::PluginScope,
     },
     Search {
         query: Option<String>,
@@ -82,14 +100,17 @@ enum Action {
     Config {
         spec: String,
         change: ConfigChange,
+        scope: plugins::PluginScope,
     },
     Setup {
         spec: String,
         approved: bool,
+        scope: plugins::PluginScope,
     },
     Update {
         spec: Option<String>,
         approved: bool,
+        scope: plugins::PluginScope,
     },
 }
 
@@ -110,6 +131,8 @@ impl PluginCmd {
         };
         let mut json = false;
         let mut approved = false;
+        let mut scope = plugins::PluginScope::User;
+        let mut scope_explicit = false;
         let mut unset = None;
         let mut values = Vec::new();
         let mut i = 3usize;
@@ -117,6 +140,10 @@ impl PluginCmd {
             match args[i].as_str() {
                 "--json" => json = true,
                 "--yes" => approved = true,
+                "--project" => {
+                    scope = plugins::PluginScope::Project;
+                    scope_explicit = true;
+                }
                 "--unset" => {
                     let Some(key) = args.get(i + 1) else {
                         return Err("--unset requires a key".to_string());
@@ -128,6 +155,12 @@ impl PluginCmd {
                 value => values.push(value.to_string()),
             }
             i += 1;
+        }
+        if scope_explicit && !matches!(action, "add" | "remove" | "config" | "setup" | "update") {
+            return Err(
+                "--project is only valid for plugins add, remove, config, setup, or update"
+                    .to_string(),
+            );
         }
         let action = match action {
             "list" => {
@@ -144,12 +177,14 @@ impl PluginCmd {
                 Action::Add {
                     spec: one_value("plugins add", values)?,
                     approved,
+                    scope,
                 }
             }
             "remove" => {
                 reject_action_flags(approved, unset.as_deref())?;
                 Action::Remove {
                     spec: one_value("plugins remove", values)?,
+                    scope,
                 }
             }
             "search" => {
@@ -213,7 +248,11 @@ impl PluginCmd {
                         return Err("plugins config NAME|PATH [KEY=VALUE | --unset KEY]".to_string())
                     }
                 };
-                Action::Config { spec, change }
+                Action::Config {
+                    spec,
+                    change,
+                    scope,
+                }
             }
             "setup" => {
                 if unset.is_some() {
@@ -222,6 +261,7 @@ impl PluginCmd {
                 Action::Setup {
                     spec: one_value("plugins setup", values)?,
                     approved,
+                    scope,
                 }
             }
             "update" => {
@@ -235,6 +275,7 @@ impl PluginCmd {
                         _ => return Err("plugins update [NAME|PATH]".to_string()),
                     },
                     approved,
+                    scope,
                 }
             }
             other => return Err(format!("unknown plugins command: {other}")),
@@ -333,15 +374,21 @@ fn one_value(command: &str, values: Vec<String>) -> Result<String, String> {
 
 fn list_plugins(json_output: bool) -> Result<(), String> {
     let mut rows = plugin_rows()?;
-    for spec in plugins::config_specs().map_err(|error| error.to_string())? {
-        let active = active_for_one(&spec)?;
-        let source = plugins::plugin_source(&spec).map_err(|error| error.to_string())?;
+    for (scope, spec) in plugins::config_specs_scoped().map_err(|error| error.to_string())? {
+        let active = plugins::active_from_scoped_specs(vec![(scope, spec.clone())], true)
+            .map_err(|error| error.to_string())?;
+        let source =
+            plugins::plugin_source_in_scope(&spec, scope).map_err(|error| error.to_string())?;
         let manifest = load_plugin_manifest(&source)?;
         rows.push(PluginRow {
             name: plugin_name(&source, manifest.as_ref()),
-            source: "enabled".to_string(),
+            source: match scope {
+                plugins::PluginScope::User => "user",
+                plugins::PluginScope::Project => "project",
+            }
+            .to_string(),
             configs: active.config_paths().len(),
-            binary: !active.binary_paths().is_empty(),
+            binary: active.has_binary(),
         });
     }
     rows.sort_by(|a, b| a.name.cmp(&b.name).then(a.source.cmp(&b.source)));
@@ -380,27 +427,35 @@ fn list_plugins(json_output: bool) -> Result<(), String> {
     Ok(())
 }
 
-fn add_plugin(spec: &str, approved: bool, json_output: bool) -> Result<(), String> {
+fn add_plugin(
+    spec: &str,
+    approved: bool,
+    scope: plugins::PluginScope,
+    json_output: bool,
+) -> Result<(), String> {
     if json_output {
         return Err("plugins add does not support --json".to_string());
     }
-    let project_guard =
-        plugins::lock_project_plugin_mutation().map_err(|error| error.to_string())?;
+    let spec = plugins::plugin_spec_for_scope(spec, scope).map_err(|error| error.to_string())?;
+    let spec = spec.as_str();
+    let project_guard = plugins::lock_plugin_mutation(scope).map_err(|error| error.to_string())?;
     let cache = plugins::snapshot_remote_plugin_cache(spec).map_err(|error| error.to_string())?;
-    let project = snapshot_project_plugin_files()?;
+    let project = snapshot_plugin_files(scope)?;
     let result = (|| {
-        let source = plugins::refresh_plugin_source(spec).map_err(|error| error.to_string())?;
+        let source = plugins::refresh_plugin_source_in_scope(spec, scope)
+            .map_err(|error| error.to_string())?;
         let lock_entry =
             plugins::remote_plugin_lock_entry(spec, &source).map_err(|error| error.to_string())?;
         if let Some(entry) = lock_entry {
-            plugins::set_project_remote_plugin_lock_with_guard(&project_guard, spec, Some(entry))
+            plugins::set_remote_plugin_lock_with_guard(scope, &project_guard, spec, Some(entry))
                 .map_err(|error| error.to_string())?;
         }
         if source.manifest_path.is_some() {
             setup_plugin_source(source.clone(), approved, false)?;
         }
         if source.manifest_path.is_none() {
-            let active = active_for_one(spec)?;
+            let active = plugins::active_from_scoped_specs(vec![(scope, spec.to_string())], true)
+                .map_err(|error| error.to_string())?;
             if active.config_paths().is_empty() {
                 return Err(format!(
                     "plugin '{}' has no plugin.toml or detector config",
@@ -408,33 +463,39 @@ fn add_plugin(spec: &str, approved: bool, json_output: bool) -> Result<(), Strin
                 ));
             }
         }
-        update_project_plugins(spec, true)?;
+        update_scoped_plugins(scope, spec, true)?;
         Ok(())
     })();
     if let Err(error) = result {
-        return Err(rollback_plugin_transaction(error, cache.as_ref(), &project));
+        return Err(rollback_plugin_transaction(
+            error,
+            cache.as_ref(),
+            &project,
+            scope,
+        ));
     }
     println!("enabled: {spec}");
     Ok(())
 }
 
-fn remove_plugin(spec: &str, json_output: bool) -> Result<(), String> {
+fn remove_plugin(spec: &str, scope: plugins::PluginScope, json_output: bool) -> Result<(), String> {
     if json_output {
         return Err("plugins remove does not support --json".to_string());
     }
-    let project_guard =
-        plugins::lock_project_plugin_mutation().map_err(|error| error.to_string())?;
-    let project = snapshot_project_plugin_files()?;
+    let spec = plugins::plugin_spec_for_scope(spec, scope).map_err(|error| error.to_string())?;
+    let spec = spec.as_str();
+    let project_guard = plugins::lock_plugin_mutation(scope).map_err(|error| error.to_string())?;
+    let project = snapshot_plugin_files(scope)?;
     let result = (|| {
-        let removed = update_project_plugins(spec, false)?;
+        let removed = update_scoped_plugins(scope, spec, false)?;
         for source in removed {
-            plugins::set_project_remote_plugin_lock_with_guard(&project_guard, &source, None)
+            plugins::set_remote_plugin_lock_with_guard(scope, &project_guard, &source, None)
                 .map_err(|error| error.to_string())?;
         }
         Ok(())
     })();
     if let Err(error) = result {
-        restore_project_plugin_files(&project)?;
+        restore_plugin_files(scope, &project)?;
         return Err(error);
     }
     println!("removed: {spec}");
@@ -446,10 +507,10 @@ struct ProjectPluginFiles {
     lock: Option<Vec<u8>>,
 }
 
-fn snapshot_project_plugin_files() -> Result<ProjectPluginFiles, String> {
+fn snapshot_plugin_files(scope: plugins::PluginScope) -> Result<ProjectPluginFiles, String> {
     snapshot_project_plugin_files_at(
-        &Path::new(".pentect").join("config.toml"),
-        &plugins::project_plugin_lock_path(),
+        &plugin_config_path(scope)?,
+        &plugins::plugin_lock_path(scope).map_err(|error| error.to_string())?,
     )
 }
 
@@ -467,11 +528,14 @@ fn snapshot_project_plugin_files_at(
     })
 }
 
-fn restore_project_plugin_files(snapshot: &ProjectPluginFiles) -> Result<(), String> {
+fn restore_plugin_files(
+    scope: plugins::PluginScope,
+    snapshot: &ProjectPluginFiles,
+) -> Result<(), String> {
     restore_project_plugin_files_at(
         snapshot,
-        &Path::new(".pentect").join("config.toml"),
-        &plugins::project_plugin_lock_path(),
+        &plugin_config_path(scope)?,
+        &plugins::plugin_lock_path(scope).map_err(|error| error.to_string())?,
     )
 }
 
@@ -489,6 +553,7 @@ fn rollback_plugin_transaction(
     error: String,
     cache: Option<&plugins::RemotePluginCacheSnapshot>,
     project: &ProjectPluginFiles,
+    scope: plugins::PluginScope,
 ) -> String {
     // Evaluate both before aggregating so a cache rollback error never skips
     // restoration of the project config and lock (or vice versa).
@@ -496,7 +561,7 @@ fn rollback_plugin_transaction(
         .map(plugins::restore_remote_plugin_cache)
         .unwrap_or(Ok(()))
         .map_err(|error| error.to_string());
-    let project = restore_project_plugin_files(project);
+    let project = restore_plugin_files(scope, project);
     let rollback =
         combine_rollback_results([("plugin source", cache), ("project plugin files", project)]);
     attach_rollback_error(error, rollback)
@@ -523,12 +588,30 @@ fn combine_rollback_results<const N: usize>(
     }
 }
 
-fn update_project_plugins(spec: &str, enable: bool) -> Result<Vec<String>, String> {
-    let path = Path::new(".pentect").join("config.toml");
-    update_project_plugins_at(&path, spec, enable)
+fn update_scoped_plugins(
+    scope: plugins::PluginScope,
+    spec: &str,
+    enable: bool,
+) -> Result<Vec<String>, String> {
+    let path = plugin_config_path(scope)?;
+    update_project_plugins_at(&path, spec, enable, scope)
 }
 
-fn update_project_plugins_at(path: &Path, spec: &str, enable: bool) -> Result<Vec<String>, String> {
+fn plugin_config_path(scope: plugins::PluginScope) -> Result<PathBuf, String> {
+    match scope {
+        plugins::PluginScope::User => {
+            plugins::user_plugin_config_path().map_err(|error| error.to_string())
+        }
+        plugins::PluginScope::Project => Ok(plugins::project_plugin_config_path()),
+    }
+}
+
+fn update_project_plugins_at(
+    path: &Path,
+    spec: &str,
+    enable: bool,
+    scope: plugins::PluginScope,
+) -> Result<Vec<String>, String> {
     let mut document = if path.is_file() {
         read_bounded_utf8(path, MAX_PLUGIN_CONFIG_BYTES, "Pentect project config")?
             .parse::<toml_edit::DocumentMut>()
@@ -568,7 +651,7 @@ fn update_project_plugins_at(path: &Path, spec: &str, enable: bool) -> Result<Ve
             .collect::<Vec<_>>();
         if matches.is_empty() {
             for value in &active {
-                let Ok(source) = plugins::plugin_source(value) else {
+                let Ok(source) = plugins::plugin_source_in_scope(value, scope) else {
                     continue;
                 };
                 let Ok(manifest) = load_plugin_manifest(&source) else {
@@ -580,7 +663,9 @@ fn update_project_plugins_at(path: &Path, spec: &str, enable: bool) -> Result<Ve
             }
         }
         if matches.is_empty() {
-            return Err(format!("plugin is not enabled in this project: {spec}"));
+            return Err(format!(
+                "plugin is not enabled in the selected scope: {spec}"
+            ));
         }
         if matches.len() > 1 {
             return Err(format!(
@@ -1713,8 +1798,14 @@ fn plugin_name(source: &plugins::PluginSource, manifest: Option<&PluginManifest>
         .to_string()
 }
 
-fn config_plugin(spec: &str, change: ConfigChange, json_output: bool) -> Result<(), String> {
-    let source = plugins::plugin_source(spec).map_err(|e| e.to_string())?;
+fn config_plugin(
+    spec: &str,
+    change: ConfigChange,
+    scope: plugins::PluginScope,
+    json_output: bool,
+) -> Result<(), String> {
+    let spec = plugins::plugin_spec_for_scope(spec, scope).map_err(|error| error.to_string())?;
+    let source = plugins::plugin_source_in_scope(&spec, scope).map_err(|e| e.to_string())?;
     let manifest = load_plugin_manifest(&source)?;
     let name = plugin_name(&source, manifest.as_ref());
     let dirs = plugin_runtime_dirs_for_source(&name, &source)?;
@@ -1877,23 +1968,35 @@ fn toml_leaf_keys(table: &toml::Table) -> Vec<String> {
     keys
 }
 
-fn setup_plugin(spec: &str, approved: bool, json_output: bool) -> Result<(), String> {
-    let project_guard =
-        plugins::lock_project_plugin_mutation().map_err(|error| error.to_string())?;
+fn setup_plugin(
+    spec: &str,
+    approved: bool,
+    scope: plugins::PluginScope,
+    json_output: bool,
+) -> Result<(), String> {
+    let spec = plugins::plugin_spec_for_scope(spec, scope).map_err(|error| error.to_string())?;
+    let spec = spec.as_str();
+    let project_guard = plugins::lock_plugin_mutation(scope).map_err(|error| error.to_string())?;
     let cache = plugins::snapshot_remote_plugin_cache(spec).map_err(|error| error.to_string())?;
-    let project = snapshot_project_plugin_files()?;
+    let project = snapshot_plugin_files(scope)?;
     let result = (|| {
-        let source = plugins::refresh_plugin_source(spec).map_err(|error| error.to_string())?;
+        let source = plugins::refresh_plugin_source_in_scope(spec, scope)
+            .map_err(|error| error.to_string())?;
         if let Some(entry) =
             plugins::remote_plugin_lock_entry(spec, &source).map_err(|error| error.to_string())?
         {
-            plugins::set_project_remote_plugin_lock_with_guard(&project_guard, spec, Some(entry))
+            plugins::set_remote_plugin_lock_with_guard(scope, &project_guard, spec, Some(entry))
                 .map_err(|error| error.to_string())?;
         }
         setup_plugin_source(source, approved, json_output)
     })();
     if let Err(error) = result {
-        return Err(rollback_plugin_transaction(error, cache.as_ref(), &project));
+        return Err(rollback_plugin_transaction(
+            error,
+            cache.as_ref(),
+            &project,
+            scope,
+        ));
     }
     Ok(())
 }
@@ -2525,17 +2628,28 @@ fn write_plugin_approval(
         .map_err(|error| format!("could not activate plugin approval: {error}"))
 }
 
-fn update_plugin(spec: &str, approved: bool, json_output: bool) -> Result<(), String> {
+fn update_plugin(
+    spec: &str,
+    approved: bool,
+    scope: plugins::PluginScope,
+    json_output: bool,
+) -> Result<(), String> {
     if json_output {
         return Err("plugins update does not support --json".to_string());
     }
-    let project_guard =
-        plugins::lock_project_plugin_mutation().map_err(|error| error.to_string())?;
+    let spec = plugins::plugin_spec_for_scope(spec, scope).map_err(|error| error.to_string())?;
+    let spec = spec.as_str();
+    let project_guard = plugins::lock_plugin_mutation(scope).map_err(|error| error.to_string())?;
     let cache = plugins::snapshot_remote_plugin_cache(spec).map_err(|error| error.to_string())?;
-    let project = snapshot_project_plugin_files()?;
-    let result = update_plugin_inner(spec, approved, cache.as_ref(), &project_guard);
+    let project = snapshot_plugin_files(scope)?;
+    let result = update_plugin_inner(spec, approved, scope, cache.as_ref(), &project_guard);
     if let Err(error) = result {
-        return Err(rollback_plugin_transaction(error, cache.as_ref(), &project));
+        return Err(rollback_plugin_transaction(
+            error,
+            cache.as_ref(),
+            &project,
+            scope,
+        ));
     }
     Ok(())
 }
@@ -2543,10 +2657,11 @@ fn update_plugin(spec: &str, approved: bool, json_output: bool) -> Result<(), St
 fn update_plugin_inner(
     spec: &str,
     approved: bool,
+    scope: plugins::PluginScope,
     previous: Option<&plugins::RemotePluginCacheSnapshot>,
     project_guard: &plugins::ProjectPluginMutationGuard,
 ) -> Result<(), String> {
-    let source = plugins::refresh_plugin_source(spec).map_err(|e| e.to_string())?;
+    let source = plugins::refresh_plugin_source_in_scope(spec, scope).map_err(|e| e.to_string())?;
     let lock_entry =
         plugins::remote_plugin_lock_entry(spec, &source).map_err(|error| error.to_string())?;
     let manifest = load_plugin_manifest(&source)?
@@ -2567,7 +2682,8 @@ fn update_plugin_inner(
             {
                 println!("plugin command, files, or hook access changed; reviewing updated access");
                 if let Some(entry) = lock_entry {
-                    plugins::set_project_remote_plugin_lock_with_guard(
+                    plugins::set_remote_plugin_lock_with_guard(
+                        scope,
                         project_guard,
                         spec,
                         Some(entry),
@@ -2579,7 +2695,7 @@ fn update_plugin_inner(
             }
         }
         if let Some(entry) = lock_entry {
-            plugins::set_project_remote_plugin_lock_with_guard(project_guard, spec, Some(entry))
+            plugins::set_remote_plugin_lock_with_guard(scope, project_guard, spec, Some(entry))
                 .map_err(|error| error.to_string())?;
         }
         println!("update: refreshed manifest for {name}");
@@ -2589,7 +2705,7 @@ fn update_plugin_inner(
     if verify_plugin_update_approval(&name, &source, &manifest).is_err() {
         println!("plugin manifest changed; reviewing updated access");
         if let Some(entry) = lock_entry {
-            plugins::set_project_remote_plugin_lock_with_guard(project_guard, spec, Some(entry))
+            plugins::set_remote_plugin_lock_with_guard(scope, project_guard, spec, Some(entry))
                 .map_err(|error| error.to_string())?;
         }
         setup_plugin_source(source, approved, false)?;
@@ -2625,7 +2741,7 @@ fn update_plugin_inner(
         )?;
         println!("plugin hook access changed; reviewing updated access");
         if let Some(entry) = lock_entry {
-            plugins::set_project_remote_plugin_lock_with_guard(project_guard, spec, Some(entry))
+            plugins::set_remote_plugin_lock_with_guard(scope, project_guard, spec, Some(entry))
                 .map_err(|error| error.to_string())?;
         }
         setup_plugin_source(source, approved, false)?;
@@ -2635,7 +2751,7 @@ fn update_plugin_inner(
     // Keeping the original digest makes any concurrent or later edit require setup again.
     if let Some(entry) = lock_entry {
         if let Err(error) =
-            plugins::set_project_remote_plugin_lock_with_guard(project_guard, spec, Some(entry))
+            plugins::set_remote_plugin_lock_with_guard(scope, project_guard, spec, Some(entry))
         {
             return Err(attach_rollback_error(
                 error.to_string(),
@@ -2798,15 +2914,23 @@ fn detector_summary(detector: &DetectorDescriptor) -> String {
     )
 }
 
-fn update_all_plugins(approved: bool, json_output: bool) -> Result<(), String> {
-    let specs = plugins::config_specs().map_err(|error| error.to_string())?;
+fn update_all_plugins(
+    approved: bool,
+    scope: plugins::PluginScope,
+    json_output: bool,
+) -> Result<(), String> {
+    let specs = plugins::config_specs_scoped()
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .filter_map(|(configured_scope, spec)| (configured_scope == scope).then_some(spec))
+        .collect::<Vec<_>>();
     if specs.is_empty() {
         println!("none");
         return Ok(());
     }
     let mut failures = Vec::new();
     for spec in specs {
-        if let Err(error) = update_plugin(&spec, approved, json_output) {
+        if let Err(error) = update_plugin(&spec, approved, scope, json_output) {
             failures.push(format!("{spec}: {error}"));
         }
     }
@@ -3326,6 +3450,9 @@ fn plugin_runtime_dirs_for_source(
     name: &str,
     source: &plugins::PluginSource,
 ) -> Result<pentect_agent::PluginRuntimeDirs, String> {
+    if source.scope == plugins::PluginScope::User {
+        return pentect_agent::global_plugin_runtime_dirs(&source.runtime_id);
+    }
     match source.manifest_path.as_deref() {
         Some(manifest) => pentect_agent::plugin_runtime_dirs_for_manifest(name, manifest),
         None => plugin_runtime_dirs(name),
@@ -3605,7 +3732,7 @@ mod tests {
         )
         .unwrap();
 
-        update_project_plugins_at(&path, "second", true).unwrap();
+        update_project_plugins_at(&path, "second", true, plugins::PluginScope::Project).unwrap();
         let after_add = std::fs::read_to_string(&path).unwrap();
         assert!(after_add.contains("# keep this comment"), "{after_add}");
         assert!(after_add.contains("# and this one"), "{after_add}");
@@ -3613,7 +3740,7 @@ mod tests {
         assert!(after_add.contains("\"first\""), "{after_add}");
         assert!(after_add.contains("\"second\""), "{after_add}");
 
-        update_project_plugins_at(&path, "first", false).unwrap();
+        update_project_plugins_at(&path, "first", false, plugins::PluginScope::Project).unwrap();
         let after_remove = std::fs::read_to_string(&path).unwrap();
         assert!(!after_remove.contains("\"first\""), "{after_remove}");
         assert!(after_remove.contains("\"second\""), "{after_remove}");
@@ -3665,7 +3792,20 @@ mod tests {
         ];
         assert!(matches!(
             PluginCmd::parse(&add).unwrap().action,
-            Action::Add { approved: true, .. }
+            Action::Add {
+                approved: true,
+                scope: plugins::PluginScope::User,
+                ..
+            }
+        ));
+        let mut project_add = add.clone();
+        project_add.push("--project".into());
+        assert!(matches!(
+            PluginCmd::parse(&project_add).unwrap().action,
+            Action::Add {
+                scope: plugins::PluginScope::Project,
+                ..
+            }
         ));
         let remove = vec![
             "pentect".into(),
@@ -3675,8 +3815,18 @@ mod tests {
         ];
         assert!(matches!(
             PluginCmd::parse(&remove).unwrap().action,
-            Action::Remove { .. }
+            Action::Remove {
+                scope: plugins::PluginScope::User,
+                ..
+            }
         ));
+        let invalid = vec![
+            "pentect".into(),
+            "plugins".into(),
+            "list".into(),
+            "--project".into(),
+        ];
+        assert!(PluginCmd::parse(&invalid).is_err());
     }
 
     #[test]
@@ -3856,6 +4006,8 @@ mod tests {
             manifest_path: Some(manifest_path),
             repository: None,
             remote_base: None,
+            scope: plugins::PluginScope::Project,
+            runtime_id: name.clone(),
         };
         let manifest = load_plugin_manifest(&source).unwrap().unwrap();
         write_command_lock(&name, &source, &manifest).unwrap();
@@ -3896,6 +4048,8 @@ mod tests {
             manifest_path: Some(manifest_path),
             repository: None,
             remote_base: None,
+            scope: plugins::PluginScope::Project,
+            runtime_id: name.clone(),
         };
         let dirs = plugin_runtime_dirs_for_source(&name, &source).unwrap();
         std::fs::create_dir_all(dirs.data_dir.join("command")).unwrap();
@@ -3974,6 +4128,8 @@ mod tests {
             manifest_path: Some(manifest),
             repository: None,
             remote_base: None,
+            scope: plugins::PluginScope::Project,
+            runtime_id: "test".to_string(),
         };
         assert_eq!(
             binary_asset("helper.wasm", PluginRuntime::Wasm, &BTreeMap::new()),
@@ -4165,6 +4321,8 @@ pattern = "token-[0-9]+"
             manifest_path: Some(manifest_path.clone()),
             repository: None,
             remote_base: None,
+            scope: plugins::PluginScope::Project,
+            runtime_id: name.clone(),
         };
         let manifest = load_plugin_manifest(&source).unwrap().unwrap();
         let hooks = vec!["inspect".to_string()];
@@ -4251,6 +4409,8 @@ pattern = "token-[0-9]+"
             manifest_path: Some(root.join(plugins::PLUGIN_MANIFEST_FILE)),
             repository: None,
             remote_base: None,
+            scope: plugins::PluginScope::Project,
+            runtime_id: "local".to_string(),
         };
         let manifest = load_plugin_manifest(&source).unwrap().unwrap();
         let err = binary_repository(&source, &manifest).unwrap_err();
@@ -4266,6 +4426,8 @@ pattern = "token-[0-9]+"
             manifest_path: None,
             repository: Some("trusted/owner".to_string()),
             remote_base: None,
+            scope: plugins::PluginScope::Project,
+            runtime_id: "remote".to_string(),
         };
         let manifest: PluginManifest = toml::from_str(
             "schema = \"pentect.plugin.v1\"\nname = \"remote\"\nrepository = \"attacker/repo\"\n",
@@ -4292,6 +4454,8 @@ pattern = "token-[0-9]+"
             manifest_path: Some(manifest),
             repository: None,
             remote_base: None,
+            scope: plugins::PluginScope::Project,
+            runtime_id: name.clone(),
         };
         let data_dir = plugin_runtime_dirs_for_source(&name, &source)
             .unwrap()

--- a/crates/pentect-cli/tests/plugin_scope.rs
+++ b/crates/pentect-cli/tests/plugin_scope.rs
@@ -1,0 +1,125 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_dir(name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("pentect-{name}-{}-{nonce}", std::process::id()))
+}
+
+fn command(home: &Path, cwd: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env_remove("USERPROFILE");
+    command
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn mask(home: &Path, cwd: &Path, input: &str) -> String {
+    let mut child = command(home, cwd)
+        .arg("mask")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_success(&output);
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn write_manifest(root: &Path, name: &str, label: &str, pattern: &str) {
+    std::fs::create_dir_all(root).unwrap();
+    std::fs::write(
+        root.join("plugin.toml"),
+        format!(
+            "schema = \"pentect.plugin.v1\"\nname = \"{name}\"\n\n[[detector]]\nlabel = \"{label}\"\npattern = '''{pattern}'''\ncategory = \"identifier\"\nconfidence = \"high\"\n"
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn plugins_are_user_global_by_default_and_project_scope_is_explicit() {
+    let root = temp_dir("plugin-scope");
+    let home = root.join("home");
+    let first_project = root.join("first-project");
+    let second_project = root.join("second-project");
+    let global_plugin = first_project.join("global-plugin");
+    let project_plugin = root.join("project-plugin");
+    for path in [&home, &first_project, &second_project] {
+        std::fs::create_dir_all(path).unwrap();
+    }
+    write_manifest(
+        &global_plugin,
+        "global-test",
+        "GLOBAL_TEST",
+        r"GLOBAL-[0-9]{6}",
+    );
+    write_manifest(
+        &project_plugin,
+        "project-test",
+        "PROJECT_TEST",
+        r"PROJECT-[0-9]{6}",
+    );
+
+    let output = command(&home, &first_project)
+        .args(["plugins", "add"])
+        .arg("./global-plugin")
+        .arg("--yes")
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let user_config = home.join(".pentect/config.toml");
+    assert!(user_config.is_file());
+    assert!(!first_project.join(".pentect/config.toml").exists());
+
+    let output = command(&home, &first_project)
+        .args(["plugins", "add"])
+        .arg(&project_plugin)
+        .args(["--project", "--yes"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    assert!(first_project.join(".pentect/config.toml").is_file());
+    let user_config_text = std::fs::read_to_string(&user_config).unwrap();
+    assert!(user_config_text.contains(global_plugin.to_str().unwrap()));
+    assert!(!user_config_text.contains("./global-plugin"));
+    assert!(!user_config_text.contains(project_plugin.to_str().unwrap()));
+
+    let elsewhere = mask(&home, &second_project, "GLOBAL-123456 PROJECT-123456");
+    assert!(elsewhere.contains("<<GLOBAL_TEST_"), "{elsewhere}");
+    assert!(elsewhere.contains("PROJECT-123456"), "{elsewhere}");
+
+    let inside_project = mask(&home, &first_project, "GLOBAL-123456 PROJECT-123456");
+    assert!(
+        inside_project.contains("<<GLOBAL_TEST_"),
+        "{inside_project}"
+    );
+    assert!(
+        inside_project.contains("<<PROJECT_TEST_"),
+        "{inside_project}"
+    );
+
+    std::fs::remove_dir_all(root).unwrap();
+}

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -21,10 +21,10 @@ mod secure_io;
 #[doc(hidden)]
 pub use network_address::embedded_ipv4;
 pub use plugin_middleware::{
-    inspect_wasm_plugin_hooks, plugin_runtime_dirs, plugin_runtime_dirs_for_manifest,
-    test_local_wasm_plugin, valid_plugin_publisher_workflow, DetectSpansRun, MiddlewareCoverage,
-    MiddlewareRun, MiddlewareStage, PluginMiddleware, PluginRuntimeDirs, StopOutcome,
-    DEFAULT_PUBLISHER_WORKFLOW,
+    global_plugin_runtime_dirs, inspect_wasm_plugin_hooks, plugin_runtime_dirs,
+    plugin_runtime_dirs_for_manifest, test_local_wasm_plugin, valid_plugin_publisher_workflow,
+    DetectSpansRun, MiddlewareCoverage, MiddlewareRun, MiddlewareStage, PluginMiddleware,
+    PluginRuntimeDirs, StopOutcome, DEFAULT_PUBLISHER_WORKFLOW,
 };
 #[doc(hidden)]
 pub use secure_io::{read_bounded_bytes, read_bounded_utf8, sha256_file};

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -16,6 +16,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 pub const BINARIES_ENV: &str = "PENTECT_PLUGIN_BINARIES";
+pub const GLOBAL_BINARIES_ENV: &str = "PENTECT_GLOBAL_PLUGIN_BINARIES";
+pub const GLOBAL_BINARY_IDS_ENV: &str = "PENTECT_GLOBAL_PLUGIN_IDS";
 
 const PLUGIN_APPROVAL_FILE: &str = "approval.toml";
 const PLUGIN_BINARY_LOCK_FILE: &str = "binary.lock";
@@ -308,10 +310,34 @@ pub struct PluginMiddleware {
 
 impl PluginMiddleware {
     pub fn from_env() -> Result<Self, String> {
-        let Some(value) = std::env::var_os(BINARIES_ENV) else {
-            return Ok(Self::default());
-        };
-        Self::from_paths(std::env::split_paths(&value).filter(|path| !path.as_os_str().is_empty()))
+        let mut plugins = Vec::new();
+        if let Some(value) = std::env::var_os(GLOBAL_BINARIES_ENV) {
+            let paths = std::env::split_paths(&value)
+                .filter(|path| !path.as_os_str().is_empty())
+                .collect::<Vec<_>>();
+            let ids = std::env::var_os(GLOBAL_BINARY_IDS_ENV)
+                .map(|value| {
+                    std::env::split_paths(&value)
+                        .filter(|path| !path.as_os_str().is_empty())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            if paths.len() != ids.len() {
+                return Err("global plugin path and identity counts do not match".to_string());
+            }
+            for (path, id) in paths.into_iter().zip(ids) {
+                let id = id
+                    .to_str()
+                    .ok_or_else(|| "global plugin identity is not UTF-8".to_string())?;
+                plugins.push(PluginBinary::load_global(&path, id)?);
+            }
+        }
+        if let Some(value) = std::env::var_os(BINARIES_ENV) {
+            for path in std::env::split_paths(&value).filter(|path| !path.as_os_str().is_empty()) {
+                plugins.push(PluginBinary::load(&path)?);
+            }
+        }
+        Ok(Self { plugins })
     }
 
     pub fn from_paths(paths: impl IntoIterator<Item = PathBuf>) -> Result<Self, String> {
@@ -608,6 +634,14 @@ struct PluginBinary {
 
 impl PluginBinary {
     fn load(path: &Path) -> Result<Self, String> {
+        Self::load_scoped(path, None)
+    }
+
+    fn load_global(path: &Path, id: &str) -> Result<Self, String> {
+        Self::load_scoped(path, Some(id))
+    }
+
+    fn load_scoped(path: &Path, global_id: Option<&str>) -> Result<Self, String> {
         if !path.is_file() {
             return Err(format!(
                 "plugin manifest does not exist: {}",
@@ -736,7 +770,10 @@ impl PluginBinary {
                 "plugin '{name}' execution limits exceed Pentect's runtime limits"
             ));
         }
-        let runtime_dirs = plugin_runtime_dirs_for_manifest(&name, path)?;
+        let runtime_dirs = match global_id {
+            Some(id) => global_plugin_runtime_dirs(id)?,
+            None => plugin_runtime_dirs_for_manifest(&name, path)?,
+        };
         let mut permissions_file = file.permissions;
         let permission_network = permissions_file
             .as_mut()
@@ -3315,6 +3352,35 @@ pub fn plugin_runtime_dirs(id_or_name: &str) -> Result<PluginRuntimeDirs, String
     })
 }
 
+/// Resolve device-wide storage for a plugin explicitly enabled in the user's
+/// global Pentect configuration. The caller supplies a stable source identity
+/// so the same approval and managed command are reused from every project.
+pub fn global_plugin_runtime_dirs(source_id: &str) -> Result<PluginRuntimeDirs, String> {
+    let id = plugin_id(source_id);
+    if id.is_empty() {
+        return Err("global plugin identity is empty".to_string());
+    }
+    let user_root = plugin_user_data_root()?;
+    if !user_root.is_absolute() {
+        return Err("Pentect plugin data directory must be absolute".to_string());
+    }
+    std::fs::create_dir_all(&user_root)
+        .map_err(|error| format!("could not create '{}': {error}", user_root.display()))?;
+    let user_root = std::fs::canonicalize(&user_root)
+        .map_err(|error| format!("could not resolve '{}': {error}", user_root.display()))?;
+    restrict_plugin_directory(&user_root)?;
+    let data_dir = user_root.join("global").join(id);
+    let cache_dir = data_dir.join(PLUGIN_CACHE_DIR);
+    std::fs::create_dir_all(&cache_dir)
+        .map_err(|error| format!("could not create '{}': {error}", cache_dir.display()))?;
+    restrict_plugin_directory(&data_dir)?;
+    Ok(PluginRuntimeDirs {
+        config_file: data_dir.join(PLUGIN_CONFIG_FILE),
+        data_dir,
+        cache_dir,
+    })
+}
+
 /// Resolve storage for one concrete plugin source. The source path is part of
 /// the identity so two publishers may safely use the same display name.
 pub fn plugin_runtime_dirs_for_manifest(
@@ -3764,11 +3830,35 @@ for line in sys.stdin:
         assert_eq!(result.spans[0].label, "CONFIGURED");
 
         drop(middleware);
+        let global_id = format!("global-command-e2e-{nonce}");
+        let global_dirs = global_plugin_runtime_dirs(&global_id).unwrap();
+        std::fs::write(&global_dirs.config_file, "label = \"GLOBAL_CONFIGURED\"\n").unwrap();
+        std::fs::write(
+            global_dirs.data_dir.join(PLUGIN_COMMAND_LOCK_FILE),
+            &command_lock,
+        )
+        .unwrap();
+        std::fs::write(
+            global_dirs.data_dir.join(PLUGIN_APPROVAL_FILE),
+            format!(
+                "schema = \"pentect.plugin-approval.v1\"\nmanifest_sha256 = \"{manifest_hash}\"\nhooks = [\"inspect\"]\ncommand_lock_sha256 = \"{command_lock_sha256}\"\n"
+            ),
+        )
+        .unwrap();
+        let global = PluginMiddleware {
+            plugins: vec![PluginBinary::load_global(&manifest, &global_id).unwrap()],
+        };
+        let result = global.detect_spans(&Input::text("SECRET"), None).unwrap();
+        assert_eq!(result.spans.len(), 1);
+        assert_eq!(result.spans[0].label, "GLOBAL_CONFIGURED");
+        drop(global);
+
         std::fs::write(&script, "print('changed')\n").unwrap();
         let error = PluginMiddleware::from_paths([manifest.clone()]).unwrap_err();
         assert!(error.contains("changed after setup"), "{error}");
 
         let _ = std::fs::remove_dir_all(dirs.data_dir);
+        let _ = std::fs::remove_dir_all(global_dirs.data_dir);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -3356,10 +3356,16 @@ pub fn plugin_runtime_dirs(id_or_name: &str) -> Result<PluginRuntimeDirs, String
 /// global Pentect configuration. The caller supplies a stable source identity
 /// so the same approval and managed command are reused from every project.
 pub fn global_plugin_runtime_dirs(source_id: &str) -> Result<PluginRuntimeDirs, String> {
-    let id = plugin_id(source_id);
-    if id.is_empty() {
-        return Err("global plugin identity is empty".to_string());
+    if source_id.len() != 32
+        || !source_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(
+            "global plugin identity must be a 32-character lowercase hex digest".to_string(),
+        );
     }
+    let id = source_id.to_string();
     let user_root = plugin_user_data_root()?;
     if !user_root.is_absolute() {
         return Err("Pentect plugin data directory must be absolute".to_string());
@@ -3830,7 +3836,7 @@ for line in sys.stdin:
         assert_eq!(result.spans[0].label, "CONFIGURED");
 
         drop(middleware);
-        let global_id = format!("global-command-e2e-{nonce}");
+        let global_id = format!("{nonce:032x}");
         let global_dirs = global_plugin_runtime_dirs(&global_id).unwrap();
         std::fs::write(&global_dirs.config_file, "label = \"GLOBAL_CONFIGURED\"\n").unwrap();
         std::fs::write(
@@ -3889,6 +3895,18 @@ for line in sys.stdin:
         let _ = std::fs::remove_dir_all(left_dirs.data_dir);
         let _ = std::fs::remove_dir_all(right_dirs.data_dir);
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn global_plugin_identity_rejects_normalization_collisions() {
+        for invalid in [
+            "",
+            "plugin",
+            "A0000000000000000000000000000000",
+            "--------------------------------",
+        ] {
+            assert!(global_plugin_runtime_dirs(invalid).is_err(), "{invalid}");
+        }
     }
 
     #[test]

--- a/website/src/content/docs/plugins/lifecycle.md
+++ b/website/src/content/docs/plugins/lifecycle.md
@@ -79,8 +79,9 @@ coverage. Optional does not mean that Pentect silently claims the plugin ran.
 
 ## Order and scope
 
-Project plugins run in the order stored in `.pentect/config.toml`. A one-off
-plugin passed with `--plugins` is added for that command or client launch.
+User plugins run first in the order stored in `~/.pentect/config.toml`, then
+project plugins from `.pentect/config.toml`. A one-off plugin passed with
+`--plugins` is added for that command or client launch.
 
 ```sh
 pentect codex --plugins ./plugins/company-policy
@@ -90,12 +91,12 @@ echo 'sample' | pentect mask --plugins first,second
 Use one plugin for one job. Small plugins are easier to approve, test, update,
 and remove than one plugin with unrelated access.
 
-`pentect plugins remove NAME` removes the project reference. A protected client
+`pentect plugins remove NAME` removes the user-wide reference. Add `--project`
+to remove a project reference. A protected client
 that is already running keeps its loaded middleware until that client exits;
 its supervised Command process is then stopped and reaped. Start a new client
 to use the updated project list. Pentect may retain verified shared cache and
-private plugin storage so removing one project reference cannot break another
-project that uses the same plugin.
+private plugin storage as appropriate for its scope.
 
 ## Sandbox boundary
 

--- a/website/src/content/docs/plugins/official.md
+++ b/website/src/content/docs/plugins/official.md
@@ -3,8 +3,8 @@ title: Official plugins
 description: First-party plugins and examples maintained with Pentect.
 ---
 
-Pentect's built-in engine works without plugins. Plugins add project-specific
-rules or optional local models.
+Pentect's built-in engine works without plugins. Plugins add user-wide or
+project-specific rules and optional local models.
 
 ## Built-in protection
 
@@ -108,7 +108,7 @@ OS access as the user; enable only plugins you trust.
 | CPU use is high | Remove the plugin when the local model is not needed |
 | Plugin file or command changed | Inspect it, then run `pentect plugins setup` |
 
-Remove it from the current project:
+Remove the user-wide installation:
 
 ```sh
 pentect plugins remove openai-privacy-filter

--- a/website/src/content/docs/plugins/overview.md
+++ b/website/src/content/docs/plugins/overview.md
@@ -42,16 +42,15 @@ Inspect a released version before you add it:
 pentect plugins inspect github:@EdamAme-x/pentect/plugins/example-regex@v0.1.0
 ```
 
-Add it to the current project:
+Add it for your user account on this computer:
 
 ```sh
 pentect plugins add github:@EdamAme-x/pentect/plugins/example-regex@v0.1.0
 ```
 
-This writes the source to `.pentect/config.toml`. The lockfile records that
-source, the normalized raw GitHub URL Pentect resolved, and the full SHA-256 of
-every fetched manifest and detector file. Commit `pentect.plugins.lock` with
-your project. A Wasm plugin
+This writes the source to `~/.pentect/config.toml` and pins downloaded source
+bytes in `~/.pentect/pentect.plugins.lock`. The plugin is then available from
+every project on this computer. A Wasm plugin
 also downloads its release file, checks its SHA-256 checksum and GitHub build
 record, and asks you to approve its hooks and network access.
 
@@ -63,7 +62,7 @@ Released Wasm plugins need
 [GitHub CLI](https://cli.github.com/) v2.51.0 or newer for build-record checks.
 Regex plugins do not need it.
 
-Use a plugin for only one launch without changing the project:
+Use a plugin for only one launch without changing saved configuration:
 
 ```sh
 pentect codex --plugins github:@owner/repository/path@0123456789abcdef0123456789abcdef01234567
@@ -72,11 +71,23 @@ pentect claude --plugins ./my-plugin
 
 Separate more than one plugin with commas. A one-off remote plugin must use a
 full 40-character commit. Tags can move, so tag-based sources must first be
-added to the project and pinned by `pentect.plugins.lock`.
+added and pinned by a lockfile.
+
+For a repository-owned plugin set, add `--project`. This writes
+`.pentect/config.toml` and `pentect.plugins.lock`; commit both project files.
+
+```sh
+pentect plugins add github:@owner/repository/path@v1.2.3 --project
+```
+
+The same `--project` switch selects project scope for `remove`, `config`,
+`setup`, and `update`. Existing project plugin settings stay project-scoped
+after upgrading; Pentect does not silently promote their permissions.
 
 ## How plugins run
 
-Pentect runs plugins in the order shown in the project config. A hook returns
+Pentect runs user plugins first, followed by project plugins and one-off
+plugins, preserving the order within each config. A hook returns
 normally to continue to the next plugin. It can also block the action. The
 `request` hook can return a response without calling the provider.
 
@@ -139,8 +150,8 @@ pentect plugins update NAME
 pentect plugins remove NAME
 ```
 
-`remove` disables the plugin in the current project. It does not run cleanup
-code from the plugin.
+`remove` disables the user plugin. Use `remove NAME --project` for a project
+plugin. Neither form runs cleanup code from the plugin.
 
 ## Next steps
 

--- a/website/src/content/docs/plugins/publish.md
+++ b/website/src/content/docs/plugins/publish.md
@@ -99,11 +99,13 @@ The release asset still comes from `repository` in the manifest.
 
 Pentect records the configured source, its normalized raw GitHub URL, and every
 fetched manifest and detector file with its full SHA-256 digest in
-`pentect.plugins.lock`. Commit this file. Normal runs
+`~/.pentect/pentect.plugins.lock`. Normal runs
 verify the cached bytes and never treat a moving `main` branch as the plugin's
 identity. `plugins update` fetches new bytes, shows detector label, category,
-confidence, and rule-digest changes, and rolls the source and project lock back
-when review or installation fails.
+confidence, and rule-digest changes, and rolls the source and user lock back
+when review or installation fails. For a reproducible repository install, add
+`--project`; Pentect then writes `pentect.plugins.lock`, which should be
+committed.
 
 ## Updates and approval
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -182,21 +182,23 @@ Treat redirected or in-place resolved output as plaintext secret material.
 | --- | --- |
 | `plugins search [QUERY]` | Search the first-party catalog |
 | `plugins inspect SOURCE` | Show the manifest, hooks, binary, and requested access |
-| `plugins add SOURCE [--yes]` | Verify, approve, and enable a plugin in this project |
-| `plugins remove NAME` | Disable a plugin in this project |
+| `plugins add SOURCE [--yes] [--project]` | Verify, approve, and enable a plugin for the user (or this project) |
+| `plugins remove NAME [--project]` | Disable a user plugin (or a project plugin) |
 | `plugins list [--json]` | Show enabled and installed plugins |
-| `plugins config NAME KEY=VALUE` | Save one JSON setting for a plugin |
-| `plugins config NAME --unset KEY` | Remove one plugin setting |
-| `plugins setup NAME [--yes]` | Review changed hooks or access again |
+| `plugins config NAME KEY=VALUE [--project]` | Save one setting in the selected scope |
+| `plugins config NAME --unset KEY [--project]` | Remove one setting in the selected scope |
+| `plugins setup NAME [--yes] [--project]` | Review changed hooks or access again |
 | `plugins test SOURCE [--json]` | Validate a manifest or installed binary |
-| `plugins update [NAME] [--yes]` | Fetch and verify a newer release |
+| `plugins update [NAME] [--yes] [--project]` | Update user plugins (or project plugins) |
 | `plugins new NAME` | Create a Rust Wasm plugin project |
 | `plugins dev PATH [--yes]` | Build, approve, and activate a local development build |
 | `plugins publish PATH` | Build a release bundle in `dist` |
 
 `SOURCE` can be a local directory or `github:@OWNER/REPOSITORY/path`. Use
 `--plugins SOURCE` on a client or mask command when you need a plugin for only
-one launch.
+one launch. Plugin-management commands use user scope by default; pass
+`--project` for `.pentect/config.toml`, the project lock, approval, settings,
+and runtime data.
 
 Approval flags skip an interactive confirmation; they do not skip checksum,
 build-record, manifest, or sandbox checks.

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -150,5 +150,7 @@ pentect plugins config PLUGIN --unset policy.level
 pentect plugins setup PLUGIN
 ```
 
-`plugins add` records an enabled source in the project config. Wasm access is
-approved separately and tied to the manifest and binary hashes.
+`plugins add` records an enabled source in the user config by default. Add
+`--project` to use the project config instead. Wasm and Command access is
+approved separately and tied to the selected scope, manifest, and binary or
+command-file hashes.


### PR DESCRIPTION
## Summary
- make plugin management user-wide by default with `--project` as the explicit repository scope
- keep configuration, content lock, approval, settings, managed Command/Wasm runtime, and process environment in the selected scope
- canonicalize user-wide local plugin paths and prevent project-local name shadowing
- document scope ordering and migration behavior

## Validation
- `cargo test --workspace` (with active Pentect session env removed to match CI)
- `cargo test -p pentect-cli --no-default-features --locked`
- `cargo test -p pentect-runtime --no-default-features plugin_middleware::tests --locked`
- `cargo clippy -p pentect-core -p pentect-runtime -p pentect-cli --all-targets --no-default-features -- -D warnings`
- `npm ci --ignore-scripts && npm run build` in `website/`
- integration test installs a relative-path plugin globally, uses it from a second project, and verifies `--project` remains isolated
- Command plugin E2E loads an approved user-global runtime and returns configured findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plugin installation and configuration now default to the user account.
  - Added `--project` support for project-specific plugin management.
  - User and project plugins use separate configuration and lock files.
  - User plugins run before project and one-off plugins.
  - Plugin approvals and command execution now support both scopes.

- **Documentation**
  - Updated plugin lifecycle, installation, configuration, locking, and CLI guidance to explain scoped behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->