### PR TITLE
chore: release v0.0.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.54"
+version = "0.0.55"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump Pentect CLI and npm package to v0.0.55
- release explicit `mask`/`pentect` and prompt-only `unmask`/`unpentect` markers
- include OCR recoverable placeholder notes merged since v0.0.54

## Tests
- `cargo check --locked -p pentect-cli`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version to 0.0.55.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->