### PR TITLE
Speed up release and AUR validation

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -35,16 +35,28 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          publish=false
+          requested=false
           if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch && '${{ inputs.publish }}' == true ]]; then
-            publish=true
+            requested=true
           elif [[ "$GITHUB_EVENT_NAME" == push ]]; then
             before='${{ github.event.before }}'
             if [[ "$before" == 0000000000000000000000000000000000000000 ]] ||
               ! git diff --quiet "$before" "$GITHUB_SHA" -- \
                 packaging/aur packaging/release.json tools/update_package_metadata.py; then
-              publish=true
+              requested=true
             fi
+          fi
+          publish=false
+          if [[ "$requested" == true && '${{ vars.AUR_PUBLISH_ENABLED }}' == true ]]; then
+            publish=true
+          elif [[ "$requested" == true ]]; then
+            echo "::warning title=AUR publishing disabled::Set the repository variable AUR_PUBLISH_ENABLED=true after registering the CI public key with an AUR account."
+            {
+              echo '### AUR publishing skipped'
+              echo
+              echo 'AUR package validation passed, but publishing is disabled.'
+              echo 'After AUR account registration is available, register the CI public key and set `AUR_PUBLISH_ENABLED` to `true`.'
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -89,6 +89,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/packages"
+          # Metadata and source integrity are architecture-independent. Check
+          # both package definitions everywhere, but compile the VCS package
+          # only once; release CI already builds and installs the same source
+          # natively on both Linux architectures.
           for package in pentect-bin pentect-git; do
             directory="$GITHUB_WORKSPACE/packaging/aur/$package"
             cd "$directory"
@@ -108,8 +112,21 @@ jobs:
               fi
               ! grep -Fq "$unexpected" "$verify_log"
             fi
-            sudo -u builder makepkg --cleanbuild --syncdeps --noconfirm
-            find . -maxdepth 1 -type f -name '*.pkg.tar.*' -exec cp {} "$RUNNER_TEMP/packages/" \;
+          done
+
+          packages=(pentect-bin)
+          if [[ '${{ matrix.arch }}' == x86_64 ]]; then
+            packages+=(pentect-git)
+          fi
+          for package in "${packages[@]}"; do
+            cd "$GITHUB_WORKSPACE/packaging/aur/$package"
+            # The repository's required CI test job already runs the Rust
+            # suite. This job still performs a real package build, install,
+            # launch, update guard, conflict check, and uninstall lifecycle.
+            sudo -u builder env CARGO_BUILD_JOBS=4 \
+              makepkg --cleanbuild --syncdeps --noconfirm --nocheck
+            find . -maxdepth 1 \( -type f -o -type l \) -name '*.pkg.tar.*' \
+              -exec cp -L {} "$RUNNER_TEMP/packages/" \;
           done
       - name: Run namcap on built packages
         run: namcap "$RUNNER_TEMP"/packages/*.pkg.tar.* || true
@@ -121,7 +138,6 @@ jobs:
           git_package=$(find "$RUNNER_TEMP/packages" -name 'pentect-git-*.pkg.tar.*' \
             ! -name 'pentect-git-debug-*' -print -quit)
           test -n "$bin_package"
-          test -n "$git_package"
           release_version=$(jq -r .version packaging/release.json)
 
           pacman -U --noconfirm "$bin_package"
@@ -132,14 +148,22 @@ jobs:
           if pentect uninstall 2>"$RUNNER_TEMP/uninstall.err"; then exit 1; fi
           grep -Fq 'managed by aur' "$RUNNER_TEMP/uninstall.err"
           test "$(sha256sum /usr/bin/pentect)" = "$before"
-          if pacman -U --noconfirm "$git_package"; then
-            echo 'pentect-git unexpectedly replaced pentect-bin' >&2
-            exit 1
+          if [[ '${{ matrix.arch }}' == x86_64 ]]; then
+            if pacman -U --noconfirm "$git_package"; then
+              echo 'pentect-git unexpectedly replaced pentect-bin' >&2
+              exit 1
+            fi
           fi
           pacman -Q pentect-bin
           pacman -Rns --noconfirm pentect-bin
           test ! -e /usr/bin/pentect
           test ! -e /usr/bin/.pentect-managed-install.json
+
+          if [[ '${{ matrix.arch }}' != x86_64 ]]; then
+            test -z "$git_package"
+            exit 0
+          fi
+          test -n "$git_package"
 
           pacman -U --noconfirm "$git_package"
           expected_git_version=$(sudo -u builder bash -c 'source packaging/aur/pentect-git/PKGBUILD; cd packaging/aur/pentect-git/src; pkgver')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,11 @@ jobs:
 
   build:
     needs: verify
+    env:
+      # The repository-wide default is intentionally conservative for local
+      # machines. Hosted release runners have four cores and enough memory;
+      # using all of them cuts the critical build path substantially.
+      CARGO_BUILD_JOBS: "4"
     permissions:
       contents: read
       id-token: write
@@ -512,7 +517,7 @@ jobs:
           test "$(pentect version)" = "pentect ${GITHUB_REF_NAME#v}"
           echo 'PENTECT_SMOKE_BINARY=/usr/bin/pentect' >> "$GITHUB_ENV"
       - name: Verify agent CLIs and desktop app contracts (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.installer == 'direct'
         shell: pwsh
         run: |
           python tools/install_portable_client_smoke.py --mode release
@@ -538,7 +543,7 @@ jobs:
           & $env:PENTECT_SMOKE_BINARY claude app --app $claudeFixture --upstream https://api.anthropic.com
           if ($LASTEXITCODE -ne 0) { throw 'pentect claude app failed to launch' }
       - name: Verify agent CLIs and desktop app contracts (POSIX)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.installer == 'direct'
         shell: bash
         run: |
           set -euo pipefail
@@ -556,7 +561,7 @@ jobs:
           cc -std=c11 -Wall -Wextra -Werror tools/claude-app-smoke-fixture.c -o "$claude_fixture"
           "$PENTECT_SMOKE_BINARY" claude app --app "$claude_fixture" --upstream https://api.anthropic.com
       - name: Verify persistent diagnostics (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.installer == 'direct'
         shell: pwsh
         run: |
           $secret = 'sk-pentect-log-smoke-secret'
@@ -578,7 +583,7 @@ jobs:
           }
           python tools/verify_client_smoke_log.py $logPath codex claude opencode pi codex-app claude-app --absent $secret
       - name: Verify persistent diagnostics (POSIX)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.installer == 'direct'
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- use all four hosted-runner cores for release builds instead of the repository-wide two-job default
- keep real installer lifecycle coverage while running expensive agent/diagnostic checks once per OS on the direct installer
- validate both AUR metadata definitions on both architectures, but compile the expensive `pentect-git` package once on x86_64
- retain real `pentect-bin` install/update-guard/uninstall coverage on x86_64 and aarch64
- accept both regular files and symlinked `makepkg` outputs with architecture-specific compression extensions

## Validation

- `python tools/update_package_metadata.py --metadata-file packaging/release.json --check`
- `python tools/test_release_package_metadata.py`
- `python tools/test_client_smoke_coverage.py`
- `bash -n .github/scripts/publish-aur.sh`
- `git diff --check`

Follow-up to #314.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Release**
  * Improved package validation across supported architectures.
  * Limited Git package builds and related checks to x86_64 systems.
  * Increased parallelism for package and release builds.
  * Improved artifact handling for regular files and symbolic links.
  * Added a control to enable or skip AUR publishing, with clear status reporting.

* **Testing**
  * Desktop-app and diagnostics checks now run for direct installations only.
  * ARM validation now skips Git lifecycle checks when no Git package is built.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->