### PR TITLE
Report incompatible Claude Desktop certificate-pin rejection

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -11,7 +11,7 @@ through the release binary:
 | OpenCode `1.18.16` | automated on Linux | `pentect opencode` |
 | Pi `0.84.1` | launcher and published extension discovery | `pentect pi` or `@pentect/pi` |
 | ChatGPT desktop app (Codex mode) | launcher and Responses protocol tests | `pentect codex app` |
-| Claude Desktop (supported Chat, attachment, and Claude Code routes) | launcher and protocol tests | `pentect claude app` |
+| Claude Desktop | protocol tests; signed app `1.24012.9` was manually launch-tested, while `1.34493.1` is known incompatible | `pentect claude app` only on an explicitly compatible build |
 
 The CLI gate proves that the vendor executable still starts under Pentect.
 Mock protocol tests cover text, streaming responses, completed tool calls,
@@ -34,6 +34,15 @@ The v0.0.23 release binary was exercised on Windows on 2026-08-03 UTC
 | Claude Code | `2.1.220` | A later PowerShell tool call using the opaque value was restored locally to the exact synthetic value; final output did not contain it. |
 | ChatGPT desktop app (Codex mode) | `26.721.4979.0` | v0.0.23 installation, running-process detection, and protected Responses routing preflight passed. No signed-GUI message was sent. |
 | Claude Desktop | `1.24012.9` | The signed app launched through v0.0.23 with the local proxy, certificate pin, and memory store attached. No signed-GUI message was sent. |
+
+Claude Desktop `1.34493.1` on Windows was tested on 2026-08-24 and deliberately
+refused Pentect's required `--ignore-certificate-errors-spki-list` switch. The
+proxy switch alone is accepted, but Pentect does not disable certificate
+verification or install its ephemeral CA into the system trust store. That
+build is therefore incompatible with `pentect claude app`; updating is not a
+remedy. Use `pentect claude` for Claude Code. The exact first incompatible
+Claude Desktop version is not known, so `1.24012.9` is an observed compatible
+point, not a claimed version ceiling.
 
 The CLI probe compares the final local file with the original synthetic value
 without printing the value and deletes its temporary files. It covers a real

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -45,8 +45,7 @@ const MAX_CERTIFICATE_CACHE_ENTRIES: usize = 64;
 const MAX_CHAT_BODY_BYTES: usize = 32 * 1024 * 1024;
 const MAX_PENDING_UPLOADS: usize = 256;
 const MAX_IDS_PER_UPLOAD: usize = 16;
-#[cfg(windows)]
-const PACKAGED_APP_STARTUP_GRACE: Duration = Duration::from_secs(2);
+const APP_STARTUP_GRACE: Duration = Duration::from_secs(2);
 
 pub(crate) fn cmd_claude_app(args: &[String]) -> i32 {
     match run_claude_app(args) {
@@ -77,7 +76,10 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
                 "no"
             }
         );
-        println!("Protection: Claude Chat, attachments, and Anthropic Messages APIs");
+        println!("Protection: supported Claude Desktop Chat and attachment routes");
+        println!(
+            "Compatibility: the app must accept Pentect's required certificate-pin switch; Claude Desktop 1.34493.1 is known incompatible"
+        );
         let upstream = options
             .upstream
             .as_deref()
@@ -130,11 +132,9 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
                 "could not install Claude Desktop shutdown handler: {error}"
             ));
         }
-        thread::sleep(PACKAGED_APP_STARTUP_GRACE);
+        thread::sleep(APP_STARTUP_GRACE);
         if let Some(status) = process.try_wait()? {
-            return Err(format!(
-                "Claude Desktop package exited before protection attached ({status}); update Claude Desktop or pass --app PATH to a non-MSIX installation"
-            ));
+            return Err(claude_desktop_early_exit_error(status, true));
         }
         print_gateway_ready(&proxy);
         let status = process.wait()?;
@@ -156,7 +156,6 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         .spawn()
         .map_err(|error| format!("could not start Claude Desktop: {error}"))?;
     let child_id = child.id();
-    print_gateway_ready(&proxy);
     if let Err(error) = ctrlc::set_handler(move || {
         terminate_child_process(child_id);
         std::process::exit(130);
@@ -167,12 +166,27 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
             "could not install Claude Desktop shutdown handler: {error}"
         ));
     }
+    thread::sleep(APP_STARTUP_GRACE);
+    if let Some(status) = child
+        .try_wait()
+        .map_err(|error| format!("could not inspect Claude Desktop startup: {error}"))?
+    {
+        return Err(claude_desktop_early_exit_error(status, false));
+    }
+    print_gateway_ready(&proxy);
     let status = child
         .wait()
         .map_err(|error| format!("could not wait for Claude Desktop: {error}"))?;
     drop(proxy);
     drop(anthropic);
     Ok(status)
+}
+
+fn claude_desktop_early_exit_error(status: impl std::fmt::Display, packaged: bool) -> String {
+    let installation = if packaged { " package" } else { "" };
+    format!(
+        "Claude Desktop{installation} exited while Pentect was attaching its required local-proxy certificate pin ({status}). Claude Desktop 1.34493.1 is known to reject this Chromium switch. Pentect will not bypass certificate verification or install a system CA, so this app build cannot be protected; use `pentect claude` for Claude Code or a Claude Desktop build explicitly listed as compatible"
+    )
 }
 
 fn claude_chromium_arguments(proxy: &ClaudeAppProxyGuard, user_data_dir: &Path) -> Vec<String> {
@@ -192,7 +206,7 @@ fn print_gateway_ready(proxy: &ClaudeAppProxyGuard) {
         proxy.proxy_url()
     );
     eprintln!(
-        "[pentect] Chat, supported attachments, and Claude Code model traffic are protected; bodies are not logged"
+        "[pentect] Supported Claude Desktop Chat and attachment traffic is protected; bodies are not logged"
     );
 }
 
@@ -2508,6 +2522,21 @@ fn success_status() -> std::process::ExitStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn early_exit_diagnostic_does_not_recommend_an_update_or_unsafe_bypass() {
+        for packaged in [false, true] {
+            let error = claude_desktop_early_exit_error("exit code: 1", packaged);
+            assert!(
+                error.contains("required local-proxy certificate pin"),
+                "{error}"
+            );
+            assert!(error.contains("1.34493.1 is known to reject"), "{error}");
+            assert!(error.contains("cannot be protected"), "{error}");
+            assert!(error.contains("`pentect claude`"), "{error}");
+            assert!(!error.contains("update Claude Desktop"), "{error}");
+        }
+    }
 
     struct MaskingTestEnv {
         _guard: crate::EnvVarGuard,

--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -62,9 +62,10 @@ pentect claude --permission-mode plan
 
 ## Protected flow
 
-Pentect checks supported Chat, attachment, and Claude Code requests before they
-reach the selected provider. Local tool calls can use handles without showing
-the real values to the model.
+`pentect claude` checks supported Claude Code requests before they reach the
+selected provider. On an explicitly compatible Desktop build,
+`pentect claude app` checks the supported Chat and attachment routes. Local tool
+calls can use handles without showing the real values to the model.
 
 Pentect adds short session instructions that explain handle use and local
 environment bindings. The instructions contain labels and syntax, not real
@@ -89,6 +90,16 @@ See [Custom upstreams](/clients/upstreams/) for compatible gateway setup,
 credentials, and troubleshooting.
 
 ## Claude Desktop
+
+::: danger
+Claude Desktop `1.34493.1` on Windows rejects the certificate-pin switch that
+Pentect requires for its ephemeral local CA, so that build cannot be protected
+with `pentect claude app`. Pentect will not bypass certificate verification or
+install a system CA. Version `1.24012.9` is an older observed-compatible point,
+not a guaranteed version ceiling. Use `pentect claude` for Claude Code and see
+the [compatibility matrix](/reference/compatibility/#desktop-testing) before
+using Desktop mode.
+:::
 
 Desktop protection affects only the launch started by Pentect. Test app
 discovery first. If Pentect cannot find the app, pass its path:

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -15,7 +15,7 @@ drift is visible before the next release.
 | OpenCode `1.18.20` | Real launch on Linux and all installer platforms | `pentect opencode` |
 | Pi `0.84.2` | Real launch, npm extension, and provider discovery | `pentect pi` or `@pentect/pi` |
 | ChatGPT desktop app, Codex mode | Executable launch contract and Responses protocol tests | `pentect codex app` |
-| Claude Desktop, supported Chat, attachment, and Code routes | Executable launch contract and protocol tests | `pentect claude app` |
+| Claude Desktop | Protocol tests; `1.24012.9` was manually launch-tested, while `1.34493.1` is known incompatible | `pentect claude app` only on an explicitly compatible build |
 
 ## Not implemented
 
@@ -46,7 +46,7 @@ links, broken data, custom gateway paths, and Codex zstd-compressed requests.
 | `pentect codex` | OpenAI Responses | Includes streaming events and completed tool calls |
 | `pentect claude` | Anthropic Messages | Includes streaming content blocks and tool use |
 | `pentect codex app` | Responses routes used by supported Codex mode | Other ChatGPT modes are outside this claim |
-| `pentect claude app` | Supported Claude Chat, attachment, and Code routes | Cowork and Voice are outside this claim |
+| `pentect claude app` | Supported Claude Chat and attachment routes on a compatible app build | Claude Code should use `pentect claude`; Cowork and Voice are outside this claim |
 
 “Supported” means Pentect recognizes and checks the route and content shapes
 documented here. “Tested” means the release suite exercised them with fake
@@ -87,8 +87,17 @@ that local handles are not printed.
 | Desktop surface | Current scope |
 | --- | --- |
 | Codex App | Supported Codex mode using the Responses protocol |
-| Claude Desktop | Supported Chat, attachment, and Code routes |
+| Claude Desktop | Protocol support exists, but current build compatibility is restricted as described below |
 | Other app modes | Not claimed unless listed here |
+
+Claude Desktop `1.34493.1` on Windows deliberately rejects the Chromium
+certificate-pin switch required by Pentect's ephemeral local CA. Pentect does
+not weaken certificate verification or install that CA into the system trust
+store, so this build cannot use `pentect claude app`. Claude Desktop
+`1.24012.9` is an observed compatible point from a manual smoke test, not a
+guaranteed version range. Do not update or downgrade solely from an inferred
+range; check this page for an explicitly tested build. Use `pentect claude` for
+Claude Code.
 
 ## Not covered
 


### PR DESCRIPTION
Closes #385.

- detect early exits before claiming that the Claude Desktop gateway is ready on packaged and direct launches
- replace the incorrect update/non-MSIX advice with the observed certificate-pin incompatibility and a safe Claude Code alternative
- keep certificate verification intact and avoid installing a system CA
- correct CLI and documentation claims for Desktop Chat/attachment versus Claude Code routes
- document the observed compatible 1.24012.9 point and known-incompatible 1.34493.1 point without inventing a version ceiling

Verification:
- cargo test -p pentect-cli claude_app_proxy::tests (19 passed)
- cargo clippy -p pentect-cli --all-targets -- -D warnings
- npm --prefix website run check (41 pages, 110 links)
- git diff --check