### PR TITLE
chore: release v0.0.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.53"
+version = "0.0.54"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump the Pentect CLI and npm package to 0.0.54
- prepare the validated OPF startup, explicit secret marker, and OCR changes for release

## Validation
- `cargo fmt --all -- --check`
- `cargo check --locked -p pentect-cli`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application package version from 0.0.53 to 0.0.54.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->