### PR TITLE
Honor global plugin scope when inspecting by name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.48"
+version = "0.0.49"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.48"
+version = "0.0.49"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -283,19 +283,6 @@ pub(crate) fn active_from_specs(
     active_from_scoped_specs(specs, create_named)
 }
 
-pub(crate) fn active_from_explicit_specs(
-    specs: Vec<String>,
-    create_named: bool,
-) -> Result<ActivePlugins> {
-    active_from_scoped_specs(
-        specs
-            .into_iter()
-            .map(|spec| (PluginScope::Project, spec))
-            .collect(),
-        create_named,
-    )
-}
-
 pub(crate) fn active_from_selected_specs(
     specs: Vec<String>,
     create_named: bool,
@@ -2099,7 +2086,7 @@ label = "INLINE_SECRET"
         )
         .unwrap();
 
-        let active = active_from_explicit_specs(vec![root.display().to_string()], true).unwrap();
+        let active = active_from_selected_specs(vec![root.display().to_string()], true).unwrap();
         assert_eq!(active.config_paths().len(), 1);
         assert!(active.config_paths()[0].ends_with("plugin.toml"));
         assert_eq!(load_config_packs_from_active(&active).unwrap().len(), 1);
@@ -2611,7 +2598,7 @@ label = "INLINE_SECRET"
         )
         .unwrap();
 
-        let active = active_from_explicit_specs(vec![root.display().to_string()], true).unwrap();
+        let active = active_from_selected_specs(vec![root.display().to_string()], true).unwrap();
         let packs = load_config_packs_from_active(&active).unwrap();
         assert!(packs.is_empty());
 

--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -296,6 +296,21 @@ pub(crate) fn active_from_explicit_specs(
     )
 }
 
+pub(crate) fn active_from_selected_specs(
+    specs: Vec<String>,
+    create_named: bool,
+) -> Result<ActivePlugins> {
+    let specs = specs
+        .into_iter()
+        .map(|spec| {
+            let resolved = resolve_configured_plugin_spec(&spec)?;
+            let scope = configured_scope(&resolved).unwrap_or(PluginScope::Project);
+            Ok((scope, resolved))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    active_from_scoped_specs(specs, create_named)
+}
+
 pub(crate) fn active_from_scoped_specs(
     specs: Vec<(PluginScope, String)>,
     create_named: bool,

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -3403,7 +3403,7 @@ fn confirm_setup() -> Result<bool, String> {
 
 fn active_for_one(spec: &str) -> Result<plugins::ActivePlugins, String> {
     let specs = plugins::parse_plugin_value(spec).map_err(|e| e.to_string())?;
-    plugins::active_from_explicit_specs(specs, true).map_err(|e| e.to_string())
+    plugins::active_from_selected_specs(specs, true).map_err(|e| e.to_string())
 }
 
 fn test_pack(path: &Path) -> Check {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- preserve the configured user/project scope when selecting one plugin by manifest name
- make `plugins inspect openai-privacy-filter` work after a default global install
- bump CLI and npm versions to 0.0.49

## Release validation
The v0.0.48 release lifecycle proved direct installation, update, remote download, setup, and masking all work. It then found this second scope bug during inspection. CI and the full release lifecycle must pass before stable promotion.