### PR TITLE
feat(masking): bundle Alcatraz PII detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
               - 'crates/**/Cargo.toml'
               - 'rust-toolchain*'
               - 'crates/**/*.rs'
+              - 'tools/alcatraz-helper/**'
             manifests:
               - 'Cargo.lock'
               - 'Cargo.toml'
@@ -133,6 +134,9 @@ jobs:
               - 'sdk/**'
             detector:
               - 'crates/pentect-core/**'
+              - 'crates/pentect-runtime/src/alcatraz.rs'
+              - 'crates/pentect-runtime/src/masking.rs'
+              - 'tools/alcatraz-helper/**'
             ocr:
               - 'crates/pentect-runtime/assets/ocr/**'
               - 'crates/pentect-runtime/src/image_ocr.rs'
@@ -342,6 +346,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      PENTECT_REQUIRE_ALCATRAZ: "1"
     steps:
       - name: Require change detection
         if: needs.changes.result != 'success'
@@ -353,6 +359,10 @@ jobs:
       - uses: ./.github/actions/rust-toolchain
         with:
           components: rustfmt, clippy
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/alcatraz-helper/go.mod
+          cache-dependency-path: tools/alcatraz-helper/go.sum
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/credsweeper-regression.yml
+++ b/.github/workflows/credsweeper-regression.yml
@@ -1,6 +1,9 @@
 name: CredSweeper regression
 
 on:
+  schedule:
+    # Compare the native port with the latest upstream release every Monday.
+    - cron: "17 3 * * 1"
   push:
     branches: [main]
     paths:
@@ -57,10 +60,15 @@ jobs:
         id: baseline
         shell: bash
         env:
+          EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
+          if [[ "$EVENT_NAME" == schedule ]]; then
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           base="$PR_BASE_SHA"
           if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
             base="$PUSH_BEFORE_SHA"
@@ -85,6 +93,10 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
+
+      - name: Sync latest CredSweeper release for weekly parity check
+        if: github.event_name == 'schedule'
+        run: python tools/update_credsweeper.py latest
 
       - name: Install official CredSweeper oracle dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/rust-toolchain
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/alcatraz-helper/go.mod
+          cache-dependency-path: tools/alcatraz-helper/go.sum
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
@@ -135,11 +139,32 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - uses: ./.github/actions/rust-toolchain
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/alcatraz-helper/go.mod
+          cache-dependency-path: tools/alcatraz-helper/go.sum
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-${{ matrix.asset }}
       - name: Build release binary
+        env:
+          PENTECT_REQUIRE_ALCATRAZ: "1"
         run: cargo build --release --locked -p pentect-cli
+      - name: Verify bundled Alcatraz without an external Go runtime
+        shell: pwsh
+        run: |
+          $env:PATH = if ($IsWindows) { "$env:WINDIR\System32;$env:WINDIR" } else { '/usr/bin:/bin' }
+          $sample = 'Contact alice@example.com or +1 415-555-2671. Card 4111 1111 1111 1111.'
+          $masked = $sample | & '${{ matrix.binary }}' mask --kind text 2>$null
+          if ($LASTEXITCODE -ne 0) { throw 'Pentect mask failed' }
+          if ($masked -match 'alice@example.com|415-555-2671|4111 1111 1111 1111') {
+            throw "Alcatraz leaked test PII: $masked"
+          }
+          foreach ($label in @('EMAIL_ADDRESS', 'PHONE_NUMBER', 'CREDIT_CARD')) {
+            if ($masked -notmatch "<<${label}_[0-9a-f]{16}>>") {
+              throw "Missing $label handle: $masked"
+            }
+          }
       - name: Package binary and checksum
         shell: pwsh
         run: |

--- a/.github/workflows/update-credsweeper.yml
+++ b/.github/workflows/update-credsweeper.yml
@@ -57,5 +57,5 @@ jobs:
               --base "$BASE_BRANCH" \
               --head "$branch" \
               --title "chore: update CredSweeper to $version" \
-              --body "Automated CredSweeper release sync. Embedded assets, generated Rust rules, and native compatibility checks have passed."
+              --body "Automated CredSweeper release sync. The CredSweeper regression workflow must pass before this update is merged."
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,6 +2504,7 @@ dependencies = [
  "windows 0.62.2",
  "windows-sys 0.61.2",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -13,6 +13,12 @@ Version: v1.17.4 (commit c7ad63b95ce0941954465a3b759046b14b88807b)
 Copyright (c) 2021 SAMSUNG
 License: MIT. The full MIT text appears below in the Cargo license documents.
 
+Alcatraz bundled PII helper
+Source: https://github.com/hoophq/alcatraz
+Version: 0.20.2 (commit cd2e19b7d0f08b113c52ef52d3485c64a0871455)
+Copyright (c) 2026 hoop.dev
+License: MIT. The full MIT text appears below.
+
 Ocrs RTen text detection and recognition models
 Creator and source: Robert Knight, https://huggingface.co/robertknight/ocrs
 License: Creative Commons Attribution-ShareAlike 4.0 International
@@ -714,6 +720,34 @@ THE SOFTWARE.
 DOCUMENT 9
 ~~~~~~~~~~
 Applies to:
+- Alcatraz 0.20.2 bundled PII helper (MIT)
+
+MIT License
+
+Copyright (c) 2026 hoop.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+DOCUMENT 10
+~~~~~~~~~~~
+Applies to:
 - allocator-api2 0.2.21 (MIT OR Apache-2.0)
 - anyhow 1.0.103 (MIT OR Apache-2.0)
 - async-trait 0.1.91 (MIT OR Apache-2.0)
@@ -928,7 +962,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 10
+DOCUMENT 11
 ~~~~~~~~~~~
 Applies to:
 - android_system_properties 0.1.5 (MIT/Apache-2.0)
@@ -948,7 +982,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 11
+DOCUMENT 12
 ~~~~~~~~~~~
 Applies to:
 - android_system_properties 0.1.5 (MIT/Apache-2.0)
@@ -975,7 +1009,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 12
+DOCUMENT 13
 ~~~~~~~~~~~
 Applies to:
 - anstream 0.6.21 (MIT OR Apache-2.0)
@@ -1209,7 +1243,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 13
+DOCUMENT 14
 ~~~~~~~~~~~
 Applies to:
 - anstream 0.6.21 (MIT OR Apache-2.0)
@@ -1247,7 +1281,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 14
+DOCUMENT 15
 ~~~~~~~~~~~
 Applies to:
 - anymap3 1.1.0 (BlueOak-1.0.0 OR MIT OR Apache-2.0)
@@ -1271,7 +1305,7 @@ When using this code, ensure you comply with the terms of at least one of
 these licenses.
 
 
-DOCUMENT 15
+DOCUMENT 16
 ~~~~~~~~~~~
 Applies to:
 - arrayvec 0.7.7 (MIT OR Apache-2.0)
@@ -1622,7 +1656,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 16
+DOCUMENT 17
 ~~~~~~~~~~~
 Applies to:
 - arrayvec 0.7.7 (MIT OR Apache-2.0)
@@ -1654,7 +1688,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 17
+DOCUMENT 18
 ~~~~~~~~~~~
 Applies to:
 - asn1-rs 0.7.2 (MIT OR Apache-2.0)
@@ -1691,7 +1725,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 18
+DOCUMENT 19
 ~~~~~~~~~~~
 Applies to:
 - asn1-rs-impl 0.2.0 (MIT/Apache-2.0)
@@ -1723,7 +1757,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 19
+DOCUMENT 20
 ~~~~~~~~~~~
 Applies to:
 - atomic-polyfill 1.0.3 (MIT OR Apache-2.0)
@@ -1755,7 +1789,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 20
+DOCUMENT 21
 ~~~~~~~~~~~
 Applies to:
 - atomic-waker 1.1.2 (Apache-2.0 OR MIT)
@@ -1807,7 +1841,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 21
+DOCUMENT 22
 ~~~~~~~~~~~
 Applies to:
 - autocfg 1.5.1 (Apache-2.0 OR MIT)
@@ -1839,7 +1873,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 22
+DOCUMENT 23
 ~~~~~~~~~~~
 Applies to:
 - base64 0.22.1 (MIT OR Apache-2.0)
@@ -1867,7 +1901,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 23
+DOCUMENT 24
 ~~~~~~~~~~~
 Applies to:
 - base64ct 1.8.3 (Apache-2.0 OR MIT)
@@ -1900,7 +1934,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 24
+DOCUMENT 25
 ~~~~~~~~~~~
 Applies to:
 - bip39 2.2.2 (CC0-1.0)
@@ -2029,7 +2063,7 @@ express Statement of Purpose.
     this CC0 or use of the Work.
 
 
-DOCUMENT 25
+DOCUMENT 26
 ~~~~~~~~~~~
 Applies to:
 - bit-set 0.10.0 (Apache-2.0 OR MIT)
@@ -2248,7 +2282,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 26
+DOCUMENT 27
 ~~~~~~~~~~~
 Applies to:
 - bit-set 0.10.0 (Apache-2.0 OR MIT)
@@ -2280,7 +2314,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 27
+DOCUMENT 28
 ~~~~~~~~~~~
 Applies to:
 - bit-set 0.8.0 (Apache-2.0 OR MIT)
@@ -2314,7 +2348,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 28
+DOCUMENT 29
 ~~~~~~~~~~~
 Applies to:
 - bitcoin_hashes 0.14.101 (CC0-1.0)
@@ -2327,7 +2361,7 @@ This package is dedicated under Creative Commons CC0 1.0 Universal.
 Legal code: https://creativecommons.org/publicdomain/zero/1.0/legalcode
 
 
-DOCUMENT 29
+DOCUMENT 30
 ~~~~~~~~~~~
 Applies to:
 - bitflags 1.3.2 (MIT/Apache-2.0)
@@ -2372,7 +2406,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 30
+DOCUMENT 31
 ~~~~~~~~~~~
 Applies to:
 - block-buffer 0.10.4 (MIT OR Apache-2.0)
@@ -2405,7 +2439,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 31
+DOCUMENT 32
 ~~~~~~~~~~~
 Applies to:
 - block-buffer 0.12.1 (MIT OR Apache-2.0)
@@ -2437,7 +2471,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 32
+DOCUMENT 33
 ~~~~~~~~~~~
 Applies to:
 - block2 0.6.2 (MIT)
@@ -2469,7 +2503,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 33
+DOCUMENT 34
 ~~~~~~~~~~~
 Applies to:
 - bs58 0.5.1 (MIT/Apache-2.0)
@@ -2496,7 +2530,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 34
+DOCUMENT 35
 ~~~~~~~~~~~
 Applies to:
 - bumpalo 3.20.3 (MIT OR Apache-2.0)
@@ -2528,7 +2562,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 35
+DOCUMENT 36
 ~~~~~~~~~~~
 Applies to:
 - bytemuck 1.25.0 (Zlib OR Apache-2.0 OR MIT)
@@ -2596,7 +2630,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 36
+DOCUMENT 37
 ~~~~~~~~~~~
 Applies to:
 - bytemuck 1.25.0 (Zlib OR Apache-2.0 OR MIT)
@@ -2612,7 +2646,7 @@ The above copyright notice and this permission notice (including the next paragr
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 37
+DOCUMENT 38
 ~~~~~~~~~~~
 Applies to:
 - bytemuck 1.25.0 (Zlib OR Apache-2.0 OR MIT)
@@ -2631,7 +2665,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 38
+DOCUMENT 39
 ~~~~~~~~~~~
 Applies to:
 - bytes 1.12.0 (MIT)
@@ -2663,7 +2697,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 39
+DOCUMENT 40
 ~~~~~~~~~~~
 Applies to:
 - cbc 0.1.2 (MIT OR Apache-2.0)
@@ -2696,7 +2730,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 40
+DOCUMENT 41
 ~~~~~~~~~~~
 Applies to:
 - cc 1.2.65 (MIT OR Apache-2.0)
@@ -2745,7 +2779,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 41
+DOCUMENT 42
 ~~~~~~~~~~~
 Applies to:
 - cff-parser 0.2.0 (MIT OR Apache-2.0)
@@ -2772,7 +2806,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 42
+DOCUMENT 43
 ~~~~~~~~~~~
 Applies to:
 - cfg_aliases 0.1.1 (MIT)
@@ -2789,7 +2823,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 43
+DOCUMENT 44
 ~~~~~~~~~~~
 Applies to:
 - cfg_aliases 0.1.1 (MIT)
@@ -2823,7 +2857,7 @@ The `cfg_aliases!` macro uses a lot of the code from [`tectonic_cfg_support::tar
 ---
 
 
-DOCUMENT 44
+DOCUMENT 45
 ~~~~~~~~~~~
 Applies to:
 - chacha20 0.10.1 (MIT OR Apache-2.0)
@@ -2855,7 +2889,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 45
+DOCUMENT 46
 ~~~~~~~~~~~
 Applies to:
 - chrono 0.4.45 (MIT OR Apache-2.0)
@@ -3101,7 +3135,7 @@ limitations under the License.
 ~~~~
 
 
-DOCUMENT 46
+DOCUMENT 47
 ~~~~~~~~~~~
 Applies to:
 - cipher 0.4.4 (MIT OR Apache-2.0)
@@ -3133,7 +3167,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 47
+DOCUMENT 48
 ~~~~~~~~~~~
 Applies to:
 - cipher 0.5.2 (MIT OR Apache-2.0)
@@ -3165,7 +3199,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 48
+DOCUMENT 49
 ~~~~~~~~~~~
 Applies to:
 - cobs 0.3.0 (MIT OR Apache-2.0)
@@ -3191,7 +3225,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 49
+DOCUMENT 50
 ~~~~~~~~~~~
 Applies to:
 - codepage-437 0.1.0 (MIT)
@@ -3219,7 +3253,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 50
+DOCUMENT 51
 ~~~~~~~~~~~
 Applies to:
 - color_quant 1.1.0 (MIT)
@@ -3247,7 +3281,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 51
+DOCUMENT 52
 ~~~~~~~~~~~
 Applies to:
 - combine 4.6.7 (MIT)
@@ -3275,7 +3309,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 52
+DOCUMENT 53
 ~~~~~~~~~~~
 Applies to:
 - const-oid 0.9.6 (Apache-2.0 OR MIT)
@@ -3307,7 +3341,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 53
+DOCUMENT 54
 ~~~~~~~~~~~
 Applies to:
 - core-foundation 0.10.1 (MIT OR Apache-2.0)
@@ -3342,7 +3376,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 54
+DOCUMENT 55
 ~~~~~~~~~~~
 Applies to:
 - cpufeatures 0.2.17 (MIT OR Apache-2.0)
@@ -3375,7 +3409,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 55
+DOCUMENT 56
 ~~~~~~~~~~~
 Applies to:
 - crc32fast 1.5.0 (MIT OR Apache-2.0)
@@ -3403,7 +3437,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 56
+DOCUMENT 57
 ~~~~~~~~~~~
 Applies to:
 - CredSweeper v1.17.4 detection assets (MIT)
@@ -3429,7 +3463,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 57
+DOCUMENT 58
 ~~~~~~~~~~~
 Applies to:
 - critical-section 1.2.0 (MIT OR Apache-2.0)
@@ -3461,7 +3495,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 58
+DOCUMENT 59
 ~~~~~~~~~~~
 Applies to:
 - crossbeam-channel 0.5.16 (MIT OR Apache-2.0)
@@ -3498,7 +3532,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 59
+DOCUMENT 60
 ~~~~~~~~~~~
 Applies to:
 - crossbeam-channel 0.5.16 (MIT OR Apache-2.0)
@@ -4098,7 +4132,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 60
+DOCUMENT 61
 ~~~~~~~~~~~
 Applies to:
 - crunchy 0.2.4 (MIT)
@@ -4126,7 +4160,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 61
+DOCUMENT 62
 ~~~~~~~~~~~
 Applies to:
 - crypto-common 0.1.7 (MIT OR Apache-2.0)
@@ -4158,7 +4192,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 62
+DOCUMENT 63
 ~~~~~~~~~~~
 Applies to:
 - crypto-common 0.2.2 (MIT OR Apache-2.0)
@@ -4190,7 +4224,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 63
+DOCUMENT 64
 ~~~~~~~~~~~
 Applies to:
 - ctrlc 3.5.2 (MIT/Apache-2.0)
@@ -4398,7 +4432,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 64
+DOCUMENT 65
 ~~~~~~~~~~~
 Applies to:
 - curve25519-dalek 4.1.3 (BSD-3-Clause)
@@ -4470,7 +4504,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 65
+DOCUMENT 66
 ~~~~~~~~~~~
 Applies to:
 - data-encoding 2.11.0 (MIT)
@@ -4499,7 +4533,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 66
+DOCUMENT 67
 ~~~~~~~~~~~
 Applies to:
 - defmt 1.1.0 (MIT OR Apache-2.0)
@@ -4532,7 +4566,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 67
+DOCUMENT 68
 ~~~~~~~~~~~
 Applies to:
 - defmt-parser 1.0.0 (MIT OR Apache-2.0)
@@ -4564,7 +4598,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 68
+DOCUMENT 69
 ~~~~~~~~~~~
 Applies to:
 - der 0.7.10 (Apache-2.0 OR MIT)
@@ -4597,7 +4631,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 69
+DOCUMENT 70
 ~~~~~~~~~~~
 Applies to:
 - deranged 0.5.8 (MIT OR Apache-2.0)
@@ -4805,7 +4839,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 70
+DOCUMENT 71
 ~~~~~~~~~~~
 Applies to:
 - deranged 0.5.8 (MIT OR Apache-2.0)
@@ -4831,7 +4865,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 71
+DOCUMENT 72
 ~~~~~~~~~~~
 Applies to:
 - derive-new 0.7.0 (MIT)
@@ -4859,7 +4893,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 72
+DOCUMENT 73
 ~~~~~~~~~~~
 Applies to:
 - digest 0.10.7 (MIT OR Apache-2.0)
@@ -4892,7 +4926,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 73
+DOCUMENT 74
 ~~~~~~~~~~~
 Applies to:
 - dispatch2 0.3.1 (Zlib OR Apache-2.0 OR MIT)
@@ -4924,7 +4958,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 74
+DOCUMENT 75
 ~~~~~~~~~~~
 Applies to:
 - downcast-rs 1.2.1 (MIT/Apache-2.0)
@@ -4957,7 +4991,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 75
+DOCUMENT 76
 ~~~~~~~~~~~
 Applies to:
 - dyn-eq 0.1.3 (MPL-2.0)
@@ -5337,7 +5371,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 
 
-DOCUMENT 76
+DOCUMENT 77
 ~~~~~~~~~~~
 Applies to:
 - ecb 0.1.2 (MIT)
@@ -5365,7 +5399,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 77
+DOCUMENT 78
 ~~~~~~~~~~~
 Applies to:
 - ed25519 2.2.3 (Apache-2.0 OR MIT)
@@ -5573,7 +5607,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 78
+DOCUMENT 79
 ~~~~~~~~~~~
 Applies to:
 - ed25519 2.2.3 (Apache-2.0 OR MIT)
@@ -5606,7 +5640,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 79
+DOCUMENT 80
 ~~~~~~~~~~~
 Applies to:
 - ed25519-dalek 2.2.0 (BSD-3-Clause)
@@ -5641,7 +5675,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 80
+DOCUMENT 81
 ~~~~~~~~~~~
 Applies to:
 - either 1.16.0 (MIT OR Apache-2.0)
@@ -5676,7 +5710,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 81
+DOCUMENT 82
 ~~~~~~~~~~~
 Applies to:
 - embedded-io 0.4.0 (MIT OR Apache-2.0)
@@ -5708,7 +5742,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 82
+DOCUMENT 83
 ~~~~~~~~~~~
 Applies to:
 - embedded-io 0.6.1 (MIT OR Apache-2.0)
@@ -5740,7 +5774,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 83
+DOCUMENT 84
 ~~~~~~~~~~~
 Applies to:
 - encoding_rs 0.8.35 ((Apache-2.0 OR MIT) AND BSD-3-Clause)
@@ -5764,7 +5798,7 @@ Test code within encoding_rs is dedicated to the Public Domain when so
 designated (see the individual files for PD/CC0-dedicated sections).
 
 
-DOCUMENT 84
+DOCUMENT 85
 ~~~~~~~~~~~
 Applies to:
 - encoding_rs 0.8.35 ((Apache-2.0 OR MIT) AND BSD-3-Clause)
@@ -5987,7 +6021,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 85
+DOCUMENT 86
 ~~~~~~~~~~~
 Applies to:
 - encoding_rs 0.8.35 ((Apache-2.0 OR MIT) AND BSD-3-Clause)
@@ -6020,7 +6054,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 86
+DOCUMENT 87
 ~~~~~~~~~~~
 Applies to:
 - encoding_rs 0.8.35 ((Apache-2.0 OR MIT) AND BSD-3-Clause)
@@ -6053,7 +6087,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 87
+DOCUMENT 88
 ~~~~~~~~~~~
 Applies to:
 - equivalent 1.0.2 (Apache-2.0 OR MIT)
@@ -6085,7 +6119,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 88
+DOCUMENT 89
 ~~~~~~~~~~~
 Applies to:
 - errno 0.3.14 (MIT OR Apache-2.0)
@@ -6117,7 +6151,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 89
+DOCUMENT 90
 ~~~~~~~~~~~
 Applies to:
 - euclid 0.20.14 (MIT / Apache-2.0)
@@ -6129,7 +6163,7 @@ option. All files in the project carrying such notice may not be
 copied, modified, or distributed except according to those terms.
 
 
-DOCUMENT 90
+DOCUMENT 91
 ~~~~~~~~~~~
 Applies to:
 - fancy-regex 0.18.0 (MIT)
@@ -6157,7 +6191,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 91
+DOCUMENT 92
 ~~~~~~~~~~~
 Applies to:
 - fdeflate 0.3.7 (MIT OR Apache-2.0)
@@ -6357,7 +6391,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 92
+DOCUMENT 93
 ~~~~~~~~~~~
 Applies to:
 - fdeflate 0.3.7 (MIT OR Apache-2.0)
@@ -6391,7 +6425,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 93
+DOCUMENT 94
 ~~~~~~~~~~~
 Applies to:
 - fiat-crypto 0.2.9 (MIT OR Apache-2.0 OR BSD-1-Clause)
@@ -6405,7 +6439,7 @@ the BSD 1-Clause License <LICENSE-BSD-1> or
 <https://spdx.org/licenses/BSD-1-Clause.html>, at your option.
 
 
-DOCUMENT 94
+DOCUMENT 95
 ~~~~~~~~~~~
 Applies to:
 - fiat-crypto 0.2.9 (MIT OR Apache-2.0 OR BSD-1-Clause)
@@ -6427,7 +6461,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 95
+DOCUMENT 96
 ~~~~~~~~~~~
 Applies to:
 - fiat-crypto 0.2.9 (MIT OR Apache-2.0 OR BSD-1-Clause)
@@ -6457,7 +6491,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 96
+DOCUMENT 97
 ~~~~~~~~~~~
 Applies to:
 - fiat-crypto 0.2.9 (MIT OR Apache-2.0 OR BSD-1-Clause)
@@ -6485,7 +6519,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 97
+DOCUMENT 98
 ~~~~~~~~~~~
 Applies to:
 - filedescriptor 0.8.3 (MIT)
@@ -6514,7 +6548,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 98
+DOCUMENT 99
 ~~~~~~~~~~~
 Applies to:
 - flatbuffers 24.12.23 (Apache-2.0)
@@ -6682,8 +6716,8 @@ such warranty or additional liability.
 END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 99
-~~~~~~~~~~~
+DOCUMENT 100
+~~~~~~~~~~~~
 Applies to:
 - flate2 1.1.9 (MIT OR Apache-2.0)
 
@@ -6714,7 +6748,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 100
+DOCUMENT 101
 ~~~~~~~~~~~~
 Applies to:
 - float-cmp 0.10.0 (MIT)
@@ -6740,7 +6774,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 
-DOCUMENT 101
+DOCUMENT 102
 ~~~~~~~~~~~~
 Applies to:
 - float-ord 0.3.2 (MIT / Apache-2.0)
@@ -6766,7 +6800,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 102
+DOCUMENT 103
 ~~~~~~~~~~~~
 Applies to:
 - fnv 1.0.7 (Apache-2.0 / MIT)
@@ -6798,7 +6832,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 103
+DOCUMENT 104
 ~~~~~~~~~~~~
 Applies to:
 - foldhash 0.1.5 (Zlib)
@@ -6825,7 +6859,7 @@ the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 104
+DOCUMENT 105
 ~~~~~~~~~~~~
 Applies to:
 - foreign-types 0.3.2 (MIT/Apache-2.0)
@@ -6852,7 +6886,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 105
+DOCUMENT 106
 ~~~~~~~~~~~~
 Applies to:
 - form_urlencoded 1.2.2 (MIT OR Apache-2.0)
@@ -6884,7 +6918,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 106
+DOCUMENT 107
 ~~~~~~~~~~~~
 Applies to:
 - futures-channel 0.3.32 (MIT OR Apache-2.0)
@@ -7099,7 +7133,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 107
+DOCUMENT 108
 ~~~~~~~~~~~~
 Applies to:
 - futures-channel 0.3.32 (MIT OR Apache-2.0)
@@ -7138,7 +7172,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 108
+DOCUMENT 109
 ~~~~~~~~~~~~
 Applies to:
 - generic-array 0.14.7 (MIT)
@@ -7166,7 +7200,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 109
+DOCUMENT 110
 ~~~~~~~~~~~~
 Applies to:
 - getrandom 0.2.17 (MIT OR Apache-2.0)
@@ -7375,7 +7409,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 110
+DOCUMENT 111
 ~~~~~~~~~~~~
 Applies to:
 - getrandom 0.2.17 (MIT OR Apache-2.0)
@@ -7408,7 +7442,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 111
+DOCUMENT 112
 ~~~~~~~~~~~~
 Applies to:
 - getrandom 0.4.2 (MIT OR Apache-2.0)
@@ -7441,7 +7475,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 112
+DOCUMENT 113
 ~~~~~~~~~~~~
 Applies to:
 - gif 0.14.2 (MIT OR Apache-2.0)
@@ -7469,7 +7503,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 113
+DOCUMENT 114
 ~~~~~~~~~~~~
 Applies to:
 - half 2.7.1 (MIT OR Apache-2.0)
@@ -7497,7 +7531,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 114
+DOCUMENT 115
 ~~~~~~~~~~~~
 Applies to:
 - halfbrown 0.4.0 (Apache-2.0/MIT)
@@ -7527,7 +7561,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 115
+DOCUMENT 116
 ~~~~~~~~~~~~
 Applies to:
 - hash32 0.2.1 (MIT OR Apache-2.0)
@@ -7559,7 +7593,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 116
+DOCUMENT 117
 ~~~~~~~~~~~~
 Applies to:
 - hashbrown 0.15.5 (MIT OR Apache-2.0)
@@ -7593,7 +7627,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 117
+DOCUMENT 118
 ~~~~~~~~~~~~
 Applies to:
 - heapless 0.7.17 (MIT OR Apache-2.0)
@@ -7625,7 +7659,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 118
+DOCUMENT 119
 ~~~~~~~~~~~~
 Applies to:
 - heck 0.5.0 (MIT OR Apache-2.0)
@@ -7664,7 +7698,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 119
+DOCUMENT 120
 ~~~~~~~~~~~~
 Applies to:
 - hickory-net 0.26.1 (MIT OR Apache-2.0)
@@ -7874,7 +7908,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 120
+DOCUMENT 121
 ~~~~~~~~~~~~
 Applies to:
 - hickory-net 0.26.1 (MIT OR Apache-2.0)
@@ -7903,7 +7937,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 121
+DOCUMENT 122
 ~~~~~~~~~~~~
 Applies to:
 - http 1.4.2 (MIT OR Apache-2.0)
@@ -8111,7 +8145,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 122
+DOCUMENT 123
 ~~~~~~~~~~~~
 Applies to:
 - http 1.4.2 (MIT OR Apache-2.0)
@@ -8143,7 +8177,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 123
+DOCUMENT 124
 ~~~~~~~~~~~~
 Applies to:
 - http-body 1.0.1 (MIT)
@@ -8175,7 +8209,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 124
+DOCUMENT 125
 ~~~~~~~~~~~~
 Applies to:
 - http-body-util 0.1.3 (MIT)
@@ -8207,7 +8241,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 125
+DOCUMENT 126
 ~~~~~~~~~~~~
 Applies to:
 - httparse 1.10.1 (MIT OR Apache-2.0)
@@ -8234,7 +8268,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 126
+DOCUMENT 127
 ~~~~~~~~~~~~
 Applies to:
 - httpdate 1.0.3 (MIT OR Apache-2.0)
@@ -8442,7 +8476,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 127
+DOCUMENT 128
 ~~~~~~~~~~~~
 Applies to:
 - httpdate 1.0.3 (MIT OR Apache-2.0)
@@ -8468,7 +8502,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 128
+DOCUMENT 129
 ~~~~~~~~~~~~
 Applies to:
 - hybrid-array 0.4.13 (MIT OR Apache-2.0)
@@ -8500,7 +8534,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 129
+DOCUMENT 130
 ~~~~~~~~~~~~
 Applies to:
 - hyper 1.10.1 (MIT)
@@ -8526,7 +8560,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 130
+DOCUMENT 131
 ~~~~~~~~~~~~
 Applies to:
 - hyper-rustls 0.27.9 (Apache-2.0 OR ISC OR MIT)
@@ -8550,7 +8584,7 @@ ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 
-DOCUMENT 131
+DOCUMENT 132
 ~~~~~~~~~~~~
 Applies to:
 - hyper-rustls 0.27.9 (Apache-2.0 OR ISC OR MIT)
@@ -8584,7 +8618,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 132
+DOCUMENT 133
 ~~~~~~~~~~~~
 Applies to:
 - hyper-util 0.1.20 (MIT)
@@ -8610,7 +8644,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 133
+DOCUMENT 134
 ~~~~~~~~~~~~
 Applies to:
 - iana-time-zone 0.1.65 (MIT OR Apache-2.0)
@@ -8819,7 +8853,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 134
+DOCUMENT 135
 ~~~~~~~~~~~~
 Applies to:
 - iana-time-zone 0.1.65 (MIT OR Apache-2.0)
@@ -8852,7 +8886,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 135
+DOCUMENT 136
 ~~~~~~~~~~~~
 Applies to:
 - icu_collections 2.2.0 (Unicode-3.0)
@@ -8922,7 +8956,7 @@ Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
 ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.
 
 
-DOCUMENT 136
+DOCUMENT 137
 ~~~~~~~~~~~~
 Applies to:
 - idna 1.1.0 (MIT OR Apache-2.0)
@@ -8956,7 +8990,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 137
+DOCUMENT 138
 ~~~~~~~~~~~~
 Applies to:
 - idna_adapter 1.2.2 (Apache-2.0 OR MIT)
@@ -8988,7 +9022,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 138
+DOCUMENT 139
 ~~~~~~~~~~~~
 Applies to:
 - indexmap 2.14.0 (Apache-2.0 OR MIT)
@@ -9020,7 +9054,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 139
+DOCUMENT 140
 ~~~~~~~~~~~~
 Applies to:
 - inout 0.1.4 (MIT OR Apache-2.0)
@@ -9053,7 +9087,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 140
+DOCUMENT 141
 ~~~~~~~~~~~~
 Applies to:
 - inout 0.2.2 (MIT OR Apache-2.0)
@@ -9086,7 +9120,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 141
+DOCUMENT 142
 ~~~~~~~~~~~~
 Applies to:
 - ipconfig 0.3.4 (MIT/Apache-2.0)
@@ -9118,7 +9152,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 142
+DOCUMENT 143
 ~~~~~~~~~~~~
 Applies to:
 - ipnet 2.12.0 (MIT OR Apache-2.0)
@@ -9327,7 +9361,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 143
+DOCUMENT 144
 ~~~~~~~~~~~~
 Applies to:
 - ipnet 2.12.0 (MIT OR Apache-2.0)
@@ -9341,7 +9375,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 144
+DOCUMENT 145
 ~~~~~~~~~~~~
 Applies to:
 - jni 0.22.4 (MIT OR Apache-2.0)
@@ -9373,7 +9407,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 145
+DOCUMENT 146
 ~~~~~~~~~~~~
 Applies to:
 - jni-macros 0.22.4 (MIT OR Apache-2.0)
@@ -9405,7 +9439,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 146
+DOCUMENT 147
 ~~~~~~~~~~~~
 Applies to:
 - jni-sys 0.4.1 (MIT OR Apache-2.0)
@@ -9431,7 +9465,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 147
+DOCUMENT 148
 ~~~~~~~~~~~~
 Applies to:
 - jni-sys-macros 0.4.1 (MIT OR Apache-2.0)
@@ -9463,7 +9497,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 148
+DOCUMENT 149
 ~~~~~~~~~~~~
 Applies to:
 - junction 2.0.0 (MIT)
@@ -9491,7 +9525,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 149
+DOCUMENT 150
 ~~~~~~~~~~~~
 Applies to:
 - keccak 0.1.6 (Apache-2.0 OR MIT)
@@ -9523,7 +9557,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 150
+DOCUMENT 151
 ~~~~~~~~~~~~
 Applies to:
 - lazy_static 1.5.0 (MIT OR Apache-2.0)
@@ -9557,7 +9591,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 151
+DOCUMENT 152
 ~~~~~~~~~~~~
 Applies to:
 - libc 0.2.186 (MIT OR Apache-2.0)
@@ -9589,7 +9623,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 152
+DOCUMENT 153
 ~~~~~~~~~~~~
 Applies to:
 - libm 0.2.16 (MIT)
@@ -9854,7 +9888,7 @@ have been licensed under extremely permissive terms.
 Copyright notices are retained in src/* files where relevant.
 
 
-DOCUMENT 153
+DOCUMENT 154
 ~~~~~~~~~~~~
 Applies to:
 - linux-raw-sys 0.12.1 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -9890,7 +9924,7 @@ is licensed under:
 at your option.
 
 
-DOCUMENT 154
+DOCUMENT 155
 ~~~~~~~~~~~~
 Applies to:
 - linux-raw-sys 0.12.1 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -10123,7 +10157,7 @@ the License, but only in their entirety and only with respect to the Combined
 Software.
 
 
-DOCUMENT 155
+DOCUMENT 156
 ~~~~~~~~~~~~
 Applies to:
 - lock_api 0.4.14 (MIT OR Apache-2.0)
@@ -10158,7 +10192,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 156
+DOCUMENT 157
 ~~~~~~~~~~~~
 Applies to:
 - lopdf 0.42.0 (MIT)
@@ -10187,7 +10221,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 157
+DOCUMENT 158
 ~~~~~~~~~~~~
 Applies to:
 - lru-slab 0.1.2 (MIT OR Apache-2.0 OR Zlib)
@@ -10201,7 +10235,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 158
+DOCUMENT 159
 ~~~~~~~~~~~~
 Applies to:
 - lru-slab 0.1.2 (MIT OR Apache-2.0 OR Zlib)
@@ -10227,7 +10261,7 @@ the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 159
+DOCUMENT 160
 ~~~~~~~~~~~~
 Applies to:
 - matrixmultiply 0.3.10 (MIT/Apache-2.0)
@@ -10261,7 +10295,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 160
+DOCUMENT 161
 ~~~~~~~~~~~~
 Applies to:
 - md-5 0.10.6 (MIT OR Apache-2.0)
@@ -10296,7 +10330,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 161
+DOCUMENT 162
 ~~~~~~~~~~~~
 Applies to:
 - memmap2 0.9.11 (MIT OR Apache-2.0)
@@ -10504,7 +10538,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 162
+DOCUMENT 163
 ~~~~~~~~~~~~
 Applies to:
 - memmap2 0.9.11 (MIT OR Apache-2.0)
@@ -10537,7 +10571,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 163
+DOCUMENT 164
 ~~~~~~~~~~~~
 Applies to:
 - minimal-lexical 0.2.1 (MIT/Apache-2.0)
@@ -10581,38 +10615,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 164
-~~~~~~~~~~~~
-Applies to:
-- miniz_oxide 0.8.9 (MIT OR Zlib OR Apache-2.0)
-
-MIT License
-
-Copyright 2013-2014 RAD Game Tools and Valve Software
-Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
-Copyright (c) 2017 Frommi
-Copyright (c) 2017-2024 oyvindln
-
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
 DOCUMENT 165
 ~~~~~~~~~~~~
 Applies to:
@@ -10624,6 +10626,7 @@ Copyright 2013-2014 RAD Game Tools and Valve Software
 Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
 Copyright (c) 2017 Frommi
 Copyright (c) 2017-2024 oyvindln
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10649,6 +10652,37 @@ DOCUMENT 166
 Applies to:
 - miniz_oxide 0.8.9 (MIT OR Zlib OR Apache-2.0)
 
+MIT License
+
+Copyright 2013-2014 RAD Game Tools and Valve Software
+Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
+Copyright (c) 2017 Frommi
+Copyright (c) 2017-2024 oyvindln
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+DOCUMENT 167
+~~~~~~~~~~~~
+Applies to:
+- miniz_oxide 0.8.9 (MIT OR Zlib OR Apache-2.0)
+
 Copyright 2013-2014 RAD Game Tools and Valve Software
 Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
 Copyright (c) 2020 Frommi
@@ -10665,7 +10699,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 167
+DOCUMENT 168
 ~~~~~~~~~~~~
 Applies to:
 - mio 1.2.1 (MIT)
@@ -10691,7 +10725,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 168
+DOCUMENT 169
 ~~~~~~~~~~~~
 Applies to:
 - moka 0.12.15 ((MIT OR Apache-2.0) AND Apache-2.0)
@@ -10899,7 +10933,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 169
+DOCUMENT 170
 ~~~~~~~~~~~~
 Applies to:
 - moka 0.12.15 ((MIT OR Apache-2.0) AND Apache-2.0)
@@ -10927,7 +10961,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 170
+DOCUMENT 171
 ~~~~~~~~~~~~
 Applies to:
 - moka 0.12.15 ((MIT OR Apache-2.0) AND Apache-2.0)
@@ -10948,7 +10982,7 @@ These files were ported from the Java Caffeine library and are not dual-licensed
 Please refer to the LICENSE-APACHE file for more details on the Apache License 2.0.
 
 
-DOCUMENT 171
+DOCUMENT 172
 ~~~~~~~~~~~~
 Applies to:
 - moxcms 0.8.1 (BSD-3-Clause OR Apache-2.0)
@@ -11157,7 +11191,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 172
+DOCUMENT 173
 ~~~~~~~~~~~~
 Applies to:
 - moxcms 0.8.1 (BSD-3-Clause OR Apache-2.0)
@@ -11191,7 +11225,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 173
+DOCUMENT 174
 ~~~~~~~~~~~~
 Applies to:
 - ndarray 0.17.2 (MIT OR Apache-2.0)
@@ -11225,7 +11259,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 174
+DOCUMENT 175
 ~~~~~~~~~~~~
 Applies to:
 - ndk-context 0.1.1 (MIT OR Apache-2.0)
@@ -11257,7 +11291,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 175
+DOCUMENT 176
 ~~~~~~~~~~~~
 Applies to:
 - nix 0.28.0 (MIT)
@@ -11286,7 +11320,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 176
+DOCUMENT 177
 ~~~~~~~~~~~~
 Applies to:
 - nom 7.1.3 (MIT)
@@ -11314,7 +11348,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 177
+DOCUMENT 178
 ~~~~~~~~~~~~
 Applies to:
 - nom-language 0.1.0 (MIT)
@@ -11346,7 +11380,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 178
+DOCUMENT 179
 ~~~~~~~~~~~~
 Applies to:
 - ntapi 0.4.3 (Apache-2.0 OR MIT)
@@ -11370,7 +11404,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 179
+DOCUMENT 180
 ~~~~~~~~~~~~
 Applies to:
 - num-conv 0.2.2 (MIT OR Apache-2.0)
@@ -11396,7 +11430,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 180
+DOCUMENT 181
 ~~~~~~~~~~~~
 Applies to:
 - objc2 0.6.4 (MIT)
@@ -11428,7 +11462,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 181
+DOCUMENT 182
 ~~~~~~~~~~~~
 Applies to:
 - objc2-core-foundation 0.3.2 (Zlib OR Apache-2.0 OR MIT)
@@ -11460,7 +11494,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 182
+DOCUMENT 183
 ~~~~~~~~~~~~
 Applies to:
 - objc2-encode 4.1.0 (MIT)
@@ -11492,7 +11526,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 183
+DOCUMENT 184
 ~~~~~~~~~~~~
 Applies to:
 - objc2-foundation 0.3.2 (MIT)
@@ -11524,7 +11558,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 184
+DOCUMENT 185
 ~~~~~~~~~~~~
 Applies to:
 - objc2-io-kit 0.3.2 (Zlib OR Apache-2.0 OR MIT)
@@ -11556,7 +11590,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 185
+DOCUMENT 186
 ~~~~~~~~~~~~
 Applies to:
 - objc2-vision 0.3.2 (Zlib OR Apache-2.0 OR MIT)
@@ -11588,7 +11622,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 186
+DOCUMENT 187
 ~~~~~~~~~~~~
 Applies to:
 - ocrs 0.12.2 (MIT OR Apache-2.0)
@@ -11620,7 +11654,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 187
+DOCUMENT 188
 ~~~~~~~~~~~~
 Applies to:
 - Ocrs bundled RTen models (CC-BY-SA-4.0 attribution)
@@ -11641,7 +11675,7 @@ Files:
   SHA-256: e484866d4cce403175bd8d00b128feb08ab42e208de30e42cd9889d8f1735a6e
 
 
-DOCUMENT 188
+DOCUMENT 189
 ~~~~~~~~~~~~
 Applies to:
 - oncemutex 0.1.1 (MIT/Apache-2.0)
@@ -11673,7 +11707,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 189
+DOCUMENT 190
 ~~~~~~~~~~~~
 Applies to:
 - openssl 0.10.81 (Apache-2.0)
@@ -11695,7 +11729,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 190
+DOCUMENT 191
 ~~~~~~~~~~~~
 Applies to:
 - openssl-macros 0.1.1 (MIT/Apache-2.0)
@@ -11721,7 +11755,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 191
+DOCUMENT 192
 ~~~~~~~~~~~~
 Applies to:
 - pdf-extract 0.12.0 (MIT)
@@ -11753,7 +11787,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 192
+DOCUMENT 193
 ~~~~~~~~~~~~
 Applies to:
 - png 0.18.1 (MIT OR Apache-2.0)
@@ -11785,7 +11819,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 193
+DOCUMENT 194
 ~~~~~~~~~~~~
 Applies to:
 - postcard 1.1.3 (MIT OR Apache-2.0)
@@ -11817,7 +11851,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 194
+DOCUMENT 195
 ~~~~~~~~~~~~
 Applies to:
 - postscript 0.14.1 (Apache-2.0/MIT)
@@ -11873,7 +11907,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 
-DOCUMENT 195
+DOCUMENT 196
 ~~~~~~~~~~~~
 Applies to:
 - powerfmt 0.2.0 (MIT OR Apache-2.0)
@@ -12081,7 +12115,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 196
+DOCUMENT 197
 ~~~~~~~~~~~~
 Applies to:
 - powerfmt 0.2.0 (MIT OR Apache-2.0)
@@ -12107,7 +12141,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 197
+DOCUMENT 198
 ~~~~~~~~~~~~
 Applies to:
 - prefix-trie 0.8.4 (MIT OR Apache-2.0)
@@ -12121,7 +12155,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 198
+DOCUMENT 199
 ~~~~~~~~~~~~
 Applies to:
 - primal-check 0.3.4 (MIT OR Apache-2.0)
@@ -12153,7 +12187,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 199
+DOCUMENT 200
 ~~~~~~~~~~~~
 Applies to:
 - proc-macro-error-attr2 2.0.0 (MIT OR Apache-2.0)
@@ -12362,7 +12396,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 200
+DOCUMENT 201
 ~~~~~~~~~~~~
 Applies to:
 - proc-macro-error-attr2 2.0.0 (MIT OR Apache-2.0)
@@ -12391,7 +12425,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 201
+DOCUMENT 202
 ~~~~~~~~~~~~
 Applies to:
 - quick-error 2.0.1 (MIT/Apache-2.0)
@@ -12417,7 +12451,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 202
+DOCUMENT 203
 ~~~~~~~~~~~~
 Applies to:
 - quick-xml 0.41.0 (MIT)
@@ -12447,7 +12481,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 203
+DOCUMENT 204
 ~~~~~~~~~~~~
 Applies to:
 - quinn 0.11.11 (MIT OR Apache-2.0)
@@ -12463,7 +12497,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 204
+DOCUMENT 205
 ~~~~~~~~~~~~
 Applies to:
 - r-efi 6.0.0 (MIT OR Apache-2.0 OR LGPL-2.1-or-later)
@@ -12495,7 +12529,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 205
+DOCUMENT 206
 ~~~~~~~~~~~~
 Applies to:
 - rand 0.10.1 (MIT OR Apache-2.0)
@@ -12517,7 +12551,7 @@ The Rand project includes code from the Rust project
 published under these same licenses.
 
 
-DOCUMENT 206
+DOCUMENT 207
 ~~~~~~~~~~~~
 Applies to:
 - rand 0.10.1 (MIT OR Apache-2.0)
@@ -12700,7 +12734,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 207
+DOCUMENT 208
 ~~~~~~~~~~~~
 Applies to:
 - rand 0.10.1 (MIT OR Apache-2.0)
@@ -12734,7 +12768,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 208
+DOCUMENT 209
 ~~~~~~~~~~~~
 Applies to:
 - rand_core 0.10.1 (MIT OR Apache-2.0)
@@ -12750,7 +12784,7 @@ licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
 <LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
 
 
-DOCUMENT 209
+DOCUMENT 210
 ~~~~~~~~~~~~
 Applies to:
 - rand_core 0.10.1 (MIT OR Apache-2.0)
@@ -12947,7 +12981,7 @@ APPENDIX: How to apply the Apache License to your work.
    identification within third-party archives.
 
 
-DOCUMENT 210
+DOCUMENT 211
 ~~~~~~~~~~~~
 Applies to:
 - rand_core 0.10.1 (MIT OR Apache-2.0)
@@ -12979,7 +13013,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 211
+DOCUMENT 212
 ~~~~~~~~~~~~
 Applies to:
 - rand_distr 0.6.0 (MIT OR Apache-2.0)
@@ -13011,7 +13045,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 212
+DOCUMENT 213
 ~~~~~~~~~~~~
 Applies to:
 - rand_pcg 0.10.2 (MIT OR Apache-2.0)
@@ -13044,7 +13078,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 213
+DOCUMENT 214
 ~~~~~~~~~~~~
 Applies to:
 - rangemap 1.7.1 (MIT/Apache-2.0)
@@ -13241,7 +13275,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 214
+DOCUMENT 215
 ~~~~~~~~~~~~
 Applies to:
 - rangemap 1.7.1 (MIT/Apache-2.0)
@@ -13255,7 +13289,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 215
+DOCUMENT 216
 ~~~~~~~~~~~~
 Applies to:
 - rcgen 0.14.8 (MIT OR Apache-2.0)
@@ -13476,7 +13510,7 @@ Apache License, version 2.0
    END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 216
+DOCUMENT 217
 ~~~~~~~~~~~~
 Applies to:
 - redox_syscall 0.5.18 (MIT)
@@ -13505,7 +13539,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 217
+DOCUMENT 218
 ~~~~~~~~~~~~
 Applies to:
 - regex-cache 0.2.1 (MIT)
@@ -13531,7 +13565,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 218
+DOCUMENT 219
 ~~~~~~~~~~~~
 Applies to:
 - reqwest 0.12.28 (MIT OR Apache-2.0)
@@ -13739,7 +13773,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 219
+DOCUMENT 220
 ~~~~~~~~~~~~
 Applies to:
 - reqwest 0.12.28 (MIT OR Apache-2.0)
@@ -13765,7 +13799,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 220
+DOCUMENT 221
 ~~~~~~~~~~~~
 Applies to:
 - resolv-conf 0.7.6 (MIT OR Apache-2.0)
@@ -13791,7 +13825,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 221
+DOCUMENT 222
 ~~~~~~~~~~~~
 Applies to:
 - ring 0.17.14 (Apache-2.0 AND ISC)
@@ -13807,7 +13841,7 @@ See src/polyfill/once_cell/LICENSE-APACHE and src/polyfill/once_cell/LICENSE-MIT
 for the license to code that was sourced from the once_cell project.
 
 
-DOCUMENT 222
+DOCUMENT 223
 ~~~~~~~~~~~~
 Applies to:
 - ring 0.17.14 (Apache-2.0 AND ISC)
@@ -14085,7 +14119,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 223
+DOCUMENT 224
 ~~~~~~~~~~~~
 Applies to:
 - ring 0.17.14 (Apache-2.0 AND ISC)
@@ -14105,7 +14139,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-DOCUMENT 224
+DOCUMENT 225
 ~~~~~~~~~~~~
 Applies to:
 - rten 0.24.0 (MIT OR Apache-2.0)
@@ -14137,7 +14171,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 225
+DOCUMENT 226
 ~~~~~~~~~~~~
 Applies to:
 - rten-base 0.24.0 (MIT OR Apache-2.0)
@@ -14169,7 +14203,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 226
+DOCUMENT 227
 ~~~~~~~~~~~~
 Applies to:
 - rten-gemm 0.24.0 (MIT OR Apache-2.0)
@@ -14201,7 +14235,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 227
+DOCUMENT 228
 ~~~~~~~~~~~~
 Applies to:
 - rten-imageproc 0.24.0 (MIT OR Apache-2.0)
@@ -14233,7 +14267,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 228
+DOCUMENT 229
 ~~~~~~~~~~~~
 Applies to:
 - rten-model-file 0.24.0 (MIT OR Apache-2.0)
@@ -14265,7 +14299,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 229
+DOCUMENT 230
 ~~~~~~~~~~~~
 Applies to:
 - rten-shape-inference 0.24.0 (MIT OR Apache-2.0)
@@ -14297,7 +14331,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 230
+DOCUMENT 231
 ~~~~~~~~~~~~
 Applies to:
 - rten-simd 0.24.0 (MIT OR Apache-2.0)
@@ -14329,7 +14363,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 231
+DOCUMENT 232
 ~~~~~~~~~~~~
 Applies to:
 - rten-tensor 0.24.0 (MIT OR Apache-2.0)
@@ -14361,7 +14395,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 232
+DOCUMENT 233
 ~~~~~~~~~~~~
 Applies to:
 - rten-vecmath 0.24.0 (MIT OR Apache-2.0)
@@ -14393,7 +14427,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 233
+DOCUMENT 234
 ~~~~~~~~~~~~
 Applies to:
 - rustfft 6.4.1 (MIT OR Apache-2.0)
@@ -14420,7 +14454,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 234
+DOCUMENT 235
 ~~~~~~~~~~~~
 Applies to:
 - rustix 1.1.4 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -14456,7 +14490,7 @@ is licensed under:
 at your option.
 
 
-DOCUMENT 235
+DOCUMENT 236
 ~~~~~~~~~~~~
 Applies to:
 - rustls-native-certs 0.8.4 (Apache-2.0 OR ISC OR MIT)
@@ -14472,7 +14506,7 @@ respectively.  You may use this software under the terms of any
 of these licenses, at your option.
 
 
-DOCUMENT 236
+DOCUMENT 237
 ~~~~~~~~~~~~
 Applies to:
 - rustls-pki-types 1.15.0 (MIT OR Apache-2.0)
@@ -14680,7 +14714,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 237
+DOCUMENT 238
 ~~~~~~~~~~~~
 Applies to:
 - rustls-pki-types 1.15.0 (MIT OR Apache-2.0)
@@ -14712,7 +14746,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 238
+DOCUMENT 239
 ~~~~~~~~~~~~
 Applies to:
 - rustls-webpki 0.103.13 (ISC)
@@ -14738,7 +14772,7 @@ The files under third-party/chromium are licensed as described in
 third-party/chromium/LICENSE.
 
 
-DOCUMENT 239
+DOCUMENT 240
 ~~~~~~~~~~~~
 Applies to:
 - rxing 0.9.1 (Apache-2.0)
@@ -14946,7 +14980,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 240
+DOCUMENT 241
 ~~~~~~~~~~~~
 Applies to:
 - ryu 1.0.23 (Apache-2.0 OR BSL-1.0)
@@ -14976,7 +15010,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 241
+DOCUMENT 242
 ~~~~~~~~~~~~
 Applies to:
 - same-file 1.0.6 (Unlicense/MIT)
@@ -15005,7 +15039,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 242
+DOCUMENT 243
 ~~~~~~~~~~~~
 Applies to:
 - scan_fmt 0.2.6 (MIT)
@@ -15033,7 +15067,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 243
+DOCUMENT 244
 ~~~~~~~~~~~~
 Applies to:
 - schannel 0.1.29 (MIT)
@@ -15047,7 +15081,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 244
+DOCUMENT 245
 ~~~~~~~~~~~~
 Applies to:
 - scopeguard 1.2.0 (MIT OR Apache-2.0)
@@ -15079,7 +15113,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 245
+DOCUMENT 246
 ~~~~~~~~~~~~
 Applies to:
 - security-framework 3.7.0 (MIT OR Apache-2.0)
@@ -15107,7 +15141,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 246
+DOCUMENT 247
 ~~~~~~~~~~~~
 Applies to:
 - serde_urlencoded 0.7.1 (MIT/Apache-2.0)
@@ -15139,7 +15173,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 247
+DOCUMENT 248
 ~~~~~~~~~~~~
 Applies to:
 - serial2 0.2.37 (BSD-2-Clause OR Apache-2.0)
@@ -15159,7 +15193,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 248
+DOCUMENT 249
 ~~~~~~~~~~~~
 Applies to:
 - serial2 0.2.37 (BSD-2-Clause OR Apache-2.0)
@@ -15190,7 +15224,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 249
+DOCUMENT 250
 ~~~~~~~~~~~~
 Applies to:
 - sha3 0.10.9 (MIT OR Apache-2.0)
@@ -15225,7 +15259,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 250
+DOCUMENT 251
 ~~~~~~~~~~~~
 Applies to:
 - shared_library 0.1.9 (Apache-2.0/MIT)
@@ -15257,7 +15291,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 251
+DOCUMENT 252
 ~~~~~~~~~~~~
 Applies to:
 - shell-words 1.1.1 (MIT/Apache-2.0)
@@ -15465,7 +15499,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 252
+DOCUMENT 253
 ~~~~~~~~~~~~
 Applies to:
 - shell-words 1.1.1 (MIT/Apache-2.0)
@@ -15497,7 +15531,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 253
+DOCUMENT 254
 ~~~~~~~~~~~~
 Applies to:
 - shlex 2.0.1 (MIT OR Apache-2.0)
@@ -15517,7 +15551,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 254
+DOCUMENT 255
 ~~~~~~~~~~~~
 Applies to:
 - shlex 2.0.1 (MIT OR Apache-2.0)
@@ -15545,7 +15579,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 255
+DOCUMENT 256
 ~~~~~~~~~~~~
 Applies to:
 - signal-hook-registry 1.4.8 (MIT OR Apache-2.0)
@@ -15577,7 +15611,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 256
+DOCUMENT 257
 ~~~~~~~~~~~~
 Applies to:
 - simd-adler32 0.3.9 (MIT)
@@ -15605,7 +15639,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 257
+DOCUMENT 258
 ~~~~~~~~~~~~
 Applies to:
 - slab 0.4.12 (MIT)
@@ -15637,7 +15671,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 258
+DOCUMENT 259
 ~~~~~~~~~~~~
 Applies to:
 - smallvec 1.15.2 (MIT OR Apache-2.0)
@@ -15669,7 +15703,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 259
+DOCUMENT 260
 ~~~~~~~~~~~~
 Applies to:
 - spin 0.9.8 (MIT)
@@ -15697,7 +15731,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 260
+DOCUMENT 261
 ~~~~~~~~~~~~
 Applies to:
 - spki 0.7.3 (Apache-2.0 OR MIT)
@@ -15729,7 +15763,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 261
+DOCUMENT 262
 ~~~~~~~~~~~~
 Applies to:
 - stable_deref_trait 1.2.1 (MIT OR Apache-2.0)
@@ -15761,7 +15795,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 262
+DOCUMENT 263
 ~~~~~~~~~~~~
 Applies to:
 - string-interner 0.19.0 (MIT/Apache-2.0)
@@ -15784,7 +15818,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 263
+DOCUMENT 264
 ~~~~~~~~~~~~
 Applies to:
 - string-interner 0.19.0 (MIT/Apache-2.0)
@@ -15813,7 +15847,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 264
+DOCUMENT 265
 ~~~~~~~~~~~~
 Applies to:
 - stringprep 0.1.5 (MIT/Apache-2.0)
@@ -15839,7 +15873,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 265
+DOCUMENT 266
 ~~~~~~~~~~~~
 Applies to:
 - strum 0.27.2 (MIT)
@@ -15868,7 +15902,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 266
+DOCUMENT 267
 ~~~~~~~~~~~~
 Applies to:
 - subtle 2.6.1 (BSD-3-Clause)
@@ -15904,7 +15938,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 267
+DOCUMENT 268
 ~~~~~~~~~~~~
 Applies to:
 - synstructure 0.13.2 (MIT)
@@ -15918,7 +15952,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 268
+DOCUMENT 269
 ~~~~~~~~~~~~
 Applies to:
 - sysinfo 0.37.2 (MIT)
@@ -15946,7 +15980,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 269
+DOCUMENT 270
 ~~~~~~~~~~~~
 Applies to:
 - system-configuration 0.7.0 (MIT OR Apache-2.0)
@@ -15979,7 +16013,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 270
+DOCUMENT 271
 ~~~~~~~~~~~~
 Applies to:
 - tagptr 0.2.0 (MIT/Apache-2.0)
@@ -15999,7 +16033,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 271
+DOCUMENT 272
 ~~~~~~~~~~~~
 Applies to:
 - tagptr 0.2.0 (MIT/Apache-2.0)
@@ -16027,7 +16061,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 272
+DOCUMENT 273
 ~~~~~~~~~~~~
 Applies to:
 - tar 0.4.46 (MIT OR Apache-2.0)
@@ -16059,7 +16093,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 273
+DOCUMENT 274
 ~~~~~~~~~~~~
 Applies to:
 - time 0.3.54 (MIT OR Apache-2.0)
@@ -16087,7 +16121,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 274
+DOCUMENT 275
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec 1.11.0 (Zlib OR Apache-2.0 OR MIT)
@@ -16099,7 +16133,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 275
+DOCUMENT 276
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec_macros 0.1.1 (MIT OR Apache-2.0 OR Zlib)
@@ -16307,7 +16341,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 276
+DOCUMENT 277
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec_macros 0.1.1 (MIT OR Apache-2.0 OR Zlib)
@@ -16335,7 +16369,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 277
+DOCUMENT 278
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec_macros 0.1.1 (MIT OR Apache-2.0 OR Zlib)
@@ -16361,7 +16395,7 @@ freely, subject to the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 278
+DOCUMENT 279
 ~~~~~~~~~~~~
 Applies to:
 - tokio 1.52.3 (MIT)
@@ -16390,7 +16424,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 279
+DOCUMENT 280
 ~~~~~~~~~~~~
 Applies to:
 - tokio-macros 2.7.0 (MIT)
@@ -16419,7 +16453,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 280
+DOCUMENT 281
 ~~~~~~~~~~~~
 Applies to:
 - tokio-rustls 0.26.4 (MIT OR Apache-2.0)
@@ -16627,7 +16661,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 281
+DOCUMENT 282
 ~~~~~~~~~~~~
 Applies to:
 - tokio-rustls 0.26.4 (MIT OR Apache-2.0)
@@ -16659,7 +16693,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 282
+DOCUMENT 283
 ~~~~~~~~~~~~
 Applies to:
 - tower 0.5.3 (MIT)
@@ -16693,7 +16727,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 283
+DOCUMENT 284
 ~~~~~~~~~~~~
 Applies to:
 - tower-http 0.6.11 (MIT)
@@ -16725,7 +16759,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 284
+DOCUMENT 285
 ~~~~~~~~~~~~
 Applies to:
 - tracing 0.1.44 (MIT)
@@ -16758,7 +16792,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 285
+DOCUMENT 286
 ~~~~~~~~~~~~
 Applies to:
 - tract-core 0.23.3 (MIT OR Apache-2.0)
@@ -16785,7 +16819,7 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
 
 
-DOCUMENT 286
+DOCUMENT 287
 ~~~~~~~~~~~~
 Applies to:
 - tract-extra 0.23.3 (MIT OR Apache-2.0)
@@ -16817,7 +16851,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 287
+DOCUMENT 288
 ~~~~~~~~~~~~
 Applies to:
 - tract-transformers 0.23.3 (MIT OR Apache-2.0)
@@ -16849,7 +16883,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 288
+DOCUMENT 289
 ~~~~~~~~~~~~
 Applies to:
 - transpose 0.2.3 (MIT OR Apache-2.0)
@@ -17057,7 +17091,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 289
+DOCUMENT 290
 ~~~~~~~~~~~~
 Applies to:
 - transpose 0.2.3 (MIT OR Apache-2.0)
@@ -17089,7 +17123,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 290
+DOCUMENT 291
 ~~~~~~~~~~~~
 Applies to:
 - try-lock 0.2.5 (MIT)
@@ -17116,7 +17150,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 291
+DOCUMENT 292
 ~~~~~~~~~~~~
 Applies to:
 - type1-encoding-parser 0.1.1 (MIT)
@@ -17148,7 +17182,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 292
+DOCUMENT 293
 ~~~~~~~~~~~~
 Applies to:
 - typenum 1.20.1 (MIT OR Apache-2.0)
@@ -17156,7 +17190,7 @@ Applies to:
 MIT OR Apache-2.0
 
 
-DOCUMENT 293
+DOCUMENT 294
 ~~~~~~~~~~~~
 Applies to:
 - typenum 1.20.1 (MIT OR Apache-2.0)
@@ -17364,7 +17398,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 294
+DOCUMENT 295
 ~~~~~~~~~~~~
 Applies to:
 - typenum 1.20.1 (MIT OR Apache-2.0)
@@ -17392,7 +17426,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 295
+DOCUMENT 296
 ~~~~~~~~~~~~
 Applies to:
 - unicode-bidi 0.3.18 (MIT OR Apache-2.0)
@@ -17407,7 +17441,7 @@ carrying such notice may not be copied, modified, or distributed except
 according to those terms.
 
 
-DOCUMENT 296
+DOCUMENT 297
 ~~~~~~~~~~~~
 Applies to:
 - unicode-ident 1.0.24 ((MIT OR Apache-2.0) AND Unicode-3.0)
@@ -17453,7 +17487,7 @@ dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
 
 
-DOCUMENT 297
+DOCUMENT 298
 ~~~~~~~~~~~~
 Applies to:
 - unicode-normalization 0.1.25 (MIT OR Apache-2.0)
@@ -17470,7 +17504,7 @@ notice may not be copied, modified, or distributed except
 according to those terms.
 
 
-DOCUMENT 298
+DOCUMENT 299
 ~~~~~~~~~~~~
 Applies to:
 - untrusted 0.9.0 (ISC)
@@ -17490,7 +17524,7 @@ Applies to:
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-DOCUMENT 299
+DOCUMENT 300
 ~~~~~~~~~~~~
 Applies to:
 - utf8_iter 1.0.4 (Apache-2.0 OR MIT)
@@ -17539,7 +17573,7 @@ licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
 <LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
 
 
-DOCUMENT 300
+DOCUMENT 301
 ~~~~~~~~~~~~
 Applies to:
 - utf8parse 0.2.2 (Apache-2.0 OR MIT)
@@ -17571,7 +17605,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 301
+DOCUMENT 302
 ~~~~~~~~~~~~
 Applies to:
 - uuid 1.24.0 (Apache-2.0 OR MIT)
@@ -17604,7 +17638,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 302
+DOCUMENT 303
 ~~~~~~~~~~~~
 Applies to:
 - vcpkg 0.2.15 (MIT/Apache-2.0)
@@ -17636,7 +17670,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 303
+DOCUMENT 304
 ~~~~~~~~~~~~
 Applies to:
 - version_check 0.9.5 (MIT/Apache-2.0)
@@ -17662,7 +17696,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 304
+DOCUMENT 305
 ~~~~~~~~~~~~
 Applies to:
 - want 0.3.1 (MIT)
@@ -17688,7 +17722,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 305
+DOCUMENT 306
 ~~~~~~~~~~~~
 Applies to:
 - wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17720,7 +17754,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 306
+DOCUMENT 307
 ~~~~~~~~~~~~
 Applies to:
 - wasm-encoder 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17752,7 +17786,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 307
+DOCUMENT 308
 ~~~~~~~~~~~~
 Applies to:
 - wasm-metadata 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17784,7 +17818,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 308
+DOCUMENT 309
 ~~~~~~~~~~~~
 Applies to:
 - wasmi 1.1.0 (MIT/Apache-2.0)
@@ -17816,7 +17850,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 309
+DOCUMENT 310
 ~~~~~~~~~~~~
 Applies to:
 - wasmi_collections 1.1.0 (MIT/Apache-2.0)
@@ -17848,7 +17882,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 310
+DOCUMENT 311
 ~~~~~~~~~~~~
 Applies to:
 - wasmi_core 1.1.0 (MIT/Apache-2.0)
@@ -17880,7 +17914,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 311
+DOCUMENT 312
 ~~~~~~~~~~~~
 Applies to:
 - wasmi_ir 1.1.0 (MIT/Apache-2.0)
@@ -17912,7 +17946,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 312
+DOCUMENT 313
 ~~~~~~~~~~~~
 Applies to:
 - wasmparser 0.239.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17944,7 +17978,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 313
+DOCUMENT 314
 ~~~~~~~~~~~~
 Applies to:
 - wasmparser 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17976,7 +18010,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 314
+DOCUMENT 315
 ~~~~~~~~~~~~
 Applies to:
 - web-time 1.1.0 (MIT OR Apache-2.0)
@@ -18184,7 +18218,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 315
+DOCUMENT 316
 ~~~~~~~~~~~~
 Applies to:
 - web-time 1.1.0 (MIT OR Apache-2.0)
@@ -18212,7 +18246,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 316
+DOCUMENT 317
 ~~~~~~~~~~~~
 Applies to:
 - weezl 0.1.12 (MIT OR Apache-2.0)
@@ -18240,7 +18274,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 317
+DOCUMENT 318
 ~~~~~~~~~~~~
 Applies to:
 - winapi 0.3.9 (MIT/Apache-2.0)
@@ -18266,7 +18300,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 318
+DOCUMENT 319
 ~~~~~~~~~~~~
 Applies to:
 - winapi-i686-pc-windows-gnu 0.4.0 (MIT/Apache-2.0)
@@ -18298,7 +18332,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 319
+DOCUMENT 320
 ~~~~~~~~~~~~
 Applies to:
 - winapi-x86_64-pc-windows-gnu 0.4.0 (MIT/Apache-2.0)
@@ -18330,7 +18364,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 320
+DOCUMENT 321
 ~~~~~~~~~~~~
 Applies to:
 - windows 0.61.3 (MIT OR Apache-2.0)
@@ -18569,7 +18603,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 321
+DOCUMENT 322
 ~~~~~~~~~~~~
 Applies to:
 - windows 0.61.3 (MIT OR Apache-2.0)
@@ -18628,7 +18662,7 @@ MIT License
     SOFTWARE
 
 
-DOCUMENT 322
+DOCUMENT 323
 ~~~~~~~~~~~~
 Applies to:
 - winnow 0.7.15 (MIT)
@@ -18653,7 +18687,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 323
+DOCUMENT 324
 ~~~~~~~~~~~~
 Applies to:
 - winreg 0.10.1 (MIT)
@@ -18679,7 +18713,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 324
+DOCUMENT 325
 ~~~~~~~~~~~~
 Applies to:
 - wit-component 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -18711,7 +18745,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 325
+DOCUMENT 326
 ~~~~~~~~~~~~
 Applies to:
 - wit-parser 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -18743,7 +18777,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 326
+DOCUMENT 327
 ~~~~~~~~~~~~
 Applies to:
 - xattr 1.6.1 (MIT OR Apache-2.0)
@@ -18775,7 +18809,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 327
+DOCUMENT 328
 ~~~~~~~~~~~~
 Applies to:
 - yasna 0.6.0 (MIT OR Apache-2.0)
@@ -18789,7 +18823,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 328
+DOCUMENT 329
 ~~~~~~~~~~~~
 Applies to:
 - zerocopy 0.8.52 (BSD-2-Clause OR Apache-2.0 OR MIT)
@@ -18998,7 +19032,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 329
+DOCUMENT 330
 ~~~~~~~~~~~~
 Applies to:
 - zerocopy 0.8.52 (BSD-2-Clause OR Apache-2.0 OR MIT)
@@ -19030,7 +19064,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 330
+DOCUMENT 331
 ~~~~~~~~~~~~
 Applies to:
 - zerocopy 0.8.52 (BSD-2-Clause OR Apache-2.0 OR MIT)
@@ -19063,7 +19097,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 331
+DOCUMENT 332
 ~~~~~~~~~~~~
 Applies to:
 - zeroize 1.8.2 (Apache-2.0 OR MIT)
@@ -19091,7 +19125,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 332
+DOCUMENT 333
 ~~~~~~~~~~~~
 Applies to:
 - zstd 0.13.3 (MIT)
@@ -19108,7 +19142,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 333
+DOCUMENT 334
 ~~~~~~~~~~~~
 Applies to:
 - zstd-safe 7.2.4 (MIT OR Apache-2.0)
@@ -19117,7 +19151,7 @@ Applies to:
 MIT or Apache-2.0
 
 
-DOCUMENT 334
+DOCUMENT 335
 ~~~~~~~~~~~~
 Applies to:
 - zstd-sys 2.0.16+zstd.1.5.7 (MIT/Apache-2.0)
@@ -19156,7 +19190,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 335
+DOCUMENT 336
 ~~~~~~~~~~~~
 Applies to:
 - zune-core 0.5.1 (MIT OR Apache-2.0 OR Zlib)
@@ -19185,7 +19219,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 336
+DOCUMENT 337
 ~~~~~~~~~~~~
 Applies to:
 - zune-core 0.5.1 (MIT OR Apache-2.0 OR Zlib)

--- a/crates/pentect-core/src/model.rs
+++ b/crates/pentect-core/src/model.rs
@@ -224,6 +224,8 @@ pub enum DetectorId {
     Plugin,
     /// Native Rust port of embedded CredSweeper rule/model assets.
     CredSweeper,
+    /// PII detected by the bundled Alcatraz helper.
+    Alcatraz,
     Rule,
     /// A plaintext key/value assignment whose key and value features are secret-like.
     KeyValue,
@@ -247,6 +249,7 @@ impl DetectorId {
             DetectorId::Explicit => "explicit",
             DetectorId::Plugin => "plugin",
             DetectorId::CredSweeper => "credsweeper",
+            DetectorId::Alcatraz => "alcatraz",
             DetectorId::Rule => "rule",
             DetectorId::KeyValue => "key_value",
             DetectorId::Entropy => "entropy",

--- a/crates/pentect-core/src/pipeline/render.rs
+++ b/crates/pentect-core/src/pipeline/render.rs
@@ -164,7 +164,8 @@ fn explicit_wrapper_bounds(raw: &str, span: &Span) -> Option<(usize, usize)> {
 }
 
 fn should_split_email(span: &Span) -> bool {
-    !(span.source == DetectorId::Plugin && span.label == "EMAIL")
+    !((span.source == DetectorId::Plugin && span.label == "EMAIL")
+        || (span.source == DetectorId::Alcatraz && span.label == "EMAIL_ADDRESS"))
 }
 
 fn push_literal(segments: &mut Vec<RenderSegment>, masked: &mut String, text: &str) {

--- a/crates/pentect-runtime/Cargo.toml
+++ b/crates/pentect-runtime/Cargo.toml
@@ -45,6 +45,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }
 sha2 = { workspace = true }
+zstd = { workspace = true }
 hmac = { workspace = true }
 chacha20 = { workspace = true }
 toml = { workspace = true }
@@ -106,3 +107,7 @@ libc = "0.2"
 [dev-dependencies]
 rxing = { workspace = true, features = ["encoders"] }
 wat = "1"
+
+[build-dependencies]
+sha2 = { workspace = true }
+zstd = { workspace = true }

--- a/crates/pentect-runtime/build.rs
+++ b/crates/pentect-runtime/build.rs
@@ -1,0 +1,90 @@
+use sha2::{Digest, Sha256};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../tools/alcatraz-helper/main.go");
+    println!("cargo:rerun-if-changed=../../tools/alcatraz-helper/go.mod");
+    println!("cargo:rerun-if-changed=../../tools/alcatraz-helper/go.sum");
+    println!("cargo:rerun-if-env-changed=PENTECT_ALCATRAZ_HELPER");
+    println!("cargo:rerun-if-env-changed=PENTECT_REQUIRE_ALCATRAZ");
+
+    let out = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR"));
+    let executable = out.join(
+        if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+            "pentect-alcatraz.exe"
+        } else {
+            "pentect-alcatraz"
+        },
+    );
+    let supplied = env::var_os("PENTECT_ALCATRAZ_HELPER").map(PathBuf::from);
+    let result = if let Some(path) = supplied {
+        fs::copy(path, &executable)
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    } else {
+        build_helper(&executable)
+    };
+
+    if let Err(error) = result {
+        if env::var_os("PENTECT_REQUIRE_ALCATRAZ").is_some() {
+            panic!("Alcatraz helper is required but could not be built: {error}");
+        }
+        println!("cargo:warning=Alcatraz PII helper disabled: {error}");
+        fs::write(&executable, []).expect("write disabled Alcatraz marker");
+    }
+
+    let bytes = fs::read(&executable).expect("read Alcatraz helper");
+    let compressed =
+        zstd::stream::encode_all(bytes.as_slice(), 19).expect("compress Alcatraz helper");
+    let compressed_path = out.join("pentect-alcatraz.zst");
+    fs::write(&compressed_path, compressed).expect("write compressed Alcatraz helper");
+    println!(
+        "cargo:rustc-env=PENTECT_ALCATRAZ_ZST={}",
+        compressed_path.display()
+    );
+    println!(
+        "cargo:rustc-env=PENTECT_ALCATRAZ_SHA256={:x}",
+        Sha256::digest(&bytes)
+    );
+    println!("cargo:rustc-env=PENTECT_ALCATRAZ_SIZE={}", bytes.len());
+}
+
+fn build_helper(output: &Path) -> Result<(), String> {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").map_err(|e| e.to_string())?;
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").map_err(|e| e.to_string())?;
+    let goos = match target_os.as_str() {
+        "linux" => "linux",
+        "macos" => "darwin",
+        "windows" => "windows",
+        other => return Err(format!("unsupported target OS {other}")),
+    };
+    let goarch = match target_arch.as_str() {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => return Err(format!("unsupported target architecture {other}")),
+    };
+    let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tools/alcatraz-helper");
+    let status = Command::new("go")
+        .current_dir(helper)
+        .env("CGO_ENABLED", "0")
+        .env("GOOS", goos)
+        .env("GOARCH", goarch)
+        .args([
+            "build",
+            "-trimpath",
+            "-buildvcs=false",
+            "-ldflags=-s -w -buildid=",
+            "-o",
+        ])
+        .arg(output)
+        .arg(".")
+        .status()
+        .map_err(|e| format!("could not run Go: {e}"))?;
+    status
+        .success()
+        .then_some(())
+        .ok_or_else(|| format!("go build exited with {status}"))
+}

--- a/crates/pentect-runtime/src/alcatraz.rs
+++ b/crates/pentect-runtime/src/alcatraz.rs
@@ -9,6 +9,11 @@ use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::{Mutex, OnceLock};
 
 const VERSION: &str = "0.20.2";
+// A JSON string can expand one input byte to six bytes (for example `\u0000`).
+// Four MiB therefore stays below the helper's 32 MiB Scanner limit even in the
+// worst case. The overlap preserves recognizers spanning a chunk boundary.
+const REQUEST_CHUNK_BYTES: usize = 4 * 1024 * 1024;
+const REQUEST_OVERLAP_BYTES: usize = 4 * 1024;
 const EXPECTED_SHA256: &str = env!("PENTECT_ALCATRAZ_SHA256");
 const UNCOMPRESSED_SIZE: usize = parse_size(env!("PENTECT_ALCATRAZ_SIZE"));
 static COMPRESSED: &[u8] = include_bytes!(env!("PENTECT_ALCATRAZ_ZST"));
@@ -177,6 +182,26 @@ impl Helper {
 }
 
 fn detect(text: &str) -> Result<Vec<Finding>, String> {
+    let mut findings = Vec::new();
+    for (start, end) in chunk_ranges(text) {
+        for mut finding in request(&text[start..end])? {
+            finding.start += start;
+            finding.end += start;
+            findings.push(finding);
+        }
+    }
+    findings.sort_by(|left, right| {
+        (&left.entity, left.start, left.end)
+            .cmp(&(&right.entity, right.start, right.end))
+            .then_with(|| right.score.total_cmp(&left.score))
+    });
+    findings.dedup_by(|right, left| {
+        right.entity == left.entity && right.start == left.start && right.end == left.end
+    });
+    Ok(findings)
+}
+
+fn request(text: &str) -> Result<Vec<Finding>, String> {
     let process = PROCESS.get_or_init(|| Mutex::new(None));
     let mut process = process.lock().map_err(|_| "Alcatraz lock poisoned")?;
     if process.is_none() {
@@ -193,6 +218,33 @@ fn detect(text: &str) -> Result<Vec<Finding>, String> {
                 .map_err(|second| format!("{first}; restart failed: {second}"))
         }
     }
+}
+
+fn chunk_ranges(text: &str) -> Vec<(usize, usize)> {
+    if text.len() <= REQUEST_CHUNK_BYTES {
+        return vec![(0, text.len())];
+    }
+    let mut ranges = Vec::with_capacity(text.len().div_ceil(REQUEST_CHUNK_BYTES));
+    let mut start = 0usize;
+    while start < text.len() {
+        let mut end = (start + REQUEST_CHUNK_BYTES).min(text.len());
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        ranges.push((start, end));
+        if end == text.len() {
+            break;
+        }
+        let mut next = end.saturating_sub(REQUEST_OVERLAP_BYTES);
+        while !text.is_char_boundary(next) {
+            next += 1;
+        }
+        start = next.max(start + 1);
+        while !text.is_char_boundary(start) {
+            start += 1;
+        }
+    }
+    ranges
 }
 
 fn ensure_extracted() -> Result<PathBuf, String> {
@@ -306,4 +358,41 @@ fn make_executable(path: &Path) -> Result<(), String> {
 #[cfg(not(unix))]
 fn make_executable(_: &Path) -> Result<(), String> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_ranges_are_bounded_overlapping_and_utf8_aligned() {
+        let text = format!(
+            "{}é{}",
+            "a".repeat(REQUEST_CHUNK_BYTES - 1),
+            "b".repeat(9000)
+        );
+        let ranges = chunk_ranges(&text);
+        assert!(ranges.len() >= 2);
+        assert_eq!(ranges.first().copied().unwrap().0, 0);
+        assert_eq!(ranges.last().copied().unwrap().1, text.len());
+        for &(start, end) in &ranges {
+            assert!(end - start <= REQUEST_CHUNK_BYTES);
+            assert!(text.is_char_boundary(start));
+            assert!(text.is_char_boundary(end));
+        }
+        for pair in ranges.windows(2) {
+            assert!(pair[1].0 < pair[0].1);
+        }
+    }
+
+    #[test]
+    fn detects_pii_after_the_helper_line_limit() {
+        let mut text = "a".repeat(33 * 1024 * 1024);
+        text.push_str("\nemail: alice@example.com\n");
+        let spans = detect_text(&text);
+        assert!(spans.iter().any(|span| {
+            span.label == "EMAIL_ADDRESS"
+                && text.get(span.range.start..span.range.end) == Some("alice@example.com")
+        }));
+    }
 }

--- a/crates/pentect-runtime/src/alcatraz.rs
+++ b/crates/pentect-runtime/src/alcatraz.rs
@@ -1,0 +1,309 @@
+use pentect_core::normalize::NormalizedView;
+use pentect_core::{ByteRange, Category, Confidence, Detector, DetectorId, Span};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::{Mutex, OnceLock};
+
+const VERSION: &str = "0.20.2";
+const EXPECTED_SHA256: &str = env!("PENTECT_ALCATRAZ_SHA256");
+const UNCOMPRESSED_SIZE: usize = parse_size(env!("PENTECT_ALCATRAZ_SIZE"));
+static COMPRESSED: &[u8] = include_bytes!(env!("PENTECT_ALCATRAZ_ZST"));
+static PROCESS: OnceLock<Mutex<Option<Helper>>> = OnceLock::new();
+
+pub(crate) struct AlcatrazDetector;
+
+pub(crate) fn detect_text(text: &str) -> Vec<Span> {
+    if UNCOMPRESSED_SIZE == 0 || text.is_empty() {
+        return Vec::new();
+    }
+    match detect(text) {
+        Ok(findings) => findings
+            .into_iter()
+            .filter_map(|finding| finding.into_direct_span(text))
+            .collect(),
+        Err(error) => {
+            eprintln!("[pentect] warning/alcatraz detector-unavailable: {error}");
+            Vec::new()
+        }
+    }
+}
+
+impl Detector for AlcatrazDetector {
+    fn detect(&self, view: &NormalizedView<'_>) -> Vec<Span> {
+        if UNCOMPRESSED_SIZE == 0 || view.text().is_empty() {
+            return Vec::new();
+        }
+        match detect(view.text()) {
+            Ok(findings) => findings
+                .into_iter()
+                .filter_map(|finding| finding.into_span(view))
+                .collect(),
+            Err(error) => {
+                eprintln!("[pentect] warning/alcatraz detector-unavailable: {error}");
+                Vec::new()
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct Response {
+    id: u64,
+    findings: Vec<Finding>,
+}
+
+#[derive(Deserialize)]
+struct Finding {
+    entity: String,
+    start: usize,
+    end: usize,
+    score: f64,
+}
+
+impl Finding {
+    fn confidence(&self) -> Confidence {
+        if self.score >= 0.8 {
+            Confidence::High
+        } else if self.score >= 0.4 {
+            Confidence::Medium
+        } else {
+            Confidence::Low
+        }
+    }
+
+    fn into_direct_span(self, text: &str) -> Option<Span> {
+        if self.start >= self.end
+            || self.end > text.len()
+            || !text.is_char_boundary(self.start)
+            || !text.is_char_boundary(self.end)
+        {
+            return None;
+        }
+        let confidence = self.confidence();
+        Some(Span {
+            range: ByteRange::new(self.start, self.end),
+            category: Category::Pii,
+            label: self.entity,
+            confidence,
+            source: DetectorId::Alcatraz,
+        })
+    }
+
+    fn into_span(self, view: &NormalizedView<'_>) -> Option<Span> {
+        if self.start >= self.end
+            || self.end > view.text().len()
+            || !view.text().is_char_boundary(self.start)
+            || !view.text().is_char_boundary(self.end)
+        {
+            return None;
+        }
+        let confidence = self.confidence();
+        Some(Span {
+            range: view.to_raw(ByteRange::new(self.start, self.end)),
+            category: Category::Pii,
+            label: self.entity,
+            confidence,
+            source: DetectorId::Alcatraz,
+        })
+    }
+}
+
+impl Drop for Helper {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+struct Helper {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl Helper {
+    fn start() -> Result<Self, String> {
+        let executable = ensure_extracted()?;
+        let mut child = Command::new(&executable)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| format!("could not start '{}': {e}", executable.display()))?;
+        let stdin = child.stdin.take().ok_or("Alcatraz stdin unavailable")?;
+        let stdout = child.stdout.take().ok_or("Alcatraz stdout unavailable")?;
+        Ok(Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            next_id: 1,
+        })
+    }
+
+    fn request(&mut self, text: &str) -> Result<Vec<Finding>, String> {
+        if self.child.try_wait().map_err(|e| e.to_string())?.is_some() {
+            return Err("Alcatraz helper exited".to_string());
+        }
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        serde_json::to_writer(
+            &mut self.stdin,
+            &serde_json::json!({"id": id, "text": text}),
+        )
+        .map_err(|e| format!("could not encode Alcatraz request: {e}"))?;
+        self.stdin
+            .write_all(b"\n")
+            .and_then(|_| self.stdin.flush())
+            .map_err(|e| format!("could not send Alcatraz request: {e}"))?;
+        let mut line = String::new();
+        self.stdout
+            .read_line(&mut line)
+            .map_err(|e| format!("could not read Alcatraz response: {e}"))?;
+        if line.is_empty() {
+            return Err("Alcatraz helper closed stdout".to_string());
+        }
+        let response: Response =
+            serde_json::from_str(&line).map_err(|e| format!("invalid Alcatraz response: {e}"))?;
+        if response.id != id {
+            return Err("Alcatraz response ID mismatch".to_string());
+        }
+        Ok(response.findings)
+    }
+}
+
+fn detect(text: &str) -> Result<Vec<Finding>, String> {
+    let process = PROCESS.get_or_init(|| Mutex::new(None));
+    let mut process = process.lock().map_err(|_| "Alcatraz lock poisoned")?;
+    if process.is_none() {
+        *process = Some(Helper::start()?);
+    }
+    match process.as_mut().expect("initialized").request(text) {
+        Ok(findings) => Ok(findings),
+        Err(first) => {
+            *process = Some(Helper::start()?);
+            process
+                .as_mut()
+                .expect("restarted")
+                .request(text)
+                .map_err(|second| format!("{first}; restart failed: {second}"))
+        }
+    }
+}
+
+fn ensure_extracted() -> Result<PathBuf, String> {
+    let root = cache_root()?
+        .join("runtime")
+        .join("alcatraz")
+        .join(VERSION)
+        .join(EXPECTED_SHA256);
+    fs::create_dir_all(&root).map_err(|e| format!("could not create '{}': {e}", root.display()))?;
+    restrict_directory(&root)?;
+    let destination = root.join(if cfg!(windows) {
+        "alcatraz.exe"
+    } else {
+        "alcatraz"
+    });
+    if valid_file(&destination)? {
+        return Ok(destination);
+    }
+    let bytes = zstd::stream::decode_all(COMPRESSED)
+        .map_err(|e| format!("could not decompress embedded Alcatraz: {e}"))?;
+    if bytes.len() != UNCOMPRESSED_SIZE || sha256_hex(&bytes) != EXPECTED_SHA256 {
+        return Err("embedded Alcatraz integrity check failed".to_string());
+    }
+    let temporary = root.join(format!(".alcatraz-{}.tmp", std::process::id()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .map_err(|e| format!("could not stage '{}': {e}", temporary.display()))?;
+    file.write_all(&bytes)
+        .and_then(|_| file.sync_all())
+        .map_err(|e| format!("could not write '{}': {e}", temporary.display()))?;
+    make_executable(&temporary)?;
+    match fs::rename(&temporary, &destination) {
+        Ok(()) => {}
+        Err(_) if valid_file(&destination)? => {
+            let _ = fs::remove_file(&temporary);
+        }
+        Err(error) => {
+            return Err(format!(
+                "could not install '{}': {error}",
+                destination.display()
+            ))
+        }
+    }
+    Ok(destination)
+}
+
+fn valid_file(path: &Path) -> Result<bool, String> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("could not verify '{}': {error}", path.display())),
+    };
+    Ok(bytes.len() == UNCOMPRESSED_SIZE && sha256_hex(&bytes) == EXPECTED_SHA256)
+}
+
+fn cache_root() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    let root = std::env::var_os("LOCALAPPDATA").map(PathBuf::from);
+    #[cfg(target_os = "macos")]
+    let root = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join("Library").join("Caches"));
+    #[cfg(not(any(windows, target_os = "macos")))]
+    let root = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .map(|home| home.join(".cache"))
+        });
+    root.map(|root| root.join("pentect"))
+        .ok_or_else(|| "could not determine Pentect cache directory".to_string())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+const fn parse_size(value: &str) -> usize {
+    let bytes = value.as_bytes();
+    let mut result = 0usize;
+    let mut index = 0usize;
+    while index < bytes.len() {
+        result = result * 10 + (bytes[index] - b'0') as usize;
+        index += 1;
+    }
+    result
+}
+
+#[cfg(unix)]
+fn restrict_directory(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|e| format!("could not restrict '{}': {e}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn restrict_directory(_: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|e| format!("could not make '{}': {e}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn make_executable(_: &Path) -> Result<(), String> {
+    Ok(())
+}

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -8,6 +8,7 @@
 //! recovery material.
 
 mod activity_log;
+mod alcatraz;
 mod config;
 mod delegated_process_host;
 mod file_pointer_manager;

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -888,6 +888,19 @@ fn mask_read_input_with_engine_plugins_and_identity(
         },
         &cfg,
     );
+    let alcatraz_input = result.masked.clone();
+    let alcatraz_spans = crate::alcatraz::detect_text(&alcatraz_input);
+    if !alcatraz_spans.is_empty() {
+        let alcatraz_result = engine.mask_spans(
+            Input {
+                kind: kind.clone(),
+                data: alcatraz_input,
+            },
+            alcatraz_spans,
+            &cfg,
+        );
+        merge_final_mask_result(&mut result, alcatraz_result);
+    }
     let data = run_read_text_plugin_stage(
         plugins,
         crate::plugin_middleware::MiddlewareStage::Prepare,
@@ -1027,6 +1040,7 @@ fn build_pentect_engine_with_prompt_detectors(prompt: bool) -> Result<Engine, St
         .parser(Kind::Har, Box::new(JsonParser))
         .parser(Kind::ToolResult, Box::new(ToolResultParser))
         .detector(Box::new(CredSweeperNativeDetector::builtin()))
+        .detector(Box::new(crate::alcatraz::AlcatrazDetector))
         .detector(Box::new(ExplicitSecretDetector));
     if prompt {
         builder = builder.detector(Box::new(KeyValueDetector));

--- a/tools/alcatraz-helper/LICENSE
+++ b/tools/alcatraz-helper/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 hoop.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/alcatraz-helper/SOURCE.json
+++ b/tools/alcatraz-helper/SOURCE.json
@@ -1,0 +1,5 @@
+{
+  "repository": "https://github.com/hoophq/alcatraz",
+  "version": "0.20.2",
+  "commit": "cd2e19b7d0f08b113c52ef52d3485c64a0871455"
+}

--- a/tools/alcatraz-helper/go.mod
+++ b/tools/alcatraz-helper/go.mod
@@ -1,0 +1,5 @@
+module github.com/EdamAme-x/pentect/tools/alcatraz-helper
+
+go 1.24
+
+require github.com/hoophq/alcatraz v0.20.2

--- a/tools/alcatraz-helper/go.sum
+++ b/tools/alcatraz-helper/go.sum
@@ -1,0 +1,2 @@
+github.com/hoophq/alcatraz v0.20.2 h1:j+fN7stHGKqHnGaloN0AZOASgYsgJQN2wC8L4iZtBI8=
+github.com/hoophq/alcatraz v0.20.2/go.mod h1:B5ZNcwna5qCRZpVN6MMjmUbzEDpk5Q04jnKxqfZucdM=

--- a/tools/alcatraz-helper/main.go
+++ b/tools/alcatraz-helper/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+
+	"github.com/hoophq/alcatraz"
+)
+
+type request struct {
+	ID   uint64 `json:"id"`
+	Text string `json:"text"`
+}
+
+type finding struct {
+	Entity string  `json:"entity"`
+	Start  int     `json:"start"`
+	End    int     `json:"end"`
+	Score  float64 `json:"score"`
+}
+
+type response struct {
+	ID       uint64    `json:"id"`
+	Findings []finding `json:"findings"`
+}
+
+func main() {
+	engine := alcatraz.NewEngine()
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 64*1024), 32*1024*1024)
+	encoder := json.NewEncoder(os.Stdout)
+	for scanner.Scan() {
+		var req request
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			os.Exit(2)
+		}
+		results := engine.Analyze(req.Text, alcatraz.Options{})
+		findings := make([]finding, 0, len(results))
+		for _, result := range results {
+			findings = append(findings, finding{
+				Entity: result.EntityType,
+				Start:  result.Start,
+				End:    result.End,
+				Score:  result.Score,
+			})
+		}
+		if err := encoder.Encode(response{ID: req.ID, Findings: findings}); err != nil {
+			os.Exit(2)
+		}
+	}
+	if scanner.Err() != nil {
+		os.Exit(2)
+	}
+}

--- a/tools/alcatraz-helper/main.go
+++ b/tools/alcatraz-helper/main.go
@@ -4,9 +4,19 @@ import (
 	"bufio"
 	"encoding/json"
 	"os"
+	"regexp"
 
 	"github.com/hoophq/alcatraz"
+	"github.com/hoophq/alcatraz/entities"
 )
+
+var uuidPattern = regexp.MustCompile(`(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b`)
+
+var piiEntities = []string{
+	entities.EmailAddress,
+	entities.PhoneNumber,
+	entities.CreditCard,
+}
 
 type request struct {
 	ID   uint64 `json:"id"`
@@ -27,6 +37,7 @@ type response struct {
 
 func main() {
 	engine := alcatraz.NewEngine()
+	threshold := 0.4
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Buffer(make([]byte, 64*1024), 32*1024*1024)
 	encoder := json.NewEncoder(os.Stdout)
@@ -35,9 +46,16 @@ func main() {
 		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
 			os.Exit(2)
 		}
-		results := engine.Analyze(req.Text, alcatraz.Options{})
+		results := engine.Analyze(req.Text, alcatraz.Options{
+			Entities:  piiEntities,
+			Threshold: &threshold,
+		})
+		uuidRanges := uuidPattern.FindAllStringIndex(req.Text, -1)
 		findings := make([]finding, 0, len(results))
 		for _, result := range results {
+			if containedInAny(result.Start, result.End, uuidRanges) {
+				continue
+			}
 			findings = append(findings, finding{
 				Entity: result.EntityType,
 				Start:  result.Start,
@@ -52,4 +70,13 @@ func main() {
 	if scanner.Err() != nil {
 		os.Exit(2)
 	}
+}
+
+func containedInAny(start, end int, ranges [][]int) bool {
+	for _, span := range ranges {
+		if span[0] <= start && end <= span[1] {
+			return true
+		}
+	}
+	return false
 }

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -213,6 +213,10 @@ def generate() -> str:
             ROOT / "crates/pentect-core/vendors/credsweeper-assets/LICENSE",
         ),
         (
+            "Alcatraz 0.20.2 bundled PII helper (MIT)",
+            ROOT / "tools/alcatraz-helper/LICENSE",
+        ),
+        (
             "Ocrs bundled RTen models (CC-BY-SA-4.0 attribution)",
             ROOT / "crates/pentect-runtime/assets/ocr/NOTICE.txt",
         ),
@@ -238,6 +242,12 @@ def generate() -> str:
         f"Version: {credsweeper_version} (commit {credsweeper_commit})",
         "Copyright (c) 2021 SAMSUNG",
         "License: MIT. The full MIT text appears below in the Cargo license documents.",
+        "",
+        "Alcatraz bundled PII helper",
+        "Source: https://github.com/hoophq/alcatraz",
+        "Version: 0.20.2 (commit cd2e19b7d0f08b113c52ef52d3485c64a0871455)",
+        "Copyright (c) 2026 hoop.dev",
+        "License: MIT. The full MIT text appears below.",
         "",
         "Ocrs RTen text detection and recognition models",
         "Creator and source: Robert Knight, https://huggingface.co/robertknight/ocrs",


### PR DESCRIPTION
## Summary

- bundle a pinned pure-Go Alcatraz v0.20.2 helper inside each Pentect release binary
- zstd-compress it at build time and securely extract it into a versioned SHA-256 cache on first use
- keep one JSONL helper process alive and feed its byte-offset PII findings through Pentect core rendering/recovery
- verify email, phone, and card masking without Go installed in every release target job
- run CredSweeper parity both on detector PRs and weekly against the latest upstream release, failing on drift

## Local verification

- `go test ./...` in `tools/alcatraz-helper`
- `PENTECT_REQUIRE_ALCATRAZ=1 cargo check -p pentect-runtime`
- `cargo test -p pentect-core --no-default-features pipeline::render::tests --locked`
- `PENTECT_REQUIRE_ALCATRAZ=1 cargo clippy -p pentect-runtime --no-default-features --locked -- -D warnings`
- standalone CLI E2E masked email, phone, and Luhn-valid card; extracted helper was SHA-addressed and mode 0700


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Alcatraz PII detection to identify and mask sensitive information.
  - Added support for splitting detected email addresses into local parts and domains.
  - Added bundled, cross-platform Alcatraz runtime support with automatic recovery if the detector stops.
  - Added Alcatraz attribution and license information.

- **Testing & Reliability**
  - Expanded automated checks for Alcatraz integration, masking, releases, and regression coverage.
  - Added scheduled CredSweeper regression validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->