### PR TITLE
Let npm-managed Pentect update and uninstall itself

### DIFF
--- a/crates/pentect-cli/src/installation.rs
+++ b/crates/pentect-cli/src/installation.rs
@@ -1,6 +1,22 @@
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
+pub(crate) const NPM_PACKAGE_ROOT_ENV: &str = "PENTECT_NPM_PACKAGE_ROOT";
+pub(crate) const NPM_PROJECT_ROOT_ENV: &str = "PENTECT_NPM_PROJECT_ROOT";
+pub(crate) const NPM_SCOPE_ENV: &str = "PENTECT_NPM_SCOPE";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum NpmScope {
+    Global,
+    Local(PathBuf),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct NpmInstallation {
+    pub(crate) package_root: PathBuf,
+    pub(crate) scope: NpmScope,
+}
+
 pub(crate) const INSTALL_MARKER: &str = ".pentect-managed-install.json";
 const MAX_MARKER_BYTES: u64 = 4 * 1024;
 
@@ -40,6 +56,41 @@ impl ManagedInstallation {
             "the package manager that installed Pentect",
         )
     }
+}
+
+pub(crate) fn npm_installation() -> Result<NpmInstallation, String> {
+    let package_root = absolute_env_path(NPM_PACKAGE_ROOT_ENV)?;
+    if !package_root.join("package.json").is_file() {
+        return Err("npm package root does not contain package.json".to_string());
+    }
+    let scope = match std::env::var(NPM_SCOPE_ENV).as_deref() {
+        Ok("global") => NpmScope::Global,
+        Ok("local") => {
+            let project = absolute_env_path(NPM_PROJECT_ROOT_ENV)?;
+            if !project.join("package.json").is_file() {
+                return Err("npm project root does not contain package.json".to_string());
+            }
+            NpmScope::Local(project)
+        }
+        _ => {
+            return Err(
+                "npm installation scope is unavailable; reinstall the npm package".to_string(),
+            )
+        }
+    };
+    Ok(NpmInstallation {
+        package_root,
+        scope,
+    })
+}
+
+fn absolute_env_path(name: &str) -> Result<PathBuf, String> {
+    let path =
+        PathBuf::from(std::env::var_os(name).ok_or_else(|| format!("{name} is unavailable"))?);
+    if !path.is_absolute() {
+        return Err(format!("{name} must be an absolute path"));
+    }
+    Ok(path)
 }
 
 fn instruction(manager: &str, action: &str, command: Option<&str>, fallback: &str) -> String {

--- a/crates/pentect-cli/src/uninstall.rs
+++ b/crates/pentect-cli/src/uninstall.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::process::Command;
 
 pub(crate) fn cmd_uninstall(args: &[String]) {
     if let Err(error) = uninstall(args) {
@@ -17,6 +18,9 @@ fn uninstall(args: &[String]) -> Result<(), String> {
         .map_err(|error| format!("could not locate the installed executable: {error}"))?;
     if let Some(installation) = crate::installation::installation_for_executable(&executable)? {
         if !installation.is_self_managed() {
+            if installation.manager == "npm" {
+                return uninstall_npm();
+            }
             return Err(installation.uninstall_message());
         }
     }
@@ -43,6 +47,36 @@ fn uninstall(args: &[String]) -> Result<(), String> {
         println!("pentect: project configuration and plugin data were kept");
     }
     Ok(())
+}
+
+fn uninstall_npm() -> Result<(), String> {
+    let installation = crate::installation::npm_installation()?;
+    let mut command = npm_uninstall_command(&installation);
+    let status = command
+        .status()
+        .map_err(|error| format!("could not start npm uninstall: {error}"))?;
+    if !status.success() {
+        return Err(format!("npm uninstall failed with {status}"));
+    }
+    println!("pentect: uninstalled npm package");
+    println!("pentect: project configuration and plugin data were kept");
+    Ok(())
+}
+
+fn npm_uninstall_command(installation: &crate::installation::NpmInstallation) -> Command {
+    let npm = if cfg!(windows) { "npm.cmd" } else { "npm" };
+    let mut command = Command::new(npm);
+    command.arg("uninstall");
+    match &installation.scope {
+        crate::installation::NpmScope::Global => {
+            command.arg("--global");
+        }
+        crate::installation::NpmScope::Local(project) => {
+            command.current_dir(project);
+        }
+    }
+    command.arg("pentect");
+    command
 }
 
 fn validate_executable_name(path: &Path) -> Result<(), String> {
@@ -209,6 +243,8 @@ fn timestamp_suffix() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::installation::{NpmInstallation, NpmScope};
+    use std::path::PathBuf;
 
     #[test]
     fn only_accepts_the_public_command_shape() {
@@ -221,6 +257,30 @@ mod tests {
         assert!(validate_executable_name(Path::new("pentect")).is_ok());
         assert!(validate_executable_name(Path::new("pentect.exe")).is_ok());
         assert!(validate_executable_name(Path::new("other.exe")).is_err());
+    }
+
+    #[test]
+    fn builds_global_and_local_npm_uninstalls_without_a_shell() {
+        let global = NpmInstallation {
+            package_root: PathBuf::from("/npm/pentect"),
+            scope: NpmScope::Global,
+        };
+        let command = npm_uninstall_command(&global);
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["uninstall", "--global", "pentect"]
+        );
+
+        let local = NpmInstallation {
+            package_root: PathBuf::from("/project/node_modules/pentect"),
+            scope: NpmScope::Local(PathBuf::from("/project")),
+        };
+        let command = npm_uninstall_command(&local);
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["uninstall", "pentect"]
+        );
+        assert_eq!(command.get_current_dir(), Some(Path::new("/project")));
     }
 
     #[test]

--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -3,7 +3,6 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::io::Read;
 use std::path::{Path, PathBuf};
-#[cfg(windows)]
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -81,11 +80,7 @@ fn parse_update_options(args: &[String]) -> Result<UpdateOptions, String> {
 }
 
 fn update(options: UpdateOptions) -> Result<(), String> {
-    if let Some(installation) = crate::installation::current_installation()? {
-        if !installation.is_self_managed() {
-            return Err(installation.update_message());
-        }
-    }
+    let installation = crate::installation::current_installation()?;
     let client = reqwest::blocking::Client::builder()
         .timeout(HTTP_TIMEOUT)
         .user_agent(USER_AGENT)
@@ -129,6 +124,16 @@ fn update(options: UpdateOptions) -> Result<(), String> {
         return Ok(());
     }
 
+    if let Some(installation) = installation
+        .as_ref()
+        .filter(|value| !value.is_self_managed())
+    {
+        if installation.manager == "npm" {
+            return install_npm_update(&latest);
+        }
+        return Err(installation.update_message());
+    }
+
     let binary_name = release_asset_name()?;
     let checksum_name = format!("{binary_name}.sha256");
     let binary = find_asset(&release, &binary_name)?;
@@ -162,6 +167,58 @@ fn update(options: UpdateOptions) -> Result<(), String> {
         ));
     }
     install_update(&bytes, &latest, &expected)
+}
+
+fn install_npm_update(version: &Version) -> Result<(), String> {
+    let installation = crate::installation::npm_installation()?;
+    let mut command = npm_update_command(&installation, version);
+    let status = command
+        .status()
+        .map_err(|error| format!("could not start npm update: {error}"))?;
+    if !status.success() {
+        return Err(format!("npm update failed with {status}"));
+    }
+    verify_npm_package_version(&installation.package_root, version)?;
+    println!("updated: {version}");
+    Ok(())
+}
+
+fn npm_update_command(
+    installation: &crate::installation::NpmInstallation,
+    version: &Version,
+) -> Command {
+    let npm = if cfg!(windows) { "npm.cmd" } else { "npm" };
+    let package = format!("pentect@{version}");
+    let mut command = Command::new(npm);
+    command.arg("install");
+    match &installation.scope {
+        crate::installation::NpmScope::Global => {
+            command.arg("--global");
+        }
+        crate::installation::NpmScope::Local(project) => {
+            command.current_dir(project);
+        }
+    }
+    command.arg(&package);
+    command
+}
+
+fn verify_npm_package_version(package_root: &Path, version: &Version) -> Result<(), String> {
+    let metadata = std::fs::read(package_root.join("package.json")).map_err(|error| {
+        format!("npm updated Pentect but its package metadata is unreadable: {error}")
+    })?;
+    let metadata: serde_json::Value = serde_json::from_slice(&metadata).map_err(|error| {
+        format!("npm updated Pentect but its package metadata is invalid: {error}")
+    })?;
+    let installed = metadata.get("version").and_then(serde_json::Value::as_str);
+    let expected = version.to_string();
+    if installed != Some(expected.as_str()) {
+        return Err(format!(
+            "npm completed but installed version {} does not match {version}",
+            installed.unwrap_or("unknown")
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn download_latest_release_asset(
@@ -570,6 +627,7 @@ Remove-Item -LiteralPath $PSCommandPath -Force
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::installation::{NpmInstallation, NpmScope};
 
     #[test]
     fn parses_update_flags() {
@@ -630,5 +688,31 @@ mod tests {
             _ => None,
         });
         assert_eq!(token.as_deref(), Some("preferred"));
+    }
+
+    #[test]
+    fn builds_global_and_local_npm_updates_without_a_shell() {
+        let version = Version::new(1, 2, 3);
+        let global = NpmInstallation {
+            package_root: PathBuf::from("/npm/pentect"),
+            scope: NpmScope::Global,
+        };
+        let command = npm_update_command(&global, &version);
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["install", "--global", "pentect@1.2.3"]
+        );
+        assert!(command.get_current_dir().is_none());
+
+        let local = NpmInstallation {
+            package_root: PathBuf::from("/project/node_modules/pentect"),
+            scope: NpmScope::Local(PathBuf::from("/project")),
+        };
+        let command = npm_update_command(&local, &version);
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["install", "pentect@1.2.3"]
+        );
+        assert_eq!(command.get_current_dir(), Some(Path::new("/project")));
     }
 }

--- a/packaging/npm/bin/pentect.js
+++ b/packaging/npm/bin/pentect.js
@@ -1,6 +1,25 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { ensureInstalled } from '../install.js';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function localProjectRoot() {
+  const candidate = resolve(packageRoot, '../..');
+  try {
+    const metadata = JSON.parse(readFileSync(resolve(candidate, 'package.json'), 'utf8'));
+    const sections = ['dependencies', 'devDependencies', 'optionalDependencies'];
+    if (sections.some((section) => Object.hasOwn(metadata[section] || {}, 'pentect'))) {
+      return candidate;
+    }
+  } catch {
+    // A global package has no owning project package.json above node_modules.
+  }
+  return undefined;
+}
 
 let executable;
 try {
@@ -10,7 +29,16 @@ try {
   process.exit(1);
 }
 
-const result = spawnSync(executable, process.argv.slice(2), { stdio: 'inherit' });
+const projectRoot = localProjectRoot();
+const result = spawnSync(executable, process.argv.slice(2), {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    PENTECT_NPM_PACKAGE_ROOT: packageRoot,
+    PENTECT_NPM_SCOPE: projectRoot ? 'local' : 'global',
+    ...(projectRoot ? { PENTECT_NPM_PROJECT_ROOT: projectRoot } : {}),
+  },
+});
 if (result.error) {
   console.error(`pentect: ${result.error.message}`);
   process.exitCode = 1;

--- a/packaging/npm/install.test.js
+++ b/packaging/npm/install.test.js
@@ -64,3 +64,10 @@ test('does not rely on npm lifecycle scripts', async () => {
   const metadata = JSON.parse(await readFile(new URL('../../package.json', import.meta.url), 'utf8'));
   assert.equal(metadata.scripts.postinstall, undefined);
 });
+
+test('npm launcher passes structured installation context instead of a shell command', async () => {
+  const launcher = await readFile(new URL('./bin/pentect.js', import.meta.url), 'utf8');
+  assert.match(launcher, /PENTECT_NPM_PACKAGE_ROOT/);
+  assert.match(launcher, /PENTECT_NPM_SCOPE/);
+  assert.doesNotMatch(launcher, /npm update -g/);
+});

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -187,7 +187,7 @@ Treat redirected or in-place resolved output as plaintext secret material.
 | `pentect doctor --json` | Print results as JSON |
 | `pentect doctor --fix` | Show and apply approved fixes |
 | `pentect doctor --fix --yes` | Apply all offered fixes without another prompt |
-| `pentect update [VERSION]` | Install a verified GitHub Release binary |
+| `pentect update [VERSION]` | Update directly or through the recorded package manager |
 | `pentect update --check` | Check without installing |
 | `pentect update --force` | Reinstall even when the selected version is already present |
 | `pentect uninstall` | Remove Pentect but keep project data |

--- a/website/src/content/docs/start/install.md
+++ b/website/src/content/docs/start/install.md
@@ -75,7 +75,9 @@ workflow. A Nix flake lock file keeps the selected revision.
 
 ## Update
 
-Use the package manager that installed Pentect:
+Run `pentect update`. Pentect uses its installation record to update through
+the original package manager when required, including global and project-local
+npm installations.
 
 For AUR installations, select the update command matching the package you
 installed.
@@ -90,7 +92,7 @@ pentect update X.Y.Z
 ```
 
 ```sh [npm]
-npm update -g pentect
+pentect update
 ```
 
 ```sh [Homebrew]


### PR DESCRIPTION
## Summary
- make `pentect update` invoke npm directly for npm-managed installations instead of delegating a command to the user
- distinguish project-local and global npm launch contexts without executing marker-provided shell strings
- make `pentect uninstall` use the same structured scope
- verify the installed package version after npm completes
- update installation and CLI documentation

## Safety
- npm is spawned directly with fixed argument structure; no shell is used
- local updates run only from the owning project identified by its `package.json`
- package roots and project roots must be absolute and contain package metadata

## Tests
- `cargo test -p pentect-cli --no-fail-fast`
- `npm test`
- `git diff --check`

Closes #365
Closes #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting global and project-local npm installations.
  * `pentect update` now updates npm installations through the recorded package manager.
  * `pentect uninstall` now removes npm-managed installations directly.

* **Bug Fixes**
  * Improved validation and error reporting for missing or invalid npm configuration.
  * Preserved configuration and plugin data during npm uninstallation.

* **Documentation**
  * Updated installation and CLI documentation to reflect package-manager-aware updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->