### PR TITLE
ci: verify CredSweeper parity across all CredData

### DIFF
--- a/.github/workflows/credsweeper-regression.yml
+++ b/.github/workflows/credsweeper-regression.yml
@@ -2,8 +2,8 @@ name: CredSweeper regression
 
 on:
   schedule:
-    # Compare the native port with the latest upstream release every Monday.
-    - cron: "17 3 * * 1"
+    # Compare every CredData repository with the latest upstream release weekly.
+    - cron: "17 4 * * 1"
   push:
     branches: [main]
     paths:
@@ -17,6 +17,8 @@ on:
       - 'crates/pentect-core/vendors/CredSweeper'
       - 'crates/pentect-core/vendors/credsweeper-assets/**'
       - 'tools/check_credsweeper_regression.py'
+      - 'tools/creddata_shards.py'
+      - 'tools/test_creddata_shards.py'
       - 'tools/credsweeper-sidecar/**'
       - 'tools/pentect-bench/**'
       - 'tools/update_credsweeper.py'
@@ -32,10 +34,17 @@ on:
       - 'crates/pentect-core/vendors/CredSweeper'
       - 'crates/pentect-core/vendors/credsweeper-assets/**'
       - 'tools/check_credsweeper_regression.py'
+      - 'tools/creddata_shards.py'
+      - 'tools/test_creddata_shards.py'
       - 'tools/credsweeper-sidecar/**'
       - 'tools/pentect-bench/**'
       - 'tools/update_credsweeper.py'
   workflow_dispatch:
+    inputs:
+      full:
+        description: Run the full 333-repository parity matrix
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -46,6 +55,7 @@ concurrency:
 
 jobs:
   regression:
+    if: github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && inputs.full)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -94,9 +104,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Sync latest CredSweeper release for weekly parity check
-        if: github.event_name == 'schedule'
-        run: python tools/update_credsweeper.py latest
+      - name: Test CredData shard tooling
+        run: python -m unittest tools/test_creddata_shards.py
 
       - name: Install official CredSweeper oracle dependencies
         run: |
@@ -167,12 +176,127 @@ jobs:
             --save-credsweeper-json "$out/rust.json" \
             --save-credsweeper-paths "$out/paths.txt" \
             --json
-          mapfile -t paths < "$out/paths.txt"
           PYTHONPATH="$PWD/crates/pentect-core/vendors/CredSweeper" \
-            python tools/credsweeper-sidecar/sidecar.py "${paths[@]}" --output "$out/oracle.json"
+            python tools/credsweeper-sidecar/sidecar.py \
+              --paths-file "$out/paths.txt" \
+              --output "$out/oracle.json"
           "$RUNNER_TEMP/pentect-bench-candidate" credsweeper-parity \
             "$out/rust.json" \
             "$out/oracle.json" \
             --min-precision 1 \
             --min-recall 1 \
             --json
+
+  weekly-parity:
+    name: Weekly parity (shard ${{ matrix.shard }})
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.full)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: ./.github/actions/rust-toolchain
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: credsweeper-weekly-parity
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync latest CredSweeper release
+        run: python tools/update_credsweeper.py latest
+
+      - name: Install official CredSweeper oracle dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r tools/credsweeper-sidecar/runtime-requirements.txt
+
+      - name: Prepare CredData shard
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
+          SHARD_COUNT: 16
+        run: |
+          mkdir -p "$RUNNER_TEMP/shard-$SHARD_INDEX"
+          version="$(python -c 'import json; print(json.load(open("crates/pentect-core/vendors/credsweeper-assets/SOURCE.json"))["version"])')"
+          python tools/creddata_shards.py prepare \
+            --root benchmarks/CredData \
+            --index "$SHARD_INDEX" \
+            --count "$SHARD_COUNT" \
+            --manifest "$RUNNER_TEMP/shard-$SHARD_INDEX/manifest.json" \
+            --credsweeper-version "$version"
+          (cd benchmarks/CredData && python download_data.py --clean_data --jobs 4)
+
+      - name: Build native benchmark
+        run: |
+          cargo build --release --manifest-path tools/pentect-bench/Cargo.toml \
+            --target-dir "$RUNNER_TEMP/target"
+
+      - name: Compare native port with official CredSweeper
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/shard-$SHARD_INDEX"
+          "$RUNNER_TEMP/target/release/pentect-bench" creddata benchmarks/CredData \
+            --ignore-x \
+            --save-credsweeper-json "$out/rust.json" \
+            --save-credsweeper-paths "$out/paths.txt" \
+            --json
+          PYTHONPATH="$PWD/crates/pentect-core/vendors/CredSweeper" \
+            python tools/credsweeper-sidecar/sidecar.py \
+              --paths-file "$out/paths.txt" \
+              --output "$out/oracle.json"
+          "$RUNNER_TEMP/target/release/pentect-bench" credsweeper-parity \
+            "$out/rust.json" \
+            "$out/oracle.json" \
+            --min-precision 1 \
+            --min-recall 1 \
+            --json | tee "$out/report.json"
+
+      - name: Upload shard report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: |
+            ${{ runner.temp }}/shard-${{ matrix.shard }}/manifest.json
+            ${{ runner.temp }}/shard-${{ matrix.shard }}/report.json
+          if-no-files-found: error
+          retention-days: 14
+
+  weekly-summary:
+    name: Weekly full CredData parity
+    if: always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.full))
+    needs: weekly-parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: shard-*
+          path: ${{ runner.temp }}/weekly-parity
+      - name: Verify complete CredData coverage and parity
+        run: |
+          python tools/creddata_shards.py summarize \
+            --root benchmarks/CredData \
+            --artifacts "$RUNNER_TEMP/weekly-parity" \
+            --count 16 \
+            --output "$RUNNER_TEMP/weekly-parity-summary.json"
+          test '${{ needs.weekly-parity.result }}' = success
+      - name: Publish summary
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/weekly-parity-summary.json" ]; then
+            cat "$RUNNER_TEMP/weekly-parity-summary.json" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/tools/creddata_shards.py
+++ b/tools/creddata_shards.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Prepare and verify deterministic CredData shards for weekly parity CI."""
+
+from __future__ import annotations
+
+import argparse
+import binascii
+import json
+from pathlib import Path
+from typing import Any
+
+
+def short_id(repo_id: str) -> str:
+    return f"{binascii.crc32(bytes.fromhex(repo_id)):08x}"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def prepare(root: Path, index: int, count: int, manifest: Path, version: str) -> None:
+    if count < 1 or not 0 <= index < count:
+        raise SystemExit(f"invalid shard {index}/{count}")
+    snapshot_path = root / "snapshot.json"
+    snapshot: dict[str, str] = load_json(snapshot_path)
+    entries = sorted(snapshot.items(), key=lambda item: (short_id(item[0]), item[0]))
+    selected = entries[index::count]
+    if not selected:
+        raise SystemExit(f"shard {index}/{count} is empty")
+
+    selected_short_ids = {short_id(repo_id) for repo_id, _ in selected}
+    available_meta = {path.stem for path in (root / "meta").glob("*.csv")}
+    missing_meta = selected_short_ids - available_meta
+    if missing_meta:
+        raise SystemExit(f"CredData metadata missing for: {sorted(missing_meta)}")
+
+    write_json(snapshot_path, dict(selected))
+    for path in (root / "meta").glob("*.csv"):
+        if path.stem not in selected_short_ids:
+            path.unlink()
+    write_json(
+        manifest,
+        {
+            "schema": 1,
+            "index": index,
+            "count": count,
+            "credsweeper_version": version,
+            "repositories": [
+                {"id": repo_id, "short_id": short_id(repo_id)}
+                for repo_id, _ in selected
+            ],
+        },
+    )
+    print(f"prepared CredData shard {index + 1}/{count}: {len(selected)} repositories")
+
+
+def summarize(root: Path, artifacts: Path, count: int, output: Path) -> None:
+    expected: dict[str, str] = load_json(root / "snapshot.json")
+    manifests = sorted(artifacts.glob("shard-*/manifest.json"))
+    reports = sorted(artifacts.glob("shard-*/report.json"))
+    if len(manifests) != count:
+        raise SystemExit(f"expected {count} shard manifests, found {len(manifests)}")
+    if len(reports) != count:
+        raise SystemExit(f"expected {count} parity reports, found {len(reports)}")
+
+    seen_indices: set[int] = set()
+    seen_repositories: set[str] = set()
+    totals = {key: 0 for key in ("rust", "oracle", "common", "missing", "extra")}
+    versions: set[str] = set()
+    for manifest_path in manifests:
+        manifest = load_json(manifest_path)
+        index = int(manifest["index"])
+        if int(manifest["count"]) != count or index in seen_indices:
+            raise SystemExit(f"invalid or duplicate manifest: {manifest_path}")
+        seen_indices.add(index)
+        versions.add(str(manifest["credsweeper_version"]))
+        for repository in manifest["repositories"]:
+            repo_id = repository["id"]
+            if repo_id in seen_repositories:
+                raise SystemExit(f"repository appears in multiple shards: {repo_id}")
+            seen_repositories.add(repo_id)
+
+        report_path = manifest_path.with_name("report.json")
+        report = load_json(report_path)
+        for key in totals:
+            totals[key] += int(report[key])
+        if int(report["missing"]) or int(report["extra"]):
+            raise SystemExit(f"CredSweeper mismatch in shard {index}: {report_path}")
+        if not bool(report["ml_probability_within_tolerance"]):
+            raise SystemExit(f"ML probability mismatch in shard {index}: {report_path}")
+
+    expected_repositories = set(expected)
+    missing = expected_repositories - seen_repositories
+    extra = seen_repositories - expected_repositories
+    if missing or extra:
+        raise SystemExit(
+            f"shard coverage mismatch: missing={len(missing)} extra={len(extra)}"
+        )
+    if seen_indices != set(range(count)):
+        raise SystemExit(f"shard index coverage mismatch: {sorted(seen_indices)}")
+    if len(versions) != 1:
+        raise SystemExit(f"shards used different CredSweeper versions: {sorted(versions)}")
+
+    summary = {
+        "schema": 1,
+        "shards": count,
+        "repositories": len(seen_repositories),
+        "credsweeper_version": versions.pop(),
+        **totals,
+    }
+    write_json(output, summary)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    prepare_parser = commands.add_parser("prepare")
+    prepare_parser.add_argument("--root", type=Path, required=True)
+    prepare_parser.add_argument("--index", type=int, required=True)
+    prepare_parser.add_argument("--count", type=int, required=True)
+    prepare_parser.add_argument("--manifest", type=Path, required=True)
+    prepare_parser.add_argument("--credsweeper-version", required=True)
+    summary_parser = commands.add_parser("summarize")
+    summary_parser.add_argument("--root", type=Path, required=True)
+    summary_parser.add_argument("--artifacts", type=Path, required=True)
+    summary_parser.add_argument("--count", type=int, required=True)
+    summary_parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "prepare":
+        prepare(
+            args.root,
+            args.index,
+            args.count,
+            args.manifest,
+            args.credsweeper_version,
+        )
+    else:
+        summarize(args.root, args.artifacts, args.count, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/credsweeper-sidecar/sidecar.py
+++ b/tools/credsweeper-sidecar/sidecar.py
@@ -104,7 +104,12 @@ def scan_paths(paths: list[Path], use_filters: bool, use_ml: bool, batch_size: i
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="pentect-credsweeper-sidecar")
-    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument("paths", nargs="*", type=Path)
+    parser.add_argument(
+        "--paths-file",
+        type=Path,
+        help="newline-delimited paths (avoids platform command-line length limits)",
+    )
     parser.add_argument("--no-filters", action="store_true")
     parser.add_argument("--no-ml", action="store_true")
     parser.add_argument("--ml-batch-size", type=int, default=16)
@@ -114,8 +119,17 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    paths = list(args.paths)
+    if args.paths_file:
+        paths.extend(
+            Path(line)
+            for line in args.paths_file.read_text(encoding="utf-8").splitlines()
+            if line
+        )
+    if not paths:
+        raise SystemExit("at least one path or --paths-file is required")
     credentials = scan_paths(
-        args.paths,
+        paths,
         use_filters=not args.no_filters,
         use_ml=not args.no_ml,
         batch_size=max(1, args.ml_batch_size),

--- a/tools/test_creddata_shards.py
+++ b/tools/test_creddata_shards.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from tools import creddata_shards
+
+
+class CredDataShardsTest(unittest.TestCase):
+    def test_prepare_and_summarize_cover_every_repository_once(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            source = workspace / "source"
+            (source / "meta").mkdir(parents=True)
+            snapshot = {
+                f"{value:064x}": f"https://example.test/{value}"
+                for value in range(1, 8)
+            }
+            self.write_json(source / "snapshot.json", snapshot)
+            for repo_id in snapshot:
+                (source / "meta" / f"{creddata_shards.short_id(repo_id)}.csv").write_text(
+                    "header\n", encoding="utf-8"
+                )
+
+            artifacts = workspace / "artifacts"
+            for index in range(3):
+                shard_root = workspace / f"root-{index}"
+                self.copy_dataset(source, shard_root)
+                shard_artifact = artifacts / f"shard-{index}"
+                creddata_shards.prepare(
+                    shard_root,
+                    index=index,
+                    count=3,
+                    manifest=shard_artifact / "manifest.json",
+                    version="v1.2.3",
+                )
+                repository_count = len(
+                    json.loads((shard_artifact / "manifest.json").read_text())["repositories"]
+                )
+                self.write_json(
+                    shard_artifact / "report.json",
+                    {
+                        "rust": repository_count,
+                        "oracle": repository_count,
+                        "common": repository_count,
+                        "missing": 0,
+                        "extra": 0,
+                        "ml_probability_within_tolerance": True,
+                    },
+                )
+
+            output = workspace / "summary.json"
+            creddata_shards.summarize(source, artifacts, count=3, output=output)
+            summary = json.loads(output.read_text())
+            self.assertEqual(summary["repositories"], len(snapshot))
+            self.assertEqual(summary["shards"], 3)
+            self.assertEqual(summary["credsweeper_version"], "v1.2.3")
+            self.assertEqual(summary["missing"], 0)
+            self.assertEqual(summary["extra"], 0)
+
+    @staticmethod
+    def copy_dataset(source: Path, destination: Path) -> None:
+        (destination / "meta").mkdir(parents=True)
+        (destination / "snapshot.json").write_bytes((source / "snapshot.json").read_bytes())
+        for path in (source / "meta").glob("*.csv"):
+            (destination / "meta" / path.name).write_bytes(path.read_bytes())
+
+    @staticmethod
+    def write_json(path: Path, value: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the weekly one-repository parity smoke test with a 16-shard matrix covering all 333 pinned CredData repositories
- compare the Rust port against the latest official CredSweeper with exact precision/recall and ML probability parity
- aggregate manifests and reports, failing on missing, duplicate, or mixed-version shards
- keep the single-repository PR/push regression gate for fast feedback
- accept newline-delimited paths in the Python oracle to avoid command-line length limits

## Verification

- shard helper unit test
- exact 333-repository/16-shard coverage check (21 or 20 repositories per shard)
- Python compile checks
- workflow YAML parse

After merge, the full workflow can be run immediately with the `full` workflow-dispatch input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Pull requests and pushes now use a faster parity check.
  * Weekly runs perform comprehensive parity validation across all repositories.
  * Added support for manually triggering a full parity run.
  * Improved validation and consolidated results from parallel checks.

* **Reliability**
  * Added safeguards to detect missing, duplicate, or inconsistent parity results.
  * Sidecar processing now accepts paths from a file in addition to command-line arguments.

* **Testing**
  * Added coverage for repository sharding and complete result aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->