### PR TITLE
Fix global GitHub plugin installation and release v0.0.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.47"
+version = "0.0.48"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -157,7 +157,7 @@ pub(crate) fn parse_plugin_value(value: &str) -> Result<Vec<String>> {
 
 pub(crate) fn plugin_spec_for_scope(spec: &str, scope: PluginScope) -> Result<String> {
     validate_plugin_spec(spec)?;
-    if scope == PluginScope::User && is_path_spec(spec) {
+    if scope == PluginScope::User && !is_remote_spec(spec) && is_path_spec(spec) {
         if config_specs_scoped()?
             .into_iter()
             .any(|(configured_scope, configured)| configured_scope == scope && configured == spec)
@@ -2104,6 +2104,15 @@ label = "INLINE_SECRET"
         assert_eq!(
             parse_plugin_value("github:@EdamAme-x/pentect/plugins/pii-ner").unwrap(),
             ["github:@EdamAme-x/pentect/plugins/pii-ner"]
+        );
+    }
+
+    #[test]
+    fn user_scoped_github_plugin_is_not_resolved_as_a_local_path() {
+        let spec = "github:@EdamAme-x/pentect/plugins/example-regex";
+        assert_eq!(
+            plugin_spec_for_scope(spec, PluginScope::User).unwrap(),
+            spec
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- classify GitHub plugin shorthand as remote before local-path handling
- add a regression test for user-scoped GitHub plugins
- bump CLI and npm package versions to 0.0.48

## Release validation
This fixes the common failure found by every direct-install lifecycle job in the v0.0.47 release workflow. CI must pass before merge and v0.0.48 tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed user-scoped GitHub plugin references being incorrectly interpreted as local file paths.
  - Remote plugin shorthand now remains intact during scope-specific resolution.

- **Chores**
  - Updated the package and command-line tool version to 0.0.48.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->