### PR TITLE
Accept managed setup metadata in plugin runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.50"
+version = "0.0.51"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -2866,6 +2866,11 @@ struct PluginFile {
     commands: Option<PlatformCommandsFile>,
     #[serde(default)]
     hooks: Vec<String>,
+    // Setup is executed and validated by pentect-cli before approval. The
+    // runtime only needs to tolerate this CLI-owned metadata when it loads an
+    // already approved command plugin.
+    #[serde(rename = "setup")]
+    _setup: Option<toml::Value>,
     publisher: Option<PublisherFile>,
     execution: Option<ExecutionFile>,
     #[serde(default)]
@@ -3876,6 +3881,26 @@ for line in sys.stdin:
                 Some(hook)
             );
         }
+    }
+
+    #[test]
+    fn runtime_manifest_accepts_cli_owned_setup_metadata() {
+        let file: PluginFile = toml::from_str(
+            r#"
+schema = "pentect.plugin.v1"
+command = ["python", "{plugin}/server.py"]
+hooks = ["inspect"]
+
+[setup]
+command = ["python", "{plugin}/setup.py"]
+profiles = ["auto", "cpu", "cuda"]
+profile_arg = "--profile"
+download = "CPU: about 3 GB"
+disk = "CPU: about 5 GB"
+"#,
+        )
+        .unwrap();
+        assert!(file._setup.is_some());
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- let the runtime accept CLI-owned `[setup]` metadata on already-approved Command plugins
- keep setup execution exclusively in the CLI; runtime treats the table as inert metadata
- add a regression test using the public setup schema
- bump the corrective release to v0.0.51

## Failure reproduced
v0.0.50 Release installer lifecycle installed OpenAI Privacy Filter successfully, then `pentect codex --version` failed because the runtime manifest parser rejected the new `setup` field.

## Validation
- `cargo fmt --check`
- `cargo test -p pentect-runtime runtime_manifest_accepts_cli_owned_setup_metadata --no-default-features`
- GitHub Actions required before merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin configuration files can now include optional setup metadata, including commands, profiles, profile arguments, and disk or download details.

* **Chores**
  * Updated the package and CLI version to 0.0.51.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->