### PR TITLE
feat: expose recoverable handles for redacted images

### DIFF
--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -55,7 +55,8 @@ pub(crate) struct ImageRedaction {
     pub(crate) secret_images: usize,
     pub(crate) notes: Vec<String>,
     pub(crate) recovery: Recovery,
-    pub(crate) pixel_redactions: usize,
+    pub(crate) visual_notes: Vec<String>,
+    pub(crate) metadata_notes: Vec<String>,
 }
 
 struct ImageRedactionState {
@@ -68,7 +69,8 @@ struct ImageRedactionState {
     started_at: std::time::Instant,
     notes: Vec<String>,
     recovery: HashMap<String, String>,
-    pixel_redactions: usize,
+    visual_notes: Vec<String>,
+    metadata_notes: Vec<String>,
 }
 
 struct RedactedImagePayload {
@@ -232,7 +234,8 @@ pub(crate) fn redact_tool_images_for_secrets(
         started_at: std::time::Instant::now(),
         notes: Vec::new(),
         recovery: HashMap::new(),
-        pixel_redactions: 0,
+        visual_notes: Vec::new(),
+        metadata_notes: Vec::new(),
     };
     let updated = redact_image_value(value, identity_key, cfg, &mut state)?;
     record_ocr_outcomes(
@@ -249,7 +252,8 @@ pub(crate) fn redact_tool_images_for_secrets(
         secret_images: state.secret_images,
         notes: state.notes,
         recovery: Recovery::seal(state.recovery, key),
-        pixel_redactions: state.pixel_redactions,
+        visual_notes: state.visual_notes,
+        metadata_notes: state.metadata_notes,
     })
 }
 
@@ -630,16 +634,19 @@ fn redact_image_bytes(
         }
     }
     state.secret_images += 1;
-    if findings_redact_pixels(&findings) {
-        state.pixel_redactions += 1;
-    }
     let index = state.notes.len() + 1;
     let summary = if handles.is_empty() {
         labels.join(", ")
     } else {
         handles.join(", ")
     };
-    state.notes.push(format!("[{index}] {summary}"));
+    let note = format!("[{index}] {summary}");
+    state.notes.push(note.clone());
+    if findings_redact_pixels(&findings) {
+        state.visual_notes.push(note);
+    } else {
+        state.metadata_notes.push(note);
+    }
     let payload = redacted_image_payload(bytes, index, cfg, &findings)?;
     Ok(ImageRedactionDecision::Redacted(payload))
 }

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -55,6 +55,7 @@ pub(crate) struct ImageRedaction {
     pub(crate) secret_images: usize,
     pub(crate) notes: Vec<String>,
     pub(crate) recovery: Recovery,
+    pub(crate) pixel_redactions: usize,
 }
 
 struct ImageRedactionState {
@@ -67,6 +68,7 @@ struct ImageRedactionState {
     started_at: std::time::Instant,
     notes: Vec<String>,
     recovery: HashMap<String, String>,
+    pixel_redactions: usize,
 }
 
 struct RedactedImagePayload {
@@ -230,6 +232,7 @@ pub(crate) fn redact_tool_images_for_secrets(
         started_at: std::time::Instant::now(),
         notes: Vec::new(),
         recovery: HashMap::new(),
+        pixel_redactions: 0,
     };
     let updated = redact_image_value(value, identity_key, cfg, &mut state)?;
     record_ocr_outcomes(
@@ -246,6 +249,7 @@ pub(crate) fn redact_tool_images_for_secrets(
         secret_images: state.secret_images,
         notes: state.notes,
         recovery: Recovery::seal(state.recovery, key),
+        pixel_redactions: state.pixel_redactions,
     })
 }
 
@@ -626,6 +630,9 @@ fn redact_image_bytes(
         }
     }
     state.secret_images += 1;
+    if findings_redact_pixels(&findings) {
+        state.pixel_redactions += 1;
+    }
     let index = state.notes.len() + 1;
     let summary = if handles.is_empty() {
         labels.join(", ")
@@ -635,6 +642,16 @@ fn redact_image_bytes(
     state.notes.push(format!("[{index}] {summary}"));
     let payload = redacted_image_payload(bytes, index, cfg, &findings)?;
     Ok(ImageRedactionDecision::Redacted(payload))
+}
+
+#[cfg(feature = "ocr")]
+fn findings_redact_pixels(findings: &[ImageSecretFinding]) -> bool {
+    findings.iter().any(|finding| finding.redact_pixels)
+}
+
+#[cfg(not(feature = "ocr"))]
+fn findings_redact_pixels(_findings: &[ImageSecretFinding]) -> bool {
+    false
 }
 
 #[cfg(feature = "ocr")]

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -619,10 +619,17 @@ fn redact_image_bytes(
         return Ok(ImageRedactionDecision::Clean);
     }
 
-    let mut labels = Vec::new();
-    let mut handles = Vec::new();
+    let mut visual_labels = Vec::new();
+    let mut visual_handles = Vec::new();
+    let mut metadata_labels = Vec::new();
+    let mut metadata_handles = Vec::new();
     for finding in &findings {
-        push_secret_labels(&mut labels, &finding.labels);
+        let (labels, handles) = if finding_redacts_pixels(finding) {
+            (&mut visual_labels, &mut visual_handles)
+        } else {
+            (&mut metadata_labels, &mut metadata_handles)
+        };
+        push_secret_labels(labels, &finding.labels);
         for (handle, value) in &finding.secrets {
             if !handles.iter().any(|seen| seen == handle) {
                 handles.push(handle.clone());
@@ -634,30 +641,38 @@ fn redact_image_bytes(
         }
     }
     state.secret_images += 1;
-    let index = state.notes.len() + 1;
-    let summary = if handles.is_empty() {
-        labels.join(", ")
-    } else {
-        handles.join(", ")
-    };
-    let note = format!("[{index}] {summary}");
-    state.notes.push(note.clone());
-    if findings_redact_pixels(&findings) {
+    let index = state.secret_images;
+    if let Some(summary) = image_note_summary(&visual_labels, &visual_handles) {
+        let note = format!("[{index}] {summary}");
+        state.notes.push(note.clone());
         state.visual_notes.push(note);
-    } else {
+    }
+    if let Some(summary) = image_note_summary(&metadata_labels, &metadata_handles) {
+        let note = format!("[{index}] {summary}");
+        state.notes.push(note.clone());
         state.metadata_notes.push(note);
     }
     let payload = redacted_image_payload(bytes, index, cfg, &findings)?;
     Ok(ImageRedactionDecision::Redacted(payload))
 }
 
+fn image_note_summary(labels: &[String], handles: &[String]) -> Option<String> {
+    if !handles.is_empty() {
+        Some(handles.join(", "))
+    } else if !labels.is_empty() {
+        Some(labels.join(", "))
+    } else {
+        None
+    }
+}
+
 #[cfg(feature = "ocr")]
-fn findings_redact_pixels(findings: &[ImageSecretFinding]) -> bool {
-    findings.iter().any(|finding| finding.redact_pixels)
+fn finding_redacts_pixels(finding: &ImageSecretFinding) -> bool {
+    finding.redact_pixels
 }
 
 #[cfg(not(feature = "ocr"))]
-fn findings_redact_pixels(_findings: &[ImageSecretFinding]) -> bool {
+fn finding_redacts_pixels(_finding: &ImageSecretFinding) -> bool {
     false
 }
 
@@ -3232,7 +3247,11 @@ mod tests {
 
     #[cfg(feature = "ocr")]
     fn png_with_raw_chunk(kind: [u8; 4], data: &[u8]) -> Vec<u8> {
-        let mut png = color_grid_png();
+        insert_png_raw_chunk(color_grid_png(), kind, data)
+    }
+
+    #[cfg(feature = "ocr")]
+    fn insert_png_raw_chunk(mut png: Vec<u8>, kind: [u8; 4], data: &[u8]) -> Vec<u8> {
         let iend = png
             .windows(8)
             .position(|window| window == b"\0\0\0\0IEND")
@@ -3354,6 +3373,42 @@ mod tests {
             .write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
             .unwrap();
         out
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn one_image_separates_visual_and_metadata_handles() {
+        let visual_secret = "AKIAIOSFODNN7EXAMPLE";
+        let metadata_secret = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+        let mut metadata = b"Description\0OPENAI_API_KEY=".to_vec();
+        metadata.extend_from_slice(metadata_secret.as_bytes());
+        let png = insert_png_raw_chunk(qr_png(visual_secret), *b"tEXt", &metadata);
+        let value = serde_json::json!({
+            "content": [{
+                "type": "image",
+                "mimeType": "image/png",
+                "data": data_encoding::BASE64.encode(&png)
+            }]
+        });
+        let key = [7; 32];
+        let redaction = redact_tool_images_for_secrets(&value, &key, &key, &test_config()).unwrap();
+        let visual = redaction.visual_notes.join("\n");
+        let metadata = redaction.metadata_notes.join("\n");
+        assert!(visual.contains("<<AWS_AKID_"), "{visual}");
+        assert!(!visual.contains("<<OPENAI_API_KEY_"), "{visual}");
+        assert!(metadata.contains("<<OPENAI_API_KEY_"), "{metadata}");
+        assert!(!metadata.contains("<<AWS_AKID_"), "{metadata}");
+        assert!(
+            redaction.recovery.resolve(&visual).contains(visual_secret),
+            "{visual}"
+        );
+        assert!(
+            redaction
+                .recovery
+                .resolve(&metadata)
+                .contains(metadata_secret),
+            "{metadata}"
+        );
     }
 
     #[cfg(feature = "ocr")]

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -5,9 +5,12 @@ use crate::config::{image_ocr_config, ImageOcrMode, ImageRedactionStyle};
 use crate::config::{ImageOcrConfig, UnscannedImagePolicy};
 #[cfg(any(feature = "ocr", test))]
 use pentect_core::model::labels;
+use pentect_core::placeholder::{identity_hash, render_placeholder};
 #[cfg(any(feature = "ocr", test))]
 use pentect_core::ByteRange;
+use pentect_core::Recovery;
 use serde_json::Value;
+use std::collections::HashMap;
 #[cfg(feature = "ocr")]
 use std::net::{IpAddr, SocketAddr};
 
@@ -50,6 +53,7 @@ pub(crate) struct ImageRedaction {
     pub(crate) ocr_failures: usize,
     pub(crate) secret_images: usize,
     pub(crate) notes: Vec<String>,
+    pub(crate) recovery: Recovery,
 }
 
 struct ImageRedactionState {
@@ -61,6 +65,7 @@ struct ImageRedactionState {
     total_image_bytes: u64,
     started_at: std::time::Instant,
     notes: Vec<String>,
+    recovery: HashMap<String, String>,
 }
 
 struct RedactedImagePayload {
@@ -88,6 +93,7 @@ struct ImageTextRegion {
 #[derive(Clone, Debug)]
 struct ImageSecretFinding {
     labels: Vec<String>,
+    secrets: Vec<(String, String)>,
     #[cfg(feature = "ocr")]
     rect: Option<NormalizedImageRect>,
     #[cfg(feature = "ocr")]
@@ -210,6 +216,7 @@ pub(crate) fn inspect_tool_images_for_secrets(
 pub(crate) fn redact_tool_images_for_secrets(
     value: &Value,
     key: &[u8; 32],
+    identity_key: &[u8; 32],
     cfg: &ImageOcrConfig,
 ) -> Result<ImageRedaction, String> {
     let mut state = ImageRedactionState {
@@ -221,8 +228,9 @@ pub(crate) fn redact_tool_images_for_secrets(
         total_image_bytes: 0,
         started_at: std::time::Instant::now(),
         notes: Vec::new(),
+        recovery: HashMap::new(),
     };
-    let updated = redact_image_value(value, key, cfg, &mut state)?;
+    let updated = redact_image_value(value, identity_key, cfg, &mut state)?;
     record_ocr_outcomes(
         state.scanned_images,
         state.unscanned_images,
@@ -236,6 +244,7 @@ pub(crate) fn redact_tool_images_for_secrets(
         ocr_failures: state.ocr_failures,
         secret_images: state.secret_images,
         notes: state.notes,
+        recovery: Recovery::seal(state.recovery, key),
     })
 }
 
@@ -602,12 +611,27 @@ fn redact_image_bytes(
     }
 
     let mut labels = Vec::new();
+    let mut handles = Vec::new();
     for finding in &findings {
         push_secret_labels(&mut labels, &finding.labels);
+        for (handle, value) in &finding.secrets {
+            if !handles.iter().any(|seen| seen == handle) {
+                handles.push(handle.clone());
+            }
+            state
+                .recovery
+                .entry(handle.clone())
+                .or_insert_with(|| value.clone());
+        }
     }
     state.secret_images += 1;
     let index = state.notes.len() + 1;
-    state.notes.push(format!("[{index}] {}", labels.join(", ")));
+    let summary = if handles.is_empty() {
+        labels.join(", ")
+    } else {
+        handles.join(", ")
+    };
+    state.notes.push(format!("[{index}] {summary}"));
     let payload = redacted_image_payload(bytes, index, cfg, &findings)?;
     Ok(ImageRedactionDecision::Redacted(payload))
 }
@@ -623,6 +647,7 @@ fn image_secret_findings(
         for hit in image_text_secret_hits(&region.text, key)? {
             findings.push(ImageSecretFinding {
                 labels: vec![hit.label.clone()],
+                secrets: secret_entries(&region.text, std::slice::from_ref(&hit), key),
                 rect: None,
                 force_black: false,
                 pad_left: false,
@@ -633,6 +658,7 @@ fn image_secret_findings(
     if image_exif_has_gps(bytes) {
         findings.push(ImageSecretFinding {
             labels: vec![labels::IMAGE_GPS_METADATA.to_string()],
+            secrets: Vec::new(),
             rect: None,
             force_black: false,
             pad_left: false,
@@ -641,12 +667,14 @@ fn image_secret_findings(
     }
 
     for region in image_barcode_regions(bytes, cfg) {
-        let labels = labels_from_text_hits(&image_text_secret_hits(&region.text, key)?);
+        let hits = image_text_secret_hits(&region.text, key)?;
+        let labels = labels_from_text_hits(&hits);
         if labels.is_empty() {
             continue;
         }
         findings.push(ImageSecretFinding {
             labels,
+            secrets: secret_entries(&region.text, &hits, key),
             rect: region.rect,
             force_black: true,
             pad_left: true,
@@ -668,6 +696,7 @@ fn image_secret_findings(
             let redaction = rect_for_text_secret_hit(region, &hit);
             findings.push(ImageSecretFinding {
                 labels: vec![hit.label.clone()],
+                secrets: secret_entries(&region.text, std::slice::from_ref(&hit), key),
                 rect: redaction.rect,
                 force_black: false,
                 pad_left: redaction.pad_left,
@@ -675,10 +704,9 @@ fn image_secret_findings(
             });
         }
     }
-    let joined_labels = labels_from_text_hits(&image_text_secret_hits(
-        &image_regions_text(&ocr_regions),
-        key,
-    )?);
+    let joined_text = image_regions_text(&ocr_regions);
+    let joined_hits = image_text_secret_hits(&joined_text, key)?;
+    let joined_labels = labels_from_text_hits(&joined_hits);
     let missing_joined_labels = joined_labels
         .into_iter()
         .filter(|label| {
@@ -688,8 +716,14 @@ fn image_secret_findings(
         })
         .collect::<Vec<_>>();
     if !missing_joined_labels.is_empty() {
+        let missing_hits = joined_hits
+            .iter()
+            .filter(|hit| missing_joined_labels.contains(&hit.label))
+            .cloned()
+            .collect::<Vec<_>>();
         findings.push(ImageSecretFinding {
             labels: missing_joined_labels,
+            secrets: secret_entries(&joined_text, &missing_hits, key),
             rect: union_region_rects(&ocr_regions),
             force_black: true,
             pad_left: true,
@@ -700,6 +734,32 @@ fn image_secret_findings(
         findings,
         scan_failure: None,
     })
+}
+
+#[cfg(any(feature = "ocr", test))]
+fn secret_entries(
+    text: &str,
+    hits: &[ImageTextSecretHit],
+    identity_key: &[u8; 32],
+) -> Vec<(String, String)> {
+    let mut entries = Vec::new();
+    for hit in hits {
+        let Some(range) = hit.range else {
+            continue;
+        };
+        let Some(value) = text.get(range.start..range.end) else {
+            continue;
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        let handle = render_placeholder(&hit.label, &identity_hash(identity_key, value), None);
+        if !entries.iter().any(|(seen, _)| seen == &handle) {
+            entries.push((handle, value.to_string()));
+        }
+    }
+    entries
 }
 
 #[cfg(feature = "ocr")]
@@ -3197,6 +3257,7 @@ mod tests {
     fn test_finding(force_black: bool) -> ImageSecretFinding {
         ImageSecretFinding {
             labels: vec![labels::KEYED_SECRET.to_string()],
+            secrets: Vec::new(),
             rect: NormalizedImageRect::new(0.12, 0.16, 0.42, 0.46),
             force_black,
             pad_left: true,
@@ -3215,6 +3276,23 @@ mod tests {
             labels.contains(&"KAGGLE_API_TOKEN".to_string()),
             "{labels:?}"
         );
+    }
+
+    #[test]
+    fn ocr_secret_entries_are_recoverable_placeholders() {
+        let key = [7; 32];
+        let text = "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+        let hits = image_text_secret_hits(text, &key).unwrap();
+        let entries = secret_entries(text, &hits, &key);
+        let (handle, value) = entries
+            .iter()
+            .find(|(handle, _)| handle.starts_with("<<OPENAI_API_KEY_"))
+            .expect("missing OpenAI API key placeholder");
+        let handle = handle.clone();
+        let value = value.clone();
+        assert_eq!(value, "sk-ABCDEFGHIJKLMNOPQRSTUVWX");
+        let recovery = Recovery::seal(entries.into_iter().collect(), &key);
+        assert_eq!(recovery.resolve(&handle), value);
     }
 
     #[test]
@@ -3337,6 +3415,7 @@ mod tests {
         let jpeg = solid_jpeg_with_app1(&app1);
         let findings = vec![ImageSecretFinding {
             labels: vec!["OPENAI_API_KEY".to_string()],
+            secrets: Vec::new(),
             rect: None,
             force_black: false,
             pad_left: false,

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -5,6 +5,7 @@ use crate::config::{image_ocr_config, ImageOcrMode, ImageRedactionStyle};
 use crate::config::{ImageOcrConfig, UnscannedImagePolicy};
 #[cfg(any(feature = "ocr", test))]
 use pentect_core::model::labels;
+#[cfg(any(feature = "ocr", test))]
 use pentect_core::placeholder::{identity_hash, render_placeholder};
 #[cfg(any(feature = "ocr", test))]
 use pentect_core::ByteRange;

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -273,7 +273,15 @@ pub fn redact_tool_images_into_active_memory_store(value: &Value) -> Result<Opti
         return Ok(None);
     }
     let session = Session::open_capability("default").map_err(|e| e.to_string())?;
-    let redaction = image_ocr::redact_tool_images_for_secrets(value, &session.key, &cfg)?;
+    let redaction = image_ocr::redact_tool_images_for_secrets(
+        value,
+        &session.key,
+        &session.identity_key,
+        &cfg,
+    )?;
+    session
+        .sync_recovery(&redaction.recovery)
+        .map_err(|error| error.to_string())?;
     activity_log::record_image(redaction.secret_images, &redaction.notes);
     if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Block) {
         if redaction.unscanned_images > 0 {
@@ -292,6 +300,7 @@ pub fn redact_tool_images_into_active_memory_store(value: &Value) -> Result<Opti
     Ok(Some(append_image_mask_notes(
         redaction.updated,
         &redaction.notes,
+        cfg.redaction,
     )))
 }
 
@@ -3901,7 +3910,15 @@ fn claude_image_tool_output(
             ),
         );
     }
-    let redaction = image_ocr::redact_tool_images_for_secrets(value, &session.key, &cfg)?;
+    let redaction = image_ocr::redact_tool_images_for_secrets(
+        value,
+        &session.key,
+        &session.identity_key,
+        &cfg,
+    )?;
+    session
+        .sync_recovery(&redaction.recovery)
+        .map_err(|error| error.to_string())?;
     activity_log::record_image(redaction.secret_images, &redaction.notes);
     if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Block) {
         if redaction.unscanned_images > 0 {
@@ -3921,7 +3938,7 @@ fn claude_image_tool_output(
                 "image blocked: secret text detected.".to_string(),
             )));
         }
-        let updated = append_image_mask_notes(redaction.updated, &redaction.notes);
+        let updated = append_image_mask_notes(redaction.updated, &redaction.notes, cfg.redaction);
         return Ok(Some(ToolTextOutput::Updated(updated)));
     }
     if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Allow) {
@@ -3930,11 +3947,22 @@ fn claude_image_tool_output(
     Ok(None)
 }
 
-fn append_image_mask_notes(mut value: Value, notes: &[String]) -> Value {
+fn append_image_mask_notes(
+    mut value: Value,
+    notes: &[String],
+    style: config::ImageRedactionStyle,
+) -> Value {
     if notes.is_empty() {
         return value;
     }
-    let text = format!("Masked regions\n{}", notes.join("\n"));
+    let protection = match style {
+        config::ImageRedactionStyle::Black => "with black boxes",
+        config::ImageRedactionStyle::Blur => "by blurring those regions",
+    };
+    let text = format!(
+        "Pentect masked sensitive information in this image {protection}.\nMasked regions:\n{}",
+        notes.join("\n")
+    );
     if append_text_block_to_content(&mut value, &text) {
         return value;
     }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -299,9 +299,9 @@ pub fn redact_tool_images_into_active_memory_store(value: &Value) -> Result<Opti
     }
     Ok(Some(append_image_mask_notes(
         redaction.updated,
-        &redaction.notes,
+        &redaction.visual_notes,
+        &redaction.metadata_notes,
         cfg.redaction,
-        redaction.pixel_redactions > 0,
     )))
 }
 
@@ -3941,9 +3941,9 @@ fn claude_image_tool_output(
         }
         let updated = append_image_mask_notes(
             redaction.updated,
-            &redaction.notes,
+            &redaction.visual_notes,
+            &redaction.metadata_notes,
             cfg.redaction,
-            redaction.pixel_redactions > 0,
         );
         return Ok(Some(ToolTextOutput::Updated(updated)));
     }
@@ -3955,28 +3955,35 @@ fn claude_image_tool_output(
 
 fn append_image_mask_notes(
     mut value: Value,
-    notes: &[String],
+    visual_notes: &[String],
+    metadata_notes: &[String],
     style: config::ImageRedactionStyle,
-    pixels_changed: bool,
 ) -> Value {
-    if notes.is_empty() {
+    if visual_notes.is_empty() && metadata_notes.is_empty() {
         return value;
     }
-    let (explanation, heading) = match (pixels_changed, style) {
-        (true, config::ImageRedactionStyle::Black) => (
-            "Pentect masked sensitive information in this image with black boxes.",
-            "Masked regions:",
-        ),
-        (true, config::ImageRedactionStyle::Blur) => (
-            "Pentect masked sensitive information in this image by blurring those regions.",
-            "Masked regions:",
-        ),
-        (false, _) => (
-            "Pentect removed sensitive metadata from this image.",
-            "Protected values:",
-        ),
-    };
-    let text = format!("{explanation}\n{heading}\n{}", notes.join("\n"));
+    let mut sections = Vec::new();
+    if !visual_notes.is_empty() {
+        let explanation = match style {
+            config::ImageRedactionStyle::Black => {
+                "Pentect masked sensitive information in this image with black boxes."
+            }
+            config::ImageRedactionStyle::Blur => {
+                "Pentect masked sensitive information in this image by blurring those regions."
+            }
+        };
+        sections.push(format!(
+            "{explanation}\nMasked regions:\n{}",
+            visual_notes.join("\n")
+        ));
+    }
+    if !metadata_notes.is_empty() {
+        sections.push(format!(
+            "Pentect removed sensitive metadata from this image.\nProtected values:\n{}",
+            metadata_notes.join("\n")
+        ));
+    }
+    let text = sections.join("\n");
     if append_text_block_to_content(&mut value, &text) {
         return value;
     }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -301,6 +301,7 @@ pub fn redact_tool_images_into_active_memory_store(value: &Value) -> Result<Opti
         redaction.updated,
         &redaction.notes,
         cfg.redaction,
+        redaction.pixel_redactions > 0,
     )))
 }
 
@@ -3938,7 +3939,12 @@ fn claude_image_tool_output(
                 "image blocked: secret text detected.".to_string(),
             )));
         }
-        let updated = append_image_mask_notes(redaction.updated, &redaction.notes, cfg.redaction);
+        let updated = append_image_mask_notes(
+            redaction.updated,
+            &redaction.notes,
+            cfg.redaction,
+            redaction.pixel_redactions > 0,
+        );
         return Ok(Some(ToolTextOutput::Updated(updated)));
     }
     if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Allow) {
@@ -3951,18 +3957,26 @@ fn append_image_mask_notes(
     mut value: Value,
     notes: &[String],
     style: config::ImageRedactionStyle,
+    pixels_changed: bool,
 ) -> Value {
     if notes.is_empty() {
         return value;
     }
-    let protection = match style {
-        config::ImageRedactionStyle::Black => "with black boxes",
-        config::ImageRedactionStyle::Blur => "by blurring those regions",
+    let (explanation, heading) = match (pixels_changed, style) {
+        (true, config::ImageRedactionStyle::Black) => (
+            "Pentect masked sensitive information in this image with black boxes.",
+            "Masked regions:",
+        ),
+        (true, config::ImageRedactionStyle::Blur) => (
+            "Pentect masked sensitive information in this image by blurring those regions.",
+            "Masked regions:",
+        ),
+        (false, _) => (
+            "Pentect removed sensitive metadata from this image.",
+            "Protected values:",
+        ),
     };
-    let text = format!(
-        "Pentect masked sensitive information in this image {protection}.\nMasked regions:\n{}",
-        notes.join("\n")
-    );
+    let text = format!("{explanation}\n{heading}\n{}", notes.join("\n"));
     if append_text_block_to_content(&mut value, &text) {
         return value;
     }

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2198,8 +2198,12 @@ fn claude_posttool_redacts_secret_qr_image_instead_of_blocking() {
     assert!(output.get("decision").is_none(), "{output}");
     let updated = &output["hookSpecificOutput"]["updatedToolOutput"];
     let rendered = serde_json::to_string(updated).unwrap();
-    assert!(rendered.contains("Masked regions"), "{rendered}");
-    assert!(rendered.contains("[1] OPENAI_API_KEY"), "{rendered}");
+    assert!(
+        rendered.contains("Pentect masked sensitive information in this image with black boxes."),
+        "{rendered}"
+    );
+    assert!(rendered.contains("Masked regions:"), "{rendered}");
+    assert!(rendered.contains("[1] <<OPENAI_API_KEY_"), "{rendered}");
     assert!(
         rendered.contains("\"mimeType\":\"image/png\""),
         "{rendered}"

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2213,6 +2213,23 @@ fn claude_posttool_redacts_secret_qr_image_instead_of_blocking() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+#[test]
+fn image_mask_note_describes_metadata_only_protection_accurately() {
+    let updated = append_image_mask_notes(
+        json!({"content": []}),
+        &["[1] <<OPENAI_API_KEY_0011223344556677>>".to_string()],
+        config::ImageRedactionStyle::Black,
+        false,
+    );
+    let rendered = serde_json::to_string(&updated).unwrap();
+    assert!(
+        rendered.contains("Pentect removed sensitive metadata from this image."),
+        "{rendered}"
+    );
+    assert!(rendered.contains("Protected values:"), "{rendered}");
+    assert!(!rendered.contains("black boxes"), "{rendered}");
+}
+
 #[cfg(feature = "ocr")]
 #[test]
 fn codex_posttool_still_blocks_secret_qr_image() {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2217,9 +2217,9 @@ fn claude_posttool_redacts_secret_qr_image_instead_of_blocking() {
 fn image_mask_note_describes_metadata_only_protection_accurately() {
     let updated = append_image_mask_notes(
         json!({"content": []}),
+        &[],
         &["[1] <<OPENAI_API_KEY_0011223344556677>>".to_string()],
         config::ImageRedactionStyle::Black,
-        false,
     );
     let rendered = serde_json::to_string(&updated).unwrap();
     assert!(
@@ -2228,6 +2228,24 @@ fn image_mask_note_describes_metadata_only_protection_accurately() {
     );
     assert!(rendered.contains("Protected values:"), "{rendered}");
     assert!(!rendered.contains("black boxes"), "{rendered}");
+}
+
+#[test]
+fn image_mask_note_separates_visual_and_metadata_protection() {
+    let updated = append_image_mask_notes(
+        json!({"content": []}),
+        &["[1] <<AWS_AKID_0011223344556677>>".to_string()],
+        &["[2] <<OPENAI_API_KEY_0011223344556677>>".to_string()],
+        config::ImageRedactionStyle::Black,
+    );
+    let rendered = serde_json::to_string(&updated).unwrap();
+    assert!(rendered.contains("black boxes"), "{rendered}");
+    assert!(rendered.contains("Masked regions:"), "{rendered}");
+    assert!(
+        rendered.contains("removed sensitive metadata"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("Protected values:"), "{rendered}");
 }
 
 #[cfg(feature = "ocr")]

--- a/website/src/content/docs/protection/files-and-images.md
+++ b/website/src/content/docs/protection/files-and-images.md
@@ -59,6 +59,11 @@ When OCR is enabled, it runs on your computer and Pentect covers detected
 sensitive areas before sending the image. Limits control the number of images,
 file size, image size, download time, and total check time.
 
+When pixels are covered, Pentect appends a short note for the agent explaining
+that the image was protected. Each region lists the same recoverable handle used
+for text, for example `[1] <<AWS_AKID_hash>>`; the original value is not included
+in the provider-visible note.
+
 Windows uses Windows OCR, macOS uses Vision, and Linux uses Pentect's bundled
 local OCR engine and model files. Linux does not require a separately installed
 Tesseract service. `pentect doctor` reports the selected backend as `windows`,

--- a/website/src/content/docs/protection/prompts-and-tools.md
+++ b/website/src/content/docs/protection/prompts-and-tools.md
@@ -88,6 +88,8 @@ side effect happens outside Pentect's provider boundary.
 A screenshot may contain a token even when the tool result has no useful text.
 With OCR enabled, Pentect scans supported image payloads locally and covers
 detected sensitive regions before the image is sent to the provider.
+The protected result also tells the agent whether Pentect added black boxes or
+blurred the regions, and lists a recoverable handle without repeating the secret.
 
 Pentect also checks text found in supported QR codes and barcodes. When an
 image must be rewritten, it removes supported metadata and sends protected


### PR DESCRIPTION
## Summary
- explain to the agent when Pentect masks image regions with black boxes or blur
- attach real recoverable placeholders instead of label-only OCR notes
- persist OCR placeholder recovery mappings in the active memory store
- document provider-visible image mask notes

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p pentect-runtime` (281 passed)
- real QR redaction test verifies black-box explanation and placeholder
- recovery unit test verifies the OCR handle resolves to the original detected value

AUR workflow is intentionally paused per maintainer request; normal CI remains enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protected images now include recoverable handles for detected secrets without exposing original values.
  * Protection notes distinguish visual masking or blurring from metadata-only removal.
  * Results can report both visual and metadata protection when applicable.

* **Documentation**
  * Updated image and screenshot guidance to explain protection notes, masking styles, and recoverable handles.

* **Tests**
  * Expanded coverage verifies explanatory messages, masked-region details, metadata-only protection, combined protection, and secret handles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->