### PR TITLE
Keep restored secrets out of model-facing process arguments

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -3170,11 +3170,12 @@ mod tests {
             .recv_timeout(std::time::Duration::from_secs(10))
             .unwrap();
         assert!(!provider_body.contains(secret.as_str()));
-        let (_, media_type, filename) = first_openai_file(&provider_body)
+        let (handle, media_type, filename) = first_openai_file(&provider_body)
             .expect("provider should receive the sanitized file and metadata");
         assert_eq!(media_type, "text/plain");
         assert_eq!(filename, "notes.txt");
         assert!(!file_response.contains(secret.as_str()), "{file_response}");
+        assert!(!file_response.contains(&handle), "{file_response}");
         assert!(file_response.contains("script-b64"), "{file_response}");
         drop(file_proxy);
         file_thread.join().unwrap();

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2111,11 +2111,17 @@ where
         if let Some(object) = value.as_object_mut() {
             for key in ["command", "script", "code"] {
                 if let Some(Value::String(text)) = object.get_mut(key) {
-                    *text = resolve_shell_text_safely_with_context(
+                    *text = match pentect_agent::wrap_shell_command_from_active_memory_store(
+                        tool_name.unwrap_or("shell"),
                         text,
-                        allow_direct_posix_secrets,
-                        resolve,
-                    )?;
+                    )? {
+                        Some(wrapped) => wrapped,
+                        None => resolve_shell_text_safely_with_context(
+                            text,
+                            allow_direct_posix_secrets,
+                            resolve,
+                        )?,
+                    };
                 }
             }
             // Non-command metadata is structured data and remains safe to
@@ -2144,6 +2150,11 @@ pub(crate) fn resolve_shell_text_safely<R>(text: &str, resolve: &mut R) -> Resul
 where
     R: FnMut(&str) -> Result<String, String>,
 {
+    if let Some(wrapped) =
+        pentect_agent::wrap_shell_command_from_active_memory_store("exec_command", text)?
+    {
+        return Ok(wrapped);
+    }
     resolve_shell_text_safely_with_context(text, !cfg!(windows), resolve)
 }
 
@@ -3045,8 +3056,12 @@ mod tests {
             .unwrap();
         assert!(!provider_body.contains(secret.as_str()));
         assert!(first_valid_handle(&provider_body).is_some());
-        assert!(openai_response.contains(&format!("python hash.py {secret}")));
+        assert!(
+            !openai_response.contains(secret.as_str()),
+            "{openai_response}"
+        );
         assert!(!openai_response.contains("<<PENTECT_E2E_TOKEN_"));
+        assert!(openai_response.contains("script-b64"), "{openai_response}");
         drop(openai_proxy);
         openai_thread.join().unwrap();
 
@@ -3078,11 +3093,12 @@ mod tests {
             .unwrap();
         assert!(!provider_body.contains(secret.as_str()));
         assert!(first_valid_handle(&provider_body).is_some());
-        assert!(chat_response.contains(secret.as_str()), "{chat_response}");
+        assert!(!chat_response.contains(secret.as_str()), "{chat_response}");
         assert!(
             first_valid_handle(&chat_response).is_none(),
             "{chat_response}"
         );
+        assert!(chat_response.contains("script-b64"), "{chat_response}");
         drop(chat_proxy);
         chat_thread.join().unwrap();
 
@@ -3158,7 +3174,8 @@ mod tests {
             .expect("provider should receive the sanitized file and metadata");
         assert_eq!(media_type, "text/plain");
         assert_eq!(filename, "notes.txt");
-        assert!(file_response.contains(&format!("python hash.py {secret}")));
+        assert!(!file_response.contains(secret.as_str()), "{file_response}");
+        assert!(file_response.contains("script-b64"), "{file_response}");
         drop(file_proxy);
         file_thread.join().unwrap();
     }

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -3298,14 +3298,10 @@ mod tests {
             .as_str()
             .unwrap();
         let arguments: Value = serde_json::from_str(arguments).unwrap();
-        assert!(
-            arguments["command"].as_str().is_some_and(|command| {
-                command
-                    .strip_prefix("echo ")
-                    .is_some_and(|value| value == secret)
-            }),
-            "trusted shell argument was not restored"
-        );
+        let command = arguments["command"].as_str().unwrap();
+        assert!(!command.contains(&secret), "{command}");
+        assert!(!command.contains(&handle), "{command}");
+        assert!(command.contains("script-b64"), "{command}");
     }
 
     #[test]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1521,7 +1521,7 @@ fn resolve_command_args(
         if resolved != *arg && !allow_secret_argv {
             resolved.zeroize();
             return Err(
-                "refusing to place a restored secret in process arguments; use a shell/stdin/environment binding, or pass --allow-secret-argv after reviewing same-user process visibility"
+                "refusing to place a restored secret in process arguments; prefer target-specific stdin, file-descriptor, or configuration support, or pass --allow-secret-argv after reviewing same-user process visibility (a shell protects the model-facing command only, not child-process arguments)"
                     .to_string(),
             );
         }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -385,6 +385,28 @@ pub fn resolve_known_text_from_active_memory_store(text: &str) -> Result<Option<
     ActiveMemoryStoreResolver::new()?.resolve_known_text(text)
 }
 
+/// Move a shell command containing known handles behind the local Pentect
+/// execution boundary. The model-facing command contains only an opaque
+/// encoded script or a one-time script identifier; plaintext is delivered to
+/// the shell over stdin or the existing same-shell bridge, never embedded in
+/// the returned command argv.
+pub fn wrap_shell_command_from_active_memory_store(
+    tool_name: &str,
+    command: &str,
+) -> Result<Option<String>, String> {
+    let resolver = ActiveMemoryStoreResolver::new()?;
+    let Some(mut probe) = resolver.resolve_known_text(command)? else {
+        return Ok(None);
+    };
+    let has_known_reference = probe != command;
+    probe.zeroize();
+    if !has_known_reference {
+        return Ok(None);
+    }
+    let session_name = default_session_name()?;
+    wrap_shell_command(HookProvider::Generic, &session_name, tool_name, command).map(Some)
+}
+
 /// A point-in-time resolver for one model-authored object or request.
 ///
 /// Constructing this value takes one memory-store snapshot. Callers should
@@ -545,6 +567,7 @@ pub fn preflight_exec_server_process_start_from_active_memory_store(
     let opts = ExecOpts {
         session: session_name,
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode: argv_mode,
     };
@@ -1440,7 +1463,7 @@ fn run_resolved_command(
                 return Err("exec requires a program after `--`".to_string());
             }
             let env = requested_env_bindings(store, &opts.mode)?;
-            let resolved_args = resolve_command_args(store, args)?;
+            let resolved_args = resolve_command_args(store, args, opts.allow_secret_argv)?;
             let program = &resolved_args[0];
             let command_args = &resolved_args[1..];
             let mut command = Command::new(program);
@@ -1467,7 +1490,7 @@ fn run_resolved_command_live(store: &MemoryStore, opts: &ExecOpts) -> Result<Exi
                 return Err("exec requires a program after `--`".to_string());
             }
             let env = requested_env_bindings(store, &opts.mode)?;
-            let resolved_args = resolve_command_args(store, args)?;
+            let resolved_args = resolve_command_args(store, args, opts.allow_secret_argv)?;
             let program = &resolved_args[0];
             let command_args = &resolved_args[1..];
             let mut command = Command::new(program);
@@ -1487,10 +1510,24 @@ fn run_resolved_command_live(store: &MemoryStore, opts: &ExecOpts) -> Result<Exi
     }
 }
 
-fn resolve_command_args(store: &MemoryStore, args: &[String]) -> Result<Vec<String>, String> {
-    args.iter()
-        .map(|arg| resolve_command_text(store, arg))
-        .collect()
+fn resolve_command_args(
+    store: &MemoryStore,
+    args: &[String],
+    allow_secret_argv: bool,
+) -> Result<Vec<String>, String> {
+    let mut resolved_args = Vec::with_capacity(args.len());
+    for arg in args {
+        let mut resolved = resolve_command_text(store, arg)?;
+        if resolved != *arg && !allow_secret_argv {
+            resolved.zeroize();
+            return Err(
+                "refusing to place a restored secret in process arguments; use a shell/stdin/environment binding, or pass --allow-secret-argv after reviewing same-user process visibility"
+                    .to_string(),
+            );
+        }
+        resolved_args.push(resolved);
+    }
+    Ok(resolved_args)
 }
 
 fn resolve_command_text(store: &MemoryStore, text: &str) -> Result<String, String> {
@@ -2296,6 +2333,7 @@ impl HookOpts {
 struct ExecOpts {
     session: String,
     live: bool,
+    allow_secret_argv: bool,
     script_shell: ScriptShell,
     mode: ExecMode,
 }
@@ -2451,6 +2489,7 @@ impl ExecOpts {
     fn parse(args: &[String]) -> Result<Self, String> {
         let mut session = default_session_name()?;
         let mut live = false;
+        let mut allow_secret_argv = false;
         let mut stdin = false;
         let mut script_shell = ScriptShell::Native;
         let mut i = 2;
@@ -2461,6 +2500,10 @@ impl ExecOpts {
                 }
                 "--live" => {
                     live = true;
+                    i += 1;
+                }
+                "--allow-secret-argv" => {
+                    allow_secret_argv = true;
                     i += 1;
                 }
                 "--stdin" => {
@@ -2485,6 +2528,7 @@ impl ExecOpts {
                     return Ok(Self {
                         session: checked_session_name(&session).map_err(|e| e.to_string())?,
                         live,
+                        allow_secret_argv,
                         script_shell,
                         mode: ExecMode::Shell(script),
                     });
@@ -2505,6 +2549,7 @@ impl ExecOpts {
                     return Ok(Self {
                         session: checked_session_name(&session).map_err(|e| e.to_string())?,
                         live,
+                        allow_secret_argv,
                         script_shell: ScriptShell::Native,
                         mode: ExecMode::Program(command),
                     });
@@ -2517,6 +2562,7 @@ impl ExecOpts {
                     return Ok(Self {
                         session: checked_session_name(&session).map_err(|e| e.to_string())?,
                         live,
+                        allow_secret_argv,
                         script_shell,
                         mode: ExecMode::Shell(args[i..].join(" ")),
                     });
@@ -2527,6 +2573,7 @@ impl ExecOpts {
             return Ok(Self {
                 session: checked_session_name(&session).map_err(|e| e.to_string())?,
                 live,
+                allow_secret_argv,
                 script_shell,
                 mode: ExecMode::Stdin,
             });

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -294,10 +294,33 @@ fn exec_parse_rejects_shell_flag() {
 #[test]
 fn exec_parse_accepts_program_after_separator() {
     let args = strings(["pentect", "exec", "--", "echo", "hi"]);
-    assert!(matches!(
-        ExecOpts::parse(&args).unwrap().mode,
-        ExecMode::Program(_)
-    ));
+    let opts = ExecOpts::parse(&args).unwrap();
+    assert!(!opts.allow_secret_argv);
+    assert!(matches!(opts.mode, ExecMode::Program(_)));
+
+    let args = strings(["pentect", "exec", "--allow-secret-argv", "--", "echo", "hi"]);
+    let opts = ExecOpts::parse(&args).unwrap();
+    assert!(opts.allow_secret_argv);
+    assert!(matches!(opts.mode, ExecMode::Program(_)));
+}
+
+#[test]
+fn direct_program_secret_arguments_require_explicit_opt_in() {
+    let root = temp_root("secret-argv-opt-in");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let store = MemoryStore::for_session(&session);
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let masked = mask_tool_output(&session, &format!("OPENAI_API_KEY={raw}\n")).unwrap();
+    let handle = masked.split_once('=').unwrap().1.trim().to_string();
+    let args = vec!["tool".to_string(), handle];
+
+    let error = resolve_command_args(&store, &args, false).unwrap_err();
+    assert!(error.contains("refusing"), "{error}");
+    assert!(!error.contains(raw), "{error}");
+
+    let resolved = resolve_command_args(&store, &args, true).unwrap();
+    assert_eq!(resolved, ["tool", raw]);
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
@@ -447,6 +470,7 @@ fn exec_allows_secret_file_reads_because_output_is_remasked() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -483,6 +507,7 @@ fn exec_registers_referenced_local_files_as_env_capabilities() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -527,6 +552,7 @@ fn exec_inherits_parent_environment_and_masks_output() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode,
     };
@@ -976,6 +1002,7 @@ fn exec_capability_env_does_not_shadow_parent_environment() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode,
     };
@@ -1004,6 +1031,7 @@ fn exec_resolves_masked_handle_in_command_text() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -1072,6 +1100,7 @@ fn exec_auto_binds_masked_env_output_in_running_session() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -1336,6 +1365,7 @@ fn exec_auto_binds_generic_masked_handles_as_pentect_env_vars() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -2362,6 +2392,7 @@ fn mcp_structured_secret_can_be_used_as_pentect_env_capability() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -2453,6 +2484,7 @@ fn browser_api_key_issue_flow_masks_value_and_keeps_capability_usable() {
     let opts = ExecOpts {
         session: DEFAULT_SESSION.to_string(),
         live: false,
+        allow_secret_argv: false,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -4072,6 +4104,27 @@ fn hook_bash_transport_keeps_shell_syntax_and_environment_aliases() {
     );
     assert!(rendered.contains(raw), "{rendered:?}");
     assert!(client.take_agent_script(&id).is_err());
+}
+
+#[test]
+fn active_shell_wrapper_keeps_plaintext_out_of_model_facing_argv() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-shell-wrapper");
+    let producer = Session::open_capability(DEFAULT_SESSION).unwrap();
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let masked = mask_tool_output(&producer, &format!("RUNPOD_API_KEY={raw}\n")).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "RUNPOD_API_KEY");
+    let command = format!("printf '%s' '{handle}'");
+
+    let wrapped = wrap_shell_command_from_active_memory_store("exec_command", &command)
+        .unwrap()
+        .expect("known handle should move behind the local execution boundary");
+
+    assert!(!wrapped.contains(raw), "{wrapped}");
+    assert!(!wrapped.contains(&handle), "{wrapped}");
+    assert!(wrapped.contains("pentect"), "{wrapped}");
+    assert!(wrapped.contains("--script-b64"), "{wrapped}");
+    assert_eq!(wrapped_payload(&wrapped), command);
 }
 
 #[test]

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -130,18 +130,16 @@ stateful.
 | `--script-shell native\|bash\|powershell` | Choose the shell for script forms |
 | `--session NAME` | Use an explicit local session instead of the current-directory session |
 
-```sh
-pentect exec 'curl -H "Authorization: Bearer <<API_TOKEN_...>>" https://api.example.test/me'
-printf '%s' 'tool <<API_TOKEN_...>>' | pentect exec --stdin
-```
-
 Use the direct program form when possible. It avoids another layer of shell
 quoting. If an argument contains a known handle, Pentect refuses to restore it
 because command arguments can be visible to other processes owned by the same
-user. Prefer a shell, stdin, or environment binding. Use
-`--allow-secret-argv` only when the target program requires a secret argument
-and you have reviewed that exposure. `--live` keeps interactive progress
-visible but still masks output in chunks before it is written.
+user. Prefer target-program support for stdin, a file descriptor, or protected
+configuration that avoids secret arguments. A shell command keeps plaintext
+out of the model-facing command, but the shell can still expand it into a child
+process argument. Use `--allow-secret-argv` only when the target program
+requires a secret argument and you have reviewed that exposure. `--live` keeps
+interactive progress visible but still masks output in chunks before it is
+written.
 
 ### `view`
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -123,20 +123,25 @@ stateful.
 | Form | Behavior |
 | --- | --- |
 | `pentect exec "COMMAND"` | Run through the native shell |
-| `pentect exec -- PROGRAM ARG...` | Run a program directly without shell parsing |
+| `pentect exec -- PROGRAM ARG...` | Run a program directly; restored secrets in arguments are refused by default |
+| `pentect exec --allow-secret-argv -- PROGRAM ARG...` | Explicitly allow restored secrets in process arguments |
 | `pentect exec --stdin` | Read the shell script from UTF-8 stdin |
 | `pentect exec --live "COMMAND"` | Stream masked output instead of buffering it |
 | `--script-shell native\|bash\|powershell` | Choose the shell for script forms |
 | `--session NAME` | Use an explicit local session instead of the current-directory session |
 
 ```sh
-pentect exec -- curl -H 'Authorization: Bearer <<API_TOKEN_...>>' https://api.example.test/me
+pentect exec 'curl -H "Authorization: Bearer <<API_TOKEN_...>>" https://api.example.test/me'
 printf '%s' 'tool <<API_TOKEN_...>>' | pentect exec --stdin
 ```
 
 Use the direct program form when possible. It avoids another layer of shell
-quoting. `--live` keeps interactive progress visible but still masks output in
-chunks before it is written.
+quoting. If an argument contains a known handle, Pentect refuses to restore it
+because command arguments can be visible to other processes owned by the same
+user. Prefer a shell, stdin, or environment binding. Use
+`--allow-secret-argv` only when the target program requires a secret argument
+and you have reviewed that exposure. `--live` keeps interactive progress
+visible but still masks output in chunks before it is written.
 
 ### `view`
 


### PR DESCRIPTION
## Summary
- route shell tool calls containing known handles through the local `pentect exec` transport
- keep restored plaintext and placeholders out of model-facing command arguments
- reject secret restoration in direct program argv by default, with an explicit `--allow-secret-argv` escape hatch
- document the safer shell/stdin/environment paths

## Tests
- `cargo test -p pentect-runtime direct_program_secret_arguments_require_explicit_opt_in`
- `cargo test -p pentect-cli --no-fail-fast`
- full runtime suite: 286 passed before the added regression test

Addresses #346. This narrows #344, but environment lifetime/inheritance needs separate enforcement. It does not claim to solve #350: unrestricted local tools need destination-aware egress enforcement, not command-text matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved protection for secrets in shell commands and tool arguments by transporting wrapped, encoded scripts instead of exposing plaintext values.
  - Direct program arguments containing secret handles are now blocked by default.
  - Added an explicit `--allow-secret-argv` option for cases where restoring secrets into arguments is required.

- **Documentation**
  - Updated CLI guidance to recommend shell, stdin, or environment-based alternatives for safer secret handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->