### PR TITLE
fix: make exec failures safe and document command boundaries

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1006,6 +1006,8 @@ fn exec_help() {
             "pentect exec --stdin\n",
             "pentect exec --secret-stdin <HANDLE> -- PROGRAM...\n",
             "pentect exec --live \"<command>\"\n\n",
+            "COMMAND is a native-shell script; after `--`, PROGRAM is executed directly.\n",
+            "exec does not interpret arbitrary text as a file, secret, or handle lookup.\n",
             "stdout/stderr: masked\n",
             "handles: in memory\n",
             "env: $env:KEY or $KEY\n",
@@ -1523,7 +1525,7 @@ fn run_resolved_command(
             } else {
                 command
                     .output()
-                    .map_err(|e| format!("could not execute command: {e}"))
+                    .map_err(|error| command_start_error(&error))
             }
         }
         ExecMode::Shell(command) => {
@@ -1562,6 +1564,7 @@ fn run_resolved_command_live(store: &MemoryStore, opts: &ExecOpts) -> Result<Exi
             let env = requested_env_bindings(store, &opts.mode)?;
             let mut shell = shell_script_command(opts.script_shell)?;
             apply_child_env_overlays(&mut shell, &env, &opts.session);
+            let command = prepare_shell_script(&command, opts.script_shell);
             run_live_command(shell, Some(&command), store.clone())
         }
         ExecMode::Stdin => Err("internal error: exec stdin was not prepared".to_string()),
@@ -1591,7 +1594,7 @@ fn run_command_with_stdin(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| format!("could not execute command: {e}"))?;
+        .map_err(|error| command_start_error(&error))?;
     let mut stdin = child
         .stdin
         .take()
@@ -1931,6 +1934,52 @@ fn looks_like_non_file_reference(value: &str) -> bool {
         || value.contains('}')
 }
 
+const POWERSHELL_EXEC_PREAMBLE: &str = concat!(
+    "[Console]::InputEncoding=[Text.UTF8Encoding]::new($false);",
+    "[Console]::OutputEncoding=[Text.UTF8Encoding]::new($false);",
+    "$OutputEncoding=[Text.UTF8Encoding]::new($false);",
+    "trap [System.Management.Automation.CommandNotFoundException] {",
+    "[Console]::Error.WriteLine('[pentect] exec could not start command: executable was not found; use `pentect exec -- PROGRAM ARG...` for direct execution');",
+    "exit 127",
+    "}\n",
+);
+
+fn prepare_shell_script(script: &str, script_shell: ScriptShell) -> String {
+    let powershell = match script_shell {
+        ScriptShell::PowerShell => true,
+        ScriptShell::Native => cfg!(windows),
+        ScriptShell::Bash => false,
+    };
+    if powershell {
+        format!("{POWERSHELL_EXEC_PREAMBLE}{script}")
+    } else {
+        script.to_string()
+    }
+}
+
+fn command_start_error(error: &std::io::Error) -> String {
+    let reason = match error.kind() {
+        std::io::ErrorKind::NotFound => {
+            "executable was not found; `pentect exec --` requires a program name"
+        }
+        std::io::ErrorKind::PermissionDenied => "permission was denied by the operating system",
+        std::io::ErrorKind::InvalidInput => "the operating system rejected the command format",
+        _ => "the operating system could not start the process",
+    };
+    format!("could not start command: {reason}")
+}
+
+fn command_shell_start_error(error: &std::io::Error) -> String {
+    let reason = match error.kind() {
+        std::io::ErrorKind::NotFound => "the native command shell was not found",
+        std::io::ErrorKind::PermissionDenied => {
+            "permission to start the native command shell was denied"
+        }
+        _ => "the operating system could not start the native command shell",
+    };
+    format!("could not start command shell: {reason}")
+}
+
 fn run_shell_script(
     script: &str,
     env: &[(String, String)],
@@ -1939,12 +1988,13 @@ fn run_shell_script(
 ) -> Result<std::process::Output, String> {
     let mut command = shell_script_command(script_shell)?;
     apply_child_env_overlays(&mut command, env, session);
+    let script = prepare_shell_script(script, script_shell);
     let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| format!("could not execute shell command: {e}"))?;
+        .map_err(|error| command_shell_start_error(&error))?;
     {
         let stdin = child
             .stdin
@@ -1979,7 +2029,7 @@ fn run_live_command(
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = command
         .spawn()
-        .map_err(|e| format!("could not execute command: {e}"))?;
+        .map_err(|error| command_start_error(&error))?;
     if let Some(payload) = stdin_payload {
         let mut stdin = child
             .stdin

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -4667,3 +4667,29 @@ fn pentect_env_name_for_handle(handle: &str) -> String {
     };
     format!("PENTECT_{core}")
 }
+#[test]
+fn exec_start_errors_never_repeat_the_command_or_os_message() {
+    let sensitive_command = "private-command-name";
+    let error = std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!("localized failure: {sensitive_command}"),
+    );
+    let diagnostic = command_start_error(&error);
+    assert_eq!(
+        diagnostic,
+        "could not start command: executable was not found; `pentect exec --` requires a program name"
+    );
+    assert!(!diagnostic.contains(sensitive_command));
+    assert!(!diagnostic.contains("localized failure"));
+}
+
+#[test]
+fn powershell_exec_preamble_forces_utf8_and_sanitizes_missing_commands() {
+    let script = "Write-Output '日本語'; private-command-name";
+    let prepared = prepare_shell_script(script, ScriptShell::PowerShell);
+    assert!(prepared.contains("[Console]::InputEncoding=[Text.UTF8Encoding]"));
+    assert!(prepared.contains("[Console]::OutputEncoding=[Text.UTF8Encoding]"));
+    assert!(prepared.contains("System.Management.Automation.CommandNotFoundException"));
+    assert!(prepared.contains("executable was not found"));
+    assert!(prepared.ends_with(script));
+}

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -49,6 +49,7 @@ const sidebar = [
       { text: sidebarLabel('Install', 'download'), link: '/start/install/' },
       { text: sidebarLabel('How it works', 'flow'), link: '/start/how-it-works/' },
       { text: sidebarLabel('Handles', 'key'), link: '/start/handles/' },
+      { text: sidebarLabel('Command guide', 'terminal'), link: '/start/commands/' },
       { text: sidebarLabel('Examples', 'examples'), link: '/start/examples/' },
     ],
   },

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -120,6 +120,10 @@ stateful.
 
 `exec` restores known handles before execution and masks stdout and stderr:
 
+It requires a command name. It does not interpret arbitrary text as a secret,
+file path, or value to resolve. See the [task-oriented command guide](/start/commands/)
+for POSIX shell and PowerShell examples.
+
 | Form | Behavior |
 | --- | --- |
 | `pentect exec "COMMAND"` | Run through the native shell |

--- a/website/src/content/docs/start/commands.md
+++ b/website/src/content/docs/start/commands.md
@@ -1,0 +1,114 @@
+---
+title: Command guide
+description: Choose the Pentect command that matches the data flow you need.
+---
+
+Pentect commands differ mainly in where plaintext is allowed to appear. Use
+this guide before reaching for the advanced `resolve` command.
+
+## Mask text or read a file
+
+| Task | Command | Plaintext destination |
+| --- | --- | --- |
+| Mask UTF-8 stdin | `pentect mask` | Nowhere; protected text is printed |
+| Read and mask a file | `pentect read PATH` | Nowhere; the file is not changed |
+| Inspect a handle | `pentect view HANDLE` | Nowhere; only safe metadata is printed |
+
+`read` uses the filename to recognize formats and can retain safe recovery
+metadata in the active local store. `mask` is a one-run stdin filter.
+
+::: code-group
+
+```sh [macOS / Linux]
+cat .env | pentect mask
+pentect read ./config.json
+pentect view '<<API_TOKEN_0123456789abcdef>>'
+```
+
+```powershell [PowerShell]
+Get-Content .env -Raw | pentect mask
+pentect read .\config.json
+pentect view '<<API_TOKEN_0123456789abcdef>>'
+```
+
+:::
+
+See [Handles](/start/handles/) and
+[Files and images](/protection/files-and-images/) for the protection details.
+
+## Run a local command
+
+`pentect exec` requires a real command. It does not treat arbitrary text as a
+secret, filename, or handle lookup. Pentect restores known handles only at the
+local execution boundary, then masks stdout and stderr before displaying them.
+
+Prefer the direct form after `--`; it avoids another quoting layer:
+
+::: code-group
+
+```sh [macOS / Linux]
+pentect exec -- git status --short
+pentect exec 'printf "%s\n" "hello"'
+```
+
+```powershell [PowerShell]
+pentect exec -- git status --short
+pentect exec 'Write-Output "hello"'
+```
+
+:::
+
+The shell form is one command string. The direct form is a program name
+followed by separate arguments. A missing executable produces a fixed Pentect
+diagnostic; Pentect does not repeat the potentially sensitive command text.
+
+For a program that reads one credential from stdin:
+
+::: code-group
+
+```sh [macOS / Linux]
+pentect exec --secret-stdin '<<SUDO_PASSWORD_0123456789abcdef>>' -- sudo -S -p '' command
+```
+
+```powershell [PowerShell]
+pentect exec --secret-stdin '<<API_TOKEN_0123456789abcdef>>' -- .\consumer.exe
+```
+
+:::
+
+The restored value reaches the child process through stdin, but not the
+terminal or Pentect log. Pentect does not append a newline. Use
+`--allow-secret-argv` only when a target program cannot accept a safer channel;
+same-user processes may be able to inspect process arguments.
+
+## Resolve plaintext only when required
+
+`pentect resolve` is advanced because its output is plaintext. With no path it
+reads stdin and prints plaintext. With paths it replaces known handles in each
+file in place.
+
+```sh
+pentect resolve config.masked.toml
+cat masked.txt | pentect resolve > plaintext.txt
+```
+
+Both destination files now contain plaintext secret material. Prefer `exec`
+when a command can consume a handle without creating a plaintext file.
+
+## Diagnose and maintain the installation
+
+| Task | Command | Notes |
+| --- | --- | --- |
+| View persistent diagnostics | `pentect log` | Values, bodies, headers, and URLs are not logged |
+| Locate the log file | `pentect log --path` | Prints the local path |
+| Machine-readable diagnostics | `pentect log --json` | Suitable for support tooling |
+| Check readiness | `pentect doctor` | Does not change configuration |
+| Offer safe repairs | `pentect doctor --fix` | Confirms changes interactively |
+| Check for an update | `pentect update --check` | Does not install |
+| Update Pentect | `pentect update` | Uses the recorded package-manager scope when available |
+| Remove Pentect | `pentect uninstall` | Keeps project data |
+
+For failures, include the value-free reason shown by `pentect log --json` and
+follow [Troubleshooting](/reference/troubleshooting/). Installation-specific
+commands are documented in [Install](/start/install/), and the complete option
+list is in the [CLI reference](/reference/cli/).


### PR DESCRIPTION
Closes #367.\nCloses #368.\n\n- maps direct-process startup errors to fixed, value-free categories without repeating command names or localized OS messages;\n- forces UTF-8 input/output for PowerShell shell execution;\n- catches PowerShell `CommandNotFoundException` and emits a fixed diagnostic without the command text;\n- applies the same protected script wrapper to buffered and live execution;\n- adds tests for non-disclosure and the PowerShell UTF-8/missing-command wrapper;\n- adds a task-oriented command guide with POSIX and PowerShell examples, plaintext-boundary notes, and cross-links.\n\nLocal verification: focused runtime tests, runtime Clippy, full docs build, 41 pages and 109 internal links.