### PR TITLE
Restore direct handles in quoted shell input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.52"
+version = "0.0.53"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2095,10 +2095,21 @@ where
     R: FnMut(&str) -> Result<String, String>,
 {
     if is_free_form_shell_tool(tool_name) {
+        let allow_direct_posix_secrets = !cfg!(windows)
+            && !tool_name.is_some_and(|name| {
+                matches!(
+                    name.to_ascii_lowercase().as_str(),
+                    "powershell" | "pwsh" | "cmd"
+                )
+            });
         if let Some(object) = value.as_object_mut() {
             for key in ["command", "script", "code"] {
                 if let Some(Value::String(text)) = object.get_mut(key) {
-                    *text = resolve_shell_text_safely(text, resolve)?;
+                    *text = resolve_shell_text_safely_with_context(
+                        text,
+                        allow_direct_posix_secrets,
+                        resolve,
+                    )?;
                 }
             }
             // Non-command metadata is structured data and remains safe to
@@ -2127,6 +2138,17 @@ pub(crate) fn resolve_shell_text_safely<R>(text: &str, resolve: &mut R) -> Resul
 where
     R: FnMut(&str) -> Result<String, String>,
 {
+    resolve_shell_text_safely_with_context(text, !cfg!(windows), resolve)
+}
+
+fn resolve_shell_text_safely_with_context<R>(
+    text: &str,
+    allow_direct_posix_secrets: bool,
+    resolve: &mut R,
+) -> Result<String, String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
     let mut environment = Vec::new();
@@ -2142,12 +2164,9 @@ where
             out.push_str(reference);
         } else if shell_safe_secret_token(&resolved) {
             out.push_str(&resolved);
-        } else if direct_secret_is_safe_in_shell_context(
-            text,
-            absolute_start,
-            end - start,
-            &resolved,
-        ) {
+        } else if allow_direct_posix_secrets
+            && direct_secret_is_safe_in_shell_context(text, absolute_start, end - start, &resolved)
+        {
             if text.as_bytes().get(absolute_start.wrapping_sub(1)) == Some(&b'\'')
                 && text.as_bytes().get(absolute_start + end - start) == Some(&b'\'')
             {
@@ -2309,14 +2328,7 @@ fn next_shell_secret_reference(text: &str) -> Option<(usize, usize)> {
         if bytes[start..].starts_with(b"<<") {
             if let Some(close) = text[start + 2..].find(">>") {
                 let end = start + 2 + close + 2;
-                let inner = &text[start + 2..end - 2];
-                if !inner.is_empty()
-                    && inner.len() <= 128
-                    && inner.contains('_')
-                    && inner
-                        .bytes()
-                        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
-                {
+                if pentect_core::parse_placeholder(&text[start..end]).is_ok() {
                     return Some((start, end));
                 }
             }
@@ -3529,9 +3541,10 @@ mod tests {
 
     #[test]
     fn shell_tool_only_resolves_conservative_token_values() {
-        let mut safe = |text: &str| Ok(text.replace("<<SECRET_safe>>", "abc_DEF-123+/="));
+        let mut safe =
+            |text: &str| Ok(text.replace("<<SECRET_0123456789abcdef>>", "abc_DEF-123+/="));
         let restored = resolve_tool_input_json(
-            r#"{"command":"curl <<SECRET_safe>>"}"#,
+            r#"{"command":"curl <<SECRET_0123456789abcdef>>"}"#,
             Some("Bash"),
             &mut safe,
         )
@@ -3539,20 +3552,22 @@ mod tests {
         assert!(restored.contains("abc_DEF-123+/="));
 
         let dangerous_value = "quoted \"; Remove-Item x\nnext";
-        let mut dangerous = |text: &str| Ok(text.replace("<<SECRET_danger>>", dangerous_value));
+        let mut dangerous =
+            |text: &str| Ok(text.replace("<<SECRET_fedcba9876543210>>", dangerous_value));
         let restored = resolve_tool_input_json(
-            r#"{"command":"echo <<SECRET_danger>>"}"#,
+            r#"{"command":"echo <<SECRET_fedcba9876543210>>"}"#,
             Some("PowerShell"),
             &mut dangerous,
         )
         .unwrap();
-        assert!(restored.contains("<<SECRET_danger>>"));
+        assert!(restored.contains("<<SECRET_fedcba9876543210>>"));
         assert!(!restored.contains(dangerous_value));
 
         let sudo_password = "fixture@password!";
-        let mut sudo = |text: &str| Ok(text.replace("<<KEYED_SECRET_fixture>>", sudo_password));
+        let mut sudo =
+            |text: &str| Ok(text.replace("<<KEYED_SECRET_a2c25e122d2e002f>>", sudo_password));
         let heredoc = resolve_shell_text_safely(
-            "sudo -S cat ./ROOT_ONLY.txt <<'EOF'\n<<KEYED_SECRET_fixture>>\nEOF",
+            "sudo -S cat ./ROOT_ONLY.txt <<'EOF'\n<<KEYED_SECRET_a2c25e122d2e002f>>\nEOF",
             &mut sudo,
         )
         .unwrap();
@@ -3560,10 +3575,10 @@ mod tests {
             heredoc.contains(&format!("\n{sudo_password}\nEOF")),
             "{heredoc}"
         );
-        assert!(!heredoc.contains("<<KEYED_SECRET_fixture>>"));
+        assert!(!heredoc.contains("<<KEYED_SECRET_a2c25e122d2e002f>>"));
 
         let single_quoted = resolve_shell_text_safely(
-            "sudo -S cat ./ROOT_ONLY.txt <<< '<<KEYED_SECRET_fixture>>'",
+            "sudo -S cat ./ROOT_ONLY.txt <<< '<<KEYED_SECRET_a2c25e122d2e002f>>'",
             &mut sudo,
         )
         .unwrap();

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2131,6 +2131,7 @@ where
     let mut rest = text;
     let mut environment = Vec::new();
     while let Some((start, end)) = next_shell_secret_reference(rest) {
+        let absolute_start = text.len().saturating_sub(rest.len()).saturating_add(start);
         out.push_str(&rest[..start]);
         let reference = &rest[start..end];
         let resolved = resolve(reference)?;
@@ -2141,6 +2142,19 @@ where
             out.push_str(reference);
         } else if shell_safe_secret_token(&resolved) {
             out.push_str(&resolved);
+        } else if direct_secret_is_safe_in_shell_context(
+            text,
+            absolute_start,
+            end - start,
+            &resolved,
+        ) {
+            if text.as_bytes().get(absolute_start.wrapping_sub(1)) == Some(&b'\'')
+                && text.as_bytes().get(absolute_start + end - start) == Some(&b'\'')
+            {
+                out.push_str(&resolved.replace('\'', "'\\''"));
+            } else {
+                out.push_str(&resolved);
+            }
         } else {
             diagnostic("shell-secret-unresolved", "resolution", "tool-input", false);
             out.push_str(reference);
@@ -2149,6 +2163,67 @@ where
     }
     out.push_str(rest);
     Ok(inject_shell_environment(out, environment))
+}
+
+fn direct_secret_is_safe_in_shell_context(
+    command: &str,
+    start: usize,
+    length: usize,
+    value: &str,
+) -> bool {
+    if value
+        .chars()
+        .any(|character| matches!(character, '\0' | '\r' | '\n'))
+    {
+        return false;
+    }
+    let bytes = command.as_bytes();
+    if start > 0
+        && bytes.get(start - 1) == Some(&b'\'')
+        && bytes.get(start + length) == Some(&b'\'')
+    {
+        return true;
+    }
+    inside_quoted_here_document(command, start)
+}
+
+fn inside_quoted_here_document(command: &str, position: usize) -> bool {
+    for (marker, quote) in [("<<'", '\''), ("<<\"", '"')] {
+        let mut search_from = 0usize;
+        while let Some(relative) = command[search_from..position].find(marker) {
+            let marker_start = search_from + relative;
+            let delimiter_start = marker_start + marker.len();
+            let Some(delimiter_end_relative) = command[delimiter_start..position].find(quote)
+            else {
+                break;
+            };
+            let delimiter_end = delimiter_start + delimiter_end_relative;
+            let delimiter = &command[delimiter_start..delimiter_end];
+            if delimiter.is_empty()
+                || delimiter.len() > 64
+                || !delimiter
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+            {
+                search_from = delimiter_end.saturating_add(1);
+                continue;
+            }
+            let Some(content_start_relative) = command[delimiter_end + 1..].find('\n') else {
+                break;
+            };
+            let content_start = delimiter_end + 1 + content_start_relative + 1;
+            let closing = format!("\n{delimiter}");
+            let Some(content_end_relative) = command[content_start..].find(&closing) else {
+                break;
+            };
+            let content_end = content_start + content_end_relative;
+            if position >= content_start && position < content_end {
+                return true;
+            }
+            search_from = delimiter_end.saturating_add(1);
+        }
+    }
+    false
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2232,8 +2307,19 @@ fn next_shell_secret_reference(text: &str) -> Option<(usize, usize)> {
     let bytes = text.as_bytes();
     for start in 0..bytes.len() {
         if bytes[start..].starts_with(b"<<") {
-            let close = text[start + 2..].find(">>")?;
-            return Some((start, start + 2 + close + 2));
+            if let Some(close) = text[start + 2..].find(">>") {
+                let end = start + 2 + close + 2;
+                let inner = &text[start + 2..end - 2];
+                if !inner.is_empty()
+                    && inner.len() <= 128
+                    && inner.contains('_')
+                    && inner
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+                {
+                    return Some((start, end));
+                }
+            }
         }
         if bytes[start] == b'$' {
             if bytes
@@ -3462,6 +3548,26 @@ mod tests {
         .unwrap();
         assert!(restored.contains("<<SECRET_danger>>"));
         assert!(!restored.contains(dangerous_value));
+
+        let sudo_password = "fixture@password!";
+        let mut sudo = |text: &str| Ok(text.replace("<<KEYED_SECRET_fixture>>", sudo_password));
+        let heredoc = resolve_shell_text_safely(
+            "sudo -S cat ./ROOT_ONLY.txt <<'EOF'\n<<KEYED_SECRET_fixture>>\nEOF",
+            &mut sudo,
+        )
+        .unwrap();
+        assert!(
+            heredoc.contains(&format!("\n{sudo_password}\nEOF")),
+            "{heredoc}"
+        );
+        assert!(!heredoc.contains("<<KEYED_SECRET_fixture>>"));
+
+        let single_quoted = resolve_shell_text_safely(
+            "sudo -S cat ./ROOT_ONLY.txt <<< '<<KEYED_SECRET_fixture>>'",
+            &mut sudo,
+        )
+        .unwrap();
+        assert!(single_quoted.contains("<<< 'fixture@password!'"));
 
         let env_name = "PENTECT_STRIPE_SECRET_KEY_a81f42c7d933";
         let secret = ["sk", "live", "51Qx7K9mN2vR4aBcD8eF"].join("_");

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -3365,16 +3365,17 @@ mod tests {
             "event: content_block_delta\n",
             "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"curl <<SE\"}}\n\n",
             "event: content_block_delta\n",
-            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"CRET_deadbeef>>\\\"}\"}}\n\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"CRET_deadbeefdeadbeef>>\\\"}\"}}\n\n",
             "event: content_block_stop\n",
             "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
             "event: content_block_delta\n",
-            "data: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"text_delta\",\"text\":\"keep <<SECRET_deadbeef>>\"}}\n\n"
+            "data: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"text_delta\",\"text\":\"keep <<SECRET_deadbeefdeadbeef>>\"}}\n\n"
         );
-        let mut resolve = |text: &str| Ok(text.replace("<<SECRET_deadbeef>>", "actual-secret"));
+        let mut resolve =
+            |text: &str| Ok(text.replace("<<SECRET_deadbeefdeadbeef>>", "actual-secret"));
         let output = rewrite_anthropic_sse_with(input, &mut resolve).unwrap();
         assert!(output.contains("actual-secret"));
-        assert!(output.contains("keep <<SECRET_deadbeef>>"));
+        assert!(output.contains("keep <<SECRET_deadbeefdeadbeef>>"));
     }
 
     #[test]
@@ -3438,14 +3439,14 @@ mod tests {
         );
         let delta_two = concat!(
             "event: content_block_delta\n",
-            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"CRET_deadbeef>>\\\"}\"}}\n\n"
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"CRET_deadbeefdeadbeef>>\\\"}\"}}\n\n"
         );
         let stop = concat!(
             "event: content_block_stop\n",
             "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n"
         );
         let mut transformer = SseStreamTransformer::new(
-            |text: &str| Ok(text.replace("<<SECRET_deadbeef>>", "actual-secret")),
+            |text: &str| Ok(text.replace("<<SECRET_deadbeefdeadbeef>>", "actual-secret")),
             None,
             false,
         );
@@ -3463,7 +3464,7 @@ mod tests {
         let output = transformer.push(stop.as_bytes()).unwrap();
         let output = join_bytes(output);
         assert!(output.contains("actual-secret"));
-        assert!(!output.contains("<<SECRET_deadbeef>>"));
+        assert!(!output.contains("<<SECRET_deadbeefdeadbeef>>"));
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- distinguish real `<<LABEL_ID>>` handles from shell here-document operators such as `<<'EOF'`
- safely restore direct handles inside quoted here-documents and single-quoted shell arguments
- keep unquoted unsafe values inert
- bump the release to 0.0.53

## Verified

- Rust shell-boundary regression test passes
- JavaScript orchestrator regression tests pass
- real Codex 0.149.0 E2E in the Debian demo container succeeded: `pentect-dev codex` passed a masked test password to `sudo -S`, read the root-owned mode-600 `ROOT_ONLY.txt`, and did not expose the password in the transcript

Follow-up to #317.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shell command secret resolution for values containing special characters when used in safely quoted contexts.
  - Added support for resolving secrets inside quoted here-documents and single-quoted shell content.
  - Invalid or malformed secret references are now ignored instead of being processed.

- **Release**
  - Updated the package version to 0.0.53.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->