### PR TITLE
fix: skip disabled AUR release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -770,7 +770,14 @@ jobs:
           test "$(gh pr view "$pull" --repo "$GITHUB_REPOSITORY" --json state --jq .state)" = MERGED
           gh workflow run package-tags.yml --repo "$GITHUB_REPOSITORY" --ref main
           gh workflow run nix.yml --repo "$GITHUB_REPOSITORY" --ref main
-          gh workflow run aur.yml --repo "$GITHUB_REPOSITORY" --ref main -f publish=true
+          aur_state=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/aur.yml" \
+            --jq .state)
+          if [ "$aur_state" = active ]; then
+            gh workflow run aur.yml --repo "$GITHUB_REPOSITORY" --ref main -f publish=true
+          else
+            echo "AUR workflow is $aur_state; skipping publication"
+          fi
 
   apt-pages:
     name: Publish signed APT repository


### PR DESCRIPTION
The v0.0.57 release published successfully, but its final metadata job failed because it unconditionally dispatched the intentionally disabled AUR workflow. This checks the workflow state and skips AUR publication while it is disabled, matching the existing automation helper behavior.\n\nTargeted verification:\n- `python tools/test_release_package_metadata.py`\n- `actionlint .github/workflows/release.yml` (when installed)\n- `git diff --check`