### PR TITLE
Preserve OCR placeholder notes across HTTP image routes

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -1630,8 +1630,25 @@ fn mask_chat_value(
             crate::claude_http_proxy::mask_string(text, tool_result, masker)
         }
         serde_json::Value::Array(values) => {
-            for value in values {
-                mask_chat_value(value, tool_result, masker, files)?;
+            let original = std::mem::take(values);
+            for mut item in original {
+                let note = if item
+                    .get("type")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|kind| kind.to_ascii_lowercase().contains("image"))
+                {
+                    match item.as_object_mut() {
+                        Some(object) => inspect_chat_image(object, files)?,
+                        None => None,
+                    }
+                } else {
+                    mask_chat_value(&mut item, tool_result, masker, files)?;
+                    None
+                };
+                values.push(item);
+                if let Some(text) = note {
+                    values.push(serde_json::json!({"type": "text", "text": text}));
+                }
             }
             Ok(())
         }
@@ -1642,7 +1659,7 @@ fn mask_chat_value(
                 .unwrap_or_default()
                 .to_ascii_lowercase();
             if kind.contains("image") {
-                inspect_chat_image(object, files)?;
+                let _ = inspect_chat_image(object, files)?;
                 return Ok(());
             }
             if kind.contains("file") || kind.contains("document") || looks_like_chat_file(object) {
@@ -1671,13 +1688,13 @@ fn mask_chat_value(
 fn inspect_chat_image(
     object: &mut serde_json::Map<String, serde_json::Value>,
     files: &HashMap<String, crate::http_files::Coverage>,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     if chat_file_reference(object)
         .and_then(|id| files.get(id))
         .copied()
         == Some(crate::http_files::Coverage::Full)
     {
-        return Ok(());
+        return Ok(None);
     }
     if let Some(source) = object
         .get_mut("source")
@@ -1690,35 +1707,37 @@ fn inspect_chat_image(
                 .is_some_and(|media_type| media_type.starts_with("image/"))
         {
             let Some(serde_json::Value::String(encoded)) = source.get_mut("data") else {
-                return unscanned_chat_image();
+                return unscanned_chat_image().map(|_| None);
             };
             if let Some(protected) = crate::claude_http_proxy::redact_inline_image_data(encoded)? {
-                *encoded = protected;
+                *encoded = protected.data;
                 source.insert(
                     "media_type".to_string(),
                     serde_json::Value::String("image/png".to_string()),
                 );
+                return Ok(Some(protected.note));
             }
-            return Ok(());
+            return Ok(None);
         }
-        return unscanned_chat_image();
+        return unscanned_chat_image().map(|_| None);
     }
     let key = ["image_url", "url", "data"]
         .into_iter()
         .find(|key| object.contains_key(*key));
     let Some(serde_json::Value::String(url)) = key.and_then(|key| object.get_mut(key)) else {
-        return unscanned_chat_image();
+        return unscanned_chat_image().map(|_| None);
     };
     let Some((metadata, encoded)) = url.split_once(',') else {
-        return unscanned_chat_image();
+        return unscanned_chat_image().map(|_| None);
     };
     if !metadata.starts_with("data:image/") || !metadata.ends_with(";base64") {
-        return unscanned_chat_image();
+        return unscanned_chat_image().map(|_| None);
     }
     if let Some(protected) = crate::claude_http_proxy::redact_inline_image_data(encoded)? {
-        *url = format!("data:image/png;base64,{protected}");
+        *url = format!("data:image/png;base64,{}", protected.data);
+        return Ok(Some(protected.note));
     }
-    Ok(())
+    Ok(None)
 }
 
 fn inspect_chat_document(

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1538,15 +1538,21 @@ fn redact_content_images(
     let Value::Array(blocks) = content else {
         return Ok(());
     };
-    for block in blocks {
-        match block.get("type").and_then(Value::as_str) {
-            Some("image") => redact_base64_image_block(block, files)?,
+    let original = std::mem::take(blocks);
+    for mut block in original {
+        let note = match block.get("type").and_then(Value::as_str) {
+            Some("image") => redact_base64_image_block(&mut block, files)?,
             Some("tool_result") => {
                 if let Some(nested) = block.get_mut("content") {
                     redact_content_images(nested, files)?;
                 }
+                None
             }
-            _ => {}
+            _ => None,
+        };
+        blocks.push(block);
+        if let Some(text) = note {
+            blocks.push(serde_json::json!({"type": "text", "text": text}));
         }
     }
     Ok(())
@@ -1555,12 +1561,12 @@ fn redact_content_images(
 fn redact_base64_image_block(
     block: &mut Value,
     files: &HashMap<String, crate::http_files::Coverage>,
-) -> Result<(), String> {
-    let block_unscanned = || -> Result<(), String> {
+) -> Result<Option<String>, String> {
+    let block_unscanned = || -> Result<Option<String>, String> {
         if pentect_agent::unscanned_images_should_block()? {
             Err("image blocked: image source could not be scanned".to_string())
         } else {
-            Ok(())
+            Ok(None)
         }
     };
     let Some(source) = block.get_mut("source") else {
@@ -1575,7 +1581,7 @@ fn redact_base64_image_block(
                 .and_then(Value::as_str)
                 .is_some_and(|id| files.get(id) == Some(&crate::http_files::Coverage::Full)) =>
         {
-            return Ok(());
+            return Ok(None);
         }
         // URL sources have already been replaced by the constrained remote
         // fetcher. Unknown Files API references follow the media policy.
@@ -1591,14 +1597,21 @@ fn redact_base64_image_block(
         // A successfully scanned image with no detected secret is unchanged.
         // The runtime returns an error for unscannable images when policy is
         // block, so `None` here is the clean-image result.
-        return Ok(());
+        return Ok(None);
     };
-    source["data"] = Value::String(protected);
+    source["data"] = Value::String(protected.data);
     source["media_type"] = Value::String("image/png".to_string());
-    Ok(())
+    Ok(Some(protected.note))
 }
 
-pub(crate) fn redact_inline_image_data(encoded: &str) -> Result<Option<String>, String> {
+pub(crate) struct ProtectedInlineImage {
+    pub(crate) data: String,
+    pub(crate) note: String,
+}
+
+pub(crate) fn redact_inline_image_data(
+    encoded: &str,
+) -> Result<Option<ProtectedInlineImage>, String> {
     let mut bytes = match data_encoding::BASE64.decode(encoded.as_bytes()) {
         Ok(bytes) => bytes,
         Err(_) => {
@@ -1614,9 +1627,12 @@ pub(crate) fn redact_inline_image_data(encoded: &str) -> Result<Option<String>, 
     let Some(mut redacted) = redacted? else {
         return Ok(None);
     };
-    let protected = data_encoding::BASE64.encode(&redacted);
-    redacted.zeroize();
-    Ok(Some(protected))
+    let protected = data_encoding::BASE64.encode(&redacted.bytes);
+    redacted.bytes.zeroize();
+    Ok(Some(ProtectedInlineImage {
+        data: protected,
+        note: redacted.note,
+    }))
 }
 
 fn mask_content(

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -695,8 +695,13 @@ pub(crate) fn mask_content(
         .ok_or_else(|| {
             "unknown format blocked: Google Cloud Code content.parts must be an array".to_string()
         })?;
-    for part in parts {
-        mask_part(part, tool_result, masker, block_unknown_formats)?;
+    let original = std::mem::take(parts);
+    for mut part in original {
+        let note = mask_part(&mut part, tool_result, masker, block_unknown_formats)?;
+        parts.push(part);
+        if let Some(text) = note {
+            parts.push(serde_json::json!({"text": text}));
+        }
     }
     Ok(())
 }
@@ -706,7 +711,7 @@ fn mask_part(
     tool_result: bool,
     masker: &mut pentect_agent::ActiveToolOutputMasker,
     block_unknown_formats: bool,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let object = part.as_object_mut().ok_or_else(|| {
         "unknown format blocked: Google Cloud Code part must be an object".to_string()
     })?;
@@ -750,9 +755,11 @@ fn mask_part(
     if let Some(response) = object.get_mut("functionResponse") {
         mask_value_strings(response, true, masker)?;
     }
-    if let Some(inline) = object.get_mut("inlineData") {
-        inspect_inline_data(inline, tool_result, masker)?;
-    }
+    let note = object
+        .get_mut("inlineData")
+        .map(|inline| inspect_inline_data(inline, tool_result, masker))
+        .transpose()?
+        .flatten();
     if object.contains_key("fileData") && pentect_agent::unscanned_images_should_block()? {
         return Err(
             "document blocked: Google Cloud Code fileData could not be scanned".to_string(),
@@ -764,7 +771,7 @@ fn mask_part(
     if let Some(result) = object.get_mut("codeExecutionResult") {
         mask_value_strings(result, true, masker)?;
     }
-    Ok(())
+    Ok(note)
 }
 
 fn mask_value_strings(
@@ -794,7 +801,7 @@ fn inspect_inline_data(
     value: &mut Value,
     tool_result: bool,
     masker: &mut pentect_agent::ActiveToolOutputMasker,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let object = value
         .as_object_mut()
         .ok_or_else(|| "unknown format blocked: inlineData must be an object".to_string())?;
@@ -813,14 +820,15 @@ fn inspect_inline_data(
     };
     if media_type.starts_with("image/") {
         if let Some(protected) = crate::claude_http_proxy::redact_inline_image_data(&data)? {
-            object.insert("data".to_string(), Value::String(protected));
+            object.insert("data".to_string(), Value::String(protected.data));
             object.insert(
                 "mimeType".to_string(),
                 Value::String("image/png".to_string()),
             );
             object.remove("mime_type");
+            return Ok(Some(protected.note));
         }
-        return Ok(());
+        return Ok(None);
     }
     if media_type.starts_with("text/") || media_type == "application/json" {
         let mut decoded = data_encoding::BASE64
@@ -836,9 +844,9 @@ fn inspect_inline_data(
             Value::String(data_encoding::BASE64.encode(protected.as_bytes())),
         );
         protected.zeroize();
-        return Ok(());
+        return Ok(None);
     }
-    crate::claude_http_proxy::enforce_unscanned_document_policy()
+    crate::claude_http_proxy::enforce_unscanned_document_policy().map(|_| None)
 }
 
 fn inject_handle_contract(value: &mut Value) -> Result<(), String> {

--- a/crates/pentect-cli/src/http_files.rs
+++ b/crates/pentect-cli/src/http_files.rs
@@ -181,8 +181,8 @@ pub(crate) fn protect_multipart_upload_with_plugins(
             } else if file.is_supported_image {
                 let protected = pentect_agent::redact_image_bytes_into_active_memory_store(content)
                     .map_err(|error| format!("file upload blocked: {error}"))?;
-                if let Some(protected) = protected {
-                    let media_type = image_media_type(&protected).ok_or_else(|| {
+                if let Some(mut protected) = protected {
+                    let media_type = image_media_type(&protected.bytes).ok_or_else(|| {
                         "file upload blocked: protected image has an unknown format".to_string()
                     })?;
                     output.extend_from_slice(
@@ -191,7 +191,11 @@ pub(crate) fn protect_multipart_upload_with_plugins(
                         })?,
                     );
                     output.extend_from_slice(body_separator);
-                    extend_protected_output(&mut output, &protected)?;
+                    extend_protected_output(&mut output, &protected.bytes)?;
+                    protected.bytes.zeroize();
+                    // A Files API upload has no adjacent model-visible text
+                    // block in which to carry the opaque handles.
+                    coverage = Coverage::Partial;
                 } else {
                     output.extend_from_slice(headers);
                     output.extend_from_slice(body_separator);

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -1652,13 +1652,14 @@ fn mask_chat_content(
         Value::String(text) => mask_text(text, tool_result, masker),
         Value::Null => Ok(()),
         Value::Array(parts) => {
-            for part in parts {
+            let original = std::mem::take(parts);
+            for mut part in original {
                 let Some(object) = part.as_object_mut() else {
                     return Err(
                         "OpenAI Chat Completions content part must be an object".to_string()
                     );
                 };
-                match object
+                let note = match object
                     .get("type")
                     .and_then(Value::as_str)
                     .unwrap_or_default()
@@ -1667,6 +1668,7 @@ fn mask_chat_content(
                         if let Some(Value::String(text)) = object.get_mut("text") {
                             mask_text(text, tool_result, masker)?;
                         }
+                        None
                     }
                     "image_url" => inspect_chat_image(object)?,
                     "input_image" => inspect_openai_image(object)?,
@@ -1676,13 +1678,19 @@ fn mask_chat_content(
                             return Err("OpenAI Chat Completions file part is invalid".to_string());
                         };
                         inspect_openai_file(file, tool_result, masker, files)?;
+                        None
                     }
                     "refusal" => {
                         if let Some(Value::String(text)) = object.get_mut("refusal") {
                             mask_text(text, tool_result, masker)?;
                         }
+                        None
                     }
-                    _ => {}
+                    _ => None,
+                };
+                parts.push(part);
+                if let Some(text) = note {
+                    parts.push(serde_json::json!({"type": "text", "text": text}));
                 }
             }
             Ok(())
@@ -1691,23 +1699,26 @@ fn mask_chat_content(
     }
 }
 
-fn inspect_chat_image(object: &mut serde_json::Map<String, Value>) -> Result<(), String> {
+fn inspect_chat_image(
+    object: &mut serde_json::Map<String, Value>,
+) -> Result<Option<String>, String> {
     let Some(image) = object.get_mut("image_url").and_then(Value::as_object_mut) else {
-        return unscanned_image_policy();
+        return unscanned_image_policy().map(|_| None);
     };
     let Some(Value::String(url)) = image.get_mut("url") else {
-        return unscanned_image_policy();
+        return unscanned_image_policy().map(|_| None);
     };
     let Some((metadata, encoded)) = url.split_once(',') else {
-        return unscanned_image_policy();
+        return unscanned_image_policy().map(|_| None);
     };
     if !metadata.starts_with("data:image/") || !metadata.ends_with(";base64") {
-        return unscanned_image_policy();
+        return unscanned_image_policy().map(|_| None);
     }
     if let Some(protected) = crate::claude_http_proxy::redact_inline_image_data(encoded)? {
-        *url = format!("data:image/png;base64,{protected}");
+        *url = format!("data:image/png;base64,{}", protected.data);
+        return Ok(Some(protected.note));
     }
-    Ok(())
+    Ok(None)
 }
 
 fn mask_openai_input(
@@ -1719,8 +1730,21 @@ fn mask_openai_input(
     match value {
         Value::String(text) => mask_text(text, tool_result, masker),
         Value::Array(items) => {
-            for item in items {
-                mask_openai_input(item, tool_result, masker, files)?;
+            let original = std::mem::take(items);
+            for mut item in original {
+                let note = if item.get("type").and_then(Value::as_str) == Some("input_image") {
+                    match item.as_object_mut() {
+                        Some(object) => inspect_openai_image(object)?,
+                        None => None,
+                    }
+                } else {
+                    mask_openai_input(&mut item, tool_result, masker, files)?;
+                    None
+                };
+                items.push(item);
+                if let Some(text) = note {
+                    items.push(serde_json::json!({"type": "input_text", "text": text}));
+                }
             }
             Ok(())
         }
@@ -1741,7 +1765,9 @@ fn mask_openai_input(
                         mask_text(text, tool_result, masker)?;
                     }
                 }
-                "input_image" => inspect_openai_image(object)?,
+                "input_image" => {
+                    let _ = inspect_openai_image(object)?;
+                }
                 "input_file" => inspect_openai_file(object, tool_result, masker, files)?,
                 "message" => {
                     let external_content =
@@ -1764,20 +1790,23 @@ fn mask_openai_input(
     }
 }
 
-fn inspect_openai_image(object: &mut serde_json::Map<String, Value>) -> Result<(), String> {
+fn inspect_openai_image(
+    object: &mut serde_json::Map<String, Value>,
+) -> Result<Option<String>, String> {
     let Some(Value::String(url)) = object.get_mut("image_url") else {
-        return unscanned_image_policy();
+        return unscanned_image_policy().map(|_| None);
     };
     let Some((metadata, encoded)) = url.split_once(',') else {
-        return unscanned_image_policy();
+        return unscanned_image_policy().map(|_| None);
     };
     if !metadata.starts_with("data:image/") || !metadata.ends_with(";base64") {
-        return unscanned_image_policy();
+        return unscanned_image_policy().map(|_| None);
     }
     if let Some(protected) = crate::claude_http_proxy::redact_inline_image_data(encoded)? {
-        *url = format!("data:image/png;base64,{protected}");
+        *url = format!("data:image/png;base64,{}", protected.data);
+        return Ok(Some(protected.note));
     }
-    Ok(())
+    Ok(None)
 }
 
 fn inspect_openai_file(

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -320,9 +320,16 @@ pub fn unscanned_images_should_block() -> Result<bool, String> {
     ))
 }
 
+/// Protected image bytes and the model-safe explanation that must accompany
+/// them. The note contains opaque handles only; OCR plaintext is never copied.
+pub struct ProtectedImage {
+    pub bytes: Vec<u8>,
+    pub note: String,
+}
+
 pub fn redact_image_bytes_into_active_memory_store(
     bytes: &[u8],
-) -> Result<Option<Vec<u8>>, String> {
+) -> Result<Option<ProtectedImage>, String> {
     let mut encoded = data_encoding::BASE64.encode(bytes);
     let mut value = Value::String(format!("data:image/png;base64,{encoded}"));
     encoded.zeroize();
@@ -339,8 +346,25 @@ pub fn redact_image_bytes_into_active_memory_store(
     let decoded = data_encoding::BASE64
         .decode(payload.as_bytes())
         .map_err(|_| "protected image payload is invalid".to_string());
+    let note = first_image_mask_note(&updated)
+        .ok_or_else(|| "protected image annotation is missing".to_string())?
+        .to_string();
     zeroize_value_strings(&mut updated);
-    decoded.map(Some)
+    decoded.map(|bytes| Some(ProtectedImage { bytes, note }))
+}
+
+fn first_image_mask_note(value: &Value) -> Option<&str> {
+    match value {
+        Value::String(text)
+            if text.starts_with("Pentect masked sensitive information")
+                || text.starts_with("Pentect removed sensitive metadata") =>
+        {
+            Some(text)
+        }
+        Value::Array(values) => values.iter().find_map(first_image_mask_note),
+        Value::Object(object) => object.values().find_map(first_image_mask_note),
+        _ => None,
+    }
 }
 
 fn first_image_data_url(value: &Value) -> Option<&str> {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1096,6 +1096,34 @@ fn ocr_off_obeys_block_policy_for_active_image_redaction() {
     assert!(unscanned_images_should_block().unwrap());
 }
 
+#[cfg(feature = "ocr")]
+#[test]
+fn active_image_byte_redaction_returns_opaque_annotation_without_plaintext() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("active-image-byte-annotation");
+    write_project_config(&root, "[image]\nocr = \"on\"\nunscanned = \"block\"\n");
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-image-byte-store");
+    let _cwd = enter_temp_cwd(&root);
+    let raw = "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+
+    let protected = redact_image_bytes_into_active_memory_store(&qr_png(raw))
+        .unwrap()
+        .expect("secret image should be redacted");
+
+    assert!(!protected.bytes.is_empty());
+    assert!(
+        protected.note.contains("Masked regions:"),
+        "{}",
+        protected.note
+    );
+    assert!(
+        protected.note.contains("<<OPENAI_API_KEY_"),
+        "{}",
+        protected.note
+    );
+    assert!(!protected.note.contains(raw), "{}", protected.note);
+}
+
 #[test]
 fn exec_capability_env_does_not_shadow_parent_environment() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();

--- a/website/src/content/docs/protection/files-and-images.md
+++ b/website/src/content/docs/protection/files-and-images.md
@@ -11,7 +11,8 @@ because text handles cannot replace pixels.
 | --- | --- | --- |
 | UTF-8 text | Detect and replace | Text with handles |
 | Supported PDF | Read and check supported content | Protected document content |
-| Supported image | Local OCR and visual masking | Masked pixels |
+| Supported inline image | Local OCR and visual masking | Masked pixels and an adjacent handle note |
+| Supported Files API image upload | Local OCR and visual masking | Masked pixels; `partial` coverage when handles cannot be attached |
 | Unknown binary | Block | Nothing |
 | File ID or remote file that Pentect cannot check | Use the unscanned setting | Nothing when set to `block` |
 
@@ -31,6 +32,9 @@ validates UTF-8 before rewriting the body.
 
 Supported upload images are PNG, JPEG, WebP, GIF, and BMP. When masking is
 needed, Pentect safely regenerates the image and updates its media type.
+Because a standalone Files API upload has no adjacent model-visible text slot,
+Pentect reports partial coverage when the protected image has recoverable
+handles. Inline image requests carry those handles in an adjacent text part.
 
 Pentect checks an upload before sending it. A later request can use its file ID
 only when Pentect knows the content behind that ID. A provider file ID alone


### PR DESCRIPTION
Closes #345

## Summary
- return protected image bytes together with model-safe OCR handle annotations
- attach annotations beside inline images for Anthropic, OpenAI, Claude App, and Cloud Code request shapes
- mark standalone protected Files API image uploads as partial when no model-visible note slot exists
- document the inline/upload distinction and add a real QR OCR regression test

## Local verification
- `cargo test -p pentect-cli`
- `cargo test -p pentect-runtime --features ocr active_image_byte_redaction_returns_opaque_annotation_without_plaintext`
- `cargo clippy -p pentect-runtime -p pentect-cli --all-targets -- -D warnings`
- `npm --prefix website run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redacted images now include explanatory notes describing masked content.
  - Notes are preserved across supported chat, response, and content-part workflows.
  - File-upload image protection now clearly indicates partial coverage where applicable.

- **Bug Fixes**
  - Improved handling of redacted image payloads and protected image data.
  - Preserved existing behavior for unsupported, malformed, and unscannable images.

- **Documentation**
  - Clarified protection behavior for inline images versus uploaded image files.

- **Tests**
  - Added coverage confirming protected image data and safe masking annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->