### PR TITLE
Restore known assistant-output handles by default

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -3481,7 +3481,7 @@ mod tests {
     }
 
     #[test]
-    fn opted_in_streaming_text_restores_handles_split_across_events() {
+    fn enabled_streaming_text_restores_handles_split_across_events() {
         let start = concat!(
             "event: content_block_start\n",
             "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n"

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -2,8 +2,8 @@
 //!
 //! Model-bound prompts and local function outputs are masked on requests.
 //! Completed client function-call arguments are resolved on responses. Local
-//! Provider-generated text remains masked unless the user opts into local
-//! output restoration.
+//! Provider-generated text restores known handles for the local user unless
+//! user or project policy opts out.
 
 use futures_util::{stream, Stream, StreamExt};
 use http_body_util::combinators::UnsyncBoxBody;
@@ -4246,7 +4246,7 @@ mod tests {
     }
 
     #[test]
-    fn opted_in_response_text_restores_known_handles_only() {
+    fn enabled_response_text_restores_known_handles_only() {
         let mut value = serde_json::json!({
             "output": [{
                 "type": "message",
@@ -4266,7 +4266,7 @@ mod tests {
     }
 
     #[test]
-    fn opted_in_openai_stream_restores_a_handle_split_across_events() {
+    fn enabled_openai_stream_restores_a_handle_split_across_events() {
         let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
         let mut streams = HashMap::new();
         let mut resolve: HandleResolver =

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -3465,7 +3465,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_boundary_masks_chat_requests_and_restores_only_tool_arguments() {
+    fn provider_boundary_masks_chat_requests_and_restores_local_assistant_output() {
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let store = pentect_agent::start_in_process_memory_store().unwrap();
         let mut env = ProviderBoundaryTestEnv::install(&store);
@@ -3537,7 +3537,7 @@ mod tests {
         assert!(request.matches(&handle).count() >= 3);
         let protected_request: Value = serde_json::from_str(&request).unwrap();
         assert_eq!(protected_request["messages"][0]["content"], HANDLE_CONTRACT);
-        assert_eq!(response["choices"][0]["message"]["content"], handle);
+        assert_eq!(response["choices"][0]["message"]["content"], secret);
         let arguments = response["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"]
             .as_str()
             .unwrap();

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -433,10 +433,10 @@ pub(crate) fn output_restore_enabled() -> Result<bool, String> {
 }
 
 fn output_restore_effective(project: Option<bool>, global: Option<bool>) -> bool {
-    // Restoring assistant prose reveals protected values to terminals and local
-    // client logs. A repository may opt out, but cannot opt a user into that
-    // wider boundary without the same setting in the user config.
-    global.unwrap_or(false) && project.unwrap_or(true)
+    // User-facing assistant output is local and restores known handles by
+    // default. Either the user policy or a project policy may narrow that
+    // boundary; a project cannot override a user-level opt-out.
+    global.unwrap_or(true) && project.unwrap_or(true)
 }
 
 pub(crate) fn unknown_formats_should_block() -> Result<bool, String> {
@@ -1324,15 +1324,17 @@ unknown_min_bytes = 32
     }
 
     #[test]
-    fn output_restore_is_opt_in_and_project_cannot_enable_it() {
+    fn output_restore_defaults_on_and_either_scope_can_disable_it() {
         let enabled = "[output]\nrestore = true".parse::<toml::Value>().unwrap();
         let disabled = "[output]\nrestore = false".parse::<toml::Value>().unwrap();
         assert_eq!(output_restore_value(&enabled).unwrap(), Some(true));
         assert_eq!(output_restore_value(&disabled).unwrap(), Some(false));
-        assert!(!output_restore_effective(None, None));
-        assert!(!output_restore_effective(Some(true), None));
+        assert!(output_restore_effective(None, None));
+        assert!(output_restore_effective(Some(true), None));
         assert!(output_restore_effective(None, Some(true)));
         assert!(!output_restore_effective(Some(false), Some(true)));
+        assert!(!output_restore_effective(None, Some(false)));
+        assert!(!output_restore_effective(Some(true), Some(false)));
     }
 
     #[test]

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -170,8 +170,9 @@ restore = false
 This affects supported JSON and streaming responses for Codex, Claude,
 OpenCode, and Pi. It does not send plaintext back to the model provider, but it
 does place the restored value in the client UI and may place it in terminal
-scrollback, screenshots, or client logs. Unknown and expired handles remain
-unchanged.
+scrollback, screenshots, or user-visible client conversation history. Pentect's
+persistent logs, diagnostics, and telemetry do not record the restored response
+body. Unknown and expired handles remain unchanged.
 
 A `false` in either scope wins, so a project cannot override a user-level
 opt-out. Set `output.restore = true` explicitly only when recording the desired

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -38,7 +38,7 @@ ignored.
 | `files.remember` | `true` | Remember safe local file-to-handle information |
 | `activity.share` | `true` | Share events with compatible local Pentect processes |
 | `agent.required` | `false` | Require supported agents to start through Pentect |
-| `output.restore` | `false` | Restore known handles in assistant text shown by supported clients |
+| `output.restore` | `true` | Restore known handles in assistant text shown by supported clients |
 | `update.check` | `true` | Check in the background for a newer Pentect release |
 
 ## Update notification
@@ -158,12 +158,13 @@ either file sets it to `true`, the effective value is true.
 
 ## Assistant output restoration
 
-By default, assistant text keeps protected handles visible. To restore known
-handles in assistant text locally, opt in from the user config:
+By default, Pentect restores known handles in assistant text shown to the local
+user. To keep handles visible instead, opt out in either the user config or a
+project config:
 
 ```toml
 [output]
-restore = true
+restore = false
 ```
 
 This affects supported JSON and streaming responses for Codex, Claude,
@@ -172,9 +173,10 @@ does place the restored value in the client UI and may place it in terminal
 scrollback, screenshots, or client logs. Unknown and expired handles remain
 unchanged.
 
-A project config cannot enable this wider output boundary by itself. It may set
-`output.restore = false` to disable a user-level opt-in for that project. Restart
-the protected client after changing the setting.
+A `false` in either scope wins, so a project cannot override a user-level
+opt-out. Set `output.restore = true` explicitly only when recording the desired
+default in managed configuration. Restart the protected client after changing
+the setting.
 
 ## Require the agent to start through Pentect
 

--- a/website/src/content/docs/start/handles.md
+++ b/website/src/content/docs/start/handles.md
@@ -11,9 +11,9 @@ A handle is a local reference to a sensitive value:
 
 The provider can see and copy this string. It cannot derive the value from it.
 Pentect restores a known handle only inside the protected local flow.
-Assistant prose keeps handles by default. The user-only
-[`output.restore`](/reference/configuration/#assistant-output-restoration)
-setting can opt into restoring known handles in the local client display.
+Assistant prose restores known handles in the local client display by default.
+Set [`output.restore = false`](/reference/configuration/#assistant-output-restoration)
+when a user or project must keep handles visible.
 
 ## Anatomy
 

--- a/website/src/content/docs/start/what-is-pentect.md
+++ b/website/src/content/docs/start/what-is-pentect.md
@@ -41,16 +41,17 @@ provider can see. Local tools still use the permissions of the current user.
 | --- | --- |
 | Local input | Finds supported sensitive values and creates handles |
 | Request to the provider | Sends handles instead of known real values |
-| Model response | Keeps handles in text by default and in tool arguments |
+| Model response | Restores known handles in local assistant text; keeps tool arguments protected until local execution |
 | Before a local tool runs | Restores handles that the current session knows |
 | Tool result | Checks and masks output before the next request |
 
 The client UI stays the same. Pentect starts the client with a local gateway for
 that process only.
 
-Assistant prose remains masked by default. Users who explicitly prefer local
-readability can enable [`output.restore`](/reference/configuration/#assistant-output-restoration).
-That opt-in restores only handles known to the active session and can expose the
+Assistant prose restores known handles locally by default. Environments that
+need opaque output can set
+[`output.restore = false`](/reference/configuration/#assistant-output-restoration).
+Restoration applies only to handles known to the active session and can expose the
 value to terminal scrollback or client logs.
 
 ## Supported surfaces

--- a/website/src/content/docs/start/what-is-pentect.md
+++ b/website/src/content/docs/start/what-is-pentect.md
@@ -52,7 +52,8 @@ Assistant prose restores known handles locally by default. Environments that
 need opaque output can set
 [`output.restore = false`](/reference/configuration/#assistant-output-restoration).
 Restoration applies only to handles known to the active session and can expose the
-value to terminal scrollback or client logs.
+value to terminal scrollback or user-visible client conversation history.
+Pentect's persistent logs, diagnostics, and telemetry remain value-free.
 
 ## Supported surfaces
 


### PR DESCRIPTION
Closes #391.

- change the effective default of `output.restore` from `false` to `true`
- let either user or project policy opt out with `output.restore = false`
- ensure a project cannot override a user-level opt-out
- update the configuration, handle, and protection-flow documentation
- retain masking for model-bound tool results, logs, telemetry, diagnostics, unknown handles, and expired handles

Verified locally:
- runtime default/precedence tests
- OpenAI JSON output restoration
- OpenAI handles split across SSE events
- Anthropic handles split across SSE events
- strict Clippy for runtime and CLI
- docs check: 41 pages and 110 internal links
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant responses now restore known handles by default in the local client display.
  * Restoration is limited to handles known in the active session.
* **Configuration**
  * Set `output.restore = false` at either configuration scope to disable restoration.
  * A disabled setting takes precedence, and clients must be restarted after configuration changes.
* **Documentation**
  * Updated configuration and handle-management guidance to reflect the new default behavior.
  * Tool arguments remain protected until local execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->