### PR TITLE
test: verify restored-secret descendant boundary

### DIFF
--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -383,6 +383,60 @@ fn direct_program_receives_a_known_secret_only_on_stdin() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+#[cfg(unix)]
+#[test]
+fn secret_stdin_does_not_create_an_inherited_binding_for_a_descendant() {
+    let root = temp_root("secret-stdin-descendant");
+    std::fs::create_dir_all(&root).unwrap();
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let store = MemoryStore::for_session(&session);
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let masked = mask_tool_output(&session, &format!("OPENAI_API_KEY={raw}\n")).unwrap();
+    let handle = masked.split_once('=').unwrap().1.trim().to_string();
+    let binding_name = store
+        .auto_env_bindings()
+        .unwrap()
+        .into_iter()
+        .find_map(|(name, value)| (value == raw).then_some(name))
+        .unwrap();
+    let descendant_env = root.join("descendant.env");
+    let script = format!(
+        "secret=$(cat); printf 'TARGET=%s' \"$secret\"; sh -c 'env > \"$1\"' sh '{}'",
+        descendant_env.display()
+    );
+    let opts = ExecOpts {
+        session: DEFAULT_SESSION.to_string(),
+        live: false,
+        allow_secret_argv: false,
+        secret_stdin: Some(handle),
+        script_shell: ScriptShell::Native,
+        mode: ExecMode::Program(vec!["sh".to_string(), "-c".to_string(), script]),
+    };
+
+    let output = run_resolved_command(&store, &opts).unwrap();
+    assert!(
+        output.status.success(),
+        "descendant fixture failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("TARGET={raw}")
+    );
+    let inherited = std::fs::read_to_string(&descendant_env).unwrap();
+    assert!(!inherited.contains(raw), "descendant inherited plaintext");
+    assert!(
+        !inherited
+            .lines()
+            .any(|line| line.starts_with(&format!("{binding_name}="))),
+        "descendant inherited the Pentect binding"
+    );
+    let safe = mask_tool_output(&session, &String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert!(!safe.contains(raw), "masked stdout exposed plaintext");
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
 #[test]
 fn resolve_parse_accepts_multiple_paths() {
     let args = strings(["pentect", "resolve", "a.env", "b.env"]);

--- a/website/src/content/docs/protection/security-model.md
+++ b/website/src/content/docs/protection/security-model.md
@@ -50,6 +50,12 @@ a child deliberately started by the command can still retain its inherited
 copy. Pentect cannot distinguish an intended child from a daemon started by
 the same command.
 
+When the target supports it, `pentect exec --secret-stdin HANDLE -- PROGRAM`
+does not create an environment binding at all. The selected program receives
+the bytes only on stdin, so descendants do not inherit a Pentect-created copy.
+This narrows the operating-system exposure but cannot stop the selected program
+from deliberately copying or exporting what it reads.
+
 ## Trust boundaries
 
 | Component | Boundary |

--- a/website/src/content/docs/start/commands.md
+++ b/website/src/content/docs/start/commands.md
@@ -77,7 +77,11 @@ pentect exec --secret-stdin '<<API_TOKEN_0123456789abcdef>>' -- .\consumer.exe
 :::
 
 The restored value reaches the child process through stdin, but not the
-terminal or Pentect log. Pentect does not append a newline. Use
+terminal, process arguments, injected environment bindings, or Pentect log.
+An ordinary or daemonized descendant therefore does not receive a Pentect
+binding from this mode. The receiving program can still deliberately copy,
+export, persist, or forward the bytes after reading them; the operating system
+cannot revoke such a copy. Pentect does not append a newline. Use
 `--allow-secret-argv` only when a target program cannot accept a safer channel;
 same-user processes may be able to inspect process arguments.
 


### PR DESCRIPTION
Closes #344

This completes the remaining acceptance work after #359, #360, and #361:

- add an adversarial Unix E2E where the intended process reads the restored secret from stdin and a descendant captures its environment
- prove that neither plaintext nor a Pentect binding reaches that descendant
- verify stdout is still remasked
- document that environment bindings remain an OS process-tree trust boundary, while `--secret-stdin` creates no inheritable Pentect environment copy
- document the explicit containment decision: Pentect cannot revoke copies deliberately made by an approved process without owning an OS sandbox/process tree