### PR TITLE
feat: add explicit mask and prompt-only unmask markers

### DIFF
--- a/crates/pentect-core/src/detect/explicit.rs
+++ b/crates/pentect-core/src/detect/explicit.rs
@@ -2,9 +2,9 @@ use super::Detector;
 use crate::model::{labels, ByteRange, Category, Confidence, DetectorId, Span};
 use crate::normalize::NormalizedView;
 
-pub(crate) const EXPLICIT_SECRET_PREFIX: &str = "pentect(";
+pub(crate) const EXPLICIT_SECRET_PREFIXES: [&str; 2] = ["pentect(", "mask("];
 
-/// Masks values deliberately wrapped as `pentect(value)`, regardless of their
+/// Masks values deliberately wrapped as `pentect(value)` or `mask(value)`, regardless of their
 /// entropy or shape. The renderer removes the opt-in wrapper while preserving
 /// only `value` in recovery, so a restored tool argument receives the intended
 /// value rather than the annotation syntax.
@@ -14,15 +14,13 @@ impl Detector for ExplicitSecretDetector {
     fn detect(&self, view: &NormalizedView) -> Vec<Span> {
         let text = view.text();
         let bytes = text.as_bytes();
-        let prefix = EXPLICIT_SECRET_PREFIX.as_bytes();
         let mut spans = Vec::new();
         let mut cursor = 0usize;
 
-        while cursor + prefix.len() < bytes.len() {
-            let Some(relative) = text[cursor..].find(EXPLICIT_SECRET_PREFIX) else {
+        while cursor < bytes.len() {
+            let Some((marker_start, prefix)) = next_explicit_marker(text, cursor) else {
                 break;
             };
-            let marker_start = cursor + relative;
             let value_start = marker_start + prefix.len();
             let mut depth = 1usize;
             let mut close = value_start;
@@ -64,6 +62,23 @@ impl Detector for ExplicitSecretDetector {
     }
 }
 
+fn next_explicit_marker(text: &str, cursor: usize) -> Option<(usize, &'static str)> {
+    EXPLICIT_SECRET_PREFIXES
+        .iter()
+        .filter_map(|prefix| {
+            text[cursor..]
+                .match_indices(prefix)
+                .map(|(relative, _)| cursor + relative)
+                .find(|&start| {
+                    start == 0
+                        || !text.as_bytes()[start - 1].is_ascii_alphanumeric()
+                            && text.as_bytes()[start - 1] != b'_'
+                })
+                .map(|start| (start, *prefix))
+        })
+        .min_by_key(|(start, _)| *start)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,7 +100,7 @@ mod tests {
 
     #[test]
     fn finds_low_entropy_and_balanced_values() {
-        let text = "a pentect(abc) b pentect(pa(ss)word)";
+        let text = "a pentect(abc) b mask(pa(ss)word)";
         let spans = detect(text);
         assert_eq!(spans.len(), 2);
         assert_eq!(&text[spans[0].range.start..spans[0].range.end], "abc");
@@ -97,7 +112,8 @@ mod tests {
 
     #[test]
     fn ignores_empty_unclosed_and_lookalike_markers() {
-        assert!(detect("pentect() pentect(unclosed").is_empty());
+        assert!(detect("pentect() mask() pentect(unclosed mask(unclosed").is_empty());
         assert!(detect("ｐｅｎｔｅｃｔ(value)").is_empty());
+        assert!(detect("unpentect(value) unmask(value)").is_empty());
     }
 }

--- a/crates/pentect-core/src/detect/mod.rs
+++ b/crates/pentect-core/src/detect/mod.rs
@@ -38,7 +38,7 @@ pub use decode::{
 };
 pub use entropy::{EntropyDetector, DEFAULT_ENTROPY_MIN_LEN, DEFAULT_ENTROPY_THRESHOLD};
 pub use explicit::ExplicitSecretDetector;
-pub(crate) use explicit::EXPLICIT_SECRET_PREFIX;
+pub(crate) use explicit::EXPLICIT_SECRET_PREFIXES;
 pub use key_value::KeyValueDetector;
 pub use pattern::{PatternMatchDetector, PatternSpec};
 pub use pem::PemDetector;

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -1406,16 +1406,26 @@ mod tests {
 
     #[test]
     fn explicit_secret_marker_forces_masking_and_is_not_restored_as_syntax() {
-        let input = "fixture value: pentect(abc)";
+        for marker in ["pentect", "mask"] {
+            assert_explicit_secret_marker(marker);
+        }
+    }
+
+    fn assert_explicit_secret_marker(marker: &str) {
+        let input = format!("fixture value: {marker}(abc)");
         let result = Engine::with_profile(Profile::Dev).mask(
             Input {
                 kind: Kind::Text,
-                data: input.to_string(),
+                data: input,
             },
             &Config::insecure_testing(),
         );
         assert_eq!(result.masked.matches("<<KEYED_SECRET_").count(), 1);
-        assert!(!result.masked.contains("pentect("), "{}", result.masked);
+        assert!(
+            !result.masked.contains(&format!("{marker}(")),
+            "{}",
+            result.masked
+        );
         assert!(!result.masked.contains("abc"), "{}", result.masked);
         assert_eq!(
             restore(&result.masked, &result.recovery).unwrap(),

--- a/crates/pentect-core/src/pipeline/render.rs
+++ b/crates/pentect-core/src/pipeline/render.rs
@@ -1,4 +1,4 @@
-use crate::detect::EXPLICIT_SECRET_PREFIX;
+use crate::detect::EXPLICIT_SECRET_PREFIXES;
 use crate::model::*;
 use crate::normalize::n_id_cow;
 use crate::placeholder::{render_placeholder, IdentityHasher};
@@ -153,13 +153,15 @@ pub fn render(raw: &str, key: &[u8; 32], mut spans: Vec<Span>, disclose_length: 
 }
 
 fn explicit_wrapper_bounds(raw: &str, span: &Span) -> Option<(usize, usize)> {
-    if span.source != DetectorId::Explicit || span.range.start < EXPLICIT_SECRET_PREFIX.len() {
+    if span.source != DetectorId::Explicit {
         return None;
     }
-    let wrapper_start = span.range.start - EXPLICIT_SECRET_PREFIX.len();
-    (raw.get(wrapper_start..span.range.start) == Some(EXPLICIT_SECRET_PREFIX)
-        && raw.as_bytes().get(span.range.end) == Some(&b')'))
-    .then_some((wrapper_start, span.range.end + 1))
+    EXPLICIT_SECRET_PREFIXES.iter().find_map(|prefix| {
+        let wrapper_start = span.range.start.checked_sub(prefix.len())?;
+        (raw.get(wrapper_start..span.range.start) == Some(*prefix)
+            && raw.as_bytes().get(span.range.end) == Some(&b')'))
+        .then_some((wrapper_start, span.range.end + 1))
+    })
 }
 
 fn should_split_email(span: &Span) -> bool {

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -16,6 +16,7 @@ use std::sync::OnceLock;
 const ENV_ALIAS_LABEL: &str = "PENTECT_ENV_ALIAS";
 const ENV_ALIAS_RECORD_PREFIX: &str = "\u{1f}pentect-env\0";
 const PLUGIN_CONFIGS_ENV: &str = "PENTECT_PLUGIN_CONFIGS";
+const EXPLICIT_UNMASK_PREFIXES: [&str; 2] = ["unpentect(", "unmask("];
 static PENTECT_ENGINE: OnceLock<Result<Engine, String>> = OnceLock::new();
 static PENTECT_PROMPT_ENGINE: OnceLock<Result<Engine, String>> = OnceLock::new();
 const BATCH_DELIMITERS: [&str; 4] = [
@@ -127,6 +128,8 @@ impl OutputMasker {
             remasked,
             &Kind::Text,
         )?;
+        let (remasked, unmasked_values) =
+            protect_prompt_unmask_markers(&remasked, &self.store.session.identity_key);
         // Prompt scalars are structurally text, but dotenv assignments can be
         // embedded in prose. Run the Env parser first so assignment labels are
         // preserved, then feed the result through the same cached text engine.
@@ -177,7 +180,10 @@ impl OutputMasker {
             .saturating_add(env_result.summary.masked_count);
         self.track_mask_result("prompt", &result);
         self.add_masked_count(masked_count);
-        let masked = compact_local_home_paths(&result.masked);
+        let masked = restore_prompt_unmask_markers(
+            &compact_local_home_paths(&result.masked),
+            &unmasked_values,
+        );
         let mut recovery = result.recovery;
         recovery.extend_same_key(env_alias_recovery(
             &masked,
@@ -547,6 +553,84 @@ impl OutputMasker {
             }
         }
     }
+}
+
+fn protect_prompt_unmask_markers(
+    text: &str,
+    identity_key: &[u8; 32],
+) -> (String, Vec<(String, String)>) {
+    let mut output = String::with_capacity(text.len());
+    let mut bindings = Vec::new();
+    let mut emit_cursor = 0usize;
+    let mut search_cursor = 0usize;
+    let mut token_index = 0usize;
+
+    while let Some((marker_start, prefix)) = next_unmask_marker(text, search_cursor) {
+        let value_start = marker_start + prefix.len();
+        let Some(close) = balanced_marker_close(text, value_start) else {
+            search_cursor = value_start;
+            continue;
+        };
+        let value = &text[value_start..close];
+        let token = loop {
+            let identity = format!("{token_index}\0{value}");
+            token_index += 1;
+            let candidate =
+                render_placeholder("UNMASKED", &identity_hash(identity_key, &identity), None);
+            if !text.contains(&candidate) && !bindings.iter().any(|(seen, _)| seen == &candidate) {
+                break candidate;
+            }
+        };
+        output.push_str(&text[emit_cursor..marker_start]);
+        output.push_str(&token);
+        bindings.push((token, value.to_string()));
+        emit_cursor = close + 1;
+        search_cursor = emit_cursor;
+    }
+    output.push_str(&text[emit_cursor..]);
+    (output, bindings)
+}
+
+fn restore_prompt_unmask_markers(text: &str, bindings: &[(String, String)]) -> String {
+    bindings
+        .iter()
+        .fold(text.to_string(), |output, (token, value)| {
+            output.replace(token, value)
+        })
+}
+
+fn next_unmask_marker(text: &str, cursor: usize) -> Option<(usize, &'static str)> {
+    EXPLICIT_UNMASK_PREFIXES
+        .iter()
+        .filter_map(|prefix| {
+            text[cursor..]
+                .match_indices(prefix)
+                .map(|(relative, _)| cursor + relative)
+                .find(|&start| {
+                    start == 0
+                        || !text.as_bytes()[start - 1].is_ascii_alphanumeric()
+                            && text.as_bytes()[start - 1] != b'_'
+                })
+                .map(|start| (start, *prefix))
+        })
+        .min_by_key(|(start, _)| *start)
+}
+
+fn balanced_marker_close(text: &str, value_start: usize) -> Option<usize> {
+    let mut depth = 1usize;
+    for (relative, byte) in text.as_bytes()[value_start..].iter().enumerate() {
+        match byte {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(value_start + relative);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 fn scalar_is_env_assignment(text: &str) -> bool {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -623,6 +623,36 @@ fn active_prompt_explicit_marker_masks_low_entropy_value_and_removes_wrapper() {
 }
 
 #[test]
+fn active_prompt_supports_mask_and_prompt_only_unmask_aliases() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-prompt-marker-aliases");
+
+    let openai = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let aws = "AKIA7K9Q2M4N6P8R1T3V";
+    let mut masker = ActiveToolOutputMasker::new().unwrap();
+    let masked = masker
+        .mask_prompt_text(&format!(
+            "pentect(abc) mask(def) unpentect({openai}) unmask({aws})"
+        ))
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(masked.matches("<<KEYED_SECRET_").count(), 2, "{masked}");
+    assert!(masked.contains(openai), "{masked}");
+    assert!(masked.contains(aws), "{masked}");
+    for wrapper in ["pentect(", "mask(", "unpentect(", "unmask("] {
+        assert!(!masked.contains(wrapper), "{masked}");
+    }
+
+    let output = masker
+        .mask_tool_output(&format!("unmask({aws})"))
+        .unwrap()
+        .unwrap();
+    assert!(!output.contains(aws), "{output}");
+    assert!(output.contains("<<"), "{output}");
+}
+
+#[test]
 fn bridge_masks_prompt_wraps_shell_and_masks_result() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (_active_store, _, _) = ActiveMemoryStoreEnv::start("bridge-mask");

--- a/website/src/content/docs/start/handles.md
+++ b/website/src/content/docs/start/handles.md
@@ -32,8 +32,8 @@ identity key stays on the local device.
 
 ## Force a value to become a handle
 
-Wrap a value in `pentect(...)` when it must be protected even if it is short,
-low-entropy, or unknown to the built-in detectors:
+Wrap a value in `pentect(...)` or its shorter alias `mask(...)` when it must be
+protected even if it is short, low-entropy, or unknown to the built-in detectors:
 
 ```text
 sudo password is pentect(passsword123)
@@ -41,9 +41,23 @@ sudo password is pentect(passsword123)
 
 Pentect removes the wrapper before the request leaves the device and sends a
 `KEYED_SECRET` handle in its place. If that handle is later used by a local tool,
-Pentect restores only `passsword123`; the `pentect(...)` annotation is not part
-of the value. The marker is case-sensitive, must be balanced, and an empty
-`pentect()` marker is ignored.
+Pentect restores only `passsword123`; the annotation is not part of the value.
+Both markers are case-sensitive, must be balanced, and are ignored when empty.
+
+## Intentionally leave a prompt value visible
+
+Use `unpentect(...)` or `unmask(...)` when a value in your own prompt must be
+sent without masking:
+
+```text
+public fixture is unmask(sk-example-not-a-real-key)
+```
+
+Pentect removes the wrapper and leaves only its contents. Unmask markers are
+recognized only in user prompt text. They are deliberately ignored in tool
+results, browser output, files, and other external content so an external source
+cannot disable protection. All four marker names are case-sensitive and require
+balanced parentheses.
 
 ## How a tool uses a handle
 


### PR DESCRIPTION
## Summary
- support `mask(...)` as an alias for `pentect(...)`
- support `unmask(...)` and `unpentect(...)` in user prompt text
- keep unmask markers disabled for tool output and external content
- document all explicit marker aliases and their security boundary

## Tests
- `cargo test -p pentect-core` (366 passed)
- `cargo test -p pentect-runtime` (285 passed)
- `cargo clippy -p pentect-core --all-targets -- -D warnings`
- `cargo clippy -p pentect-runtime --all-targets --no-default-features -- -D warnings`