### PR TITLE
fix(ci): support CredSweeper 1.18 ML callback API

### DIFF
--- a/tools/credsweeper-sidecar/ml_compat.py
+++ b/tools/credsweeper-sidecar/ml_compat.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+
+def validate_groups(validator: Any, groups: list[Any], batch_size: int) -> Any:
+    """Call CredSweeper's ML validator across supported upstream signatures."""
+    parameters = inspect.signature(validator.validate_groups).parameters
+    if "progress_callback" in parameters:
+        return validator.validate_groups(groups, batch_size, progress_callback=None)
+    return validator.validate_groups(groups, batch_size)

--- a/tools/credsweeper-sidecar/sidecar.py
+++ b/tools/credsweeper-sidecar/sidecar.py
@@ -19,6 +19,7 @@ from credsweeper.file_handler.text_content_provider import TextContentProvider
 from credsweeper.ml_model.ml_validator import MlValidator
 from credsweeper.scanner.scanner import Scanner
 from credsweeper.utils.util import Util
+from ml_compat import validate_groups
 
 
 def build_config(use_filters: bool) -> Config:
@@ -78,7 +79,7 @@ def apply_ml(candidates: list[Candidate], batch_size: int) -> list[Candidate]:
         return result
 
     validator = MlValidator(ThresholdPreset.medium)
-    is_cred, probability = validator.validate_groups(ml_groups, batch_size)
+    is_cred, probability = validate_groups(validator, ml_groups, batch_size)
     for index, (_, group_candidates) in enumerate(ml_groups):
         for candidate in group_candidates:
             if candidate.use_ml:

--- a/tools/test_credsweeper_ml_compat.py
+++ b/tools/test_credsweeper_ml_compat.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parent / "credsweeper-sidecar" / "ml_compat.py"
+SPEC = importlib.util.spec_from_file_location("credsweeper_ml_compat", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class OldValidator:
+    def validate_groups(self, groups, batch_size):
+        return groups, batch_size
+
+
+class NewValidator:
+    def validate_groups(self, groups, batch_size, progress_callback):
+        return groups, batch_size, progress_callback
+
+
+class MlCompatTests(unittest.TestCase):
+    def test_old_signature(self):
+        self.assertEqual(MODULE.validate_groups(OldValidator(), ["group"], 32), (["group"], 32))
+
+    def test_new_signature_disables_progress_output(self):
+        self.assertEqual(
+            MODULE.validate_groups(NewValidator(), ["group"], 32),
+            (["group"], 32, None),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
The weekly full-CredData run synced CredSweeper v1.18.0, whose `MlValidator.validate_groups` now requires a `progress_callback`. The oracle sidecar still used the older two-argument API, so 15 shards stopped before producing parity reports.

## Fix
- detect the upstream method signature at the adapter boundary
- pass `progress_callback=None` when supported
- retain compatibility with the older two-argument API
- test both signatures

## Verification
- `python -m unittest tools/test_credsweeper_ml_compat.py tools/test_creddata_shards.py`