### PR TITLE
Add explicit pentect(...) secret marker

### DIFF
--- a/crates/pentect-core/src/detect/explicit.rs
+++ b/crates/pentect-core/src/detect/explicit.rs
@@ -1,0 +1,103 @@
+use super::Detector;
+use crate::model::{labels, ByteRange, Category, Confidence, DetectorId, Span};
+use crate::normalize::NormalizedView;
+
+pub(crate) const EXPLICIT_SECRET_PREFIX: &str = "pentect(";
+
+/// Masks values deliberately wrapped as `pentect(value)`, regardless of their
+/// entropy or shape. The renderer removes the opt-in wrapper while preserving
+/// only `value` in recovery, so a restored tool argument receives the intended
+/// value rather than the annotation syntax.
+pub struct ExplicitSecretDetector;
+
+impl Detector for ExplicitSecretDetector {
+    fn detect(&self, view: &NormalizedView) -> Vec<Span> {
+        let text = view.text();
+        let bytes = text.as_bytes();
+        let prefix = EXPLICIT_SECRET_PREFIX.as_bytes();
+        let mut spans = Vec::new();
+        let mut cursor = 0usize;
+
+        while cursor + prefix.len() < bytes.len() {
+            let Some(relative) = text[cursor..].find(EXPLICIT_SECRET_PREFIX) else {
+                break;
+            };
+            let marker_start = cursor + relative;
+            let value_start = marker_start + prefix.len();
+            let mut depth = 1usize;
+            let mut close = value_start;
+            while close < bytes.len() {
+                match bytes[close] {
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+                close += 1;
+            }
+            if depth != 0 {
+                break;
+            }
+
+            let raw_marker = view.to_raw(ByteRange::new(marker_start, value_start));
+            let raw_close = view.to_raw(ByteRange::new(close, close + 1));
+            if close > value_start && raw_marker.len() == prefix.len() && raw_close.len() == 1 {
+                let raw_value = view.to_raw(ByteRange::new(value_start, close));
+                if !raw_value.is_empty() {
+                    spans.push(Span {
+                        range: raw_value,
+                        category: Category::Secret,
+                        label: labels::KEYED_SECRET.to_string(),
+                        confidence: Confidence::High,
+                        source: DetectorId::Explicit,
+                    });
+                }
+            }
+            cursor = close + 1;
+        }
+
+        spans
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Context, Kind, Region, RegionKind};
+
+    fn detect(text: &str) -> Vec<Span> {
+        let region = Region {
+            span: ByteRange::new(0, text.len()),
+            ctx: Context {
+                path: None,
+                key: None,
+                hints: Vec::new(),
+                kind: RegionKind::PlainText,
+                format: Kind::Text,
+            },
+        };
+        ExplicitSecretDetector.detect(&NormalizedView::build(&region, text))
+    }
+
+    #[test]
+    fn finds_low_entropy_and_balanced_values() {
+        let text = "a pentect(abc) b pentect(pa(ss)word)";
+        let spans = detect(text);
+        assert_eq!(spans.len(), 2);
+        assert_eq!(&text[spans[0].range.start..spans[0].range.end], "abc");
+        assert_eq!(
+            &text[spans[1].range.start..spans[1].range.end],
+            "pa(ss)word"
+        );
+    }
+
+    #[test]
+    fn ignores_empty_unclosed_and_lookalike_markers() {
+        assert!(detect("pentect() pentect(unclosed").is_empty());
+        assert!(detect("ｐｅｎｔｅｃｔ(value)").is_empty());
+    }
+}

--- a/crates/pentect-core/src/detect/mod.rs
+++ b/crates/pentect-core/src/detect/mod.rs
@@ -11,6 +11,7 @@ mod credsweeper_ml;
 mod decode;
 mod documentation;
 mod entropy;
+mod explicit;
 mod key_value;
 mod pattern;
 mod pem;
@@ -36,6 +37,8 @@ pub use decode::{
     DEFAULT_MAX_INFLATE_BYTES, DEFAULT_MIN_DECODE_BYTES, DEFAULT_MIN_OPAQUE_RUN,
 };
 pub use entropy::{EntropyDetector, DEFAULT_ENTROPY_MIN_LEN, DEFAULT_ENTROPY_THRESHOLD};
+pub use explicit::ExplicitSecretDetector;
+pub(crate) use explicit::EXPLICIT_SECRET_PREFIX;
 pub use key_value::KeyValueDetector;
 pub use pattern::{PatternMatchDetector, PatternSpec};
 pub use pem::PemDetector;

--- a/crates/pentect-core/src/lib.rs
+++ b/crates/pentect-core/src/lib.rs
@@ -35,8 +35,8 @@ pub use detect::{
     AuthCodeDetector, Bip39Detector, CardDetector, CliCredentialDetector,
     CredSweeperNativeDetector, CredSweeperNativeFinding, CredSweeperNativeRelatedFinding,
     CredSweeperNativeStats, DecodeConfig, DecodeDetector, Detector, EntropyDetector,
-    EnvValueDetector, KeyValueDetector, PatternMatchDetector, PatternSpec, PemDetector,
-    RuleDetector, RuleSpec, SensitiveKeyDetector, StructuralDetector, UrlDetector,
+    EnvValueDetector, ExplicitSecretDetector, KeyValueDetector, PatternMatchDetector, PatternSpec,
+    PemDetector, RuleDetector, RuleSpec, SensitiveKeyDetector, StructuralDetector, UrlDetector,
 };
 pub use model::{
     ByteRange, Category, Confidence, Context, DetectorId, Input, Kind, Region, RegionKind, Span,

--- a/crates/pentect-core/src/model.rs
+++ b/crates/pentect-core/src/model.rs
@@ -218,6 +218,8 @@ mod tests {
 /// label is kept (e.g. OPAQUE_BLOB over a generic LIKELY_SECRET).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum DetectorId {
+    /// A value explicitly wrapped by the user as `pentect(value)`.
+    Explicit,
     /// Span supplied by a plugin adapter outside deterministic core.
     Plugin,
     /// Native Rust port of embedded CredSweeper rule/model assets.
@@ -242,6 +244,7 @@ pub enum DetectorId {
 impl DetectorId {
     pub fn as_str(self) -> &'static str {
         match self {
+            DetectorId::Explicit => "explicit",
             DetectorId::Plugin => "plugin",
             DetectorId::CredSweeper => "credsweeper",
             DetectorId::Rule => "rule",

--- a/crates/pentect-core/src/pipeline/merge.rs
+++ b/crates/pentect-core/src/pipeline/merge.rs
@@ -27,6 +27,19 @@ pub fn merge(mut spans: Vec<Span>, protected: &[ByteRange]) -> Vec<Span> {
                 || can_touch_protected(s))
     });
 
+    // An explicit marker defines the user's exact value boundary. A broader
+    // heuristic overlap must not expand it back over the `pentect(...)` wrapper,
+    // otherwise recovery would include annotation syntax instead of only the
+    // intended value.
+    let explicit = RangeIndex::new(
+        spans
+            .iter()
+            .filter(|span| span.source == DetectorId::Explicit)
+            .map(|span| span.range)
+            .collect(),
+    );
+    spans.retain(|span| span.source == DetectorId::Explicit || !explicit.overlaps(&span.range));
+
     // Every connected overlap describes one underlying byte sequence. Mask its
     // full union so a weaker candidate cannot leave a prefix or suffix visible.
     // Ranges that merely touch at an edge remain independent.
@@ -175,6 +188,28 @@ mod tests {
         );
         assert_eq!(out.len(), 2);
         assert!(out[0].range.start < out[1].range.start);
+    }
+
+    #[test]
+    fn explicit_span_keeps_its_exact_boundary_over_broader_overlap() {
+        let explicit = Span {
+            range: ByteRange::new(8, 11),
+            category: Category::Secret,
+            label: labels::KEYED_SECRET.into(),
+            confidence: Confidence::High,
+            source: DetectorId::Explicit,
+        };
+        let broader = Span {
+            range: ByteRange::new(0, 12),
+            category: Category::Secret,
+            label: labels::KEYED_SECRET.into(),
+            confidence: Confidence::High,
+            source: DetectorId::KeyValue,
+        };
+        let out = merge(vec![broader, explicit], &[]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].source, DetectorId::Explicit);
+        assert_eq!(out[0].range, ByteRange::new(8, 11));
     }
 
     fn entropy_span(start: usize, end: usize) -> Span {

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -6,8 +6,9 @@ mod sweep;
 use crate::detect::{
     AuthCodeDetector, Bip39Detector, CardDetector, CliCredentialDetector,
     CredSweeperNativeDetector, DecodeConfig, DecodeDetector, Detector, EntropyDetector,
-    EnvValueDetector, KeyValueDetector, PemDetector, PhoneDetector, RuleDetector,
-    SensitiveKeyDetector, StructuralDetector, UrlDetector, UuidDetector, SECRET_VALUE_HINT,
+    EnvValueDetector, ExplicitSecretDetector, KeyValueDetector, PemDetector, PhoneDetector,
+    RuleDetector, SensitiveKeyDetector, StructuralDetector, UrlDetector, UuidDetector,
+    SECRET_VALUE_HINT,
 };
 use crate::model::*;
 use crate::normalize::NormalizedView;
@@ -705,6 +706,7 @@ impl EngineBuilder {
             .parser(Kind::Env, Box::new(EnvParser))
             .structured_parsers()
             .parser(Kind::Har, Box::new(JsonParser))
+            .detector(Box::new(ExplicitSecretDetector))
             .detector(Box::new(UrlDetector))
             .detector(Box::new(CliCredentialDetector))
             .detector(Box::new(RuleDetector::builtin()))
@@ -735,6 +737,7 @@ impl EngineBuilder {
             .parser(Kind::Env, Box::new(EnvParser))
             .structured_parsers()
             .parser(Kind::Har, Box::new(JsonParser))
+            .detector(Box::new(ExplicitSecretDetector))
             .detector(Box::new(CredSweeperNativeDetector::builtin()))
             .detector(Box::new(KeyValueDetector))
             .detector(Box::new(PemDetector::default()))
@@ -1399,6 +1402,34 @@ mod tests {
         assert!(r.masked.contains("<<KEYED_SECRET_"), "{}", r.masked);
         assert_eq!(r.masked.matches("<<").count(), 1, "{}", r.masked);
         assert_eq!(restore(&r.masked, &r.recovery).unwrap(), input);
+    }
+
+    #[test]
+    fn explicit_secret_marker_forces_masking_and_is_not_restored_as_syntax() {
+        let input = "fixture value: pentect(abc)";
+        let result = Engine::with_profile(Profile::Dev).mask(
+            Input {
+                kind: Kind::Text,
+                data: input.to_string(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert_eq!(result.masked.matches("<<KEYED_SECRET_").count(), 1);
+        assert!(!result.masked.contains("pentect("), "{}", result.masked);
+        assert!(!result.masked.contains("abc"), "{}", result.masked);
+        assert_eq!(
+            restore(&result.masked, &result.recovery).unwrap(),
+            "fixture value: abc"
+        );
+
+        let remasked = Engine::with_profile(Profile::Dev).mask(
+            Input {
+                kind: Kind::Text,
+                data: result.masked.clone(),
+            },
+            &Config::insecure_testing(),
+        );
+        assert_eq!(remasked.masked, result.masked);
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/render.rs
+++ b/crates/pentect-core/src/pipeline/render.rs
@@ -1,3 +1,4 @@
+use crate::detect::EXPLICIT_SECRET_PREFIX;
 use crate::model::*;
 use crate::normalize::n_id_cow;
 use crate::placeholder::{render_placeholder, IdentityHasher};
@@ -83,7 +84,11 @@ pub fn render(raw: &str, key: &[u8; 32], mut spans: Vec<Span>, disclose_length: 
         if s.range.start < cursor {
             continue;
         }
-        push_literal(&mut segments, &mut masked, &raw[cursor..s.range.start]);
+        let explicit_wrapper = explicit_wrapper_bounds(raw, s);
+        let literal_end = explicit_wrapper
+            .map(|(start, _)| start)
+            .unwrap_or(s.range.start);
+        push_literal(&mut segments, &mut masked, &raw[cursor..literal_end]);
         let val = &raw[s.range.start..s.range.end];
 
         match should_split_email(s).then(|| split_email(val)).flatten() {
@@ -135,7 +140,7 @@ pub fn render(raw: &str, key: &[u8; 32], mut spans: Vec<Span>, disclose_length: 
                 );
             }
         }
-        cursor = s.range.end;
+        cursor = explicit_wrapper.map(|(_, end)| end).unwrap_or(s.range.end);
     }
     push_literal(&mut segments, &mut masked, &raw[cursor..]);
 
@@ -145,6 +150,16 @@ pub fn render(raw: &str, key: &[u8; 32], mut spans: Vec<Span>, disclose_length: 
         map,
         collisions,
     }
+}
+
+fn explicit_wrapper_bounds(raw: &str, span: &Span) -> Option<(usize, usize)> {
+    if span.source != DetectorId::Explicit || span.range.start < EXPLICIT_SECRET_PREFIX.len() {
+        return None;
+    }
+    let wrapper_start = span.range.start - EXPLICIT_SECRET_PREFIX.len();
+    (raw.get(wrapper_start..span.range.start) == Some(EXPLICIT_SECRET_PREFIX)
+        && raw.as_bytes().get(span.range.end) == Some(&b')'))
+    .then_some((wrapper_start, span.range.end + 1))
 }
 
 fn should_split_email(span: &Span) -> bool {

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -6,9 +6,9 @@ use crate::session::Session;
 use pentect_core::placeholder::{identity_hash, render_placeholder};
 use pentect_core::{
     load_pack, ByteRange, Category, Config, Context, CredSweeperNativeDetector, Engine,
-    EntropyDetector, EnvParser, EnvValueDetector, Input, JsonParser, KeyValueDetector, Kind,
-    MaskResult, NdjsonParser, PemDetector, Profile, ProfilePolicy, Recovery, Region, RegionKind,
-    SensitiveKeyDetector, ShapeGuard, ToolResultParser,
+    EntropyDetector, EnvParser, EnvValueDetector, ExplicitSecretDetector, Input, JsonParser,
+    KeyValueDetector, Kind, MaskResult, NdjsonParser, PemDetector, Profile, ProfilePolicy,
+    Recovery, Region, RegionKind, SensitiveKeyDetector, ShapeGuard, ToolResultParser,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::sync::OnceLock;
@@ -938,7 +938,8 @@ fn build_pentect_engine_with_prompt_detectors(prompt: bool) -> Result<Engine, St
         .structured_parsers()
         .parser(Kind::Har, Box::new(JsonParser))
         .parser(Kind::ToolResult, Box::new(ToolResultParser))
-        .detector(Box::new(CredSweeperNativeDetector::builtin()));
+        .detector(Box::new(CredSweeperNativeDetector::builtin()))
+        .detector(Box::new(ExplicitSecretDetector));
     if prompt {
         builder = builder.detector(Box::new(KeyValueDetector));
     }

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -604,6 +604,25 @@ fn active_prompt_masks_keyed_and_vendor_secrets_in_prose() {
 }
 
 #[test]
+fn active_prompt_explicit_marker_masks_low_entropy_value_and_removes_wrapper() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-prompt-explicit-marker");
+
+    let mut masker = ActiveToolOutputMasker::new().unwrap();
+    let masked = masker
+        .mask_prompt_text("sudo password is pentect(abc)")
+        .unwrap()
+        .unwrap();
+
+    assert!(
+        masked.starts_with("sudo password is <<KEYED_SECRET_"),
+        "{masked}"
+    );
+    assert!(!masked.contains("pentect("), "{masked}");
+    assert!(!masked.contains("abc"), "{masked}");
+}
+
+#[test]
 fn bridge_masks_prompt_wraps_shell_and_masks_result() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (_active_store, _, _) = ActiveMemoryStoreEnv::start("bridge-mask");

--- a/website/src/content/docs/start/handles.md
+++ b/website/src/content/docs/start/handles.md
@@ -30,6 +30,21 @@ a general `SECRET` or `PII` label.
 The ID is a keyed hash. It is not a plain checksum of the value. The private
 identity key stays on the local device.
 
+## Force a value to become a handle
+
+Wrap a value in `pentect(...)` when it must be protected even if it is short,
+low-entropy, or unknown to the built-in detectors:
+
+```text
+sudo password is pentect(passsword123)
+```
+
+Pentect removes the wrapper before the request leaves the device and sends a
+`KEYED_SECRET` handle in its place. If that handle is later used by a local tool,
+Pentect restores only `passsword123`; the `pentect(...)` annotation is not part
+of the value. The marker is case-sensitive, must be balanced, and an empty
+`pentect()` marker is ignored.
+
 ## How a tool uses a handle
 
 Protected launches provide an environment binding for each handle. Remove the


### PR DESCRIPTION
## Summary
- add `pentect(value)` as an explicit, high-confidence secret marker
- remove the annotation wrapper before provider output while preserving only the inner value for local recovery
- keep explicit boundaries exact when heuristic detectors overlap
- document the marker and its balanced/case-sensitive behavior

## Verification
- `cargo check --workspace`
- `cargo test -p pentect-core` (366 passed)
- `cargo test -p pentect-runtime` (277 passed)
- actual CLI masking: `sudo password is pentect(abc)` became one `KEYED_SECRET` handle
- actual memory-store + `pentect exec` E2E restored that handle as exactly `abc`