### PR TITLE
Fix OpenAI Privacy Filter cold-start timeout

### DIFF
--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -1350,6 +1350,7 @@ struct ExecutionConfig {
     runtime: Option<String>,
     mode: Option<String>,
     timeout_ms: Option<u64>,
+    startup_timeout_ms: Option<u64>,
     max_input_bytes: Option<usize>,
     max_output_bytes: Option<usize>,
     max_spans: Option<usize>,
@@ -1907,6 +1908,9 @@ fn validate_execution(manifest: &PluginManifest) -> Result<(), String> {
     if execution
         .timeout_ms
         .is_some_and(|value| value == 0 || value > 60_000)
+        || execution
+            .startup_timeout_ms
+            .is_some_and(|value| value == 0 || value > 600_000)
         || execution
             .max_input_bytes
             .is_some_and(|value| value == 0 || value > 4 * 1024 * 1024)

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -33,6 +33,7 @@ const DEFAULT_MAX_INPUT_BYTES: usize = 256 * 1024;
 const DEFAULT_MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 const DEFAULT_MAX_SPANS: usize = 512;
 const MAX_TIMEOUT_MS: u64 = 60_000;
+const MAX_STARTUP_TIMEOUT_MS: u64 = 600_000;
 const MAX_PLUGIN_INPUT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_PLUGIN_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_PLUGIN_SPANS: usize = 4096;
@@ -143,6 +144,7 @@ pub fn test_local_wasm_plugin(bytes: &[u8], name: &str) -> Result<usize, String>
             required: true,
             command_config: None,
             timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+            startup_timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
             max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
             max_output_bytes: DEFAULT_MAX_OUTPUT_BYTES,
             max_spans: DEFAULT_MAX_SPANS,
@@ -254,6 +256,13 @@ impl PluginChainBudget {
         } else {
             Ok(remaining)
         }
+    }
+
+    fn exclude_startup(&mut self, elapsed: Duration) {
+        // An approved native command may need to load a large local model before
+        // its first response. That separately bounded initialization must not
+        // consume the request-wide budget of the remaining plugin chain.
+        self.deadline = self.deadline.checked_add(elapsed).unwrap_or(self.deadline);
     }
 
     fn charge_input(&mut self, bytes: usize) -> Result<(), String> {
@@ -627,6 +636,7 @@ struct PluginBinary {
     required: bool,
     command_config: Option<Value>,
     timeout: Duration,
+    startup_timeout: Duration,
     max_input_bytes: usize,
     max_output_bytes: usize,
     max_spans: usize,
@@ -752,6 +762,7 @@ impl PluginBinary {
             ));
         }
         let timeout_ms = execution.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
+        let startup_timeout_ms = execution.startup_timeout_ms.unwrap_or(timeout_ms);
         let max_input_bytes = execution.max_input_bytes.unwrap_or(DEFAULT_MAX_INPUT_BYTES);
         let max_output_bytes = execution
             .max_output_bytes
@@ -759,6 +770,8 @@ impl PluginBinary {
         let max_spans = execution.max_spans.unwrap_or(DEFAULT_MAX_SPANS);
         if timeout_ms == 0
             || timeout_ms > MAX_TIMEOUT_MS
+            || startup_timeout_ms == 0
+            || startup_timeout_ms > MAX_STARTUP_TIMEOUT_MS
             || max_input_bytes == 0
             || max_input_bytes > MAX_PLUGIN_INPUT_BYTES
             || max_output_bytes == 0
@@ -850,6 +863,7 @@ impl PluginBinary {
             required: file.required,
             command_config,
             timeout: Duration::from_millis(timeout_ms),
+            startup_timeout: Duration::from_millis(startup_timeout_ms),
             max_input_bytes,
             max_output_bytes,
             max_spans,
@@ -895,7 +909,13 @@ impl PluginBinary {
                 budget.deadline,
                 Arc::clone(&budget.network_requests),
             )?,
-            PluginProgram::Command(command) => command.invoke(&encoded, timeout, &self.name)?,
+            PluginProgram::Command(command) => command.invoke_with_startup_timeout(
+                &encoded,
+                timeout,
+                self.startup_timeout,
+                &self.name,
+                budget,
+            )?,
         };
         budget
             .charge_output(output.len())
@@ -1043,13 +1063,28 @@ impl CommandProgram {
         })
     }
 
+    #[cfg(test)]
     fn invoke(&self, request: &[u8], timeout: Duration, name: &str) -> Result<Vec<u8>, String> {
+        let mut budget = PluginChainBudget::new();
+        self.invoke_with_startup_timeout(request, timeout, timeout, name, &mut budget)
+    }
+
+    fn invoke_with_startup_timeout(
+        &self,
+        request: &[u8],
+        timeout: Duration,
+        startup_timeout: Duration,
+        name: &str,
+        budget: &mut PluginChainBudget,
+    ) -> Result<Vec<u8>, String> {
         record_plugin_access(name, "command");
         let mut state = self
             .state
             .lock()
             .map_err(|_| format!("plugin '{name}' command state is unavailable"))?;
-        if state.is_none() {
+        let starting = state.is_none();
+        let started = Instant::now();
+        if starting {
             *state = Some(CommandSession::start(
                 &self.argv,
                 &self.cwd,
@@ -1060,7 +1095,14 @@ impl CommandProgram {
         let result = state
             .as_mut()
             .expect("command session initialized")
-            .exchange(request, timeout, name);
+            .exchange(
+                request,
+                if starting { startup_timeout } else { timeout },
+                name,
+            );
+        if starting {
+            budget.exclude_startup(started.elapsed());
+        }
         if result.is_err() {
             if let Some(mut session) = state.take() {
                 session.stop();
@@ -1432,10 +1474,10 @@ fn verify_command_files(
         .iter()
         .map(|file| file.path.clone())
         .collect::<BTreeSet<_>>();
-    if !expected.is_subset(&locked)
-        || (!lock.managed && expected != locked)
-        || locked.len() != lock.file.len()
-    {
+    // The setup command may reference additional reviewed files that are also
+    // hashed into the approval lock. Runtime argv must be covered by that lock,
+    // but it need not be the entire locked set.
+    if !expected.is_subset(&locked) || locked.len() != lock.file.len() {
         return Err(format!(
             "plugin '{name}' command file set changed after setup"
         ));
@@ -2893,6 +2935,7 @@ struct ExecutionFile {
     runtime: Option<String>,
     mode: Option<String>,
     timeout_ms: Option<u64>,
+    startup_timeout_ms: Option<u64>,
     max_input_bytes: Option<usize>,
     max_output_bytes: Option<usize>,
     max_spans: Option<usize>,
@@ -3646,6 +3689,86 @@ mod tests {
     }
 
     #[test]
+    fn command_program_uses_longer_timeout_only_for_cold_start() {
+        let Some(command) = python_protocol_fixture(
+            "import json,sys,time; time.sleep(0.15);\nfor line in sys.stdin:\n r=json.loads(line); time.sleep(0.10); print(json.dumps({'id':r['id']}), flush=True)",
+        ) else {
+            return;
+        };
+        let program = CommandProgram::new(command, std::env::current_dir().unwrap(), 4096).unwrap();
+        let mut budget = PluginChainBudget::new();
+        budget.deadline = Instant::now() + Duration::from_millis(50);
+
+        let first = program
+            .invoke_with_startup_timeout(
+                br#"{"id":1}"#,
+                Duration::from_millis(50),
+                Duration::from_secs(1),
+                "fixture",
+                &mut budget,
+            )
+            .unwrap();
+        assert_eq!(serde_json::from_slice::<Value>(&first).unwrap()["id"], 1);
+        assert!(
+            budget.remaining().is_ok(),
+            "cold start consumed chain budget"
+        );
+
+        let second = program
+            .invoke_with_startup_timeout(
+                br#"{"id":2}"#,
+                Duration::from_millis(50),
+                Duration::from_secs(1),
+                "fixture",
+                &mut budget,
+            )
+            .unwrap_err();
+        assert!(second.contains("timed out"), "{second}");
+    }
+
+    #[test]
+    fn local_command_lock_may_include_reviewed_setup_file() {
+        use sha2::{Digest, Sha256};
+
+        let Some(command) = python_protocol_fixture("pass") else {
+            return;
+        };
+        let directory = std::env::temp_dir().join(format!(
+            "pentect-command-setup-lock-{}-{}",
+            std::process::id(),
+            REQUEST_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        let root = directory.join("plugin");
+        let data = directory.join("runtime");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&data).unwrap();
+        std::fs::write(root.join("server.py"), "print('server')\n").unwrap();
+        std::fs::write(root.join("setup.py"), "print('setup')\n").unwrap();
+        let digest = |name: &str| {
+            data_encoding::HEXLOWER.encode(&Sha256::digest(std::fs::read(root.join(name)).unwrap()))
+        };
+        let executable = resolve_command_executable(&command[0]).unwrap();
+        std::fs::write(
+            data.join(PLUGIN_COMMAND_LOCK_FILE),
+            format!(
+                "schema = \"pentect.plugin-command-lock.v1\"\nexecutable = {:?}\nmanaged = false\n\n[[file]]\npath = \"server.py\"\nsha256 = \"{}\"\n\n[[file]]\npath = \"setup.py\"\nsha256 = \"{}\"\n",
+                executable.to_string_lossy(),
+                digest("server.py"),
+                digest("setup.py"),
+            ),
+        )
+        .unwrap();
+        let dirs = PluginRuntimeDirs {
+            data_dir: data,
+            cache_dir: directory.join("cache"),
+            config_file: directory.join("config.toml"),
+        };
+        let argv = vec![command[0].clone(), "{plugin}/server.py".to_string()];
+        verify_command_files("fixture", &argv, &root, &dirs).unwrap();
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[test]
     fn command_program_enforces_deadline_and_output_limit() {
         let timeout = CommandProgram::new(
             sleeping_command_fixture(),
@@ -3720,6 +3843,7 @@ mod tests {
             required: true,
             command_config: Some(json!({})),
             timeout: Duration::from_secs(5),
+            startup_timeout: Duration::from_secs(5),
             max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
             max_output_bytes: 4096,
             max_spans: DEFAULT_MAX_SPANS,
@@ -3750,6 +3874,7 @@ mod tests {
             required,
             command_config: Some(json!({})),
             timeout: Duration::from_secs(5),
+            startup_timeout: Duration::from_secs(5),
             max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
             max_output_bytes: 4096,
             max_spans: DEFAULT_MAX_SPANS,

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -3697,10 +3697,7 @@ mod tests {
         };
         let program = CommandProgram::new(command, std::env::current_dir().unwrap(), 4096).unwrap();
         let mut budget = PluginChainBudget::new();
-        // Keep the chain budget comfortably above process-spawn jitter on
-        // macOS and Windows. The per-invocation timeout below remains 50 ms and
-        // is the behavior this test is exercising.
-        budget.deadline = Instant::now() + Duration::from_secs(1);
+        let deadline_before_start = budget.deadline;
 
         let first = program
             .invoke_with_startup_timeout(
@@ -3714,9 +3711,10 @@ mod tests {
         assert_eq!(serde_json::from_slice::<Value>(&first).unwrap()["id"], 1);
         assert!(
             budget
-                .remaining()
-                .is_ok_and(|remaining| remaining > Duration::from_millis(500)),
-            "cold start consumed chain budget"
+                .deadline
+                .saturating_duration_since(deadline_before_start)
+                > Duration::from_millis(200),
+            "cold start was not excluded from the chain deadline"
         );
 
         let second = program

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -3697,7 +3697,10 @@ mod tests {
         };
         let program = CommandProgram::new(command, std::env::current_dir().unwrap(), 4096).unwrap();
         let mut budget = PluginChainBudget::new();
-        budget.deadline = Instant::now() + Duration::from_millis(50);
+        // Keep the chain budget comfortably above process-spawn jitter on
+        // macOS and Windows. The per-invocation timeout below remains 50 ms and
+        // is the behavior this test is exercising.
+        budget.deadline = Instant::now() + Duration::from_secs(1);
 
         let first = program
             .invoke_with_startup_timeout(
@@ -3710,7 +3713,9 @@ mod tests {
             .unwrap();
         assert_eq!(serde_json::from_slice::<Value>(&first).unwrap()["id"], 1);
         assert!(
-            budget.remaining().is_ok(),
+            budget
+                .remaining()
+                .is_ok_and(|remaining| remaining > Duration::from_millis(500)),
             "cold start consumed chain budget"
         );
 

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, TryLockError};
 use std::time::{Duration, Instant};
 
 pub const BINARIES_ENV: &str = "PENTECT_PLUGIN_BINARIES";
@@ -1078,10 +1078,21 @@ impl CommandProgram {
         budget: &mut PluginChainBudget,
     ) -> Result<Vec<u8>, String> {
         record_plugin_access(name, "command");
-        let mut state = self
-            .state
-            .lock()
-            .map_err(|_| format!("plugin '{name}' command state is unavailable"))?;
+        let mut state = loop {
+            match self.state.try_lock() {
+                Ok(state) => break state,
+                Err(TryLockError::Poisoned(_)) => {
+                    return Err(format!("plugin '{name}' command state is unavailable"));
+                }
+                Err(TryLockError::WouldBlock) => {
+                    let remaining = budget.deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Err(format!("plugin '{name}' command state is unavailable"));
+                    }
+                    std::thread::sleep(remaining.min(Duration::from_millis(5)));
+                }
+            }
+        };
         let starting = state.is_none();
         let started = Instant::now();
         if starting {
@@ -1092,14 +1103,19 @@ impl CommandProgram {
                 name,
             )?);
         }
+        let exchange_timeout = if starting {
+            startup_timeout
+        } else {
+            timeout.min(
+                budget
+                    .remaining()
+                    .map_err(|_| format!("plugin '{name}' command state is unavailable"))?,
+            )
+        };
         let result = state
             .as_mut()
             .expect("command session initialized")
-            .exchange(
-                request,
-                if starting { startup_timeout } else { timeout },
-                name,
-            );
+            .exchange(request, exchange_timeout, name);
         if starting {
             budget.exclude_startup(started.elapsed());
         }
@@ -3727,6 +3743,33 @@ mod tests {
             )
             .unwrap_err();
         assert!(second.contains("timed out"), "{second}");
+    }
+
+    #[test]
+    fn command_program_state_wait_is_bounded_by_chain_deadline() {
+        let Some(command) = python_protocol_fixture("pass") else {
+            return;
+        };
+        let program = CommandProgram::new(command, std::env::current_dir().unwrap(), 4096).unwrap();
+        let held_state = program.state.lock().unwrap();
+        let waiting_program = program.clone();
+        let waiting = std::thread::spawn(move || {
+            let mut budget = PluginChainBudget::new();
+            budget.deadline = Instant::now() + Duration::from_millis(50);
+            waiting_program
+                .invoke_with_startup_timeout(
+                    br#"{"id":1}"#,
+                    Duration::from_secs(1),
+                    Duration::from_secs(1),
+                    "fixture",
+                    &mut budget,
+                )
+                .unwrap_err()
+        });
+        std::thread::sleep(Duration::from_millis(150));
+        assert!(waiting.is_finished(), "state wait exceeded chain deadline");
+        drop(held_state);
+        assert!(waiting.join().unwrap().contains("state is unavailable"));
     }
 
     #[test]

--- a/plugins/openai-privacy-filter/plugin.toml
+++ b/plugins/openai-privacy-filter/plugin.toml
@@ -22,6 +22,7 @@ linux = ["python3", "{plugin}/setup.py"]
 
 [execution]
 timeout_ms = 60000
+startup_timeout_ms = 300000
 max_input_bytes = 1048576
 max_output_bytes = 1048576
 max_spans = 4096

--- a/plugins/openai-privacy-filter/server.py
+++ b/plugins/openai-privacy-filter/server.py
@@ -29,11 +29,12 @@ def _use_managed_python() -> None:
     if not candidate.is_file():
         return
     try:
-        current = Path(sys.executable).resolve()
-        managed = candidate.resolve()
+        current_environment = Path(sys.prefix).resolve()
+        managed_environment = root.resolve()
     except OSError:
-        return
-    if current != managed:
+        current_environment = Path(sys.prefix)
+        managed_environment = root
+    if current_environment != managed_environment:
         # Execute through the venv path rather than its resolved interpreter.
         # Python discovers pyvenv.cfg from the executable path; bypassing the
         # symlink starts the base interpreter without the venv's packages.

--- a/plugins/openai-privacy-filter/tests/test_server.py
+++ b/plugins/openai-privacy-filter/tests/test_server.py
@@ -40,6 +40,7 @@ class ServerTests(unittest.TestCase):
             candidate.symlink_to(runtime)
 
             with (
+                mock.patch.dict(SERVER.os.environ, {"PENTECT_OPF_ROOT": ""}),
                 mock.patch.object(SERVER.Path, "home", return_value=home),
                 mock.patch.object(SERVER.sys, "executable", "/usr/bin/python3"),
                 mock.patch.object(SERVER.sys, "prefix", "/usr"),
@@ -58,6 +59,7 @@ class ServerTests(unittest.TestCase):
             candidate.parent.mkdir(parents=True)
             candidate.touch()
             with (
+                mock.patch.dict(SERVER.os.environ, {"PENTECT_OPF_ROOT": ""}),
                 mock.patch.object(SERVER.Path, "home", return_value=Path(directory)),
                 mock.patch.object(SERVER.sys, "prefix", str(root)),
                 mock.patch.object(SERVER.os, "execv") as execv,

--- a/plugins/openai-privacy-filter/tests/test_server.py
+++ b/plugins/openai-privacy-filter/tests/test_server.py
@@ -42,6 +42,7 @@ class ServerTests(unittest.TestCase):
             with (
                 mock.patch.object(SERVER.Path, "home", return_value=home),
                 mock.patch.object(SERVER.sys, "executable", "/usr/bin/python3"),
+                mock.patch.object(SERVER.sys, "prefix", "/usr"),
                 mock.patch.object(SERVER.os, "execv") as execv,
             ):
                 SERVER._use_managed_python()
@@ -49,6 +50,20 @@ class ServerTests(unittest.TestCase):
             executable, arguments = execv.call_args.args
             self.assertEqual(executable, str(candidate))
             self.assertEqual(arguments[0], str(candidate))
+
+    def test_managed_python_does_not_reexec_inside_venv(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ".pentect" / "openai-privacy-filter" / "venv"
+            candidate = root / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+            candidate.parent.mkdir(parents=True)
+            candidate.touch()
+            with (
+                mock.patch.object(SERVER.Path, "home", return_value=Path(directory)),
+                mock.patch.object(SERVER.sys, "prefix", str(root)),
+                mock.patch.object(SERVER.os, "execv") as execv,
+            ):
+                SERVER._use_managed_python()
+            execv.assert_not_called()
 
     def test_offsets_are_utf8_bytes(self) -> None:
         result = SERVER.inspect_text(Redactor(), "AéZ")

--- a/website/src/content/docs/plugins/manifest.md
+++ b/website/src/content/docs/plugins/manifest.md
@@ -100,14 +100,18 @@ use the same name in both places.
 ```toml
 [execution]
 timeout_ms = 10000
+startup_timeout_ms = 120000
 max_input_bytes = 262144
 max_output_bytes = 1048576
 max_spans = 512
 ```
 
-The largest allowed values are 60 seconds, 4 MiB input, 4 MiB output, and 4,096
-findings. The Wasm file itself must be 32 MiB or smaller. Pentect infers the
-form, so new manifests do not set a runtime or mode.
+The largest allowed values are 60 seconds per invocation, 10 minutes for
+`startup_timeout_ms`, 4 MiB input, 4 MiB output, and 4,096 findings. The startup
+limit applies only to the first response from a native Command process; later
+responses use `timeout_ms`. If omitted, it equals `timeout_ms`. The Wasm file
+itself must be 32 MiB or smaller. Pentect infers the form, so new manifests do
+not set a runtime or mode.
 
 Use small limits. They protect the user from a slow or broken plugin.
 

--- a/website/src/content/docs/plugins/official.md
+++ b/website/src/content/docs/plugins/official.md
@@ -73,7 +73,8 @@ therefore replaces PyTorch and the managed virtual environment, not the model.
 Review the exact runtime and environment setup commands, downloaded file
 hashes, `inspect` hook, and required status. Pentect prepares the model before
 enabling the plugin, so the first protected request does not unexpectedly start
-a multi-gigabyte download.
+a multi-gigabyte download. The first process start has a five-minute model-load
+budget; later requests retain the normal 60-second inference limit.
 
 Test with fake data:
 


### PR DESCRIPTION
## Summary
- detect the managed Python environment by `sys.prefix` so symlinked venv interpreters re-exec correctly
- allow reviewed setup files to remain in native-command approval locks
- add a separately bounded command startup timeout and give OpenAI Privacy Filter five minutes for its first response
- document the startup timeout behavior

## Verification
- `cargo test -p pentect-runtime` (278 passed)
- `cargo test -p pentect-cli --no-default-features` with inherited Pentect memory-store variables removed (all passed)
- OpenAI Privacy Filter Python tests (17 passed)
- real CPU setup/model inference in `~/pentect-demo` (3 findings, exit 0, 11s cold start)
- real CLI E2E for two- and three-layer Base64 (both masked as AWS_AKID handles)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable plugin startup timeouts, from 1 millisecond to 10 minutes.
  * Native command plugins can use a dedicated timeout for initial startup while retaining normal request limits afterward.
  * Improved support for reviewed setup files during plugin lock validation.
  * OpenAI Privacy Filter now allows up to five minutes for initial model loading.

* **Bug Fixes**
  * Improved detection of managed Python environments, including cases where path resolution fails.

* **Documentation**
  * Documented startup timeout behavior and updated OpenAI Privacy Filter installation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->