### PR TITLE
Restore PowerShell environment after protected commands

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1144,16 +1144,57 @@ fn render_agent_script(
             }
         }
         "powershell" => {
+            let env = env
+                .iter()
+                .filter(|(name, _)| looks_like_env_name(name) && !is_pentect_control_env_name(name))
+                .collect::<Vec<_>>();
+            if env.is_empty() {
+                rendered.push_str(resolved);
+                return Ok(rendered);
+            }
+            let digest = Sha256::digest(
+                env.iter()
+                    .flat_map(|(name, _)| name.as_bytes().iter().copied())
+                    .chain(resolved.as_bytes().iter().copied())
+                    .collect::<Vec<_>>(),
+            );
+            let suffix = digest[..6]
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>();
+            let saved = format!("__pentect_saved_env_{suffix}");
+            let entry = format!("__pentect_env_entry_{suffix}");
+            rendered.push('$');
+            rendered.push_str(&saved);
+            rendered.push_str(" = @{}\n");
             for (name, value) in env {
-                if !looks_like_env_name(name) || is_pentect_control_env_name(name) {
-                    continue;
-                }
+                rendered.push('$');
+                rendered.push_str(&saved);
+                rendered.push('[');
+                rendered.push_str(&powershell_string_literal(name));
+                rendered.push_str("] = [Environment]::GetEnvironmentVariable(");
+                rendered.push_str(&powershell_string_literal(name));
+                rendered.push_str(", 'Process')\n");
                 rendered.push_str("$env:");
                 rendered.push_str(name);
                 rendered.push_str(" = ");
                 rendered.push_str(&powershell_string_literal(value));
                 rendered.push('\n');
             }
+            rendered.push_str("try {\n");
+            rendered.push_str(resolved);
+            rendered.push_str("\n} finally {\nforeach ($");
+            rendered.push_str(&entry);
+            rendered.push_str(" in $");
+            rendered.push_str(&saved);
+            rendered.push_str(".GetEnumerator()) { [Environment]::SetEnvironmentVariable($");
+            rendered.push_str(&entry);
+            rendered.push_str(".Key, $");
+            rendered.push_str(&entry);
+            rendered.push_str(".Value, 'Process') }\n$");
+            rendered.push_str(&saved);
+            rendered.push_str(" = $null\n}\n");
+            return Ok(rendered);
         }
         _ => return Err("agent script shell is invalid".to_string()),
     }

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -4068,6 +4068,66 @@ fn hook_shell_transport_round_trips_powershell_without_outer_shell_quoting() {
 }
 
 #[test]
+fn powershell_agent_script_restores_the_previous_process_environment() {
+    let rendered = render_agent_script(
+        "powershell",
+        &[(
+            "PENTECT_TEST_SECRET".to_string(),
+            "temporary-value".to_string(),
+        )],
+        "Write-Output $env:PENTECT_TEST_SECRET",
+    )
+    .unwrap();
+
+    assert!(
+        rendered.contains("[Environment]::GetEnvironmentVariable("),
+        "{rendered}"
+    );
+    assert!(rendered.contains("try {"), "{rendered}");
+    assert!(rendered.contains("finally {"), "{rendered}");
+    assert!(
+        rendered.contains("[Environment]::SetEnvironmentVariable("),
+        "{rendered}"
+    );
+    assert!(rendered.contains("temporary-value"), "{rendered}");
+}
+
+#[test]
+fn powershell_agent_script_without_bindings_is_unchanged() {
+    let script = "Write-Output 'ok'";
+    assert_eq!(
+        render_agent_script("powershell", &[], script).unwrap(),
+        script
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn powershell_agent_script_cleans_up_environment_in_a_real_shell() {
+    let rendered = render_agent_script(
+        "powershell",
+        &[(
+            "PENTECT_TEST_SECRET".to_string(),
+            "temporary-value".to_string(),
+        )],
+        "Write-Output \"DURING=$env:PENTECT_TEST_SECRET\"",
+    )
+    .unwrap();
+    let command = format!(
+        "$env:PENTECT_TEST_SECRET = 'previous-value'; {rendered}; Write-Output \"AFTER=$env:PENTECT_TEST_SECRET\""
+    );
+    let output = Command::new(windows_powershell_path())
+        .args(["-NoProfile", "-Command", &command])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stdout}\n{stderr}");
+    assert!(stdout.contains("DURING=temporary-value"), "{stdout}");
+    assert!(stdout.contains("AFTER=previous-value"), "{stdout}");
+}
+
+#[test]
 fn hook_bash_transport_keeps_shell_syntax_and_environment_aliases() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (_active_store, _, _) = ActiveMemoryStoreEnv::start("hook-shared-env-alias");

--- a/website/src/content/docs/protection/security-model.md
+++ b/website/src/content/docs/protection/security-model.md
@@ -40,6 +40,16 @@ Pentect control environment variables carry local process-host addresses and
 tokens. They are filtered from normal tool environment exposure. Wasm plugins
 do not receive them.
 
+When a command explicitly references a recovered environment binding, Pentect
+passes only that binding to the command process. The operating system then
+makes it part of that process environment, so child processes can inherit it
+and other processes running as the same user may be able to inspect it. Bash
+same-shell execution runs in a temporary subshell. PowerShell same-shell
+execution restores every previous environment value in a `finally` block, but
+a child deliberately started by the command can still retain its inherited
+copy. Pentect cannot distinguish an intended child from a daemon started by
+the same command.
+
 ## Trust boundaries
 
 | Component | Boundary |
@@ -71,6 +81,8 @@ a remote service.
   sandboxes
 - Protection from a malicious local process running as the same user with
   access to the same files or debugging rights
+- Revoking a secret already inherited by a child or daemon started by an
+  approved command
 - Proof that every OCR engine or detector will find every sensitive value
 
 ## Compatibility mode


### PR DESCRIPTION
## Summary
- preserve and restore existing process-environment values around same-shell PowerShell execution
- run cleanup in `finally` so failed commands do not leave recovered bindings behind
- leave scripts without recovered environment bindings byte-for-byte unchanged
- document the exact child-process and same-user inheritance boundary

## UX compatibility
- existing `$env:...` references remain available during the command
- prior values are restored afterward instead of being removed blindly
- Bash behavior is unchanged; it already runs the generated script inside a temporary subshell

## Tests
- `cargo test -p pentect-runtime --no-fail-fast` (289 passed)

Narrows #344 without changing the default command syntax or disabling existing environment-based clients.