### PR TITLE
Deliver restored secrets directly through program stdin

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1963,11 +1963,11 @@ enum StreamTarget {
 
 fn run_live_command(
     mut command: Command,
-    stdin_script: Option<&str>,
+    stdin_payload: Option<&str>,
     store: MemoryStore,
 ) -> Result<ExitStatus, String> {
     live_status("streaming masked command output");
-    if stdin_script.is_some() {
+    if stdin_payload.is_some() {
         command.stdin(Stdio::piped());
     } else {
         command.stdin(Stdio::null());
@@ -1976,14 +1976,14 @@ fn run_live_command(
     let mut child = command
         .spawn()
         .map_err(|e| format!("could not execute command: {e}"))?;
-    if let Some(script) = stdin_script {
+    if let Some(payload) = stdin_payload {
         let mut stdin = child
             .stdin
             .take()
             .ok_or_else(|| "could not open command stdin".to_string())?;
         stdin
-            .write_all(script.as_bytes())
-            .map_err(|e| format!("could not write shell script to stdin: {e}"))?;
+            .write_all(payload.as_bytes())
+            .map_err(|e| format!("could not write command stdin: {e}"))?;
     }
     let stdout = child
         .stdout

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -568,6 +568,7 @@ pub fn preflight_exec_server_process_start_from_active_memory_store(
         session: session_name,
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode: argv_mode,
     };
@@ -999,10 +1000,12 @@ fn exec_help() {
         concat!(
             "pentect exec \"<command>\"\n",
             "pentect exec --stdin\n",
+            "pentect exec --secret-stdin <HANDLE> -- PROGRAM...\n",
             "pentect exec --live \"<command>\"\n\n",
             "stdout/stderr: masked\n",
             "handles: in memory\n",
             "env: $env:KEY or $KEY\n",
+            "secret stdin: restored locally, never added to program arguments\n",
         )
     );
 }
@@ -1510,9 +1513,14 @@ fn run_resolved_command(
             let mut command = Command::new(program);
             command.args(command_args);
             apply_child_env_overlays(&mut command, &env, &opts.session);
-            command
-                .output()
-                .map_err(|e| format!("could not execute command: {e}"))
+            let secret_stdin = resolve_secret_stdin(store, opts)?;
+            if let Some(secret) = secret_stdin.as_deref() {
+                run_command_with_stdin(command, secret)
+            } else {
+                command
+                    .output()
+                    .map_err(|e| format!("could not execute command: {e}"))
+            }
         }
         ExecMode::Shell(command) => {
             let command = resolve_command_text(store, command)?;
@@ -1537,7 +1545,12 @@ fn run_resolved_command_live(store: &MemoryStore, opts: &ExecOpts) -> Result<Exi
             let mut command = Command::new(program);
             command.args(command_args);
             apply_child_env_overlays(&mut command, &env, &opts.session);
-            run_live_command(command, None, store.clone())
+            let secret_stdin = resolve_secret_stdin(store, opts)?;
+            run_live_command(
+                command,
+                secret_stdin.as_ref().map(|value| value.as_str()),
+                store.clone(),
+            )
         }
         ExecMode::Shell(command) => {
             let command = resolve_command_text(store, command)?;
@@ -1549,6 +1562,43 @@ fn run_resolved_command_live(store: &MemoryStore, opts: &ExecOpts) -> Result<Exi
         }
         ExecMode::Stdin => Err("internal error: exec stdin was not prepared".to_string()),
     }
+}
+
+fn resolve_secret_stdin(
+    store: &MemoryStore,
+    opts: &ExecOpts,
+) -> Result<Option<Zeroizing<String>>, String> {
+    let Some(handle) = opts.secret_stdin.as_deref() else {
+        return Ok(None);
+    };
+    let resolved = resolve_command_text(store, handle)?;
+    if resolved == handle {
+        return Err("secret stdin requires a known handle from the active session".to_string());
+    }
+    Ok(Some(Zeroizing::new(resolved)))
+}
+
+fn run_command_with_stdin(
+    mut command: Command,
+    stdin_payload: &str,
+) -> Result<std::process::Output, String> {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("could not execute command: {e}"))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "could not open command stdin".to_string())?;
+    stdin
+        .write_all(stdin_payload.as_bytes())
+        .map_err(|e| format!("could not write command stdin: {e}"))?;
+    drop(stdin);
+    child
+        .wait_with_output()
+        .map_err(|e| format!("could not read command output: {e}"))
 }
 
 fn resolve_command_args(
@@ -2375,6 +2425,7 @@ struct ExecOpts {
     session: String,
     live: bool,
     allow_secret_argv: bool,
+    secret_stdin: Option<String>,
     script_shell: ScriptShell,
     mode: ExecMode,
 }
@@ -2531,6 +2582,7 @@ impl ExecOpts {
         let mut session = default_session_name()?;
         let mut live = false;
         let mut allow_secret_argv = false;
+        let mut secret_stdin = None;
         let mut stdin = false;
         let mut script_shell = ScriptShell::Native;
         let mut i = 2;
@@ -2547,6 +2599,13 @@ impl ExecOpts {
                     allow_secret_argv = true;
                     i += 1;
                 }
+                "--secret-stdin" => {
+                    let handle = value(args, &mut i, "--secret-stdin")?;
+                    parse_placeholder(&handle).map_err(|_| {
+                        "exec --secret-stdin requires exactly one masked handle".to_string()
+                    })?;
+                    secret_stdin = Some(handle);
+                }
                 "--stdin" => {
                     stdin = true;
                     i += 1;
@@ -2560,6 +2619,11 @@ impl ExecOpts {
                             "exec --stdin does not accept a base64 script argument".to_string()
                         );
                     }
+                    if secret_stdin.is_some() {
+                        return Err(
+                            "exec --script-b64 cannot be combined with --secret-stdin".to_string()
+                        );
+                    }
                     let script = decode_script_base64(&value(args, &mut i, "--script-b64")?)?;
                     if i < args.len() {
                         return Err(
@@ -2570,6 +2634,7 @@ impl ExecOpts {
                         session: checked_session_name(&session).map_err(|e| e.to_string())?,
                         live,
                         allow_secret_argv,
+                        secret_stdin: None,
                         script_shell,
                         mode: ExecMode::Shell(script),
                     });
@@ -2591,6 +2656,7 @@ impl ExecOpts {
                         session: checked_session_name(&session).map_err(|e| e.to_string())?,
                         live,
                         allow_secret_argv,
+                        secret_stdin,
                         script_shell: ScriptShell::Native,
                         mode: ExecMode::Program(command),
                     });
@@ -2600,10 +2666,14 @@ impl ExecOpts {
                     if stdin {
                         return Err("exec --stdin does not accept a command argument".to_string());
                     }
+                    if secret_stdin.is_some() {
+                        return Err("exec --secret-stdin requires a program after `--`".to_string());
+                    }
                     return Ok(Self {
                         session: checked_session_name(&session).map_err(|e| e.to_string())?,
                         live,
                         allow_secret_argv,
+                        secret_stdin: None,
                         script_shell,
                         mode: ExecMode::Shell(args[i..].join(" ")),
                     });
@@ -2611,10 +2681,14 @@ impl ExecOpts {
             }
         }
         if stdin {
+            if secret_stdin.is_some() {
+                return Err("exec --stdin cannot be combined with --secret-stdin".to_string());
+            }
             return Ok(Self {
                 session: checked_session_name(&session).map_err(|e| e.to_string())?,
                 live,
                 allow_secret_argv,
+                secret_stdin: None,
                 script_shell,
                 mode: ExecMode::Stdin,
             });

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -305,6 +305,36 @@ fn exec_parse_accepts_program_after_separator() {
 }
 
 #[test]
+fn exec_parse_accepts_one_handle_for_program_stdin_only() {
+    let handle = "<<API_TOKEN_0123456789abcdef>>";
+    let args = strings(["pentect", "exec", "--secret-stdin", handle, "--", "tool"]);
+    let opts = ExecOpts::parse(&args).unwrap();
+    assert_eq!(opts.secret_stdin.as_deref(), Some(handle));
+    assert!(matches!(opts.mode, ExecMode::Program(_)));
+
+    let args = strings([
+        "pentect",
+        "exec",
+        "--secret-stdin",
+        "not-a-handle",
+        "--",
+        "tool",
+    ]);
+    let error = match ExecOpts::parse(&args) {
+        Ok(_) => panic!("expected a non-handle to fail"),
+        Err(error) => error,
+    };
+    assert!(error.contains("exactly one masked handle"), "{error}");
+
+    let args = strings(["pentect", "exec", "--secret-stdin", handle, "echo ok"]);
+    let error = match ExecOpts::parse(&args) {
+        Ok(_) => panic!("expected shell mode to fail"),
+        Err(error) => error,
+    };
+    assert!(error.contains("program after `--`"), "{error}");
+}
+
+#[test]
 fn direct_program_secret_arguments_require_explicit_opt_in() {
     let root = temp_root("secret-argv-opt-in");
     let session = Session::open_capability_at(&root, "t").unwrap();
@@ -320,6 +350,36 @@ fn direct_program_secret_arguments_require_explicit_opt_in() {
 
     let resolved = resolve_command_args(&store, &args, true).unwrap();
     assert_eq!(resolved, ["tool", raw]);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn direct_program_receives_a_known_secret_only_on_stdin() {
+    let root = temp_root("secret-stdin");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let store = MemoryStore::for_session(&session);
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let masked = mask_tool_output(&session, &format!("OPENAI_API_KEY={raw}\n")).unwrap();
+    let handle = masked.split_once('=').unwrap().1.trim().to_string();
+    let opts = ExecOpts {
+        session: DEFAULT_SESSION.to_string(),
+        live: false,
+        allow_secret_argv: false,
+        secret_stdin: Some(handle),
+        script_shell: ScriptShell::Native,
+        mode: ExecMode::Program(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf 'STDIN='; cat".to_string(),
+        ]),
+    };
+
+    let output = run_resolved_command(&store, &opts).unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, format!("STDIN={raw}"));
+    let masked = mask_tool_output(&session, &stdout).unwrap();
+    assert!(!masked.contains(raw), "{masked}");
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -471,6 +531,7 @@ fn exec_allows_secret_file_reads_because_output_is_remasked() {
         session: DEFAULT_SESSION.to_string(),
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -508,6 +569,7 @@ fn exec_registers_referenced_local_files_as_env_capabilities() {
         session: DEFAULT_SESSION.to_string(),
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -553,6 +615,7 @@ fn exec_inherits_parent_environment_and_masks_output() {
         session: DEFAULT_SESSION.to_string(),
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode,
     };
@@ -1003,6 +1066,7 @@ fn exec_capability_env_does_not_shadow_parent_environment() {
         session: DEFAULT_SESSION.to_string(),
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode,
     };
@@ -1032,6 +1096,7 @@ fn exec_resolves_masked_handle_in_command_text() {
         session: DEFAULT_SESSION.to_string(),
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -1101,6 +1166,7 @@ fn exec_auto_binds_masked_env_output_in_running_session() {
         session: DEFAULT_SESSION.to_string(),
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -1366,6 +1432,7 @@ fn exec_auto_binds_generic_masked_handles_as_pentect_env_vars() {
         session: DEFAULT_SESSION.to_string(),
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -2393,6 +2460,7 @@ fn mcp_structured_secret_can_be_used_as_pentect_env_capability() {
         session: DEFAULT_SESSION.to_string(),
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };
@@ -2485,6 +2553,7 @@ fn browser_api_key_issue_flow_masks_value_and_keeps_capability_usable() {
         session: DEFAULT_SESSION.to_string(),
         live: false,
         allow_secret_argv: false,
+        secret_stdin: None,
         script_shell: ScriptShell::Native,
         mode: ExecMode::Shell(command),
     };

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -125,6 +125,7 @@ stateful.
 | `pentect exec "COMMAND"` | Run through the native shell |
 | `pentect exec -- PROGRAM ARG...` | Run a program directly; restored secrets in arguments are refused by default |
 | `pentect exec --allow-secret-argv -- PROGRAM ARG...` | Explicitly allow restored secrets in process arguments |
+| `pentect exec --secret-stdin HANDLE -- PROGRAM ARG...` | Write one restored handle directly to the program's stdin |
 | `pentect exec --stdin` | Read the shell script from UTF-8 stdin |
 | `pentect exec --live "COMMAND"` | Stream masked output instead of buffering it |
 | `--script-shell native\|bash\|powershell` | Choose the shell for script forms |
@@ -140,6 +141,19 @@ process argument. Use `--allow-secret-argv` only when the target program
 requires a secret argument and you have reviewed that exposure. `--live` keeps
 interactive progress visible but still masks output in chunks before it is
 written.
+
+For programs that accept a credential on stdin, `--secret-stdin` avoids both
+secret arguments and environment inheritance:
+
+```sh
+pentect exec --secret-stdin '<<SUDO_PASSWORD_...>>' -- sudo -S -p '' cat ./ROOT_ONLY.txt
+```
+
+The handle must be one complete known handle from the active session. Pentect
+writes the recovered bytes exactly once and closes stdin; it does not append a
+newline. stdout and stderr are still masked. The target program can still use
+or forward bytes it intentionally reads, so this narrows local exposure but is
+not network-destination authorization.
 
 ### `view`
 

--- a/website/src/content/docs/start/handles.md
+++ b/website/src/content/docs/start/handles.md
@@ -143,5 +143,12 @@ pentect exec 'command --token <<API_TOKEN_...>>'
 pentect resolve config.masked.toml
 ```
 
+If a program supports credentials on stdin, keep the value out of both argv
+and the environment:
+
+```sh
+pentect exec --secret-stdin '<<SUDO_PASSWORD_...>>' -- sudo -S -p '' command
+```
+
 `resolve` changes the data boundary. Review its destination and permissions
 before running it.


### PR DESCRIPTION
## Summary
- add `pentect exec --secret-stdin HANDLE -- PROGRAM...`
- restore exactly one known active-session handle and write it only to the child stdin
- keep the plaintext out of program argv and injected environment bindings
- close stdin after one exact write and retain normal output remasking
- reject non-handles and shell/script combinations with value-free errors
- document the sudo use case and residual target-program trust

## Compatibility
- additive syntax only; existing `pentect exec` forms are unchanged
- no newline is appended, so arbitrary token bytes are preserved

## Tests
- `cargo test -p pentect-runtime --no-fail-fast` (291 passed)
- `cargo clippy -p pentect-runtime --all-targets --no-default-features -- -D warnings`

Narrows #344 and provides the stdin alternative requested there.