### PR TITLE
fix(release): keep Claude app fixture alive through startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.56"
+version = "0.0.57"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/tools/claude-app-smoke-fixture.c
+++ b/tools/claude-app-smoke-fixture.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
     if (!proxy || !certificate || !user_data) {
         return 64;
     }
-    struct timespec delay = {1, 0};
+    struct timespec delay = {5, 0};
     nanosleep(&delay, 0);
     return 0;
 }

--- a/tools/claude-app-smoke-fixture.cs
+++ b/tools/claude-app-smoke-fixture.cs
@@ -13,7 +13,7 @@ public static class ClaudeAppSmokeFixture
         {
             return 64;
         }
-        Thread.Sleep(1000);
+        Thread.Sleep(5000);
         return 0;
     }
 }


### PR DESCRIPTION
## Summary

Fix the release lifecycle fixture and bump the release to v0.0.57.

Pentect intentionally treats a Claude Desktop process that exits during the two-second startup grace period as incompatible. The C and C# smoke fixtures exited after one second, so every POSIX installer E2E failed even though installation, update, plugins, and client CLI checks had succeeded.

The fixtures now remain alive for five seconds, matching the existing Codex fixture behavior and testing the supported startup path without weakening Pentect’s fail-closed behavior.

## Verification

- Compiled the POSIX fixture with warnings as errors
- Ran `pentect claude app` against the fixture
- Observed gateway readiness and a successful exit after the startup grace period
- Cargo/npm versions agree on 0.0.57
- Formatting, diff, and license checks pass
- npm tests: 8 passed
- npm dry-run package: passed

The failed v0.0.56 prerelease was removed. Its protected tag remains immutable and will not be reused.