### PR TITLE
Prepare v0.0.47 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.46"
+version = "0.0.47"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.46"
+version = "0.0.47"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2,7 +2,7 @@
 //!
 //! Security boundary:
 //! - outbound model-visible text and client tool results are masked;
-//! - inbound assistant text stays masked;
+//! - inbound assistant text stays masked unless the user opts into local restoration;
 //! - only completed client `tool_use.input` values are resolved;
 //! - unknown events and incomplete/invalid tool JSON remain unresolved.
 //!
@@ -37,9 +37,61 @@ const MAX_HTTP_BODY_BYTES: usize = 32 * 1024 * 1024;
 const MAX_PENDING_SSE_BYTES: usize = 32 * 1024 * 1024;
 const MAX_INLINE_PDF_BYTES: usize = 8 * 1024 * 1024;
 const MAX_EXTRACTED_PDF_TEXT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_OUTPUT_HANDLE_BYTES: usize = 512;
 static WARNED_UNKNOWN_CONTENT_BLOCK: AtomicBool = AtomicBool::new(false);
 static WARNED_UNKNOWN_ENDPOINT: AtomicBool = AtomicBool::new(false);
 static WARNED_PROVIDER_MCP_CREDENTIALS: AtomicBool = AtomicBool::new(false);
+
+#[derive(Default)]
+pub(crate) struct OutputTextRestorer {
+    pending: String,
+}
+
+impl OutputTextRestorer {
+    pub(crate) fn push<R>(&mut self, chunk: &str, resolve: &mut R) -> Result<String, String>
+    where
+        R: FnMut(&str) -> Result<String, String>,
+    {
+        self.pending.push_str(chunk);
+        let mut input = std::mem::take(&mut self.pending);
+        let mut output = String::with_capacity(input.len());
+        loop {
+            let Some(start) = input.find("<<") else {
+                if input.ends_with('<') {
+                    let split = input.len() - 1;
+                    output.push_str(&input[..split]);
+                    self.pending.push('<');
+                } else {
+                    output.push_str(&input);
+                }
+                return Ok(output);
+            };
+            output.push_str(&input[..start]);
+            input.drain(..start);
+            let Some(close) = input[2..].find(">>") else {
+                if input.len() <= MAX_OUTPUT_HANDLE_BYTES {
+                    self.pending = input;
+                    return Ok(output);
+                }
+                output.push_str("<<");
+                input.drain(..2);
+                continue;
+            };
+            let end = close + 4;
+            if end > MAX_OUTPUT_HANDLE_BYTES {
+                output.push_str("<<");
+                input.drain(..2);
+                continue;
+            }
+            output.push_str(&resolve(&input[..end])?);
+            input.drain(..end);
+        }
+    }
+
+    pub(crate) fn finish(&mut self) -> String {
+        std::mem::take(&mut self.pending)
+    }
+}
 
 fn diagnostic(event: &str, kind: &str, endpoint: &str, retryable: bool) {
     pentect_agent::record_http_diagnostic_activity(
@@ -472,6 +524,7 @@ async fn proxy_request_inner(
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.split(';').next())
         .is_some_and(|value| value.trim().eq_ignore_ascii_case("text/event-stream"));
+    let restore_output = pentect_agent::output_restore_enabled()?;
     let mut builder = Response::builder().status(status);
     let connection_headers = connection_named_headers(&response_headers);
     for (name, value) in &response_headers {
@@ -494,6 +547,7 @@ async fn proxy_request_inner(
                 upstream_response,
                 transform,
                 Arc::clone(&state.plugins),
+                restore_output,
             ))
             .map_err(|error| format!("could not build Claude streaming response: {error}"));
     }
@@ -538,7 +592,7 @@ async fn proxy_request_inner(
     }
     let response_body = if status.is_success() && messages_path {
         let response_body = run_response_plugins(response_body, &state.plugins)?;
-        match rewrite_anthropic_json_response(&response_body) {
+        match rewrite_anthropic_json_response(&response_body, restore_output) {
             Ok(rewritten) => Bytes::from(rewritten),
             Err(_error) => {
                 diagnostic("response-restore-skipped", "protection", "messages", false);
@@ -1011,6 +1065,7 @@ fn streaming_response_body(
     response: reqwest::Response,
     transform: bool,
     plugins: Arc<StdMutex<pentect_agent::PluginMiddleware>>,
+    restore_output: bool,
 ) -> ProxyBody {
     if !transform {
         let stream = response.bytes_stream().map(|item| {
@@ -1022,7 +1077,11 @@ fn streaming_response_body(
 
     let state = TransformedStreamState {
         upstream: Box::pin(response.bytes_stream()),
-        transformer: SseStreamTransformer::new(Box::new(request_scoped_resolver()), Some(plugins)),
+        transformer: SseStreamTransformer::new(
+            Box::new(request_scoped_resolver()),
+            Some(plugins),
+            restore_output,
+        ),
         ready: VecDeque::new(),
         finished: false,
     };
@@ -1075,6 +1134,8 @@ struct SseStreamTransformer<R> {
     active_tool: Option<ActiveToolStream>,
     passthrough: bool,
     plugins: Option<Arc<StdMutex<pentect_agent::PluginMiddleware>>>,
+    restore_output: bool,
+    output_text: HashMap<u64, OutputTextRestorer>,
 }
 
 struct ActiveToolStream {
@@ -1093,13 +1154,19 @@ impl<R> SseStreamTransformer<R>
 where
     R: FnMut(&str) -> Result<String, String>,
 {
-    fn new(resolve: R, plugins: Option<Arc<StdMutex<pentect_agent::PluginMiddleware>>>) -> Self {
+    fn new(
+        resolve: R,
+        plugins: Option<Arc<StdMutex<pentect_agent::PluginMiddleware>>>,
+        restore_output: bool,
+    ) -> Self {
         Self {
             resolve,
             pending: Vec::new(),
             active_tool: None,
             passthrough: false,
             plugins,
+            restore_output,
+            output_text: HashMap::new(),
         }
     }
 
@@ -1121,7 +1188,7 @@ where
     }
 
     fn finish(&mut self) -> Vec<Bytes> {
-        let mut output = Vec::new();
+        let mut output = self.finish_output_text();
         if let Some(mut tool) = self.active_tool.take() {
             tool.bytes.append(&mut self.pending);
             if !tool.bytes.is_empty() {
@@ -1131,6 +1198,29 @@ where
             output.push(Bytes::from(std::mem::take(&mut self.pending)));
         }
         output
+    }
+
+    fn finish_output_text(&mut self) -> Vec<Bytes> {
+        let mut streams = self.output_text.drain().collect::<Vec<_>>();
+        streams.sort_by_key(|(index, _)| *index);
+        streams
+            .into_iter()
+            .filter_map(|(index, mut restorer)| {
+                let pending = restorer.finish();
+                if pending.is_empty() {
+                    return None;
+                }
+                Some(Bytes::from(render_sse(&[SseBlock {
+                    event: Some("content_block_delta".to_string()),
+                    data: Some(serde_json::json!({
+                        "type": "content_block_delta",
+                        "index": index,
+                        "delta": {"type": "text_delta", "text": pending},
+                    })),
+                    passthrough: Vec::new(),
+                }])))
+            })
+            .collect()
     }
 
     fn process_block(&mut self, block: Vec<u8>, output: &mut Vec<Bytes>) -> Result<(), String> {
@@ -1192,12 +1282,23 @@ where
                     bytes: block,
                 });
             }
+            _ if self.restore_output => {
+                match rewrite_anthropic_output_sse_block(
+                    &block,
+                    &mut self.output_text,
+                    &mut self.resolve,
+                )? {
+                    Some(rewritten) => output.push(Bytes::from(rewritten)),
+                    None => output.push(Bytes::from(block)),
+                }
+            }
             _ => output.push(Bytes::from(block)),
         }
         Ok(())
     }
 
     fn fail_open_with(&mut self, chunk: &[u8]) -> Vec<Bytes> {
+        let mut output = self.finish_output_text();
         let mut bytes = self
             .active_tool
             .take()
@@ -1205,8 +1306,89 @@ where
         bytes.append(&mut self.pending);
         bytes.extend_from_slice(chunk);
         self.passthrough = true;
-        vec![Bytes::from(bytes)]
+        output.push(Bytes::from(bytes));
+        output
     }
+}
+
+fn rewrite_anthropic_output_sse_block<R>(
+    block: &[u8],
+    streams: &mut HashMap<u64, OutputTextRestorer>,
+    resolve: &mut R,
+) -> Result<Option<Vec<u8>>, String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
+    let Ok(text) = std::str::from_utf8(block) else {
+        return Ok(None);
+    };
+    let mut blocks = parse_sse(text);
+    let Some(parsed) = blocks.first_mut() else {
+        return Ok(None);
+    };
+    let Some(data) = parsed.data.as_mut() else {
+        return Ok(None);
+    };
+    let event_type = data.get("type").and_then(Value::as_str).map(str::to_owned);
+    let Some(index) = data.get("index").and_then(Value::as_u64) else {
+        return Ok(None);
+    };
+    match event_type.as_deref() {
+        Some("content_block_start")
+            if data
+                .get("content_block")
+                .and_then(|value| value.get("type"))
+                .and_then(Value::as_str)
+                == Some("text") =>
+        {
+            let restorer = streams.entry(index).or_default();
+            if let Some(Value::String(value)) = data
+                .get_mut("content_block")
+                .and_then(Value::as_object_mut)
+                .and_then(|value| value.get_mut("text"))
+            {
+                *value = restorer.push(value, resolve)?;
+            }
+        }
+        Some("content_block_delta")
+            if data
+                .get("delta")
+                .and_then(|value| value.get("type"))
+                .and_then(Value::as_str)
+                == Some("text_delta") =>
+        {
+            let restorer = streams.entry(index).or_default();
+            if let Some(Value::String(value)) = data
+                .get_mut("delta")
+                .and_then(Value::as_object_mut)
+                .and_then(|value| value.get_mut("text"))
+            {
+                *value = restorer.push(value, resolve)?;
+            }
+        }
+        Some("content_block_stop") => {
+            let Some(mut restorer) = streams.remove(&index) else {
+                return Ok(None);
+            };
+            let pending = restorer.finish();
+            if !pending.is_empty() {
+                let prefix = SseBlock {
+                    event: Some("content_block_delta".to_string()),
+                    data: Some(serde_json::json!({
+                        "type": "content_block_delta",
+                        "index": index,
+                        "delta": {"type": "text_delta", "text": pending},
+                    })),
+                    passthrough: Vec::new(),
+                };
+                return Ok(Some(
+                    format!("{}{}", render_sse(&[prefix]), render_sse(&blocks)).into_bytes(),
+                ));
+            }
+        }
+        _ => return Ok(None),
+    }
+    Ok(Some(render_sse(&blocks).into_bytes()))
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1643,7 +1825,7 @@ fn mask_value_strings(
     }
 }
 
-fn rewrite_anthropic_json_response(body: &[u8]) -> Result<Vec<u8>, String> {
+fn rewrite_anthropic_json_response(body: &[u8], restore_output: bool) -> Result<Vec<u8>, String> {
     let mut value: Value = serde_json::from_slice(body)
         .map_err(|error| format!("Claude response was not valid JSON: {error}"))?;
     let mut resolve = request_scoped_resolver();
@@ -1653,6 +1835,10 @@ fn rewrite_anthropic_json_response(body: &[u8]) -> Result<Vec<u8>, String> {
                 let tool_name = block.get("name").and_then(Value::as_str).map(str::to_owned);
                 if let Some(input) = block.get_mut("input") {
                     resolve_tool_input_value(input, tool_name.as_deref(), &mut resolve)?;
+                }
+            } else if restore_output && block.get("type").and_then(Value::as_str) == Some("text") {
+                if let Some(Value::String(text)) = block.get_mut("text") {
+                    *text = resolve(text)?;
                 }
             }
         }
@@ -3099,7 +3285,8 @@ mod tests {
             "event: content_block_delta\r\n",
             "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\r\n\r\n"
         );
-        let mut transformer = SseStreamTransformer::new(|text: &str| Ok(text.to_string()), None);
+        let mut transformer =
+            SseStreamTransformer::new(|text: &str| Ok(text.to_string()), None, false);
         let split = event.len() - 2;
         assert!(transformer
             .push(&event.as_bytes()[..split])
@@ -3107,6 +3294,38 @@ mod tests {
             .is_empty());
         let output = transformer.push(&event.as_bytes()[split..]).unwrap();
         assert_eq!(output, vec![Bytes::from(event)]);
+    }
+
+    #[test]
+    fn opted_in_streaming_text_restores_handles_split_across_events() {
+        let start = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n"
+        );
+        let first = concat!(
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"before <<CHAR\"}}\n\n"
+        );
+        let second = concat!(
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"GE_0123456789abcdef>> after\"}}\n\n"
+        );
+        let stop = concat!(
+            "event: content_block_stop\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"
+        );
+        let mut transformer = SseStreamTransformer::new(
+            |text: &str| Ok(text.replace("<<CHARGE_0123456789abcdef>>", "local-value")),
+            None,
+            true,
+        );
+        let mut output = transformer.push(start.as_bytes()).unwrap();
+        output.extend(transformer.push(first.as_bytes()).unwrap());
+        output.extend(transformer.push(second.as_bytes()).unwrap());
+        output.extend(transformer.push(stop.as_bytes()).unwrap());
+        let output = join_bytes(output);
+        assert!(output.contains("local-value"), "{output}");
+        assert!(!output.contains("<<CHARGE_"), "{output}");
     }
 
     #[test]
@@ -3130,6 +3349,7 @@ mod tests {
         let mut transformer = SseStreamTransformer::new(
             |text: &str| Ok(text.replace("<<SECRET_deadbeef>>", "actual-secret")),
             None,
+            false,
         );
         assert!(transformer.push(start.as_bytes()).unwrap().is_empty());
         assert!(transformer.push(delta_one.as_bytes()).unwrap().is_empty());
@@ -3159,6 +3379,7 @@ mod tests {
         let mut transformer = SseStreamTransformer::new(
             |text: &str| Ok(text.replace("<<SECRET_deadbeef>>", "must-not-appear")),
             None,
+            false,
         );
         assert!(transformer.push(incomplete.as_bytes()).unwrap().is_empty());
         let output = join_bytes(transformer.finish());
@@ -3182,6 +3403,7 @@ mod tests {
                     .replace("<<SECRET_two>>", "second"))
             },
             None,
+            false,
         );
         let mut output = transformer
             .push(tool(1, "<<SECRET_one>>").as_bytes())
@@ -3209,6 +3431,7 @@ mod tests {
         let mut transformer = SseStreamTransformer::new(
             |text: &str| Ok(text.replace("<<SECRET_deadbeef>>", "must-not-appear")),
             None,
+            false,
         );
         assert!(transformer.push(start.as_bytes()).unwrap().is_empty());
         assert_eq!(join_bytes(transformer.push(ping.as_bytes()).unwrap()), ping);

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -2,7 +2,8 @@
 //!
 //! Model-bound prompts and local function outputs are masked on requests.
 //! Completed client function-call arguments are resolved on responses. Local
-//! UI and provider-generated text remain unchanged.
+//! Provider-generated text remains masked unless the user opts into local
+//! output restoration.
 
 use futures_util::{stream, Stream, StreamExt};
 use http_body_util::combinators::UnsyncBoxBody;
@@ -62,6 +63,7 @@ type ProxyBodyError = Box<dyn Error + Send + Sync>;
 type ProxyBody = UnsyncBoxBody<Bytes, ProxyBodyError>;
 type UpstreamByteStream =
     Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static>>;
+type HandleResolver = Box<dyn FnMut(&str) -> Result<String, String> + Send>;
 
 pub(crate) struct OpenAiHttpProxyGuard {
     base_url: String,
@@ -531,6 +533,7 @@ async fn proxy_request_inner(
     }) || ((responses_response || chat_response)
         && !request_streaming
         && response_media_type.is_none());
+    let restore_output = pentect_agent::output_restore_enabled()?;
     let mut builder = Response::builder().status(status);
     let connection_headers = connection_named_headers(&response_headers);
     for (name, value) in &response_headers {
@@ -558,6 +561,7 @@ async fn proxy_request_inner(
                     StreamTransform::None
                 },
                 Arc::clone(&state.plugins),
+                restore_output,
             ))
             .map_err(|error| format!("could not build OpenAI streaming response: {error}"));
     }
@@ -604,9 +608,9 @@ async fn proxy_request_inner(
         if (responses_response || chat_response) && status.is_success() && is_json_response {
             let response_body = run_response_plugins(response_body, &state.plugins, "openai")?;
             let rewritten = if chat_response {
-                rewrite_chat_completions_json_response(&response_body)
+                rewrite_chat_completions_json_response(&response_body, restore_output)
             } else {
-                rewrite_openai_json_response(&response_body)
+                rewrite_openai_json_response(&response_body, restore_output)
             };
             match rewritten {
                 Ok(rewritten) => Bytes::from(rewritten),
@@ -1698,22 +1702,91 @@ fn mask_text(
     crate::claude_http_proxy::mask_string(text, tool_result, masker)
 }
 
-fn rewrite_openai_json_response(body: &[u8]) -> Result<Vec<u8>, String> {
+fn rewrite_openai_json_response(body: &[u8], restore_output: bool) -> Result<Vec<u8>, String> {
     let mut value: Value = serde_json::from_slice(body)
         .map_err(|error| format!("OpenAI response was not valid JSON: {error}"))?;
     let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
     rewrite_function_calls(&mut value, &mut resolve)?;
+    if restore_output {
+        restore_openai_output_text(&mut value, &mut resolve)?;
+    }
     serde_json::to_vec(&value)
         .map_err(|error| format!("could not encode restored OpenAI response: {error}"))
 }
 
-fn rewrite_chat_completions_json_response(body: &[u8]) -> Result<Vec<u8>, String> {
+fn rewrite_chat_completions_json_response(
+    body: &[u8],
+    restore_output: bool,
+) -> Result<Vec<u8>, String> {
     let mut value: Value = serde_json::from_slice(body)
         .map_err(|error| format!("OpenAI Chat Completions response was not valid JSON: {error}"))?;
     let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
     rewrite_chat_tool_calls(&mut value, &mut resolve)?;
+    if restore_output {
+        restore_chat_output_text(&mut value, &mut resolve)?;
+    }
     serde_json::to_vec(&value)
         .map_err(|error| format!("could not encode restored Chat Completions response: {error}"))
+}
+
+fn restore_openai_output_text<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                restore_openai_output_text(value, resolve)?;
+            }
+        }
+        Value::Object(object) => {
+            let is_output_text = object.get("type").and_then(Value::as_str) == Some("output_text");
+            if is_output_text {
+                if let Some(Value::String(text)) = object.get_mut("text") {
+                    *text = resolve(text)?;
+                }
+            }
+            for key in ["output", "content", "response", "item"] {
+                if let Some(value) = object.get_mut(key) {
+                    restore_openai_output_text(value, resolve)?;
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn restore_chat_output_text<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
+    let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    for choice in choices {
+        let Some(content) = choice
+            .get_mut("message")
+            .and_then(Value::as_object_mut)
+            .and_then(|message| message.get_mut("content"))
+        else {
+            continue;
+        };
+        match content {
+            Value::String(text) => *text = resolve(text)?,
+            Value::Array(parts) => {
+                for part in parts {
+                    if part.get("type").and_then(Value::as_str) == Some("text") {
+                        if let Some(Value::String(text)) = part.get_mut("text") {
+                            *text = resolve(text)?;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 fn rewrite_chat_tool_calls<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
@@ -1855,6 +1928,9 @@ struct StreamState {
     chat: ChatStreamState,
     finished: bool,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
+    restore_output: bool,
+    output_text: HashMap<String, crate::claude_http_proxy::OutputTextRestorer>,
+    output_resolve: HandleResolver,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1868,6 +1944,7 @@ fn streaming_response_body(
     response: reqwest::Response,
     transform: StreamTransform,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
+    restore_output: bool,
 ) -> ProxyBody {
     let state = StreamState {
         upstream: Box::pin(response.bytes_stream()),
@@ -1877,6 +1954,9 @@ fn streaming_response_body(
         chat: ChatStreamState::default(),
         finished: false,
         plugins,
+        restore_output,
+        output_text: HashMap::new(),
+        output_resolve: Box::new(crate::claude_http_proxy::request_scoped_resolver()),
     };
     let stream = stream::unfold(state, |mut state| async move {
         loop {
@@ -1913,13 +1993,20 @@ fn streaming_response_body(
                     while let Some(end) = first_sse_block_end(&state.pending) {
                         let block = state.pending.drain(..end).collect::<Vec<_>>();
                         let rewritten = match state.transform {
-                            StreamTransform::Responses => {
-                                rewrite_openai_sse_block(&block, &state.plugins)
-                                    .map(|block| vec![block])
-                            }
-                            StreamTransform::ChatCompletions => {
-                                state.chat.rewrite_block(&block, &state.plugins)
-                            }
+                            StreamTransform::Responses => rewrite_openai_sse_block(
+                                &block,
+                                &state.plugins,
+                                state.restore_output,
+                                &mut state.output_text,
+                                &mut state.output_resolve,
+                            )
+                            .map(|block| vec![block]),
+                            StreamTransform::ChatCompletions => state.chat.rewrite_block(
+                                &block,
+                                &state.plugins,
+                                state.restore_output,
+                                &mut state.output_resolve,
+                            ),
                             StreamTransform::None => Ok(vec![Bytes::from(block)]),
                         };
                         match rewritten {
@@ -1968,6 +2055,7 @@ fn streaming_response_body(
 struct ChatStreamState {
     calls: HashMap<(u64, u64), ChatStreamCall>,
     buffered_bytes: usize,
+    output_text: HashMap<u64, crate::claude_http_proxy::OutputTextRestorer>,
 }
 
 #[derive(Default)]
@@ -1989,6 +2077,8 @@ impl ChatStreamState {
         &mut self,
         block: &[u8],
         plugins: &Mutex<pentect_agent::PluginMiddleware>,
+        restore_output: bool,
+        resolve: &mut HandleResolver,
     ) -> Result<Vec<Bytes>, String> {
         let Ok(text) = std::str::from_utf8(block) else {
             return Ok(vec![Bytes::copy_from_slice(block)]);
@@ -2012,15 +2102,37 @@ impl ChatStreamState {
         if let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) {
             for choice in choices {
                 let choice_index = choice.get("index").and_then(Value::as_u64).unwrap_or(0);
-                if choice
+                let choice_finished = choice
                     .get("finish_reason")
-                    .is_some_and(|reason| !reason.is_null())
-                {
+                    .is_some_and(|reason| !reason.is_null());
+                if choice_finished {
                     completed_choices.push(choice_index);
                 }
                 let Some(delta) = choice.get_mut("delta").and_then(Value::as_object_mut) else {
                     continue;
                 };
+                if restore_output {
+                    if let Some(Value::String(content)) = delta.get_mut("content") {
+                        *content = self
+                            .output_text
+                            .entry(choice_index)
+                            .or_default()
+                            .push(content, resolve)?;
+                    }
+                    if choice_finished {
+                        if let Some(mut restorer) = self.output_text.remove(&choice_index) {
+                            let pending = restorer.finish();
+                            if !pending.is_empty() {
+                                let content = delta
+                                    .entry("content".to_string())
+                                    .or_insert_with(|| Value::String(String::new()));
+                                if let Value::String(content) = content {
+                                    content.push_str(&pending);
+                                }
+                            }
+                        }
+                    }
+                }
                 let Some(tool_calls) = delta
                     .remove("tool_calls")
                     .and_then(|calls| calls.as_array().cloned())
@@ -2190,6 +2302,9 @@ fn encode_sse_value(template: &str, value: &Value) -> Result<Bytes, String> {
 fn rewrite_openai_sse_block(
     block: &[u8],
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
+    restore_output: bool,
+    output_text: &mut HashMap<String, crate::claude_http_proxy::OutputTextRestorer>,
+    resolve: &mut HandleResolver,
 ) -> Result<Bytes, String> {
     let Ok(text) = std::str::from_utf8(block) else {
         return Ok(Bytes::copy_from_slice(block));
@@ -2207,18 +2322,24 @@ fn rewrite_openai_sse_block(
     let Ok(mut value) = serde_json::from_str::<Value>(data) else {
         return Ok(Bytes::copy_from_slice(block));
     };
-    if !contains_completed_function_call(&value) {
+    let completed_function_call = contains_completed_function_call(&value);
+    let output_event = restore_output && contains_openai_output_text(&value);
+    if !completed_function_call && !output_event {
         return Ok(Bytes::copy_from_slice(block));
     }
-    let plugins = plugins
-        .lock()
-        .map_err(|_| "OpenAI plugin lock was poisoned".to_string())?;
-    run_openai_tool_plugins(&mut value, &plugins)?;
-    let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
-    if let Err(error) = rewrite_function_calls(&mut value, &mut resolve) {
+    if completed_function_call {
+        let plugins = plugins
+            .lock()
+            .map_err(|_| "OpenAI plugin lock was poisoned".to_string())?;
+        run_openai_tool_plugins(&mut value, &plugins)?;
+    }
+    if let Err(error) = rewrite_function_calls(&mut value, resolve) {
         let _ = error;
         proxy_diagnostic("sse-restore-skipped");
         return Ok(Bytes::copy_from_slice(block));
+    }
+    if output_event {
+        restore_openai_sse_output_text(&mut value, output_text, resolve)?;
     }
     let Ok(encoded) = serde_json::to_string(&value) else {
         return Ok(Bytes::copy_from_slice(block));
@@ -2240,6 +2361,70 @@ fn rewrite_openai_sse_block(
         }
     }
     Ok(Bytes::from(output))
+}
+
+fn contains_openai_output_text(value: &Value) -> bool {
+    matches!(
+        value.get("type").and_then(Value::as_str),
+        Some("response.output_text.delta" | "response.output_text.done" | "response.completed")
+    )
+}
+
+fn openai_output_stream_key(value: &Value) -> String {
+    if let Some(item_id) = value.get("item_id").and_then(Value::as_str) {
+        return format!(
+            "{item_id}:{}",
+            value
+                .get("content_index")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        );
+    }
+    format!(
+        "{}:{}",
+        value
+            .get("output_index")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        value
+            .get("content_index")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+    )
+}
+
+fn restore_openai_sse_output_text<R>(
+    value: &mut Value,
+    streams: &mut HashMap<String, crate::claude_http_proxy::OutputTextRestorer>,
+    resolve: &mut R,
+) -> Result<(), String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
+    let event_type = value.get("type").and_then(Value::as_str).map(str::to_owned);
+    match event_type.as_deref() {
+        Some("response.output_text.delta") => {
+            let key = openai_output_stream_key(value);
+            if let Some(Value::String(delta)) = value.get_mut("delta") {
+                *delta = streams.entry(key).or_default().push(delta, resolve)?;
+            }
+        }
+        Some("response.output_text.done") => {
+            let key = openai_output_stream_key(value);
+            streams.remove(&key);
+            if let Some(Value::String(text)) = value.get_mut("text") {
+                *text = resolve(text)?;
+            }
+        }
+        Some("response.completed") => {
+            if let Some(response) = value.get_mut("response") {
+                restore_openai_output_text(response, resolve)?;
+            }
+            streams.clear();
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 fn contains_completed_function_call(value: &Value) -> bool {
@@ -3037,14 +3222,19 @@ mod tests {
                 "id": "chat_1", "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]
             })
         );
-        let first_out = state.rewrite_block(first.as_bytes(), &plugins).unwrap();
+        let mut resolve: HandleResolver = Box::new(|text: &str| Ok(text.to_string()));
+        let first_out = state
+            .rewrite_block(first.as_bytes(), &plugins, false, &mut resolve)
+            .unwrap();
         assert_eq!(first_out.len(), 1);
         assert!(!String::from_utf8_lossy(&first_out[0]).contains("tool_calls"));
         assert!(state
-            .rewrite_block(second.as_bytes(), &plugins)
+            .rewrite_block(second.as_bytes(), &plugins, false, &mut resolve)
             .unwrap()
             .is_empty());
-        let finished = state.rewrite_block(finish.as_bytes(), &plugins).unwrap();
+        let finished = state
+            .rewrite_block(finish.as_bytes(), &plugins, false, &mut resolve)
+            .unwrap();
         assert_eq!(finished.len(), 2);
         let completed = String::from_utf8_lossy(&finished[0]);
         assert!(completed.contains("call_1"), "{completed}");
@@ -3257,6 +3447,47 @@ mod tests {
     }
 
     #[test]
+    fn opted_in_response_text_restores_known_handles_only() {
+        let mut value = serde_json::json!({
+            "output": [{
+                "type": "message",
+                "content": [{
+                    "type": "output_text",
+                    "text": "use <<CHARGE_0123456789abcdef>> and <<UNKNOWN_0123456789abcdef>>"
+                }]
+            }]
+        });
+        let mut resolve =
+            |text: &str| Ok(text.replace("<<CHARGE_0123456789abcdef>>", "local-value"));
+        restore_openai_output_text(&mut value, &mut resolve).unwrap();
+        assert_eq!(
+            value["output"][0]["content"][0]["text"],
+            "use local-value and <<UNKNOWN_0123456789abcdef>>"
+        );
+    }
+
+    #[test]
+    fn opted_in_openai_stream_restores_a_handle_split_across_events() {
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let mut streams = HashMap::new();
+        let mut resolve: HandleResolver =
+            Box::new(|text: &str| Ok(text.replace("<<CHARGE_0123456789abcdef>>", "local-value")));
+        let first = b"data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"content_index\":0,\"delta\":\"before <<CHAR\"}\n\n";
+        let second = b"data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"content_index\":0,\"delta\":\"GE_0123456789abcdef>> after\"}\n\n";
+        let first =
+            rewrite_openai_sse_block(first, &plugins, true, &mut streams, &mut resolve).unwrap();
+        let second =
+            rewrite_openai_sse_block(second, &plugins, true, &mut streams, &mut resolve).unwrap();
+        let output = format!(
+            "{}{}",
+            String::from_utf8_lossy(&first),
+            String::from_utf8_lossy(&second)
+        );
+        assert!(output.contains("local-value"), "{output}");
+        assert!(!output.contains("<<CHARGE_"), "{output}");
+    }
+
+    #[test]
     fn authenticated_path_does_not_accept_prefix_confusion() {
         assert_eq!(
             authenticated_request_path("/token/v1/responses", "token"),
@@ -3282,8 +3513,12 @@ mod tests {
     fn untouched_sse_framing_is_preserved() {
         let input = b"event: response.output_text.delta\r\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\r\n\r\n";
         let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let mut streams = HashMap::new();
+        let mut resolve: HandleResolver = Box::new(|text: &str| Ok(text.to_string()));
         assert_eq!(
-            rewrite_openai_sse_block(input, &plugins).unwrap().as_ref(),
+            rewrite_openai_sse_block(input, &plugins, false, &mut streams, &mut resolve,)
+                .unwrap()
+                .as_ref(),
             input
         );
     }

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -420,6 +420,19 @@ pub(crate) fn activity_share_enabled() -> Result<bool, String> {
     Ok(project.or(global).unwrap_or(true))
 }
 
+pub(crate) fn output_restore_enabled() -> Result<bool, String> {
+    let project = read_output_restore(project_config_path())?;
+    let global = read_output_restore(global_config_path()?)?;
+    Ok(output_restore_effective(project, global))
+}
+
+fn output_restore_effective(project: Option<bool>, global: Option<bool>) -> bool {
+    // Restoring assistant prose reveals protected values to terminals and local
+    // client logs. A repository may opt out, but cannot opt a user into that
+    // wider boundary without the same setting in the user config.
+    global.unwrap_or(false) && project.unwrap_or(true)
+}
+
 pub(crate) fn unknown_formats_should_block() -> Result<bool, String> {
     let project = read_unknown_format_policy(project_config_path())?;
     let global = read_unknown_format_policy(global_config_path()?)?;
@@ -587,6 +600,23 @@ fn decode_config_value(value: &toml::Value) -> Result<DecodeConfigPartial, Strin
 
 fn read_files_remember(path: PathBuf) -> Result<Option<bool>, String> {
     parse_config_file(&path)?.map_or(Ok(None), |value| files_remember_value(&value))
+}
+
+fn read_output_restore(path: PathBuf) -> Result<Option<bool>, String> {
+    parse_config_file(&path)?.map_or(Ok(None), |value| output_restore_value(&value))
+}
+
+fn output_restore_value(value: &toml::Value) -> Result<Option<bool>, String> {
+    let Some(raw) = value.get("output") else {
+        return Ok(None);
+    };
+    let Some(table) = raw.as_table() else {
+        return Err("output config must be a table".to_string());
+    };
+    table
+        .get("restore")
+        .map(|raw| config_bool(raw, "output.restore"))
+        .transpose()
 }
 
 fn reject_removed_environment_config(path: PathBuf) -> Result<(), String> {
@@ -1254,5 +1284,25 @@ unknown_min_bytes = 32
 
         let value = "[log]\nshare = true".parse::<toml::Value>().unwrap();
         assert!(activity_share_value(&value).is_err());
+    }
+
+    #[test]
+    fn output_restore_is_opt_in_and_project_cannot_enable_it() {
+        let enabled = "[output]\nrestore = true".parse::<toml::Value>().unwrap();
+        let disabled = "[output]\nrestore = false".parse::<toml::Value>().unwrap();
+        assert_eq!(output_restore_value(&enabled).unwrap(), Some(true));
+        assert_eq!(output_restore_value(&disabled).unwrap(), Some(false));
+        assert!(!output_restore_effective(None, None));
+        assert!(!output_restore_effective(Some(true), None));
+        assert!(output_restore_effective(None, Some(true)));
+        assert!(!output_restore_effective(Some(false), Some(true)));
+    }
+
+    #[test]
+    fn output_restore_rejects_non_boolean_values() {
+        let value = "[output]\nrestore = \"sometimes\""
+            .parse::<toml::Value>()
+            .unwrap();
+        assert!(output_restore_value(&value).is_err());
     }
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -127,6 +127,10 @@ pub fn load_decode_config(profile: Profile) -> Result<pentect_core::DecodeConfig
     config::decode_config(profile)
 }
 
+pub fn output_restore_enabled() -> Result<bool, String> {
+    config::output_restore_enabled()
+}
+
 pub fn load_environment_variable_prefix() -> Result<String, String> {
     config::environment_variable_prefix()
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -38,6 +38,7 @@ ignored.
 | `files.remember` | `true` | Remember safe local file-to-handle information |
 | `activity.share` | `true` | Share events with compatible local Pentect processes |
 | `agent.required` | `false` | Require supported agents to start through Pentect |
+| `output.restore` | `false` | Restore known handles in assistant text shown by supported clients |
 
 ## Handle identity
 
@@ -125,6 +126,26 @@ share = true
 
 Project values normally override user values. `agent.required` is stricter: if
 either file sets it to `true`, the effective value is true.
+
+## Assistant output restoration
+
+By default, assistant text keeps protected handles visible. To restore known
+handles in assistant text locally, opt in from the user config:
+
+```toml
+[output]
+restore = true
+```
+
+This affects supported JSON and streaming responses for Codex, Claude,
+OpenCode, and Pi. It does not send plaintext back to the model provider, but it
+does place the restored value in the client UI and may place it in terminal
+scrollback, screenshots, or client logs. Unknown and expired handles remain
+unchanged.
+
+A project config cannot enable this wider output boundary by itself. It may set
+`output.restore = false` to disable a user-level opt-in for that project. Restart
+the protected client after changing the setting.
 
 ## Require the agent to start through Pentect
 

--- a/website/src/content/docs/start/handles.md
+++ b/website/src/content/docs/start/handles.md
@@ -11,6 +11,9 @@ A handle is a local reference to a sensitive value:
 
 The provider can see and copy this string. It cannot derive the value from it.
 Pentect restores a known handle only inside the protected local flow.
+Assistant prose keeps handles by default. The user-only
+[`output.restore`](/reference/configuration/#assistant-output-restoration)
+setting can opt into restoring known handles in the local client display.
 
 ## Anatomy
 

--- a/website/src/content/docs/start/what-is-pentect.md
+++ b/website/src/content/docs/start/what-is-pentect.md
@@ -41,12 +41,17 @@ provider can see. Local tools still use the permissions of the current user.
 | --- | --- |
 | Local input | Finds supported sensitive values and creates handles |
 | Request to the provider | Sends handles instead of known real values |
-| Model response | Keeps handles in text and tool arguments |
+| Model response | Keeps handles in text by default and in tool arguments |
 | Before a local tool runs | Restores handles that the current session knows |
 | Tool result | Checks and masks output before the next request |
 
 The client UI stays the same. Pentect starts the client with a local gateway for
 that process only.
+
+Assistant prose remains masked by default. Users who explicitly prefer local
+readability can enable [`output.restore`](/reference/configuration/#assistant-output-restoration).
+That opt-in restores only handles known to the active session and can expose the
+value to terminal scrollback or client logs.
 
 ## Supported surfaces
 


### PR DESCRIPTION
## Summary
- add user-only opt-in `output.restore = true` for known handles in assistant JSON and streaming text
- keep assistant output masked by default and prevent project config from enabling restoration by itself
- preserve completed tool-argument restoration and unknown handles
- document the output boundary and its local logging/scrollback risk
- bump the Pentect CLI and npm wrapper to 0.0.47

## Validation
- GitHub Actions is the authoritative test run for Rust, npm, macOS, Windows, OCR, plugins, and installer coverage
- formatting and diff integrity checked before push