### PR TITLE
perf: remove detector warm-up from gateway startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,15 +242,18 @@ jobs:
         if: needs.changes.result != 'success'
         run: exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        if: needs.changes.outputs.plugins == 'true'
+        if: needs.changes.outputs.plugins == 'true' || needs.changes.outputs.detector == 'true'
         with:
           persist-credentials: false
       - uses: ./.github/actions/rust-toolchain
-        if: needs.changes.outputs.plugins == 'true'
+        if: needs.changes.outputs.plugins == 'true' || needs.changes.outputs.detector == 'true'
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: needs.changes.outputs.plugins == 'true'
+        if: needs.changes.outputs.plugins == 'true' || needs.changes.outputs.detector == 'true'
+      - name: Measure canonical engine cold construction
+        if: needs.changes.outputs.detector == 'true'
+        run: cargo test -p pentect-runtime --lib --locked canonical_engine_construction_stays_off_the_warm_up_path -- --nocapture
       - name: Test plugin runtime
         if: needs.changes.outputs.plugins == 'true'
         run: cargo test -p pentect-runtime plugin_middleware::tests --locked
@@ -274,7 +277,7 @@ jobs:
         if: needs.changes.outputs.plugins == 'true'
         run: python -m unittest discover plugins/openai-privacy-filter/tests
       - name: No plugin changes
-        if: needs.changes.outputs.plugins != 'true'
+        if: needs.changes.outputs.plugins != 'true' && needs.changes.outputs.detector != 'true'
         run: echo "No plugin changes"
 
   app-platform:
@@ -434,6 +437,9 @@ jobs:
       - name: Test detector changes
         if: needs.changes.outputs.detector == 'true'
         run: cargo test -p pentect-core --no-default-features --locked
+      - name: Measure canonical engine cold construction
+        if: needs.changes.outputs.detector == 'true'
+        run: cargo test -p pentect-runtime --lib --locked canonical_engine_construction_stays_off_the_warm_up_path -- --nocapture
       - name: Full test on main
         if: github.event_name == 'push'
         run: cargo test --all-features --locked

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -63,7 +63,7 @@ const PENTECT_AGENT_LAUNCHED_ENV: &str = "PENTECT_AGENT_LAUNCHED";
 const PENTECT_MEMORY_STORE_ADDR_ENV: &str = "PENTECT_MEMORY_STORE_ADDR";
 const PENTECT_MEMORY_STORE_TOKEN_ENV: &str = "PENTECT_MEMORY_STORE_TOKEN";
 const MEMORY_STORE_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
-pub(crate) const GATEWAY_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const GATEWAY_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_MEMORY_STORE_STARTUP_STDERR: usize = 64 * 1024;
 const ISSUE_NEW_URL: &str = "https://github.com/EdamAme-x/pentect/issues/new";
 

--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -37,6 +37,7 @@ static BUILTIN: LazyLock<CredSweeperNativeDetector> = LazyLock::new(|| {
 });
 static BUILTIN_STATS: LazyLock<CredSweeperNativeStats> =
     LazyLock::new(|| audit_builtin_stats().expect("embedded CredSweeper assets compile"));
+static REGEX_WARMED: OnceLock<()> = OnceLock::new();
 static CREDSWEEPER_BASE64: LazyLock<data_encoding::Encoding> = LazyLock::new(|| {
     let mut specification = BASE64.specification();
     // Python's base64.b64decode(validate=True), used by CredSweeper, validates
@@ -86,6 +87,14 @@ pub struct CredSweeperNativeStats {
     pub secret_config_json_bytes: usize,
     pub ml_config_json_bytes: usize,
     pub ml_model_onnx_bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CredSweeperWarmUpTimings {
+    pub regexes: std::time::Duration,
+    pub ml: std::time::Duration,
+    pub verification: std::time::Duration,
+    pub total: std::time::Duration,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -259,15 +268,59 @@ impl CredSweeperNativeDetector {
     /// Compile deferred upstream patterns before a caller starts a bounded
     /// operation timer. Clones of the built-in detector share these caches.
     pub fn warm_up(&self) {
-        for rule in &self.rules {
-            for pattern in &rule.patterns {
-                if let PatternMatcher::Deferred(regex) = &pattern.matcher {
-                    let _ = regex.compiled();
-                    let _ = regex.compiled_keyword();
-                }
-            }
-        }
-        credsweeper_ml::warm_up();
+        let _ = self.warm_up_timed();
+    }
+
+    /// Warm cached detector state and return value-free phase timings.
+    pub fn warm_up_timed(&self) -> CredSweeperWarmUpTimings {
+        let total_started = std::time::Instant::now();
+        // Regex OnceLocks are process-wide through the shared BUILTIN Arcs.
+        // Compile independent rules in parallel, while the caller initializes
+        // its thread-local ML validator. Cap workers to avoid turning startup
+        // into a memory spike on large CI hosts.
+        let (regexes, ml) = if REGEX_WARMED.get().is_some() {
+            let ml_started = std::time::Instant::now();
+            credsweeper_ml::warm_up();
+            (std::time::Duration::ZERO, ml_started.elapsed())
+        } else {
+            std::thread::scope(|scope| {
+                let regexes = scope.spawn(|| {
+                    let started = std::time::Instant::now();
+                    REGEX_WARMED.get_or_init(|| {
+                        let workers = std::thread::available_parallelism()
+                            .map_or(1, usize::from)
+                            .min(8)
+                            .min(self.rules.len().max(1));
+                        let chunk_size = self.rules.len().div_ceil(workers);
+                        std::thread::scope(|workers_scope| {
+                            for rules in self.rules.chunks(chunk_size) {
+                                workers_scope.spawn(move || {
+                                    for rule in rules {
+                                        for pattern in &rule.patterns {
+                                            if let PatternMatcher::Deferred(regex) =
+                                                &pattern.matcher
+                                            {
+                                                let _ = regex.compiled();
+                                                let _ = regex.compiled_keyword();
+                                            }
+                                        }
+                                    }
+                                });
+                            }
+                        });
+                    });
+                    started.elapsed()
+                });
+                let ml_started = std::time::Instant::now();
+                credsweeper_ml::warm_up();
+                let ml = ml_started.elapsed();
+                (
+                    regexes.join().expect("CredSweeper regex warm-up worker"),
+                    ml,
+                )
+            })
+        };
+        let verification_started = std::time::Instant::now();
         let sample = "AKIACSVC3FV5KQHYWH8A";
         let region = Region {
             span: ByteRange::new(0, sample.len()),
@@ -281,6 +334,12 @@ impl CredSweeperNativeDetector {
         };
         let view = NormalizedView::build(&region, sample);
         let _ = self.detect_findings(&view);
+        CredSweeperWarmUpTimings {
+            regexes,
+            ml,
+            verification: verification_started.elapsed(),
+            total: total_started.elapsed(),
+        }
     }
 
     pub fn builtin_stats() -> &'static CredSweeperNativeStats {
@@ -6699,6 +6758,18 @@ mod tests {
 
         assert!(!deferred.is_empty());
         assert!(deferred.iter().all(|regex| regex.compiled.get().is_none()));
+    }
+
+    #[test]
+    fn warm_up_reports_value_free_phase_timings() {
+        let timings = CredSweeperNativeDetector::builtin().warm_up_timed();
+        eprintln!(
+            "CredSweeper warm-up: regexes={:?} ml={:?} verification={:?} total={:?}",
+            timings.regexes, timings.ml, timings.verification, timings.total
+        );
+        assert!(timings.total >= timings.regexes);
+        assert!(timings.total >= timings.ml);
+        assert!(timings.total >= timings.verification);
     }
 
     #[test]

--- a/crates/pentect-core/src/detect/decode.rs
+++ b/crates/pentect-core/src/detect/decode.rs
@@ -202,10 +202,6 @@ impl DecodeDetector {
 
     pub fn builtin_with_config(config: DecodeConfig) -> Self {
         let credsweeper = CredSweeperNativeDetector::builtin();
-        // Regex compilation is initialization, not input processing. Keep it
-        // outside DecodeDetector's per-input safety deadline so the first
-        // encoded secret receives the same coverage as subsequent inputs.
-        credsweeper.warm_up();
         Self::new(
             vec![
                 Box::new(BinaryCodec),
@@ -374,6 +370,27 @@ impl DecodeDetector {
     fn accepts_run(&self, len: usize) -> bool {
         len >= self.config.min_bytes && self.config.max_bytes.is_none_or(|max| len <= max)
     }
+
+    fn candidate_decodes(&self, run: &str) -> bool {
+        self.codecs.iter().any(|codec| codec.decode(run).is_some())
+            || run.split_once('=').is_some_and(|(_, value)| {
+                self.accepts_run(value.len())
+                    && self
+                        .codecs
+                        .iter()
+                        .any(|codec| codec.decode(value).is_some())
+            })
+    }
+
+    fn has_decodable_candidate(&self, text: &str) -> bool {
+        token_runs(text)
+            .chain(encoded85_runs(text, self.config.min_bytes))
+            .chain(wrapped_base64_runs(text, self.config.min_bytes))
+            .chain(percent_encoded_runs(text, self.config.min_bytes))
+            .any(|(start, end)| {
+                self.accepts_run(end - start) && self.candidate_decodes(&text[start..end])
+            })
+    }
 }
 
 fn consume_depth(remaining: Option<usize>) -> Option<Option<usize>> {
@@ -426,6 +443,16 @@ impl Detector for DecodeDetector {
             return Vec::new();
         }
         let s = view.text();
+        if !self.has_decodable_candidate(s) {
+            return Vec::new();
+        }
+        // Engine construction is on every gateway's readiness path. Defer the
+        // expensive process-cached regex compilation and thread-local ML setup
+        // until encoded input is actually scanned. Do this before creating the
+        // per-input deadline so a cold first request gets exactly the same
+        // detector coverage as a warm request instead of timing out halfway
+        // through initialization.
+        CredSweeperNativeDetector::builtin().warm_up();
         let mut out = Vec::new();
         let mut budget = DecodeBudget::new(self.config.limit_reporter);
         for (start, end) in token_runs(s) {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -16,6 +16,23 @@ impl RecoveringTestMutex {
 static TEST_ENV_LOCK: RecoveringTestMutex = RecoveringTestMutex(std::sync::Mutex::new(()));
 
 #[test]
+fn canonical_engine_construction_stays_off_the_warm_up_path() {
+    let started = std::time::Instant::now();
+    let _engine = build_masking_engine(
+        Profile::Strict,
+        Vec::new(),
+        false,
+        pentect_core::DecodeConfig::default(),
+    )
+    .expect("canonical engine");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(1),
+        "canonical engine construction took {elapsed:?}; detector warm-up must remain lazy"
+    );
+}
+
+#[test]
 fn claude_hook_cli_is_retired_in_favor_of_http_gateway() {
     let error = parse_hook_provider("claude").unwrap_err();
     assert!(error.contains("HTTP gateway"), "{error}");


### PR DESCRIPTION
Closes #954

## What changed
- move CredSweeper/ML warm-up off canonical engine construction and run it only when DecodeDetector sees a decodable candidate
- start DecodeDetector safety budgets after cold warm-up so the first request keeps full coverage
- compile process-cached CredSweeper regexes across up to eight workers while initializing thread-local ML on the caller
- expose value-free warm-up phase timings
- restore the gateway readiness timeout from the temporary 30 seconds to 5 seconds
- run an isolated sub-second cold-construction regression on Linux, macOS, and Windows CI paths

## Local evidence
- canonical engine construction: 0.01s (filtered fresh test process)
- parallel warm-up: 1.36–1.66s total vs approximately 5.6–6s before; regexes dominate, ML overlaps
- pentect-core: 412 passed
- DecodeDetector: 14 passed
- runtime masking tests passed
- clippy passed for core/runtime/CLI with no default features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved application startup by deferring detector initialization until encoded or otherwise decodable content is detected.
  * Accelerated detector preparation through parallel processing and optimized machine-learning initialization.
  * Reduced gateway startup timeout from 30 seconds to 5 seconds.

* **Bug Fixes**
  * Added safeguards to ensure detection continues to work correctly for supported encoded content, including Base85, Base64, and percent-encoded values.

* **Tests**
  * Added coverage confirming fast engine startup and detector warm-up timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->