### PR TITLE
Fix plugin refresh and automate OpenAI Privacy Filter setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.49"
+version = "0.0.50"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -856,6 +856,9 @@ fn plugin_source_with_refresh(
             )?;
         }
         let manifest_path = fetch_remote_plugin_file_with_refresh(&manifest_url, refresh)?;
+        if refresh {
+            refresh_remote_command_files(&base, manifest_path.as_deref())?;
+        }
         let name = remote_plugin_name(&base)?;
         let remote_base = if points_to_manifest {
             manifest_url.clone()
@@ -938,6 +941,9 @@ fn plugin_source_with_refresh(
     }
     let manifest_path =
         fetch_remote_plugin_file_with_refresh(&format!("{base}/{PLUGIN_MANIFEST_FILE}"), refresh)?;
+    if refresh {
+        refresh_remote_command_files(&base, manifest_path.as_deref())?;
+    }
     Ok(PluginSource {
         name: spec.to_string(),
         manifest_path,
@@ -1424,10 +1430,26 @@ fn command_files_from_manifest(base: &str, manifest: &Path) -> Result<Vec<(PathB
     if direct.is_some() && platforms.is_some() {
         bail!("plugin.toml cannot set both command and [commands]");
     }
+    let setup = value.get("setup").and_then(toml::Value::as_table);
+    let setup_direct = setup
+        .and_then(|table| table.get("command"))
+        .and_then(toml::Value::as_array);
+    let setup_platforms = setup
+        .and_then(|table| table.get("commands"))
+        .and_then(toml::Value::as_table);
+    if setup_direct.is_some() && setup_platforms.is_some() {
+        bail!("plugin.toml cannot set both setup.command and [setup.commands]");
+    }
     let commands = direct
         .into_iter()
         .chain(
             platforms
+                .into_iter()
+                .flat_map(|table| table.values().filter_map(toml::Value::as_array)),
+        )
+        .chain(setup_direct)
+        .chain(
+            setup_platforms
                 .into_iter()
                 .flat_map(|table| table.values().filter_map(toml::Value::as_array)),
         )
@@ -1464,6 +1486,17 @@ fn command_files_from_manifest(base: &str, manifest: &Path) -> Result<Vec<(PathB
     files.sort_by(|left, right| left.0.cmp(&right.0));
     files.dedup_by(|left, right| left.0 == right.0);
     Ok(files)
+}
+
+fn refresh_remote_command_files(base: &str, manifest: Option<&Path>) -> Result<()> {
+    let Some(manifest) = manifest else {
+        return Ok(());
+    };
+    for (_, url) in command_files_from_manifest(base.trim_end_matches("/plugin.toml"), manifest)? {
+        fetch_remote_plugin_file_with_refresh(&url, true)?
+            .ok_or_else(|| anyhow!("remote command plugin file was not found: {url}"))?;
+    }
+    Ok(())
 }
 
 pub(crate) fn remote_command_files(source: &PluginSource) -> Result<Vec<(PathBuf, PathBuf)>> {
@@ -2203,7 +2236,7 @@ label = "INLINE_SECRET"
         let manifest = root.join("plugin.toml");
         std::fs::write(
             &manifest,
-            "schema = \"pentect.plugin.v1\"\n[commands]\nwindows = [\"{plugin}/windows.exe\"]\nmacos = [\"{plugin}/macos\"]\nlinux = [\"{plugin}/linux\"]\n",
+            "schema = \"pentect.plugin.v1\"\n[commands]\nwindows = [\"{plugin}/windows.exe\"]\nmacos = [\"{plugin}/macos\"]\nlinux = [\"{plugin}/linux\"]\n[setup.commands]\nwindows = [\"py\", \"{plugin}/setup.py\"]\nmacos = [\"python3\", \"{plugin}/setup.py\"]\nlinux = [\"python3\", \"{plugin}/setup.py\"]\n",
         )
         .unwrap();
         let files = command_files_from_manifest("https://example.test/plugin", &manifest).unwrap();
@@ -2212,8 +2245,47 @@ label = "INLINE_SECRET"
                 .iter()
                 .map(|(path, _)| path.to_string_lossy().replace('\\', "/"))
                 .collect::<Vec<_>>(),
-            ["linux", "macos", "windows.exe"]
+            ["linux", "macos", "setup.py", "windows.exe"]
         );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn refreshing_a_manifest_refetches_cached_command_files() {
+        use std::io::{Read as _, Write as _};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let command_url = format!("{base}/server.py");
+        let cached = remote_cache_file(&command_url).unwrap();
+        std::fs::create_dir_all(cached.parent().unwrap()).unwrap();
+        std::fs::write(&cached, b"old command").unwrap();
+        let root = std::env::temp_dir().join(format!(
+            "pentect-refresh-command-files-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let manifest = root.join("plugin.toml");
+        std::fs::write(
+            &manifest,
+            "schema = \"pentect.plugin.v1\"\ncommand = [\"python3\", \"{plugin}/server.py\"]\n",
+        )
+        .unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\nConnection: close\r\n\r\nnew command")
+                .unwrap();
+        });
+
+        refresh_remote_command_files(&base, Some(&manifest)).unwrap();
+        server.join().unwrap();
+
+        assert_eq!(std::fs::read(&cached).unwrap(), b"new command");
+        let _ = std::fs::remove_dir_all(cached.parent().unwrap());
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -4251,7 +4251,6 @@ mod tests {
         )
         .unwrap();
         let source = plugins::plugin_source(&root.to_string_lossy()).unwrap();
-        let manifest = load_plugin_manifest(&source).unwrap().unwrap();
         let runtime = plugin_runtime_dirs_for_source(&name, &source).unwrap();
 
         setup_plugin_source(source, true, Some("cpu"), false).unwrap();

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -27,7 +27,8 @@ pub(crate) fn cmd_plugins(args: &[String]) {
             spec,
             approved,
             scope,
-        } => add_plugin(&spec, approved, scope, opts.json),
+            profile,
+        } => add_plugin(&spec, approved, scope, profile.as_deref(), opts.json),
         Action::Remove { spec, scope } => remove_plugin(&spec, scope, opts.json),
         Action::Search { query } => search_plugins(query.as_deref(), opts.json),
         Action::Inspect { spec } => inspect_plugin(&spec, opts.json),
@@ -44,7 +45,8 @@ pub(crate) fn cmd_plugins(args: &[String]) {
             spec,
             approved,
             scope,
-        } => setup_plugin(&spec, approved, scope, opts.json),
+            profile,
+        } => setup_plugin(&spec, approved, scope, profile.as_deref(), opts.json),
         Action::Update {
             spec,
             approved,
@@ -72,6 +74,7 @@ enum Action {
         spec: String,
         approved: bool,
         scope: plugins::PluginScope,
+        profile: Option<String>,
     },
     Remove {
         spec: String,
@@ -106,6 +109,7 @@ enum Action {
         spec: String,
         approved: bool,
         scope: plugins::PluginScope,
+        profile: Option<String>,
     },
     Update {
         spec: Option<String>,
@@ -134,6 +138,7 @@ impl PluginCmd {
         let mut scope = plugins::PluginScope::User;
         let mut scope_explicit = false;
         let mut unset = None;
+        let mut profile = None;
         let mut values = Vec::new();
         let mut i = 3usize;
         while i < args.len() {
@@ -149,6 +154,18 @@ impl PluginCmd {
                         return Err("--unset requires a key".to_string());
                     };
                     unset = Some(key.clone());
+                    i += 1;
+                }
+                "--profile" => {
+                    let Some(value) = args.get(i + 1) else {
+                        return Err("--profile requires a profile name".to_string());
+                    };
+                    if value.starts_with("--") {
+                        return Err("--profile requires a profile name".to_string());
+                    }
+                    if profile.replace(value.clone()).is_some() {
+                        return Err("--profile may only be set once".to_string());
+                    }
                     i += 1;
                 }
                 flag if flag.starts_with("--") => return Err(format!("unknown option: {flag}")),
@@ -178,6 +195,7 @@ impl PluginCmd {
                     spec: one_value("plugins add", values)?,
                     approved,
                     scope,
+                    profile: profile.clone(),
                 }
             }
             "remove" => {
@@ -262,6 +280,7 @@ impl PluginCmd {
                     spec: one_value("plugins setup", values)?,
                     approved,
                     scope,
+                    profile: profile.clone(),
                 }
             }
             "update" => {
@@ -280,6 +299,9 @@ impl PluginCmd {
             }
             other => return Err(format!("unknown plugins command: {other}")),
         };
+        if profile.is_some() && !matches!(action, Action::Add { .. } | Action::Setup { .. }) {
+            return Err("--profile is only valid for plugins add or setup".to_string());
+        }
         Ok(Self { action, json })
     }
 }
@@ -431,6 +453,7 @@ fn add_plugin(
     spec: &str,
     approved: bool,
     scope: plugins::PluginScope,
+    profile: Option<&str>,
     json_output: bool,
 ) -> Result<(), String> {
     if json_output {
@@ -451,7 +474,7 @@ fn add_plugin(
                 .map_err(|error| error.to_string())?;
         }
         if source.manifest_path.is_some() {
-            setup_plugin_source(source.clone(), approved, false)?;
+            setup_plugin_source(source.clone(), approved, profile, false)?;
         }
         if source.manifest_path.is_none() {
             let active = plugins::active_from_scoped_specs(vec![(scope, spec.to_string())], true)
@@ -1296,6 +1319,7 @@ struct PluginManifest {
     #[serde(default)]
     command: Vec<String>,
     commands: Option<PlatformCommands>,
+    setup: Option<CommandSetupConfig>,
     #[serde(default)]
     hooks: Vec<String>,
     repository: Option<String>,
@@ -1366,6 +1390,64 @@ struct PlatformCommands {
     windows: Option<Vec<String>>,
     macos: Option<Vec<String>>,
     linux: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CommandSetupConfig {
+    #[serde(default)]
+    command: Vec<String>,
+    commands: Option<PlatformCommands>,
+    #[serde(default)]
+    profiles: Vec<String>,
+    profile_arg: Option<String>,
+    download: Option<String>,
+    disk: Option<String>,
+}
+
+impl CommandSetupConfig {
+    fn selected_command(&self) -> Result<&[String], String> {
+        if !self.command.is_empty() && self.commands.is_some() {
+            return Err("[setup] cannot set both command and [setup.commands]".to_string());
+        }
+        if !self.command.is_empty() {
+            return Ok(&self.command);
+        }
+        let Some(commands) = self.commands.as_ref() else {
+            return Err("[setup] requires command or [setup.commands]".to_string());
+        };
+        #[cfg(windows)]
+        let selected = commands.windows.as_deref();
+        #[cfg(target_os = "macos")]
+        let selected = commands.macos.as_deref();
+        #[cfg(target_os = "linux")]
+        let selected = commands.linux.as_deref();
+        #[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
+        let selected: Option<&[String]> = None;
+        selected.ok_or_else(|| {
+            format!(
+                "plugin environment setup is unsupported on {}",
+                std::env::consts::OS
+            )
+        })
+    }
+
+    fn command_variants(&self) -> Vec<&[String]> {
+        if !self.command.is_empty() {
+            return vec![&self.command];
+        }
+        self.commands
+            .iter()
+            .flat_map(|commands| {
+                [
+                    commands.windows.as_deref(),
+                    commands.macos.as_deref(),
+                    commands.linux.as_deref(),
+                ]
+            })
+            .flatten()
+            .collect()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -1551,14 +1633,15 @@ fn load_plugin_manifest(source: &plugins::PluginSource) -> Result<Option<PluginM
     }
     if form == PluginRuntime::Command {
         validate_command(&manifest)?;
+        validate_command_setup(manifest.setup.as_ref())?;
         if manifest.network.is_some() || manifest.permissions.is_some() {
             return Err(
                 "command plugins run natively; [network] and [permissions] apply only to Wasm"
                     .to_string(),
             );
         }
-    } else if !manifest.hooks.is_empty() {
-        return Err("hooks are declared only by command plugins".to_string());
+    } else if !manifest.hooks.is_empty() || manifest.setup.is_some() {
+        return Err("hooks and [setup] are declared only by command plugins".to_string());
     }
     if form == PluginRuntime::Wasm {
         validate_permissions(manifest.permissions.as_ref())?;
@@ -1679,6 +1762,60 @@ fn validate_command(manifest: &PluginManifest) -> Result<(), String> {
             return Err(format!(
                 "command plugin declares hook '{hook}' more than once"
             ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_command_setup(setup: Option<&CommandSetupConfig>) -> Result<(), String> {
+    let Some(setup) = setup else {
+        return Ok(());
+    };
+    let variants = setup.command_variants();
+    if variants.is_empty() {
+        return Err("[setup] requires at least one command argv".to_string());
+    }
+    for command in variants {
+        if command.is_empty() || command[0].trim().is_empty() {
+            return Err("[setup] requires a non-empty command argv".to_string());
+        }
+        if command.len() > 256 || command.iter().any(|argument| argument.len() > 32 * 1024) {
+            return Err("setup command argv exceeds its limit".to_string());
+        }
+    }
+    if setup.profiles.len() > 16 {
+        return Err("[setup] allows at most 16 profiles".to_string());
+    }
+    let mut profiles = BTreeSet::new();
+    for profile in &setup.profiles {
+        if profile.is_empty()
+            || profile.len() > 32
+            || !profile
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return Err(format!("invalid setup profile: {profile}"));
+        }
+        if !profiles.insert(profile) {
+            return Err(format!("duplicate setup profile: {profile}"));
+        }
+    }
+    match (setup.profiles.is_empty(), setup.profile_arg.as_deref()) {
+        (true, Some(_)) => return Err("setup profile_arg requires profiles".to_string()),
+        (false, None) => return Err("setup profiles require profile_arg".to_string()),
+        (_, Some(argument))
+            if argument.is_empty()
+                || argument.len() > 128
+                || !argument.starts_with('-')
+                || argument.chars().any(char::is_whitespace) =>
+        {
+            return Err("setup profile_arg must be one bounded option".to_string())
+        }
+        _ => {}
+    }
+    for (name, value) in [("download", &setup.download), ("disk", &setup.disk)] {
+        if value.as_ref().is_some_and(|value| value.len() > 512) {
+            return Err(format!("setup {name} description exceeds its limit"));
         }
     }
     Ok(())
@@ -1972,6 +2109,7 @@ fn setup_plugin(
     spec: &str,
     approved: bool,
     scope: plugins::PluginScope,
+    profile: Option<&str>,
     json_output: bool,
 ) -> Result<(), String> {
     let spec = plugins::plugin_spec_for_scope(spec, scope).map_err(|error| error.to_string())?;
@@ -1988,7 +2126,7 @@ fn setup_plugin(
             plugins::set_remote_plugin_lock_with_guard(scope, &project_guard, spec, Some(entry))
                 .map_err(|error| error.to_string())?;
         }
-        setup_plugin_source(source, approved, json_output)
+        setup_plugin_source(source, approved, profile, json_output)
     })();
     if let Err(error) = result {
         return Err(rollback_plugin_transaction(
@@ -2004,6 +2142,7 @@ fn setup_plugin(
 fn setup_plugin_source(
     source: plugins::PluginSource,
     approved: bool,
+    profile: Option<&str>,
     json_output: bool,
 ) -> Result<(), String> {
     let command_snapshot = load_plugin_manifest(&source)?
@@ -2013,7 +2152,7 @@ fn setup_plugin_source(
             snapshot_command_runtime(&name, &source)
         })
         .transpose()?;
-    let result = setup_plugin_source_inner(source, approved, json_output);
+    let result = setup_plugin_source_inner(source, approved, profile, json_output);
     match (result, command_snapshot) {
         (Ok(()), Some(snapshot)) => {
             snapshot.discard();
@@ -2028,6 +2167,7 @@ fn setup_plugin_source(
 fn setup_plugin_source_inner(
     source: plugins::PluginSource,
     approved: bool,
+    profile: Option<&str>,
     json_output: bool,
 ) -> Result<(), String> {
     if json_output {
@@ -2042,6 +2182,9 @@ fn setup_plugin_source_inner(
         .transpose()?;
     let name = plugin_name(&source, Some(&manifest));
     let form = manifest.form()?;
+    if profile.is_some() && manifest.setup.is_none() {
+        return Err("this plugin does not declare setup profiles".to_string());
+    }
     if form == PluginRuntime::Manifest {
         println!("verified: manifest-only plugin");
         return Ok(());
@@ -2089,6 +2232,34 @@ fn setup_plugin_source_inner(
             command_executable_preview(&name, &source, &command[0])?.display()
         );
         println!("isolation: native process (runs with your user permissions)");
+        if let Some(setup) = manifest.setup.as_ref() {
+            if let Some(profile) = profile {
+                if !setup.profiles.iter().any(|candidate| candidate == profile) {
+                    return Err(format!(
+                        "unknown setup profile '{profile}'; choose one of: {}",
+                        setup.profiles.join(", ")
+                    ));
+                }
+            }
+            println!(
+                "environment setup: {}",
+                display_command(setup.selected_command()?)
+            );
+            if !setup.profiles.is_empty() {
+                println!("setup profiles: {}", setup.profiles.join(", "));
+                println!(
+                    "selected profile: {}",
+                    profile.unwrap_or("automatic or previously selected")
+                );
+            }
+            if let Some(download) = setup.download.as_deref() {
+                println!("expected download: {download}");
+            }
+            if let Some(disk) = setup.disk.as_deref() {
+                println!("expected disk: {disk}");
+            }
+            println!("WARNING: environment setup runs natively with your user permissions");
+        }
     }
     if let Some(network) = manifest.network_config() {
         println!("requested network access:");
@@ -2175,6 +2346,9 @@ fn setup_plugin_source_inner(
             return Err("plugin setup was not approved".to_string());
         }
         write_command_lock(&name, &source, &manifest)?;
+        if let Some(setup) = manifest.setup.as_ref() {
+            run_command_environment_setup(&name, &source, setup, profile)?;
+        }
         manifest.hooks.clone()
     };
     if form != PluginRuntime::Manifest {
@@ -2189,6 +2363,72 @@ fn setup_plugin_source_inner(
         write_plugin_approval(&name, &source, &manifest, &approved_hooks)?;
     }
     println!("setup: complete");
+    Ok(())
+}
+
+fn run_command_environment_setup(
+    name: &str,
+    source: &plugins::PluginSource,
+    setup: &CommandSetupConfig,
+    profile: Option<&str>,
+) -> Result<(), String> {
+    let remote = plugins::remote_command_files(source).map_err(|error| error.to_string())?;
+    let root = if remote.is_empty() {
+        source
+            .manifest_path
+            .as_deref()
+            .and_then(Path::parent)
+            .ok_or_else(|| "command plugin manifest has no parent directory".to_string())?
+            .to_path_buf()
+    } else {
+        plugin_runtime_dirs_for_source(name, source)?
+            .data_dir
+            .join("command")
+    };
+    let mut argv = setup.selected_command()?.to_vec();
+    for argument in &mut argv {
+        if argument == "{plugin}" {
+            *argument = root.to_string_lossy().into_owned();
+        } else if let Some(relative) = argument.strip_prefix("{plugin}/") {
+            let relative = Path::new(relative);
+            if relative.as_os_str().is_empty()
+                || relative
+                    .components()
+                    .any(|component| !matches!(component, std::path::Component::Normal(_)))
+            {
+                return Err("setup command path must stay inside the plugin directory".to_string());
+            }
+            *argument = root.join(relative).to_string_lossy().into_owned();
+        }
+    }
+    if let Some(profile) = profile {
+        let argument = setup
+            .profile_arg
+            .as_deref()
+            .ok_or_else(|| "this plugin does not accept a setup profile".to_string())?;
+        argv.push(argument.to_string());
+        argv.push(profile.to_string());
+    }
+    let executable = resolve_command_executable(&argv[0])?;
+    println!("environment setup: starting");
+    let status = Command::new(executable)
+        .args(&argv[1..])
+        .current_dir(&root)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|error| format!("could not start plugin environment setup: {error}"))?;
+    if !status.success() {
+        return Err(format!(
+            "plugin environment setup failed with {}",
+            status
+                .code()
+                .map(|code| format!("exit {code}"))
+                .unwrap_or_else(|| "a signal".to_string())
+        ));
+    }
+    println!("environment setup: complete");
     Ok(())
 }
 
@@ -2415,6 +2655,16 @@ fn write_command_lock(
         .iter()
         .filter_map(|argument| argument.strip_prefix("{plugin}/").map(PathBuf::from))
         .collect::<Vec<_>>();
+    let mut command_files = command_files;
+    if let Some(setup) = manifest.setup.as_ref() {
+        command_files.extend(
+            setup
+                .selected_command()?
+                .iter()
+                .filter_map(|argument| argument.strip_prefix("{plugin}/"))
+                .map(PathBuf::from),
+        );
+    }
     let locked_files = if managed {
         remote
             .iter()
@@ -2690,7 +2940,7 @@ fn update_plugin_inner(
                     )
                     .map_err(|error| error.to_string())?;
                 }
-                setup_plugin_source(source, approved, false)?;
+                setup_plugin_source(source, approved, None, false)?;
                 return Ok(());
             }
         }
@@ -2708,7 +2958,7 @@ fn update_plugin_inner(
             plugins::set_remote_plugin_lock_with_guard(scope, project_guard, spec, Some(entry))
                 .map_err(|error| error.to_string())?;
         }
-        setup_plugin_source(source, approved, false)?;
+        setup_plugin_source(source, approved, None, false)?;
         return Ok(());
     }
     let runtime = plugin_runtime(&manifest);
@@ -2744,7 +2994,7 @@ fn update_plugin_inner(
             plugins::set_remote_plugin_lock_with_guard(scope, project_guard, spec, Some(entry))
                 .map_err(|error| error.to_string())?;
         }
-        setup_plugin_source(source, approved, false)?;
+        setup_plugin_source(source, approved, None, false)?;
         return Ok(());
     }
     // Updating a release binary must not rewrite the user's manifest approval.
@@ -3867,6 +4117,24 @@ mod tests {
         let args = vec![
             "pentect".into(),
             "plugins".into(),
+            "setup".into(),
+            "example-plugin".into(),
+            "--profile".into(),
+            "cuda".into(),
+            "--yes".into(),
+        ];
+        assert!(matches!(
+            PluginCmd::parse(&args).unwrap().action,
+            Action::Setup {
+                approved: true,
+                profile: Some(profile),
+                ..
+            } if profile == "cuda"
+        ));
+
+        let args = vec![
+            "pentect".into(),
+            "plugins".into(),
             "update".into(),
             "example-plugin".into(),
         ];
@@ -3955,6 +4223,48 @@ mod tests {
         )
         .unwrap();
         assert!(ambiguous.form().is_err());
+    }
+
+    #[test]
+    fn approved_command_setup_runs_selected_profile_and_is_locked() {
+        let Some(python) = python_test_executable() else {
+            return;
+        };
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let name = format!("command-setup-{nonce}");
+        let root = std::env::temp_dir().join(&name);
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("server.py"), "print('unused')\n").unwrap();
+        std::fs::write(
+            root.join("setup.py"),
+            "import argparse\nfrom pathlib import Path\np=argparse.ArgumentParser();p.add_argument('--profile');a=p.parse_args();Path(__file__).with_name('selected.txt').write_text(a.profile)\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join(plugins::PLUGIN_MANIFEST_FILE),
+            format!(
+                "schema = \"pentect.plugin.v1\"\nname = \"{name}\"\ncommand = [\"{python}\", \"{{plugin}}/server.py\"]\nhooks = [\"inspect\"]\n[setup]\ncommand = [\"{python}\", \"{{plugin}}/setup.py\"]\nprofiles = [\"cpu\", \"cuda\"]\nprofile_arg = \"--profile\"\ndownload = \"fixture\"\ndisk = \"fixture\"\n"
+            ),
+        )
+        .unwrap();
+        let source = plugins::plugin_source(&root.to_string_lossy()).unwrap();
+        let manifest = load_plugin_manifest(&source).unwrap().unwrap();
+        let runtime = plugin_runtime_dirs_for_source(&name, &source).unwrap();
+
+        setup_plugin_source(source, true, Some("cpu"), false).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("selected.txt")).unwrap(),
+            "cpu"
+        );
+        let lock =
+            std::fs::read_to_string(runtime.data_dir.join(PLUGIN_COMMAND_LOCK_FILE)).unwrap();
+        assert!(lock.contains("path = \"setup.py\""), "{lock}");
+        let _ = std::fs::remove_dir_all(runtime.data_dir);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -477,6 +477,9 @@ fn add_plugin(
             setup_plugin_source(source.clone(), approved, profile, false)?;
         }
         if source.manifest_path.is_none() {
+            if profile.is_some() {
+                return Err("this plugin does not declare setup profiles".to_string());
+            }
             let active = plugins::active_from_scoped_specs(vec![(scope, spec.to_string())], true)
                 .map_err(|error| error.to_string())?;
             if active.config_paths().is_empty() {
@@ -2241,9 +2244,11 @@ fn setup_plugin_source_inner(
                     ));
                 }
             }
+            let setup_command = setup.selected_command()?;
+            println!("environment setup: {}", display_command(setup_command));
             println!(
-                "environment setup: {}",
-                display_command(setup.selected_command()?)
+                "setup executable: {}",
+                command_executable_preview(&name, &source, &setup_command[0])?.display()
             );
             if !setup.profiles.is_empty() {
                 println!("setup profiles: {}", setup.profiles.join(", "));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/plugins/openai-privacy-filter/README.md
+++ b/plugins/openai-privacy-filter/README.md
@@ -13,9 +13,11 @@ and Windows otherwise, and PyTorch's official default package on macOS. See the
 [setup guide](https://pentect.dev/plugins/official/#openai-privacy-filter).
 
 ```sh
-pentect plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter
-pentect plugins setup openai-privacy-filter --profile cpu
+pentect plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --profile cpu
 ```
+
+To change the profile later, run
+`pentect plugins setup openai-privacy-filter --profile cuda`.
 
 The server returns byte ranges and labels. It does not return the matched text.
 Pentect turns those ranges into normal handles such as

--- a/plugins/openai-privacy-filter/README.md
+++ b/plugins/openai-privacy-filter/README.md
@@ -8,8 +8,8 @@ stdin/stdout and does not expose a local HTTP port.
 The model is not bundled with Pentect. During plugin approval, Pentect displays
 the expected cost and creates the managed environment at
 `~/.pentect/openai-privacy-filter/venv`. Automatic setup selects a compatible
-NVIDIA CUDA wheel when available and the official CPU-only PyTorch wheel
-otherwise. See the
+NVIDIA CUDA wheel when available, the official CPU-only PyTorch index on Linux
+and Windows otherwise, and PyTorch's official default package on macOS. See the
 [setup guide](https://pentect.dev/plugins/official/#openai-privacy-filter).
 
 ```sh

--- a/plugins/openai-privacy-filter/README.md
+++ b/plugins/openai-privacy-filter/README.md
@@ -5,13 +5,16 @@ This first-party plugin adds local, context-aware PII detection from
 the plugin process run on your computer. Pentect communicates with it over
 stdin/stdout and does not expose a local HTTP port.
 
-The model is not bundled with Pentect. Install its Python dependency in the
-documented managed environment at `~/.pentect/openai-privacy-filter/venv`
-before enabling the plugin. Pentect starts the process only when it is needed.
-See the [setup guide](https://pentect.dev/plugins/official/#openai-privacy-filter).
+The model is not bundled with Pentect. During plugin approval, Pentect displays
+the expected cost and creates the managed environment at
+`~/.pentect/openai-privacy-filter/venv`. Automatic setup selects a compatible
+NVIDIA CUDA wheel when available and the official CPU-only PyTorch wheel
+otherwise. See the
+[setup guide](https://pentect.dev/plugins/official/#openai-privacy-filter).
 
 ```sh
 pentect plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter
+pentect plugins setup openai-privacy-filter --profile cpu
 ```
 
 The server returns byte ranges and labels. It does not return the matched text.

--- a/plugins/openai-privacy-filter/plugin.toml
+++ b/plugins/openai-privacy-filter/plugin.toml
@@ -5,9 +5,20 @@ hooks = ["inspect"]
 required = false
 
 [commands]
-windows = ["py", "{plugin}/server.py", "--device", "cpu"]
-macos = ["python3", "{plugin}/server.py", "--device", "cpu"]
-linux = ["python3", "{plugin}/server.py", "--device", "cpu"]
+windows = ["py", "{plugin}/server.py"]
+macos = ["python3", "{plugin}/server.py"]
+linux = ["python3", "{plugin}/server.py"]
+
+[setup]
+profiles = ["auto", "cpu", "cuda"]
+profile_arg = "--profile"
+download = "CPU: about 2.7 GB; CUDA: about 5-6 GB (checkpoint included)"
+disk = "CPU: about 5 GB; CUDA: about 8 GB"
+
+[setup.commands]
+windows = ["py", "{plugin}/setup.py"]
+macos = ["python3", "{plugin}/setup.py"]
+linux = ["python3", "{plugin}/setup.py"]
 
 [execution]
 timeout_ms = 60000

--- a/plugins/openai-privacy-filter/server.py
+++ b/plugins/openai-privacy-filter/server.py
@@ -15,7 +15,12 @@ PROTOCOL_SCHEMA = "pentect.plugin.v1"
 
 
 def _use_managed_python() -> None:
-    root = Path.home() / ".pentect" / "openai-privacy-filter" / "venv"
+    managed_root = os.environ.get("PENTECT_OPF_ROOT")
+    root = (
+        Path(managed_root).expanduser()
+        if managed_root
+        else Path.home() / ".pentect" / "openai-privacy-filter"
+    ) / "venv"
     candidate = (
         root / "Scripts" / "python.exe"
         if os.name == "nt"
@@ -36,6 +41,45 @@ def _use_managed_python() -> None:
             str(candidate),
             [str(candidate), str(Path(__file__).resolve()), *sys.argv[1:]],
         )
+
+
+def _selected_device(argument: str) -> str:
+    if argument != "auto":
+        return argument
+    managed_root = os.environ.get("PENTECT_OPF_ROOT")
+    root = (
+        Path(managed_root).expanduser()
+        if managed_root
+        else Path.home() / ".pentect" / "openai-privacy-filter"
+    )
+    try:
+        state = json.loads((root / "setup.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return "cpu"
+    device = state.get("device") if isinstance(state, dict) else None
+    return device if device in {"cpu", "cuda"} else "cpu"
+
+
+def _managed_checkpoint(argument: Path | None) -> Path | None:
+    if argument is not None:
+        return argument
+    managed_root = os.environ.get("PENTECT_OPF_ROOT")
+    root = (
+        Path(managed_root).expanduser()
+        if managed_root
+        else Path.home() / ".pentect" / "openai-privacy-filter"
+    )
+    try:
+        state = json.loads((root / "setup.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        state = {}
+    configured = state.get("checkpoint") if isinstance(state, dict) else None
+    if isinstance(configured, str) and configured:
+        checkpoint = Path(configured).expanduser()
+        if checkpoint.is_dir():
+            return checkpoint
+    checkpoint = root / "checkpoint"
+    return checkpoint if checkpoint.is_dir() else None
 
 
 def _byte_offset(text: str, character_offset: int) -> int:
@@ -124,15 +168,15 @@ def serve(redactor: Any) -> None:
 def main() -> None:
     _use_managed_python()
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--device", choices=("cpu", "cuda"), default="cpu")
+    parser.add_argument("--device", choices=("auto", "cpu", "cuda"), default="auto")
     parser.add_argument("--checkpoint", type=Path)
     args = parser.parse_args()
 
     from opf import OPF
 
     redactor = OPF(
-        model=args.checkpoint,
-        device=args.device,
+        model=_managed_checkpoint(args.checkpoint),
+        device=_selected_device(args.device),
         output_mode="typed",
         output_text_only=False,
     )

--- a/plugins/openai-privacy-filter/server.py
+++ b/plugins/openai-privacy-filter/server.py
@@ -56,6 +56,11 @@ def _selected_device(argument: str) -> str:
         state = json.loads((root / "setup.json").read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return "cpu"
+    if isinstance(state, dict) and state.get("fixture") is True:
+        raise RuntimeError(
+            "OpenAI Privacy Filter fixture setup cannot be used at runtime; "
+            "run `pentect plugins setup openai-privacy-filter` outside release CI"
+        )
     device = state.get("device") if isinstance(state, dict) else None
     return device if device in {"cpu", "cuda"} else "cpu"
 

--- a/plugins/openai-privacy-filter/setup.py
+++ b/plugins/openai-privacy-filter/setup.py
@@ -16,6 +16,7 @@ from typing import Any
 
 OPF_REVISION = "f7f00ca7fb869683eb732c010299d901457f19c3"
 OPF_SOURCE = f"git+https://github.com/openai/privacy-filter.git@{OPF_REVISION}"
+# First-match selection requires descending driver thresholds.
 CUDA_INDEXES = ((580, "cu130"), (525, "cu126"))
 DEPENDENCIES = ("huggingface_hub", "numpy", "packaging", "safetensors", "tiktoken")
 

--- a/plugins/openai-privacy-filter/setup.py
+++ b/plugins/openai-privacy-filter/setup.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Install and select a managed OpenAI Privacy Filter runtime for Pentect."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+OPF_REVISION = "f7f00ca7fb869683eb732c010299d901457f19c3"
+OPF_SOURCE = f"git+https://github.com/openai/privacy-filter.git@{OPF_REVISION}"
+CUDA_INDEXES = ((580, "cu130"), (525, "cu126"))
+DEPENDENCIES = ("huggingface_hub", "numpy", "packaging", "safetensors", "tiktoken")
+
+
+def managed_root() -> Path:
+    override = os.environ.get("PENTECT_OPF_ROOT")
+    return Path(override).expanduser() if override else Path.home() / ".pentect" / "openai-privacy-filter"
+
+
+def managed_python(root: Path) -> Path:
+    return root / "venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def valid_checkpoint(path: Path) -> bool:
+    return path.is_dir() and (path / "config.json").is_file() and any(path.glob("*.safetensors"))
+
+
+def shared_checkpoint(root: Path) -> Path:
+    managed = root / "checkpoint"
+    legacy = Path.home() / ".opf" / "privacy_filter"
+    if valid_checkpoint(managed):
+        return managed
+    if valid_checkpoint(legacy):
+        return legacy
+    return managed
+
+
+def read_state(root: Path) -> dict[str, Any]:
+    try:
+        value = json.loads((root / "setup.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def nvidia_driver_major() -> int | None:
+    executable = shutil.which("nvidia-smi")
+    if not executable:
+        return None
+    try:
+        output = subprocess.check_output(
+            [executable, "--query-gpu=driver_version", "--format=csv,noheader"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=10,
+        )
+        return max(int(line.strip().split(".", 1)[0]) for line in output.splitlines() if line.strip())
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def cuda_wheel(driver_major: int | None) -> str | None:
+    if platform.system() == "Darwin" or driver_major is None:
+        return None
+    if platform.system() == "Windows" and driver_major < 528:
+        return None
+    for minimum, wheel in CUDA_INDEXES:
+        if driver_major >= minimum:
+            return wheel
+    return None
+
+
+def resolve_requested_profile(requested: str, state: dict[str, Any]) -> str:
+    if requested != "keep":
+        return requested
+    previous = state.get("requested_profile")
+    return previous if previous in {"auto", "cpu", "cuda"} else "auto"
+
+
+def build_plan(requested: str, state: dict[str, Any]) -> dict[str, Any]:
+    requested = resolve_requested_profile(requested, state)
+    driver = nvidia_driver_major()
+    wheel = cuda_wheel(driver)
+    if requested == "cuda" and wheel is None:
+        detail = "no NVIDIA driver was detected" if driver is None else f"NVIDIA driver {driver} is too old"
+        raise RuntimeError(f"CUDA profile is unavailable: {detail}; use --profile cpu")
+    device = "cuda" if requested == "cuda" or (requested == "auto" and wheel) else "cpu"
+    wheel = wheel if device == "cuda" else "cpu"
+    return {
+        "schema": "pentect.opf-setup.v1",
+        "requested_profile": requested,
+        "device": device,
+        "nvidia_driver_major": driver,
+        "torch_index": f"https://download.pytorch.org/whl/{wheel}",
+        "torch_wheel": wheel,
+        "opf_revision": OPF_REVISION,
+    }
+
+
+def run(argv: list[str]) -> None:
+    print("+", " ".join(argv), flush=True)
+    subprocess.run(argv, check=True)
+
+
+def runtime_matches(python: Path, plan: dict[str, Any]) -> bool:
+    if not python.is_file():
+        return False
+    code = (
+        "import opf, torch; "
+        + ("assert torch.cuda.is_available()" if plan["device"] == "cuda" else "assert not torch.version.cuda")
+    )
+    try:
+        subprocess.run(
+            [str(python), "-c", code],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+        return True
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def write_state(root: Path, plan: dict[str, Any]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    temporary = root / f"setup.json.tmp-{os.getpid()}"
+    temporary.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, root / "setup.json")
+
+
+def controlled_fixture() -> bool:
+    if os.environ.get("PENTECT_OPF_SETUP_FIXTURE") == "1":
+        return True
+    return (
+        os.environ.get("GITHUB_ACTIONS") == "true"
+        and os.environ.get("GITHUB_WORKFLOW") == "Release"
+        and os.environ.get("GITHUB_REPOSITORY") == "EdamAme-x/pentect"
+    )
+
+
+def install(root: Path, plan: dict[str, Any]) -> None:
+    active = managed_python(root)
+    current = read_state(root)
+    identity = ("requested_profile", "device", "torch_index", "opf_revision")
+    if all(current.get(key) == plan.get(key) for key in identity) and runtime_matches(active, plan):
+        print(f"OpenAI Privacy Filter environment is already ready ({plan['device']}).")
+        return
+    if not current and runtime_matches(active, plan):
+        write_state(root, plan)
+        print(f"Adopted the existing OpenAI Privacy Filter environment ({plan['device']}).")
+        return
+
+    root.mkdir(parents=True, exist_ok=True)
+    staged = root / f"venv.staged-{os.getpid()}"
+    backup = root / f"venv.previous-{os.getpid()}"
+    shutil.rmtree(staged, ignore_errors=True)
+    shutil.rmtree(backup, ignore_errors=True)
+    try:
+        run([sys.executable, "-m", "venv", str(staged)])
+        python = staged / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+        run([str(python), "-m", "pip", "install", "--upgrade", "pip"])
+        run([str(python), "-m", "pip", "install", "torch", "--index-url", plan["torch_index"]])
+        run([str(python), "-m", "pip", "install", *DEPENDENCIES])
+        run([str(python), "-m", "pip", "install", "--no-deps", OPF_SOURCE])
+        checkpoint = shared_checkpoint(root)
+        plan["checkpoint"] = str(checkpoint)
+        checkpoint_setup = r"""
+from pathlib import Path
+import os
+import shutil
+import sys
+from huggingface_hub import snapshot_download
+
+target = Path(sys.argv[1])
+def valid(path):
+    return path.is_dir() and (path / "config.json").is_file() and any(path.glob("*.safetensors"))
+if valid(target):
+    raise SystemExit(0)
+staged = target.with_name(target.name + f".staged-{os.getpid()}")
+shutil.rmtree(staged, ignore_errors=True)
+snapshot_download(repo_id="openai/privacy-filter", local_dir=str(staged), allow_patterns=["original/*"])
+original = staged / "original"
+if not original.is_dir():
+    raise RuntimeError("downloaded checkpoint has no original directory")
+for source in original.iterdir():
+    shutil.move(str(source), staged / source.name)
+original.rmdir()
+if not valid(staged):
+    raise RuntimeError("downloaded checkpoint is incomplete")
+if target.exists():
+    shutil.rmtree(target)
+os.replace(staged, target)
+"""
+        run([str(python), "-c", checkpoint_setup, str(checkpoint)])
+        warmup = (
+            "from opf import OPF; "
+            f"OPF(model={str(checkpoint)!r}, device={plan['device']!r}, "
+            "output_mode='typed', output_text_only=False).get_runtime()"
+        )
+        run([str(python), "-c", warmup])
+        active_dir = root / "venv"
+        if active_dir.exists():
+            os.replace(active_dir, backup)
+        os.replace(staged, active_dir)
+        write_state(root, plan)
+        shutil.rmtree(backup, ignore_errors=True)
+    except Exception:
+        shutil.rmtree(staged, ignore_errors=True)
+        if backup.exists() and not (root / "venv").exists():
+            os.replace(backup, root / "venv")
+        raise
+
+
+def main() -> None:
+    if sys.version_info < (3, 10):
+        raise SystemExit("OpenAI Privacy Filter requires Python 3.10 or newer")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=("keep", "auto", "cpu", "cuda"), default="keep")
+    args = parser.parse_args()
+    root = managed_root()
+    try:
+        plan = build_plan(args.profile, read_state(root))
+    except RuntimeError as error:
+        raise SystemExit(str(error)) from error
+    print(
+        f"OpenAI Privacy Filter plan: profile={plan['requested_profile']} "
+        f"device={plan['device']} torch={plan['torch_wheel']}"
+    )
+    print("Expected checkpoint: about 2.5 GB download / 2.8 GB disk (shared by profiles).")
+    if controlled_fixture():
+        plan["fixture"] = True
+        write_state(root, plan)
+        print("Fixture mode: setup plan validated without downloading model assets.")
+        return
+    try:
+        install(root, plan)
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise SystemExit(f"OpenAI Privacy Filter setup failed: {error}") from error
+    print(f"OpenAI Privacy Filter is ready on {plan['device']}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/openai-privacy-filter/setup.py
+++ b/plugins/openai-privacy-filter/setup.py
@@ -68,7 +68,11 @@ def nvidia_driver_major() -> int | None:
 
 
 def cuda_wheel(driver_major: int | None) -> str | None:
-    if platform.system() == "Darwin" or driver_major is None:
+    if (
+        platform.system() == "Darwin"
+        or platform.machine().lower() not in {"x86_64", "amd64"}
+        or driver_major is None
+    ):
         return None
     if platform.system() == "Windows" and driver_major < 528:
         return None
@@ -93,13 +97,14 @@ def build_plan(requested: str, state: dict[str, Any]) -> dict[str, Any]:
         detail = "no NVIDIA driver was detected" if driver is None else f"NVIDIA driver {driver} is too old"
         raise RuntimeError(f"CUDA profile is unavailable: {detail}; use --profile cpu")
     device = "cuda" if requested == "cuda" or (requested == "auto" and wheel) else "cpu"
-    wheel = wheel if device == "cuda" else "cpu"
+    wheel = wheel if device == "cuda" else ("macos" if platform.system() == "Darwin" else "cpu")
+    torch_index = None if wheel == "macos" else f"https://download.pytorch.org/whl/{wheel}"
     return {
         "schema": "pentect.opf-setup.v1",
         "requested_profile": requested,
         "device": device,
         "nvidia_driver_major": driver,
-        "torch_index": f"https://download.pytorch.org/whl/{wheel}",
+        "torch_index": torch_index,
         "torch_wheel": wheel,
         "opf_revision": OPF_REVISION,
     }
@@ -168,7 +173,10 @@ def install(root: Path, plan: dict[str, Any]) -> None:
         run([sys.executable, "-m", "venv", str(staged)])
         python = staged / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
         run([str(python), "-m", "pip", "install", "--upgrade", "pip"])
-        run([str(python), "-m", "pip", "install", "torch", "--index-url", plan["torch_index"]])
+        torch_command = [str(python), "-m", "pip", "install", "torch"]
+        if plan["torch_index"]:
+            torch_command.extend(["--index-url", plan["torch_index"]])
+        run(torch_command)
         run([str(python), "-m", "pip", "install", *DEPENDENCIES])
         run([str(python), "-m", "pip", "install", "--no-deps", OPF_SOURCE])
         checkpoint = shared_checkpoint(root)

--- a/plugins/openai-privacy-filter/tests/test_server.py
+++ b/plugins/openai-privacy-filter/tests/test_server.py
@@ -80,6 +80,16 @@ class ServerTests(unittest.TestCase):
             with mock.patch.dict(os.environ, {"PENTECT_OPF_ROOT": directory}):
                 self.assertEqual(SERVER._selected_device("auto"), "cpu")
 
+    def test_fixture_setup_state_is_rejected_at_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "setup.json").write_text(
+                '{"device":"cpu","fixture":true}', encoding="utf-8"
+            )
+            with mock.patch.dict(os.environ, {"PENTECT_OPF_ROOT": str(root)}):
+                with self.assertRaisesRegex(RuntimeError, "fixture setup"):
+                    SERVER._selected_device("auto")
+
     def test_command_protocol_response_matches_request(self) -> None:
         result = SERVER.handle_request(
             Redactor(),

--- a/plugins/openai-privacy-filter/tests/test_server.py
+++ b/plugins/openai-privacy-filter/tests/test_server.py
@@ -67,6 +67,19 @@ class ServerTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             SERVER._byte_offset("short", 6)
 
+    def test_device_comes_from_persisted_setup(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "setup.json").write_text('{"device":"cuda"}', encoding="utf-8")
+            with mock.patch.dict(os.environ, {"PENTECT_OPF_ROOT": str(root)}):
+                self.assertEqual(SERVER._selected_device("auto"), "cuda")
+                self.assertEqual(SERVER._selected_device("cpu"), "cpu")
+
+    def test_missing_setup_state_fails_safe_to_cpu(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with mock.patch.dict(os.environ, {"PENTECT_OPF_ROOT": directory}):
+                self.assertEqual(SERVER._selected_device("auto"), "cpu")
+
     def test_command_protocol_response_matches_request(self) -> None:
         result = SERVER.handle_request(
             Redactor(),

--- a/plugins/openai-privacy-filter/tests/test_setup.py
+++ b/plugins/openai-privacy-filter/tests/test_setup.py
@@ -1,0 +1,70 @@
+import importlib.util
+from pathlib import Path
+import platform
+import unittest
+from unittest import mock
+
+
+SETUP_PATH = Path(__file__).parents[1] / "setup.py"
+SPEC = importlib.util.spec_from_file_location("pentect_opf_setup", SETUP_PATH)
+SETUP = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(SETUP)
+
+
+class SetupTests(unittest.TestCase):
+    def test_cpu_profile_uses_official_cpu_index(self) -> None:
+        with mock.patch.object(SETUP, "nvidia_driver_major", return_value=600):
+            plan = SETUP.build_plan("cpu", {})
+        self.assertEqual(plan["device"], "cpu")
+        self.assertEqual(plan["torch_index"], "https://download.pytorch.org/whl/cpu")
+
+    @unittest.skipIf(platform.system() == "Darwin", "CUDA is intentionally unavailable on macOS")
+    def test_auto_profile_selects_cuda_wheel_from_driver(self) -> None:
+        with mock.patch.object(SETUP, "nvidia_driver_major", return_value=579):
+            self.assertEqual(SETUP.build_plan("auto", {})["torch_wheel"], "cu126")
+        with mock.patch.object(SETUP, "nvidia_driver_major", return_value=580):
+            self.assertEqual(SETUP.build_plan("auto", {})["torch_wheel"], "cu130")
+
+    def test_auto_profile_falls_back_to_cpu_without_nvidia(self) -> None:
+        with mock.patch.object(SETUP, "nvidia_driver_major", return_value=None):
+            plan = SETUP.build_plan("auto", {})
+        self.assertEqual(plan["device"], "cpu")
+
+    def test_keep_preserves_manual_profile(self) -> None:
+        state = {"requested_profile": "cpu"}
+        with mock.patch.object(SETUP, "nvidia_driver_major", return_value=600):
+            plan = SETUP.build_plan("keep", state)
+        self.assertEqual(plan["requested_profile"], "cpu")
+        self.assertEqual(plan["device"], "cpu")
+
+    def test_explicit_cuda_fails_without_driver(self) -> None:
+        with mock.patch.object(SETUP, "nvidia_driver_major", return_value=None):
+            with self.assertRaises(RuntimeError):
+                SETUP.build_plan("cuda", {})
+
+    def test_fixture_is_limited_to_explicit_or_official_release_ci(self) -> None:
+        with mock.patch.dict(
+            SETUP.os.environ,
+            {
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_WORKFLOW": "Release",
+                "GITHUB_REPOSITORY": "EdamAme-x/pentect",
+            },
+            clear=True,
+        ):
+            self.assertTrue(SETUP.controlled_fixture())
+        with mock.patch.dict(
+            SETUP.os.environ,
+            {
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_WORKFLOW": "Release",
+                "GITHUB_REPOSITORY": "someone/fork",
+            },
+            clear=True,
+        ):
+            self.assertFalse(SETUP.controlled_fixture())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/openai-privacy-filter/tests/test_setup.py
+++ b/plugins/openai-privacy-filter/tests/test_setup.py
@@ -14,17 +14,46 @@ SPEC.loader.exec_module(SETUP)
 
 class SetupTests(unittest.TestCase):
     def test_cpu_profile_uses_official_cpu_index(self) -> None:
-        with mock.patch.object(SETUP, "nvidia_driver_major", return_value=600):
+        with (
+            mock.patch.object(SETUP, "nvidia_driver_major", return_value=600),
+            mock.patch.object(SETUP.platform, "system", return_value="Linux"),
+            mock.patch.object(SETUP.platform, "machine", return_value="x86_64"),
+        ):
             plan = SETUP.build_plan("cpu", {})
         self.assertEqual(plan["device"], "cpu")
         self.assertEqual(plan["torch_index"], "https://download.pytorch.org/whl/cpu")
 
     @unittest.skipIf(platform.system() == "Darwin", "CUDA is intentionally unavailable on macOS")
     def test_auto_profile_selects_cuda_wheel_from_driver(self) -> None:
-        with mock.patch.object(SETUP, "nvidia_driver_major", return_value=579):
+        with (
+            mock.patch.object(SETUP, "nvidia_driver_major", return_value=579),
+            mock.patch.object(SETUP.platform, "machine", return_value="x86_64"),
+        ):
             self.assertEqual(SETUP.build_plan("auto", {})["torch_wheel"], "cu126")
-        with mock.patch.object(SETUP, "nvidia_driver_major", return_value=580):
+        with (
+            mock.patch.object(SETUP, "nvidia_driver_major", return_value=580),
+            mock.patch.object(SETUP.platform, "machine", return_value="x86_64"),
+        ):
             self.assertEqual(SETUP.build_plan("auto", {})["torch_wheel"], "cu130")
+
+    def test_macos_uses_the_official_default_pytorch_package(self) -> None:
+        with (
+            mock.patch.object(SETUP, "nvidia_driver_major", return_value=None),
+            mock.patch.object(SETUP.platform, "system", return_value="Darwin"),
+        ):
+            plan = SETUP.build_plan("auto", {})
+        self.assertEqual(plan["device"], "cpu")
+        self.assertEqual(plan["torch_wheel"], "macos")
+        self.assertIsNone(plan["torch_index"])
+
+    def test_arm_does_not_select_an_unsupported_cuda_index(self) -> None:
+        with (
+            mock.patch.object(SETUP, "nvidia_driver_major", return_value=600),
+            mock.patch.object(SETUP.platform, "system", return_value="Linux"),
+            mock.patch.object(SETUP.platform, "machine", return_value="aarch64"),
+        ):
+            plan = SETUP.build_plan("auto", {})
+        self.assertEqual(plan["device"], "cpu")
 
     def test_auto_profile_falls_back_to_cpu_without_nvidia(self) -> None:
         with mock.patch.object(SETUP, "nvidia_driver_major", return_value=None):

--- a/plugins/openai-privacy-filter/tests/test_setup.py
+++ b/plugins/openai-privacy-filter/tests/test_setup.py
@@ -36,6 +36,19 @@ class SetupTests(unittest.TestCase):
         ):
             self.assertEqual(SETUP.build_plan("auto", {})["torch_wheel"], "cu130")
 
+    def test_windows_requires_a_newer_driver_than_linux(self) -> None:
+        with (
+            mock.patch.object(SETUP.platform, "system", return_value="Windows"),
+            mock.patch.object(SETUP.platform, "machine", return_value="x86_64"),
+        ):
+            self.assertIsNone(SETUP.cuda_wheel(527))
+            self.assertEqual(SETUP.cuda_wheel(530), "cu126")
+        with (
+            mock.patch.object(SETUP.platform, "system", return_value="Linux"),
+            mock.patch.object(SETUP.platform, "machine", return_value="x86_64"),
+        ):
+            self.assertEqual(SETUP.cuda_wheel(527), "cu126")
+
     def test_macos_uses_the_official_default_pytorch_package(self) -> None:
         with (
             mock.patch.object(SETUP, "nvidia_driver_major", return_value=None),
@@ -89,6 +102,20 @@ class SetupTests(unittest.TestCase):
                 "GITHUB_ACTIONS": "true",
                 "GITHUB_WORKFLOW": "Release",
                 "GITHUB_REPOSITORY": "someone/fork",
+            },
+            clear=True,
+        ):
+            self.assertFalse(SETUP.controlled_fixture())
+        with mock.patch.dict(
+            SETUP.os.environ, {"PENTECT_OPF_SETUP_FIXTURE": "1"}, clear=True
+        ):
+            self.assertTrue(SETUP.controlled_fixture())
+        with mock.patch.dict(
+            SETUP.os.environ,
+            {
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_WORKFLOW": "CI",
+                "GITHUB_REPOSITORY": "EdamAme-x/pentect",
             },
             clear=True,
         ):

--- a/website/src/content/docs/plugins/command.md
+++ b/website/src/content/docs/plugins/command.md
@@ -113,6 +113,32 @@ The handler reads it from `request["config"]` in Python or `request.config` in
 JavaScript. Command is native, so it receives the complete plugin-specific
 configuration object. Wasm keeps the narrower key-by-key `c.config(...)` API.
 
+## Managed environment setup
+
+Command plugins that need a model, virtual environment, or device-specific
+runtime can declare `[setup]` in `plugin.toml`. The command is displayed as part
+of the native approval and runs during `plugins add` and `plugins setup`.
+Platform-specific commands use `[setup.commands]`.
+
+```toml
+[setup]
+command = ["python", "{plugin}/setup.py"]
+profiles = ["auto", "cpu", "cuda"]
+profile_arg = "--profile"
+download = "CPU: about 3 GB; CUDA: about 6 GB"
+disk = "CPU: about 5 GB; CUDA: about 8 GB"
+```
+
+```sh
+pentect plugins add ./my-model --profile auto
+pentect plugins setup my-model --profile cpu
+```
+
+Setup is still native code, not a sandboxed package hook. Pentect never invokes
+a shell, locks every distributed `{plugin}/...` setup file, and rolls managed
+command state back when setup fails. The setup program should stage and replace
+its own external environment atomically.
+
 ## Security boundary
 
 Command is native. It runs with the current user's OS permissions. Pentect

--- a/website/src/content/docs/plugins/manifest.md
+++ b/website/src/content/docs/plugins/manifest.md
@@ -211,7 +211,7 @@ download = "CPU: about 3 GB; CUDA: about 6 GB"
 disk = "CPU: about 5 GB; CUDA: about 8 GB"
 ```
 
-Use `[setup.commands]` for `windows`, `macos`, and `linux` variants. Pentect
+Use `[setup.commands]` for `windows`, `macos` (macOS), and `linux` variants. Pentect
 shows this native command and the declared costs before approval, includes all
 referenced files in the command lock, and runs it without a shell. Users select
 a declared profile with `plugins add|setup --profile NAME`. The setup program

--- a/website/src/content/docs/plugins/manifest.md
+++ b/website/src/content/docs/plugins/manifest.md
@@ -200,6 +200,24 @@ and checks them before every launch. The process stays alive and exchanges one
 `pentect.plugin.v1` request and response per line on stdin/stdout. Do not print
 logs to stdout.
 
+A trusted Command plugin may declare an explicit environment setup command:
+
+```toml
+[setup]
+command = ["python", "{plugin}/setup.py"]
+profiles = ["auto", "cpu", "cuda"]
+profile_arg = "--profile"
+download = "CPU: about 3 GB; CUDA: about 6 GB"
+disk = "CPU: about 5 GB; CUDA: about 8 GB"
+```
+
+Use `[setup.commands]` for `windows`, `macos`, and `linux` variants. Pentect
+shows this native command and the declared costs before approval, includes all
+referenced files in the command lock, and runs it without a shell. Users select
+a declared profile with `plugins add|setup --profile NAME`. The setup program
+owns its idempotency and persisted profile; omitting `--profile` lets it keep an
+existing choice or make its documented automatic selection.
+
 ## Full Wasm example
 
 ```toml

--- a/website/src/content/docs/plugins/official.md
+++ b/website/src/content/docs/plugins/official.md
@@ -99,7 +99,8 @@ OS access as the user; enable only plugins you trust.
 
 | Symptom | What to do |
 | --- | --- |
-| Python or `opf` is missing | Run `pentect plugins setup openai-privacy-filter` |
+| `opf` is missing | Run `pentect plugins setup openai-privacy-filter` |
+| Python is missing | Install a supported Python executable, then run `pentect plugins setup openai-privacy-filter` |
 | CUDA setup is unavailable | Update the NVIDIA driver or select `--profile cpu` |
 | CPU use is high | Select CUDA, or remove the plugin when it is not needed |
 | Plugin file or command changed | Inspect it, then run `pentect plugins setup` |

--- a/website/src/content/docs/plugins/official.md
+++ b/website/src/content/docs/plugins/official.md
@@ -51,9 +51,11 @@ pentect plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter
 Pentect shows the expected transfer and disk cost, asks once, detects a
 compatible NVIDIA driver, and installs the complete managed environment. The
 automatic profile chooses CUDA when a supported NVIDIA driver is visible and
-CPU otherwise. CPU installation uses PyTorch's official CPU-only wheel index,
-so it does not pull CUDA runtimes. macOS uses CPU because OPF currently exposes
-`cpu` and `cuda`, not an MPS profile.
+CPU otherwise. Linux and Windows CPU installation use PyTorch's official
+CPU-only wheel index, so they do not pull CUDA runtimes. macOS uses PyTorch's
+official default package and the CPU device because OPF currently exposes
+`cpu` and `cuda`, not an MPS profile. Unsupported architectures do not select
+an x86-only CUDA wheel.
 
 Force a profile when automatic selection is not what you want:
 

--- a/website/src/content/docs/plugins/official.md
+++ b/website/src/content/docs/plugins/official.md
@@ -42,42 +42,36 @@ JSONL over stdin/stdout. There is no local HTTP server.
 The model is large and mainly targets English. It can still miss private text
 or mark safe text, so built-in detection stays enabled.
 
-### 1. Install the model
-
-The commands create the location that the plugin automatically detects.
-
-::: code-group
-
-```powershell [Windows]
-$root = "$HOME\.pentect\openai-privacy-filter"
-py -m venv "$root\venv"
-& "$root\venv\Scripts\python.exe" -m pip install `
-  "git+https://github.com/openai/privacy-filter.git@f7f00ca7fb869683eb732c010299d901457f19c3"
-& "$root\venv\Scripts\python.exe" -c `
-  "from opf import OPF; OPF(device='cpu', output_mode='typed', output_text_only=False).get_runtime()"
-```
-
-```sh [macOS / Linux]
-root="$HOME/.pentect/openai-privacy-filter"
-python3 -m venv "$root/venv"
-"$root/venv/bin/python" -m pip install \
-  "git+https://github.com/openai/privacy-filter.git@f7f00ca7fb869683eb732c010299d901457f19c3"
-"$root/venv/bin/python" -c \
-  "from opf import OPF; OPF(device='cpu', output_mode='typed', output_text_only=False).get_runtime()"
-```
-
-:::
-
-### 2. Add the plugin
+### Install
 
 ```sh
 pentect plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter
 ```
 
-Review the exact Python command, `server.py` hash, `inspect` hook, and required
-status. Pentect starts the process only when protected text needs inspection.
-The install command prepares the model runtime so the first protected request
-does not have to download it.
+Pentect shows the expected transfer and disk cost, asks once, detects a
+compatible NVIDIA driver, and installs the complete managed environment. The
+automatic profile chooses CUDA when a supported NVIDIA driver is visible and
+CPU otherwise. CPU installation uses PyTorch's official CPU-only wheel index,
+so it does not pull CUDA runtimes. macOS uses CPU because OPF currently exposes
+`cpu` and `cuda`, not an MPS profile.
+
+Force a profile when automatic selection is not what you want:
+
+```sh
+pentect plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --profile cpu
+pentect plugins setup openai-privacy-filter --profile cuda
+```
+
+The selected profile is stored in
+`~/.pentect/openai-privacy-filter/setup.json`. Updates keep an explicit choice;
+run `plugins setup --profile auto` to return to driver-based selection. CPU and
+CUDA environments share the same roughly 2.8 GB checkpoint. Switching profiles
+therefore replaces PyTorch and the managed virtual environment, not the model.
+
+Review the exact runtime and environment setup commands, downloaded file
+hashes, `inspect` hook, and required status. Pentect prepares the model before
+enabling the plugin, so the first protected request does not unexpectedly start
+a multi-gigabyte download.
 
 Test with fake data:
 
@@ -103,9 +97,9 @@ OS access as the user; enable only plugins you trust.
 
 | Symptom | What to do |
 | --- | --- |
-| Python or `opf` is missing | Repeat the managed-environment install step |
-| First request times out | Let the checkpoint finish downloading, then retry |
-| CPU use is high | Remove the plugin when the local model is not needed |
+| Python or `opf` is missing | Run `pentect plugins setup openai-privacy-filter` |
+| CUDA setup is unavailable | Update the NVIDIA driver or select `--profile cpu` |
+| CPU use is high | Select CUDA, or remove the plugin when it is not needed |
 | Plugin file or command changed | Inspect it, then run `pentect plugins setup` |
 
 Remove the user-wide installation:

--- a/website/src/content/docs/plugins/overview.md
+++ b/website/src/content/docs/plugins/overview.md
@@ -137,7 +137,10 @@ hooks. If any of these change, you must review the plugin again.
 
 Command plugins do not receive the Wasm sandbox. Their downloaded files are
 hash-locked, their argv is never passed through a shell, and access changes
-require approval. Setup scripts are not supported.
+require approval. A Command plugin may declare one explicit native environment
+setup command and bounded profiles. Pentect displays its argv and expected
+cost, locks its distributed files, and runs it only as part of approval; it
+does not support hidden package lifecycle scripts.
 
 ## Manage installed plugins
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -182,12 +182,12 @@ Treat redirected or in-place resolved output as plaintext secret material.
 | --- | --- |
 | `plugins search [QUERY]` | Search the first-party catalog |
 | `plugins inspect SOURCE` | Show the manifest, hooks, binary, and requested access |
-| `plugins add SOURCE [--yes] [--project]` | Verify, approve, and enable a plugin for the user (or this project) |
+| `plugins add SOURCE [--yes] [--project] [--profile NAME]` | Verify, approve, and enable a plugin for the user (or this project) |
 | `plugins remove NAME [--project]` | Disable a user plugin (or a project plugin) |
 | `plugins list [--json]` | Show enabled and installed plugins |
 | `plugins config NAME KEY=VALUE [--project]` | Save one setting in the selected scope |
 | `plugins config NAME --unset KEY [--project]` | Remove one setting in the selected scope |
-| `plugins setup NAME [--yes] [--project]` | Review changed hooks or access again |
+| `plugins setup NAME [--yes] [--project] [--profile NAME]` | Review changed hooks or access and run declared environment setup |
 | `plugins test SOURCE [--json]` | Validate a manifest or installed binary |
 | `plugins update [NAME] [--yes] [--project]` | Update user plugins (or project plugins) |
 | `plugins new NAME` | Create a Rust Wasm plugin project |


### PR DESCRIPTION
## Summary
- refetch every manifest-declared Command file during plugin update/remove-add so changed sources regenerate locks and approvals
- add approved, profile-aware native environment setup for Command plugins
- install OpenAI Privacy Filter automatically with CPU/CUDA driver selection, atomic managed environments, and a shared checkpoint
- document setup profiles and prepare v0.0.50

## Validation
- GitHub Actions is the authoritative test gate for Rust, Python, Windows, macOS, Linux, installers, and release lifecycle
- local preflight was limited to formatting, diff checks, and compile diagnostics

Fixes #302
Fixes #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed setup for command plugins, including platform-specific commands, selectable profiles, resource estimates, and rollback on failure.
  * Added `--profile NAME` to plugin add and setup commands.
  * OpenAI Privacy Filter now supports automatic CPU/CUDA selection, managed dependencies, checkpoints, and configurable installation locations.
  * Remote command files refresh during plugin updates.

* **Bug Fixes**
  * Improved command-file locking and cache refresh reliability.

* **Documentation**
  * Updated plugin and CLI documentation with setup, profiles, and Privacy Filter installation guidance.

* **Chores**
  * Incremented the package version to 0.0.50.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->