### PR TITLE
chore: release v0.0.56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.55"
+version = "0.0.56"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bump Pentect to v0.0.56 for the current main baseline.

This release includes the native Rust CredSweeper v1.17.4 parity implementation merged in #659. It intentionally does not include the still-open agent/command routing work in #396.

## Local release checks

- Cargo and npm versions agree on 0.0.56
- Cargo metadata parses with the lockfile
- Formatting and diff checks pass
- Third-party license bundle is current
- Existing package metadata is internally consistent
- npm tests: 8 passed
- npm dry-run package: passed

After merge, tag `v0.0.56` must point exactly at the resulting main HEAD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and command-line package versions to 0.0.56.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->