### PR TITLE
fix: skip disabled AUR validation

### DIFF
--- a/tools/propose_automation_pr.sh
+++ b/tools/propose_automation_pr.sh
@@ -59,7 +59,12 @@ previous_ci=$(latest_run ci.yml)
 previous_nix=$(latest_run nix.yml)
 gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
 gh workflow run nix.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
-gh workflow run aur.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
+aur_state=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/aur.yml" --jq .state)
+if [ "$aur_state" = active ]; then
+  gh workflow run aur.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
+else
+  echo "AUR workflow is $aur_state; skipping automation PR validation" >&2
+fi
 
 new_run() {
   workflow=$1

--- a/tools/test_propose_automation_pr.sh
+++ b/tools/test_propose_automation_pr.sh
@@ -21,6 +21,7 @@ case "$1 $2" in
     case "$*" in
       *ci.yml*) touch "$MOCK_STATE/ci" ;;
       *nix.yml*) touch "$MOCK_STATE/nix" ;;
+      *aur.yml*) touch "$MOCK_STATE/aur" ;;
     esac
     ;;
   "run list")
@@ -30,6 +31,9 @@ case "$1 $2" in
     esac
     ;;
   "run watch") printf '%s\n' "$*" >> "$MOCK_STATE/watch" ;;
+  "api repos/example/project/actions/workflows/aur.yml")
+    printf '%s\n' "${MOCK_AUR_STATE:-disabled_manually}"
+    ;;
   "api --method") printf '%s\n' "$*" >> "$MOCK_STATE/api" ;;
   *) echo "unexpected gh invocation: $*" >&2; exit 1 ;;
 esac
@@ -46,6 +50,7 @@ output=$(
       automation/test "test automation" "test body" 2>/dev/null
 )
 test "$output" = https://github.com/example/project/pull/1
+test ! -e "$tmp/state/aur"
 test "$(wc -l < "$tmp/state/watch")" -eq 2
 grep -Fx 'run watch 101 --repo example/project --exit-status' "$tmp/state/watch"
 grep -Fx 'run watch 102 --repo example/project --exit-status' "$tmp/state/watch"


### PR DESCRIPTION
## Summary
- detect whether the AUR workflow is active before automation PR validation
- keep package metadata automation working while AUR is intentionally paused
- cover the disabled workflow path in the automation test

## Tests
- `sh -n tools/propose_automation_pr.sh tools/test_propose_automation_pr.sh`
- `sh tools/test_propose_automation_pr.sh`