### PR TITLE
Do not shell-rewrite JavaScript tool orchestrators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.51"
+version = "0.0.52"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2114,7 +2114,7 @@ where
     resolve_value_strings_with(value, resolve)
 }
 
-fn is_free_form_shell_tool(name: Option<&str>) -> bool {
+pub(crate) fn is_free_form_shell_tool(name: Option<&str>) -> bool {
     name.is_some_and(|name| {
         matches!(
             name.to_ascii_lowercase().as_str(),

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -1876,11 +1876,21 @@ where
                     });
                 for key in ["arguments", "input"] {
                     if let Some(Value::String(arguments)) = object.get_mut(key) {
-                        *arguments = if is_custom_call && key == "input" {
+                        *arguments = if is_custom_call
+                            && key == "input"
+                            && crate::claude_http_proxy::is_free_form_shell_tool(
+                                tool_name.as_deref(),
+                            ) {
                             // Custom tools carry completed free-form input rather than
-                            // JSON arguments. Resolve only shell-safe token values so a
-                            // represented value cannot inject syntax into the tool call.
+                            // JSON arguments. Only tools whose complete input is a shell
+                            // program may receive shell environment injection. In
+                            // particular, `functions.exec` carries JavaScript that can
+                            // invoke nested tools; prepending `export` to it both breaks
+                            // the program and can expose a protected value in a syntax
+                            // error.
                             crate::claude_http_proxy::resolve_shell_text_safely(arguments, resolve)?
+                        } else if is_custom_call && key == "input" {
+                            arguments.clone()
                         } else {
                             crate::claude_http_proxy::resolve_tool_input_json(
                                 arguments,
@@ -3295,6 +3305,26 @@ mod tests {
         rewrite_function_calls(&mut value, &mut resolve).unwrap();
         assert_eq!(value["item"]["input"], "python hash.py safe-secret-token");
         assert_eq!(value["visible_text"], "keep <<SECRET_0123456789abcdef>>");
+    }
+
+    #[test]
+    fn javascript_orchestrator_input_is_not_rewritten_as_shell() {
+        for name in ["exec", "functions.exec"] {
+            let input = r#"const result = await tools.exec_command({cmd:"test -n \"${PENTECT_SAMPLE_0123456789abcdef}\""}); text(result)"#;
+            let mut value = serde_json::json!({
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "custom_tool_call",
+                    "name": name,
+                    "input": input
+                }
+            });
+            let mut resolve = |_text: &str| -> Result<String, String> {
+                panic!("JavaScript orchestrator input must not enter shell resolution")
+            };
+            rewrite_function_calls(&mut value, &mut resolve).unwrap();
+            assert_eq!(value["item"]["input"], input);
+        }
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- restrict free-form shell restoration to tools that are actually shell tools
- keep `exec` / `functions.exec` JavaScript unchanged so nested `exec_command` and `write_stdin` calls reach their own local tool boundaries
- prevent shell `export` prefixes and plaintext values from being inserted into JavaScript source
- preserve existing completed custom shell-tool restoration
- bump the corrective release to v0.0.52

## Reproduction
A protected environment binding inside `functions.exec` was treated as if the complete custom-tool input were shell. Pentect prepended `export ...` to JavaScript, causing a syntax error and exposing the injected assignment in the error path. Interactive `write_stdin` inside the same orchestrator also could not reach the intended nested boundary.

## GitHub Actions required
- CI / test
- Windows and macOS plugin jobs
- Security audit
- release installer lifecycle before stable promotion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OpenAI tool calls by limiting shell command processing to recognized shell tools.
  * Preserved inputs for non-shell custom tools, including JavaScript-based tools.

* **Chores**
  * Updated the package version to 0.0.52.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->