### PR TITLE
fix: preserve Codex App provider authentication

### DIFF
--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -43,7 +43,10 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
             }
         );
         let routing = crate::codex_app_routing(options.upstream)?;
-        crate::upstream::header_overrides(&options.upstream_header_env)?;
+        crate::upstream::header_overrides_with_bearer_env(
+            &options.upstream_header_env,
+            routing.bearer_env.as_deref(),
+        )?;
         println!("Provider: {}", routing.provider);
         println!("Protection: OpenAI Responses API (HTTP)");
         if !installed {
@@ -62,10 +65,12 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     }
 
     let routing = crate::codex_app_routing(options.upstream)?;
-    let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env(
-        routing.upstream,
-        &options.upstream_header_env,
-    )?;
+    let proxy =
+        crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env_and_bearer_env(
+            routing.upstream,
+            &options.upstream_header_env,
+            routing.bearer_env.as_deref(),
+        )?;
     let config_lock = Arc::new(Mutex::new(Some(CodexConfigLock::acquire()?)));
     let session_home = CodexSessionHome::create(&routing.provider, proxy.base_url())?;
     let lifecycle_log = match CodexAppLifecycleLog::open(session_home.source_home()) {
@@ -1405,6 +1410,7 @@ model_provider = "proxy"
 [model_providers.proxy]
 base_url = "https://upstream.example/v1"
 wire_api = "responses"
+env_key = "PROXY_API_KEY"
 
 [model_providers.other]
 base_url = "https://other.example/v1"
@@ -1423,6 +1429,10 @@ base_url = "https://other.example/v1"
         assert_eq!(
             config["model_providers"]["proxy"]["supports_websockets"].as_bool(),
             Some(false)
+        );
+        assert_eq!(
+            config["model_providers"]["proxy"]["env_key"].as_str(),
+            Some("PROXY_API_KEY")
         );
     }
 

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -2487,6 +2487,7 @@ fn codex_effective_routing(opts: &AgentToolOpts) -> Result<CodexHttpRouting, Str
 pub(crate) struct CodexAppRouting {
     upstream: String,
     provider: String,
+    bearer_env: Option<String>,
 }
 
 /// Resolve the App's selected provider without changing user configuration.
@@ -2499,18 +2500,23 @@ pub(crate) fn codex_app_routing(explicit: Option<String>) -> Result<CodexAppRout
         .and_then(toml::Value::as_str)
         .unwrap_or("openai")
         .to_string();
+    let provider_config = (provider != "openai")
+        .then(|| {
+            config
+                .get("model_providers")
+                .and_then(toml::Value::as_table)
+                .and_then(|providers| providers.get(&provider))
+                .and_then(toml::Value::as_table)
+                .ok_or_else(|| format!("Codex provider '{provider}' has no configuration"))
+        })
+        .transpose()?;
     let configured_upstream = if provider == "openai" {
         config
             .get("openai_base_url")
             .and_then(toml::Value::as_str)
             .map(str::to_owned)
     } else {
-        let provider_config = config
-            .get("model_providers")
-            .and_then(toml::Value::as_table)
-            .and_then(|providers| providers.get(&provider))
-            .and_then(toml::Value::as_table)
-            .ok_or_else(|| format!("Codex provider '{provider}' has no configuration"))?;
+        let provider_config = provider_config.expect("custom provider config resolved");
         let wire_api = provider_config
             .get("wire_api")
             .and_then(toml::Value::as_str)
@@ -2540,7 +2546,15 @@ pub(crate) fn codex_app_routing(explicit: Option<String>) -> Result<CodexAppRout
                 "could not determine upstream for Codex App provider '{provider}'; pass --upstream URL"
             )
         })?;
-    Ok(CodexAppRouting { upstream, provider })
+    let bearer_env = provider_config
+        .and_then(|provider| provider.get("env_key"))
+        .and_then(toml::Value::as_str)
+        .map(str::to_owned);
+    Ok(CodexAppRouting {
+        upstream,
+        provider,
+        bearer_env,
+    })
 }
 
 fn load_codex_user_config(args: &[String]) -> Result<toml::Value, String> {

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -82,8 +82,16 @@ impl OpenAiHttpProxyGuard {
         upstream: String,
         header_env: &[String],
     ) -> Result<Self, String> {
+        Self::start_with_header_env_and_bearer_env(upstream, header_env, None)
+    }
+
+    pub(crate) fn start_with_header_env_and_bearer_env(
+        upstream: String,
+        header_env: &[String],
+        bearer_env: Option<&str>,
+    ) -> Result<Self, String> {
         let upstream = parse_upstream_base(&upstream)?;
-        let headers = crate::upstream::header_overrides(header_env)?;
+        let headers = crate::upstream::header_overrides_with_bearer_env(header_env, bearer_env)?;
         let auth = random_auth_token()?;
         let (ready_tx, ready_rx) = mpsc::channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -3168,6 +3176,11 @@ mod tests {
                 process_host_candidate,
             }
         }
+
+        fn set(&mut self, name: &'static str, value: &str) {
+            self.saved.push((name, std::env::var_os(name)));
+            std::env::set_var(name, value);
+        }
     }
 
     impl Drop for ProviderBoundaryTestEnv {
@@ -3371,7 +3384,8 @@ mod tests {
     fn provider_boundary_masks_chat_requests_and_restores_only_tool_arguments() {
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let store = pentect_agent::start_in_process_memory_store().unwrap();
-        let _env = ProviderBoundaryTestEnv::install(&store);
+        let mut env = ProviderBoundaryTestEnv::install(&store);
+        env.set("PENTECT_TEST_OPENAI_PROVIDER_KEY", "provider-test-key");
         let secret = [
             "rpa_",
             "ZYXWVUTS",
@@ -3382,7 +3396,12 @@ mod tests {
         ]
         .concat();
         let (upstream, captured, thread) = mock_chat_upstream();
-        let proxy = OpenAiHttpProxyGuard::start(upstream).unwrap();
+        let proxy = OpenAiHttpProxyGuard::start_with_header_env_and_bearer_env(
+            upstream,
+            &[],
+            Some("PENTECT_TEST_OPENAI_PROVIDER_KEY"),
+        )
+        .unwrap();
         let response = reqwest::blocking::Client::new()
             .post(format!("{}/v1/chat/completions", proxy.base_url()))
             .header(reqwest::header::CONTENT_TYPE, "application/json")
@@ -3419,10 +3438,16 @@ mod tests {
             .text()
             .unwrap();
         let response: Value = serde_json::from_str(&response).unwrap();
-        let (_, request) = captured
+        let (headers, request) = captured
             .recv_timeout(std::time::Duration::from_secs(5))
             .unwrap();
         thread.join().unwrap();
+        assert!(
+            headers
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case("authorization: Bearer provider-test-key")),
+            "provider bearer header did not reach the upstream"
+        );
         assert!(!request.contains(&secret), "{request}");
         let handle = first_handle(&request).unwrap();
         assert!(request.matches(&handle).count() >= 3);

--- a/crates/pentect-cli/src/upstream.rs
+++ b/crates/pentect-cli/src/upstream.rs
@@ -147,6 +147,45 @@ pub(crate) fn header_overrides(specs: &[String]) -> Result<HeaderOverrides, Stri
     Ok(overrides)
 }
 
+pub(crate) fn header_overrides_with_bearer_env(
+    specs: &[String],
+    bearer_env: Option<&str>,
+) -> Result<HeaderOverrides, String> {
+    let mut overrides = header_overrides(specs)?;
+    let Some(env_name) = bearer_env.filter(|_| !overrides.suppress_origin_auth) else {
+        return Ok(overrides);
+    };
+    if env_name.is_empty() || env_name.contains('=') || env_name.contains('\0') {
+        return Err("provider API key environment variable name is invalid".to_string());
+    }
+    let mut value = std::env::var(env_name).map_err(|_| {
+        format!(
+            "provider API key environment variable {env_name} is not set or is not valid Unicode"
+        )
+    })?;
+    if value.is_empty() {
+        return Err(format!(
+            "provider API key environment variable {env_name} is empty"
+        ));
+    }
+    if value.len() > 16 * 1024 {
+        value.zeroize();
+        return Err(format!(
+            "provider API key environment variable {env_name} is too large"
+        ));
+    }
+    let mut authorization = format!("Bearer {value}");
+    value.zeroize();
+    let header = sensitive_header_value(&authorization, env_name);
+    authorization.zeroize();
+    overrides.suppress_origin_auth = true;
+    overrides.values.push(HeaderOverride {
+        name: reqwest::header::AUTHORIZATION,
+        value: Some(header?),
+    });
+    Ok(overrides)
+}
+
 pub(crate) fn hide_header_source_env(command: &mut std::process::Command, specs: &[String]) {
     for spec in specs {
         if let Some((_, env_name)) = spec.split_once('=') {
@@ -410,5 +449,49 @@ mod tests {
         std::env::remove_var("PENTECT_TEST_MISSING_KEY");
         assert!(header_overrides(&["x-bf-vk=PENTECT_TEST_MISSING_KEY".to_string()]).is_err());
         assert!(header_overrides(&["host=PENTECT_TEST_MISSING_KEY".to_string()]).is_err());
+    }
+
+    #[test]
+    fn provider_env_key_becomes_a_bearer_header() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let _secret = EnvRestore::set("PENTECT_TEST_PROVIDER_KEY", "provider-test-key");
+        let overrides =
+            header_overrides_with_bearer_env(&[], Some("PENTECT_TEST_PROVIDER_KEY")).unwrap();
+        let request = overrides
+            .apply(reqwest::Client::new().get("https://example.test"))
+            .build()
+            .unwrap();
+        assert_eq!(
+            request
+                .headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .unwrap(),
+            "Bearer provider-test-key"
+        );
+        assert!(!overrides.forward_incoming_header("authorization"));
+    }
+
+    #[test]
+    fn explicit_header_override_takes_precedence_over_provider_env_key() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let _explicit = EnvRestore::set("PENTECT_TEST_EXPLICIT_KEY", "explicit-test-key");
+        std::env::remove_var("PENTECT_TEST_PROVIDER_MISSING");
+        let overrides = header_overrides_with_bearer_env(
+            &["x-api-key=PENTECT_TEST_EXPLICIT_KEY".to_string()],
+            Some("PENTECT_TEST_PROVIDER_MISSING"),
+        )
+        .unwrap();
+        let request = overrides
+            .apply(reqwest::Client::new().get("https://example.test"))
+            .build()
+            .unwrap();
+        assert_eq!(
+            request.headers().get("x-api-key").unwrap(),
+            "explicit-test-key"
+        );
+        assert!(request
+            .headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .is_none());
     }
 }

--- a/website/src/content/docs/clients/upstreams.md
+++ b/website/src/content/docs/clients/upstreams.md
@@ -101,6 +101,14 @@ Pentect also respects the documented endpoint variable for each supported
 client, such as `OPENAI_BASE_URL`. You normally do not set it for Pentect. Use
 `--upstream` when you want an explicit one-launch override.
 
+For `pentect codex app`, a selected custom Codex provider may declare
+`env_key` in `config.toml`. Pentect reads that variable before launch and
+applies it as the upstream Bearer credential itself, so authentication does
+not depend on the desktop app forwarding the header. A missing or empty
+variable stops launch with its variable name, never its value. An explicit
+`--upstream-header-env` credential takes precedence when the upstream expects
+a different header.
+
 ## Supported API formats
 
 - Gateways that support OpenAI Responses for Codex


### PR DESCRIPTION
Closes #371

- derive the selected custom Codex provider bearer credential from its `env_key`
- inject that credential at the trusted upstream gateway even when Codex App omits it
- keep explicit upstream header overrides authoritative and fail before launch for missing provider keys
- add an end-to-end local upstream assertion and document the behavior