### PR TITLE
ci: allow Windows plugin tests to finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
     needs: changes
     if: always()
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- raise only the cross-platform plugin job timeout from 15 to 25 minutes
- preserve all test commands and pass/fail conditions

## Why

The Windows plugin job on #945 was cancelled at the exact 15-minute job limit while compiling `pentect-plugin-runtime`; the equivalent macOS job and all product/regression checks passed. This prevents a cold Windows build from being reported as a test failure.