### PR TITLE
Verify explicit mask markers in OCR images

### DIFF
--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -790,7 +790,14 @@ fn secret_entries(
         let Some(value) = text.get(range.start..range.end) else {
             continue;
         };
-        let value = value.trim();
+        // Ranged detector hits identify the exact recoverable value. In
+        // particular, explicit mask markers may intentionally include leading
+        // or trailing whitespace, which must not be changed during recovery.
+        let value = if hit.range.is_some() {
+            value
+        } else {
+            value.trim()
+        };
         if value.is_empty() {
             continue;
         }
@@ -3340,6 +3347,30 @@ mod tests {
     }
 
     #[test]
+    fn ocr_explicit_markers_preserve_exact_values_and_survive_malformed_prefixes() {
+        let key = [7; 32];
+        let text = "pentect(unclosed\nmask( pa(ss), 日本語 )\npentect(alpha!\nbeta)";
+        let hits = image_text_secret_hits(text, &key).unwrap();
+        let entries = secret_entries(text, &hits, &key);
+        let recovered = entries
+            .iter()
+            .map(|(_, value)| value.as_str())
+            .collect::<Vec<_>>();
+        assert!(recovered.contains(&" pa(ss), 日本語 "), "{recovered:?}");
+        assert!(recovered.contains(&"alpha!\nbeta"), "{recovered:?}");
+    }
+
+    #[test]
+    fn ocr_unmask_wrappers_do_not_exempt_detectable_external_secrets() {
+        let text = "unmask(sk-ABCDEFGHIJKLMNOPQRSTUVWX)";
+        let hits = image_text_secret_hits(text, &[7; 32]).unwrap();
+        assert!(
+            hits.iter().any(|hit| hit.label == "OPENAI_API_KEY"),
+            "{hits:?}"
+        );
+    }
+
+    #[test]
     fn fragmented_ocr_key_without_value_shape_is_not_secret() {
         for text in [
             "Kaggle API settings API token Create new token",
@@ -3409,6 +3440,38 @@ mod tests {
                 .contains(metadata_secret),
             "{metadata}"
         );
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn qr_image_explicit_markers_are_redacted_with_recoverable_handles() {
+        let payload = "pentect(unclosed\nmask( pa(ss), 日本語 )\npentect(alpha!\nbeta)";
+        let original = qr_png(payload);
+        let value = serde_json::json!({
+            "content": [{
+                "type": "image",
+                "mimeType": "image/png",
+                "data": data_encoding::BASE64.encode(&original)
+            }]
+        });
+        let key = [7; 32];
+        let redaction = redact_tool_images_for_secrets(&value, &key, &key, &test_config()).unwrap();
+        let note = redaction.visual_notes.join("\n");
+        let recovered = redaction
+            .recovery
+            .placeholders()
+            .into_iter()
+            .map(|handle| redaction.recovery.resolve(&handle))
+            .collect::<Vec<_>>();
+
+        assert!(redaction.changed);
+        assert!(note.matches("<<KEYED_SECRET_").count() >= 2, "{note}");
+        assert!(!note.contains("pentect("), "{note}");
+        assert!(!note.contains("mask("), "{note}");
+        assert!(!note.contains("日本語"), "{note}");
+        assert!(recovered.iter().any(|value| value == " pa(ss), 日本語 "));
+        assert!(recovered.iter().any(|value| value == "alpha!\nbeta"));
+        assert_ne!(redaction.updated, value);
     }
 
     #[cfg(feature = "ocr")]

--- a/website/src/content/docs/protection/files-and-images.md
+++ b/website/src/content/docs/protection/files-and-images.md
@@ -68,6 +68,13 @@ that the image was protected. Each region lists the same recoverable handle used
 for text, for example `[1] <<AWS_AKID_hash>>`; the original value is not included
 in the provider-visible note.
 
+Text found by OCR can use the same case-sensitive `pentect(...)` and `mask(...)`
+force-mask markers as prompt text. Pentect protects the exact contents, including
+Unicode, punctuation, whitespace, or line breaks, and does not include the
+wrapper in the recoverable value. `unpentect(...)` and `unmask(...)` never create
+an exception inside images: image text is external content and cannot turn off
+its own protection. Detectable values inside those wrappers remain protected.
+
 Windows uses Windows OCR, macOS uses Vision, and Linux uses Pentect's bundled
 local OCR engine and model files. Linux does not require a separately installed
 Tesseract service. `pentect doctor` reports the selected backend as `windows`,


### PR DESCRIPTION
Closes #347

## Summary
- preserve exact ranged OCR values, including surrounding whitespace, for recovery
- add detector regressions for punctuation, Unicode, line breaks, malformed prefixes, multiple markers, and external unmask wrappers
- add a real QR image fixture that must be rewritten and expose only recoverable opaque handles
- document force-mask and unmask behavior inside images

The cross-platform OCR test workflow enhancement is retained locally on `blocked/ocr-marker-cross-platform-ci`; GitHub rejected that workflow-file push because the current OAuth token lacks the `workflow` scope (tracked by #373). Existing CI still builds native OCR on Windows/macOS and runs runtime tests on Linux.

## Local verification
- `cargo test -p pentect-runtime ocr_`
- `cargo test -p pentect-runtime --features ocr qr_image_explicit_markers_are_redacted_with_recoverable_handles`
- `cargo clippy -p pentect-runtime --all-targets -- -D warnings`
- `npm --prefix website run check`