### PR TITLE
ci: avoid duplicate weekly CredSweeper builds

### DIFF
--- a/.github/workflows/credsweeper-regression.yml
+++ b/.github/workflows/credsweeper-regression.yml
@@ -210,7 +210,9 @@ jobs:
           python-version: "3.12"
 
       - name: Sync latest CredSweeper release
-        run: python tools/update_credsweeper.py latest
+        # The parity build and exact oracle comparison below are the validation.
+        # Avoid compiling and testing the same Rust code twice in every shard.
+        run: python tools/update_credsweeper.py latest --skip-validation
 
       - name: Install official CredSweeper oracle dependencies
         run: |


### PR DESCRIPTION
The full 16-shard parity matrix was invoking the updater validation build in every shard and then immediately rebuilding for the actual exact parity comparison. Skip only that redundant updater validation in weekly shards; the release build and official-oracle comparison remain mandatory.