### PR TITLE
fix: bound command-plugin cold start by chain deadline

### DIFF
--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -1084,14 +1084,8 @@ impl CommandProgram {
         let remaining = budget.remaining().map_err(|_| {
             format!("plugin '{name}' command chain deadline exceeded before execution")
         })?;
-        let (exchange_timeout, phase) = if starting {
-            (
-                startup_timeout.min(remaining),
-                CommandExchangePhase::Startup,
-            )
-        } else {
-            (timeout.min(remaining), CommandExchangePhase::Request)
-        };
+        let (exchange_timeout, phase) =
+            command_exchange_timeout(starting, timeout, startup_timeout, remaining);
         let result = state
             .as_mut()
             .expect("command session initialized")
@@ -1128,6 +1122,22 @@ impl CommandProgram {
                 }
             }
         }
+    }
+}
+
+fn command_exchange_timeout(
+    starting: bool,
+    timeout: Duration,
+    startup_timeout: Duration,
+    remaining: Duration,
+) -> (Duration, CommandExchangePhase) {
+    if starting {
+        (
+            startup_timeout.min(remaining),
+            CommandExchangePhase::Startup,
+        )
+    } else {
+        (timeout.min(remaining), CommandExchangePhase::Request)
     }
 }
 
@@ -3723,7 +3733,11 @@ mod tests {
         )
         .unwrap();
         let output = program
-            .invoke(br#"{"id":42}"#, Duration::from_secs(5), "fixture")
+            .invoke(
+                br#"{"id":42}"#,
+                Duration::from_millis(DEFAULT_TIMEOUT_MS),
+                "fixture",
+            )
             .unwrap();
         assert_eq!(serde_json::from_slice::<Value>(&output).unwrap()["id"], 42);
     }
@@ -3743,7 +3757,7 @@ mod tests {
             .invoke_with_startup_timeout(
                 br#"{"id":1}"#,
                 Duration::from_millis(50),
-                Duration::from_secs(1),
+                Duration::from_millis(DEFAULT_TIMEOUT_MS),
                 "fixture",
                 &mut budget,
             )
@@ -3755,7 +3769,7 @@ mod tests {
             .invoke_with_startup_timeout(
                 br#"{"id":2}"#,
                 Duration::from_millis(50),
-                Duration::from_secs(1),
+                Duration::from_millis(DEFAULT_TIMEOUT_MS),
                 "fixture",
                 &mut budget,
             )
@@ -3765,26 +3779,30 @@ mod tests {
 
     #[test]
     fn command_program_cold_start_is_capped_by_remaining_chain_budget() {
-        let Some(command) = python_protocol_fixture(
-            "import json,sys,time; time.sleep(2);\nfor line in sys.stdin:\n r=json.loads(line); print(json.dumps({'id':r['id']}), flush=True)",
-        ) else {
-            return;
-        };
-        let program = CommandProgram::new(command, std::env::current_dir().unwrap(), 4096).unwrap();
-        let mut budget = PluginChainBudget::new();
-        budget.deadline = Instant::now() + Duration::from_millis(50);
-        let started = Instant::now();
-        let error = program
-            .invoke_with_startup_timeout(
-                br#"{"id":1}"#,
-                Duration::from_secs(5),
-                Duration::from_secs(5),
-                "fixture",
-                &mut budget,
-            )
-            .unwrap_err();
-        assert!(error.contains("startup timed out"), "{error}");
-        assert!(started.elapsed() < Duration::from_secs(1));
+        let remaining = Duration::from_millis(50);
+        let (timeout, phase) = command_exchange_timeout(
+            true,
+            Duration::from_secs(5),
+            Duration::from_secs(10),
+            remaining,
+        );
+
+        assert_eq!(timeout, remaining);
+        assert!(matches!(phase, CommandExchangePhase::Startup));
+    }
+
+    #[test]
+    fn command_program_warm_request_is_capped_by_remaining_chain_budget() {
+        let remaining = Duration::from_millis(50);
+        let (timeout, phase) = command_exchange_timeout(
+            false,
+            Duration::from_secs(5),
+            Duration::from_secs(10),
+            remaining,
+        );
+
+        assert_eq!(timeout, remaining);
+        assert!(matches!(phase, CommandExchangePhase::Request));
     }
 
     #[test]
@@ -3875,7 +3893,7 @@ mod tests {
             4096,
         )
         .unwrap()
-        .invoke(b"{}", Duration::from_secs(5), "fixture")
+        .invoke(b"{}", Duration::from_millis(DEFAULT_TIMEOUT_MS), "fixture")
         .unwrap_err();
         assert!(partial.contains("incomplete protocol line"), "{partial}");
 
@@ -3885,7 +3903,7 @@ mod tests {
             4096,
         )
         .unwrap()
-        .invoke(b"{}", Duration::from_secs(5), "fixture")
+        .invoke(b"{}", Duration::from_millis(DEFAULT_TIMEOUT_MS), "fixture")
         .unwrap_err();
         assert!(crash.contains("closed stdout"), "{crash}");
     }
@@ -3919,7 +3937,7 @@ mod tests {
             required: true,
             command_config: Some(json!({})),
             timeout: Duration::from_secs(5),
-            startup_timeout: Duration::from_secs(5),
+            startup_timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
             max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
             max_output_bytes: 4096,
             max_spans: DEFAULT_MAX_SPANS,
@@ -3950,7 +3968,7 @@ mod tests {
             required,
             command_config: Some(json!({})),
             timeout: Duration::from_secs(5),
-            startup_timeout: Duration::from_secs(5),
+            startup_timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
             max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
             max_output_bytes: 4096,
             max_spans: DEFAULT_MAX_SPANS,

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -258,13 +258,6 @@ impl PluginChainBudget {
         }
     }
 
-    fn exclude_startup(&mut self, elapsed: Duration) {
-        // An approved native command may need to load a large local model before
-        // its first response. That separately bounded initialization must not
-        // consume the request-wide budget of the remaining plugin chain.
-        self.deadline = self.deadline.checked_add(elapsed).unwrap_or(self.deadline);
-    }
-
     fn charge_input(&mut self, bytes: usize) -> Result<(), String> {
         charge_chain_total(
             &mut self.input_bytes,
@@ -1080,7 +1073,6 @@ impl CommandProgram {
         record_plugin_access(name, "command");
         let mut state = self.lock_state_until(budget.deadline, name)?;
         let starting = state.is_none();
-        let started = Instant::now();
         if starting {
             *state = Some(CommandSession::start(
                 &self.argv,
@@ -1089,21 +1081,23 @@ impl CommandProgram {
                 name,
             )?);
         }
-        let exchange_timeout = if starting {
-            startup_timeout
-        } else {
-            timeout.min(
-                budget
-                    .remaining()
-                    .map_err(|_| format!("plugin '{name}' command state is unavailable"))?,
+        let remaining = budget.remaining().map_err(|_| {
+            format!("plugin '{name}' command chain deadline exceeded before execution")
+        })?;
+        let (exchange_timeout, phase) = if starting {
+            (
+                startup_timeout.min(remaining),
+                CommandExchangePhase::Startup,
             )
+        } else {
+            (timeout.min(remaining), CommandExchangePhase::Request)
         };
         let result = state
             .as_mut()
             .expect("command session initialized")
-            .exchange(request, exchange_timeout, name);
-        if starting {
-            budget.exclude_startup(started.elapsed());
+            .exchange(request, exchange_timeout, name, phase);
+        if result.is_err() {
+            record_plugin_access(name, phase.diagnostic_operation());
         }
         if result.is_err() {
             if let Some(mut session) = state.take() {
@@ -1127,7 +1121,8 @@ impl CommandProgram {
                 Err(TryLockError::WouldBlock) => {
                     let remaining = deadline.saturating_duration_since(Instant::now());
                     if remaining.is_zero() {
-                        return Err(format!("plugin '{name}' command state is unavailable"));
+                        record_plugin_access(name, "command-lock-timeout");
+                        return Err(format!("plugin '{name}' command lock wait timed out"));
                     }
                     std::thread::sleep(remaining.min(Duration::from_millis(5)));
                 }
@@ -1141,6 +1136,28 @@ struct CommandSession {
     tree: CommandTree,
     stdin: Option<ChildStdin>,
     responses: mpsc::Receiver<Result<Vec<u8>, String>>,
+}
+
+#[derive(Clone, Copy)]
+enum CommandExchangePhase {
+    Startup,
+    Request,
+}
+
+impl CommandExchangePhase {
+    fn timeout_error(self, name: &str) -> String {
+        match self {
+            Self::Startup => format!("plugin '{name}' command startup timed out"),
+            Self::Request => format!("plugin '{name}' command request timed out"),
+        }
+    }
+
+    fn diagnostic_operation(self) -> &'static str {
+        match self {
+            Self::Startup => "command-startup-failed",
+            Self::Request => "command-request-failed",
+        }
+    }
 }
 
 impl CommandSession {
@@ -1224,6 +1241,7 @@ impl CommandSession {
         request: &[u8],
         timeout: Duration,
         name: &str,
+        phase: CommandExchangePhase,
     ) -> Result<Vec<u8>, String> {
         let deadline = Instant::now() + timeout;
         let mut stdin = self
@@ -1245,21 +1263,19 @@ impl CommandSession {
         match write_rx.recv_timeout(timeout) {
             Ok((stdin, Ok(()))) => self.stdin = Some(stdin),
             Ok((_stdin, Err(_))) => return Err(format!("plugin '{name}' command input failed")),
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                return Err(format!("plugin '{name}' timed out"))
-            }
+            Err(mpsc::RecvTimeoutError::Timeout) => return Err(phase.timeout_error(name)),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 return Err(format!("plugin '{name}' command input failed"));
             }
         }
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
-            return Err(format!("plugin '{name}' timed out"));
+            return Err(phase.timeout_error(name));
         }
         self.responses
             .recv_timeout(remaining)
             .map_err(|error| match error {
-                mpsc::RecvTimeoutError::Timeout => format!("plugin '{name}' timed out"),
+                mpsc::RecvTimeoutError::Timeout => phase.timeout_error(name),
                 mpsc::RecvTimeoutError::Disconnected => {
                     format!("plugin '{name}' command stopped without a response")
                 }
@@ -3713,7 +3729,7 @@ mod tests {
     }
 
     #[test]
-    fn command_program_uses_longer_timeout_only_for_cold_start() {
+    fn command_program_cold_start_consumes_the_chain_deadline() {
         let Some(command) = python_protocol_fixture(
             "import json,sys,time; time.sleep(0.15);\nfor line in sys.stdin:\n r=json.loads(line); time.sleep(0.10); print(json.dumps({'id':r['id']}), flush=True)",
         ) else {
@@ -3733,13 +3749,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(serde_json::from_slice::<Value>(&first).unwrap()["id"], 1);
-        assert!(
-            budget
-                .deadline
-                .saturating_duration_since(deadline_before_start)
-                > Duration::from_millis(200),
-            "cold start was not excluded from the chain deadline"
-        );
+        assert_eq!(budget.deadline, deadline_before_start);
 
         let second = program
             .invoke_with_startup_timeout(
@@ -3754,6 +3764,30 @@ mod tests {
     }
 
     #[test]
+    fn command_program_cold_start_is_capped_by_remaining_chain_budget() {
+        let Some(command) = python_protocol_fixture(
+            "import json,sys,time; time.sleep(2);\nfor line in sys.stdin:\n r=json.loads(line); print(json.dumps({'id':r['id']}), flush=True)",
+        ) else {
+            return;
+        };
+        let program = CommandProgram::new(command, std::env::current_dir().unwrap(), 4096).unwrap();
+        let mut budget = PluginChainBudget::new();
+        budget.deadline = Instant::now() + Duration::from_millis(50);
+        let started = Instant::now();
+        let error = program
+            .invoke_with_startup_timeout(
+                br#"{"id":1}"#,
+                Duration::from_secs(5),
+                Duration::from_secs(5),
+                "fixture",
+                &mut budget,
+            )
+            .unwrap_err();
+        assert!(error.contains("startup timed out"), "{error}");
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
     fn command_program_state_wait_is_bounded_by_chain_deadline() {
         let Some(command) = python_protocol_fixture("pass") else {
             return;
@@ -3765,7 +3799,7 @@ mod tests {
             Err(error) => error,
         };
         drop(held_state);
-        assert!(error.contains("state is unavailable"));
+        assert!(error.contains("lock wait timed out"));
     }
 
     #[test]

--- a/website/src/content/docs/plugins/manifest.md
+++ b/website/src/content/docs/plugins/manifest.md
@@ -109,7 +109,10 @@ max_spans = 512
 The largest allowed values are 60 seconds per invocation, 10 minutes for
 `startup_timeout_ms`, 4 MiB input, 4 MiB output, and 4,096 findings. The startup
 limit applies only to the first response from a native Command process; later
-responses use `timeout_ms`. If omitted, it equals `timeout_ms`. The Wasm file
+responses use `timeout_ms`. If omitted, it equals `timeout_ms`. It is still
+capped by the time remaining in the 60-second plugin-chain deadline; cold
+startup never extends that deadline. Waiting for another request to release a
+shared Command process uses the same remaining deadline. The Wasm file
 itself must be 32 MiB or smaller. Pentect infers the form, so new manifests do
 not set a runtime or mode.
 
@@ -119,6 +122,8 @@ Pentect also applies one shared ceiling to the complete plugin chain for a
 protected action: 60 seconds, 16 MiB total input, 16 MiB total output, 8,192
 findings, and 32 brokered HTTP requests. These host limits need no manifest
 settings. A plugin's own limits can only make its invocation stricter.
+Value-free diagnostics distinguish Command startup failure, shared-session
+lock timeout, and request execution failure.
 
 Wasm modules are checked before compilation with `wasmi`'s strict untrusted
 module limits. At runtime Pentect permits one memory, one table, and one


### PR DESCRIPTION
Closes #336.\n\nRemoves the cold-start deadline extension, caps first response and warm requests by the remaining 60-second chain budget, and bounds shared-session lock waits by that same deadline. Value-free activity reasons now distinguish lock timeout, startup failure, and request failure. Documentation explains how manifest startup limits interact with the aggregate ceiling.\n\nRegression coverage verifies the deadline is unchanged by startup, a long configured startup timeout is cut off by the remaining chain budget, and lock waits fail with their own reason.