### PR TITLE
fix: preserve exact placeholder identity

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -919,7 +919,7 @@ fn cmd_mask(args: &[String]) {
     }
     if !result.summary.collisions.is_empty() {
         eprintln!(
-            "[pentect] WARNING: {} placeholder collision(s) — resolve/restore may be wrong for the colliding value(s).",
+            "[pentect] note: {} short placeholder collision(s) safely disambiguated with full-width handles.",
             result.summary.collisions.len()
         );
     }

--- a/crates/pentect-core/src/normalize.rs
+++ b/crates/pentect-core/src/normalize.rs
@@ -1,8 +1,8 @@
 //! Two deliberately opposite normalizations live here, and conflating them is a
 //! bug:
-//! - `n_id` (identity): conservative NFC, so distinct values never merge. Used
-//!   for placeholder hashing and the identity sweep — folding here would make two
-//!   different secrets share one placeholder.
+//! - `n_id` (detection identity): conservative NFC for the identity sweep. It
+//!   may merge canonically equivalent source bytes, so placeholder hashing uses
+//!   the original UTF-8 value instead.
 //! - `NormalizedView` (detection): aggressive NFKC + percent-decode, so spoofing
 //!   tricks can't hide a secret from a detector. It keeps a map back to raw, so
 //!   spans are always reported in raw coordinates.
@@ -13,8 +13,8 @@ use std::borrow::Cow;
 use unicode_normalization::UnicodeNormalization;
 
 /// Identity normalization: NFC only (deliberately not NFKC, and deliberately
-/// not dropping zero-width/bidi controls). Used for placeholder hashing and the
-/// sweep, where merging distinct source bytes would make restore ambiguous.
+/// not dropping zero-width/bidi controls). Used only for detection-time identity
+/// sweep grouping; exact recovery identity hashes the original UTF-8 bytes.
 pub fn n_id(s: &str) -> String {
     s.nfc().collect()
 }

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -94,9 +94,8 @@ pub struct Summary {
     /// Opaque candidates that were warned about rather than masked (no value).
     #[serde(default)]
     pub residual: Vec<ResidualNote>,
-    /// Placeholders that two distinct values collided on (restore would be wrong
-    /// for the second). Practically never with a 64-bit keyed hash, but surfaced
-    /// instead of silently corrupting reversibility.
+    /// Short placeholders that two distinct values collided on and were safely
+    /// disambiguated with a full-width keyed hash.
     #[serde(default)]
     pub collisions: Vec<String>,
     /// The requested format parser failed and we fell back to plaintext, so key
@@ -799,11 +798,11 @@ impl Default for EngineBuilder {
 }
 
 static PLACEHOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
-    // Hash width comes from the renderer so the freeze pattern can't drift from
-    // what we emit.
+    // Normal handles use the compact width. A safely disambiguated short-hash
+    // collision uses the full SHA-256 HMAC and must also remain frozen.
     let w = crate::placeholder::HASH_HEX_WIDTH;
     Regex::new(&format!(
-        r"<<[A-Z][A-Z0-9_]*_[0-9a-f]{{{w}}}(?:_(?:len[0-9]+|length_[0-9]+_chars|length_at_least_[0-9]+_chars))?>>"
+        r"<<[A-Z][A-Z0-9_]*_(?:[0-9a-f]{{{w}}}|[0-9a-f]{{64}})(?:_(?:len[0-9]+|length_[0-9]+_chars|length_at_least_[0-9]+_chars))?>>"
     ))
     .expect("placeholder regex compiles")
 });
@@ -819,6 +818,15 @@ fn scan_placeholders(raw: &str) -> Vec<ByteRange> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn full_width_collision_handle_is_frozen() {
+        let handle = format!("<<SECRET_{}>>", "a".repeat(64));
+        assert_eq!(
+            scan_placeholders(&handle),
+            [ByteRange::new(0, handle.len())]
+        );
+    }
 
     struct InvalidUtf8BoundaryDetector;
 

--- a/crates/pentect-core/src/pipeline/render.rs
+++ b/crates/pentect-core/src/pipeline/render.rs
@@ -1,6 +1,5 @@
 use crate::detect::EXPLICIT_SECRET_PREFIXES;
 use crate::model::*;
-use crate::normalize::n_id_cow;
 use crate::placeholder::{render_placeholder, IdentityHasher};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -208,10 +207,12 @@ fn masked_seg(
     let ph = match placeholder_cache.get(&cache_key) {
         Some(ph) => ph.clone(),
         None => {
-            let hash = hasher.hash(&n_id_cow(val));
-            let ph = render_placeholder(&span.label, &hash, len);
+            let hash = hasher.hash(val);
+            let mut ph = render_placeholder(&span.label, &hash, len);
             if record(map, &ph, val) {
                 collisions.push(ph.clone());
+                ph = render_placeholder(&span.label, &hasher.full_hash(val), len);
+                assert!(!record(map, &ph, val), "full HMAC placeholder collision");
             }
             placeholder_cache.insert(cache_key, ph.clone());
             ph
@@ -228,7 +229,7 @@ fn masked_seg(
 /// Insert a placeholder->value mapping. Returns true on collision: the
 /// placeholder already maps to a *different* value (same value is the expected
 /// identity case). On collision the first mapping is kept and restore would
-/// mis-expand the second, so the caller surfaces it rather than failing silently.
+/// mis-expand the second unless the caller switches it to the full HMAC handle.
 fn record(map: &mut HashMap<String, String>, ph: &str, val: &str) -> bool {
     match map.get(ph) {
         Some(existing) => existing != val,
@@ -250,6 +251,75 @@ mod tests {
         assert!(!record(&mut map, "<<X_aa>>", "alice")); // same value, identity
         assert!(record(&mut map, "<<X_aa>>", "bob")); // collision
         assert_eq!(map["<<X_aa>>"], "alice"); // first mapping kept
+    }
+
+    #[test]
+    fn truncated_collision_uses_an_unambiguous_full_hmac_placeholder() {
+        let hasher = IdentityHasher::new(&[3u8; 32]);
+        let span = Span {
+            range: ByteRange::new(0, 3),
+            category: Category::Secret,
+            label: "SECRET".into(),
+            confidence: Confidence::High,
+            source: DetectorId::Rule,
+        };
+        let short = render_placeholder("SECRET", &hasher.hash("bob"), None);
+        let mut map = HashMap::from([(short.clone(), "alice".to_string())]);
+        let mut cache = HashMap::new();
+        let mut collisions = Vec::new();
+
+        let segment = masked_seg(
+            &hasher,
+            &span,
+            "bob",
+            None,
+            &mut map,
+            &mut cache,
+            &mut collisions,
+        );
+
+        assert_ne!(segment.text(), short);
+        assert_eq!(segment.text().len(), "<<SECRET_>>".len() + 64);
+        assert_eq!(map[segment.text()], "bob");
+        assert_eq!(collisions, [short]);
+    }
+
+    #[test]
+    fn canonically_equivalent_raw_values_get_distinct_recovery_handles() {
+        let raw = "\u{00e9} e\u{0301}";
+        let spans = vec![
+            Span {
+                range: ByteRange::new(0, 2),
+                category: Category::Secret,
+                label: "SECRET".into(),
+                confidence: Confidence::High,
+                source: DetectorId::Rule,
+            },
+            Span {
+                range: ByteRange::new(3, raw.len()),
+                category: Category::Secret,
+                label: "SECRET".into(),
+                confidence: Confidence::High,
+                source: DetectorId::Rule,
+            },
+        ];
+
+        let key = [5u8; 32];
+        let rendered = render(raw, &key, spans, false);
+        let handles = rendered.map.keys().collect::<Vec<_>>();
+        assert_eq!(handles.len(), 2);
+        assert_ne!(handles[0], handles[1]);
+        assert!(rendered.map.values().any(|value| value == "\u{00e9}"));
+        assert!(rendered.map.values().any(|value| value == "e\u{0301}"));
+        assert!(rendered.collisions.is_empty());
+        assert_eq!(
+            crate::recovery::restore(
+                &rendered.masked,
+                &crate::recovery::Recovery::seal(rendered.map, &key),
+            )
+            .unwrap(),
+            raw
+        );
     }
 
     fn email_span(start: usize, end: usize) -> Span {

--- a/crates/pentect-core/src/placeholder.rs
+++ b/crates/pentect-core/src/placeholder.rs
@@ -12,10 +12,16 @@ impl IdentityHasher {
         Self(HmacSha256::new_from_slice(key).expect("HMAC accepts any key length"))
     }
 
-    pub(crate) fn hash(&self, n_id_value: &str) -> String {
+    pub(crate) fn hash(&self, value: &str) -> String {
         let mut mac = self.0.clone();
-        mac.update(n_id_value.as_bytes());
+        mac.update(value.as_bytes());
         encode_hash(mac.finalize().into_bytes().as_slice())
+    }
+
+    pub(crate) fn full_hash(&self, value: &str) -> String {
+        let mut mac = self.0.clone();
+        mac.update(value.as_bytes());
+        encode_full_hash(mac.finalize().into_bytes().as_slice())
     }
 }
 
@@ -56,13 +62,23 @@ impl LengthHint {
 
 /// Keyed so the cloud side cannot dictionary-attack low-entropy values such as
 /// emails, names, or "admin"; an unkeyed digest would be a reversible commitment.
-pub fn identity_hash(key: &[u8; 32], n_id_value: &str) -> String {
-    IdentityHasher::new(key).hash(n_id_value)
+pub fn identity_hash(key: &[u8; 32], value: &str) -> String {
+    IdentityHasher::new(key).hash(value)
 }
 
 fn encode_hash(out: &[u8]) -> String {
     let mut s = String::with_capacity(HASH_HEX_WIDTH);
     for b in out.iter().take(HASH_HEX_WIDTH / 2) {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+fn encode_full_hash(out: &[u8]) -> String {
+    let mut s = String::with_capacity(out.len() * 2);
+    for b in out {
         const HEX: &[u8; 16] = b"0123456789abcdef";
         s.push(HEX[(b >> 4) as usize] as char);
         s.push(HEX[(b & 0x0f) as usize] as char);
@@ -146,9 +162,9 @@ fn validate_label(label: &str) -> Result<(), String> {
 }
 
 fn validate_hash(hash: &str) -> Result<(), String> {
-    if hash.len() != HASH_HEX_WIDTH || !hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+    if !matches!(hash.len(), HASH_HEX_WIDTH | 64) || !hash.bytes().all(|b| b.is_ascii_hexdigit()) {
         return Err(format!(
-            "placeholder hash must be {HASH_HEX_WIDTH} lowercase hex chars"
+            "placeholder hash must be {HASH_HEX_WIDTH} or 64 lowercase hex chars"
         ));
     }
     if !hash
@@ -156,7 +172,7 @@ fn validate_hash(hash: &str) -> Result<(), String> {
         .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
     {
         return Err(format!(
-            "placeholder hash must be {HASH_HEX_WIDTH} lowercase hex chars"
+            "placeholder hash must be {HASH_HEX_WIDTH} or 64 lowercase hex chars"
         ));
     }
     Ok(())
@@ -178,6 +194,14 @@ mod tests {
         assert_eq!(identity_hash(&key, "alice"), identity_hash(&key, "alice"));
         assert_ne!(identity_hash(&key, "alice"), identity_hash(&key, "bob"));
         assert_eq!(identity_hash(&key, "alice").len(), HASH_HEX_WIDTH);
+    }
+
+    #[test]
+    fn ascii_identity_hash_vector_is_stable() {
+        assert_eq!(
+            identity_hash(&[7u8; 32], "ascii-secret"),
+            "81d9224f60a278d6"
+        );
     }
 
     #[test]
@@ -220,6 +244,15 @@ mod tests {
         assert_eq!(env.label, "TOKEN");
         assert_eq!(env.hash, "0123456789abcdef");
         assert_eq!(env.length_hint, Some(LengthHint::LegacyLen(24)));
+    }
+
+    #[test]
+    fn placeholder_parse_accepts_full_width_collision_handle() {
+        let hash = "a".repeat(64);
+        let handle = format!("<<SECRET_{hash}>>");
+        let parts = parse_placeholder(&handle).unwrap();
+        assert_eq!(parts.hash, hash);
+        assert_eq!(parts.handle, handle);
     }
 
     #[test]

--- a/website/src/content/docs/start/handles.md
+++ b/website/src/content/docs/start/handles.md
@@ -30,6 +30,11 @@ a general `SECRET` or `PII` label.
 The ID is a keyed hash. It is not a plain checksum of the value. The private
 identity key stays on the local device.
 
+IDs normally use 16 hexadecimal characters. If two different values ever
+produce the same short ID under the same label, Pentect keeps the first compact
+handle and gives the other value a 64-character full-width ID. This preserves
+exact recovery instead of publishing an ambiguous mapping.
+
 ## Force a value to become a handle
 
 Wrap a value in `pentect(...)` or its shorter alias `mask(...)` when it must be


### PR DESCRIPTION
Closes #316

- hash original UTF-8 bytes for recovery identity instead of NFC-normalized text
- preserve the existing ASCII hash vector
- safely disambiguate a real short-hash collision with a full-width HMAC handle
- teach parsing and idempotent placeholder freezing about full-width handles
- verify exact restoration of precomposed and decomposed Unicode values under the same label
- document the rare collision handle shape