### PR TITLE
Expand high-precision Alcatraz PII coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,13 +154,13 @@ jobs:
         shell: pwsh
         run: |
           $env:PATH = if ($IsWindows) { "$env:WINDIR\System32;$env:WINDIR" } else { '/usr/bin:/bin' }
-          $sample = 'Contact alice@example.com or +1 415-555-2671. Card 4111 1111 1111 1111.'
+          $sample = 'Contact alice@example.com or +1 415-555-2671. Card 4111 1111 1111 1111. IBAN DE89 3704 0044 0532 0130 00. NINO AB 12 34 56 C.'
           $masked = $sample | & '${{ matrix.binary }}' mask --kind text 2>$null
           if ($LASTEXITCODE -ne 0) { throw 'Pentect mask failed' }
           if ($masked -match 'alice@example.com|415-555-2671|4111 1111 1111 1111') {
             throw "Alcatraz leaked test PII: $masked"
           }
-          foreach ($label in @('EMAIL_ADDRESS', 'PHONE_NUMBER', 'CREDIT_CARD')) {
+          foreach ($label in @('EMAIL_ADDRESS', 'PHONE_NUMBER', 'CREDIT_CARD', 'IBAN_CODE', 'UK_NINO')) {
             if ($masked -notmatch "<<${label}_[0-9a-f]{16}>>") {
               throw "Missing $label handle: $masked"
             }

--- a/crates/pentect-runtime/src/alcatraz.rs
+++ b/crates/pentect-runtime/src/alcatraz.rs
@@ -395,4 +395,23 @@ mod tests {
                 && text.get(span.range.start..span.range.end) == Some("alice@example.com")
         }));
     }
+
+    #[test]
+    fn bundled_helper_detects_expanded_high_precision_pii() {
+        let text = "IBAN DE89 3704 0044 0532 0130 00; NINO AB 12 34 56 C; NIF 12345678Z";
+        let labels: std::collections::HashSet<_> = detect_text(text)
+            .into_iter()
+            .map(|span| span.label)
+            .collect();
+        assert!(labels.contains("IBAN_CODE"));
+        assert!(labels.contains("UK_NINO"));
+        assert!(labels.contains("ES_NIF"));
+    }
+
+    #[test]
+    fn bundled_helper_preserves_common_developer_metadata() {
+        let text = "id=550e8400-e29b-41d4-a716-446655440000 version=10.20.30 \
+                    at=2026-08-26T12:34:56Z url=http://localhost:8080/docs";
+        assert!(detect_text(text).is_empty());
+    }
 }

--- a/tools/alcatraz-helper/main.go
+++ b/tools/alcatraz-helper/main.go
@@ -16,6 +16,18 @@ var piiEntities = []string{
 	entities.EmailAddress,
 	entities.PhoneNumber,
 	entities.CreditCard,
+	// These identifiers have a constrained shape and, except for IN PAN,
+	// checksum validation in Alcatraz. Broad operational identifiers such as
+	// URLs, IP addresses and dates intentionally remain visible by default.
+	entities.IBANCode,
+	entities.UKNINO,
+	entities.INPAN,
+	entities.ITFiscalCode,
+	entities.ESNIF,
+	entities.ESNIE,
+	entities.SGFIN,
+	entities.KRRRN,
+	entities.FIPersonalIdentityCode,
 }
 
 type request struct {
@@ -46,10 +58,7 @@ func main() {
 		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
 			os.Exit(2)
 		}
-		results := engine.Analyze(req.Text, alcatraz.Options{
-			Entities:  piiEntities,
-			Threshold: &threshold,
-		})
+		results := analyze(engine, req.Text, threshold)
 		uuidRanges := uuidPattern.FindAllStringIndex(req.Text, -1)
 		findings := make([]finding, 0, len(results))
 		for _, result := range results {
@@ -70,6 +79,13 @@ func main() {
 	if scanner.Err() != nil {
 		os.Exit(2)
 	}
+}
+
+func analyze(engine *alcatraz.Engine, text string, threshold float64) []alcatraz.Result {
+	return engine.Analyze(text, alcatraz.Options{
+		Entities:  piiEntities,
+		Threshold: &threshold,
+	})
 }
 
 func containedInAny(start, end int, ranges [][]int) bool {

--- a/tools/alcatraz-helper/main_test.go
+++ b/tools/alcatraz-helper/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/hoophq/alcatraz"
+)
+
+func TestDefaultPIIEntities(t *testing.T) {
+	engine := alcatraz.NewEngine()
+	const threshold = 0.4
+	tests := []struct {
+		name   string
+		text   string
+		entity string
+	}{
+		{"email", "email alice@example.com", "EMAIL_ADDRESS"},
+		{"phone", "phone +1 415-555-2671", "PHONE_NUMBER"},
+		{"card", "card 4111 1111 1111 1111", "CREDIT_CARD"},
+		{"iban", "IBAN DE89 3704 0044 0532 0130 00", "IBAN_CODE"},
+		{"uk nino", "NINO AB 12 34 56 C", "UK_NINO"},
+		{"india pan", "PAN ABCDE1234F", "IN_PAN"},
+		{"italy fiscal code", "codice fiscale RSSMRA85T10A562C", "IT_FISCAL_CODE"},
+		{"spain nif", "NIF 12345678Z", "ES_NIF"},
+		{"spain nie", "NIE X1234567L", "ES_NIE"},
+		{"singapore fin", "FIN F1234567N", "SG_FIN"},
+		{"korea rrn", "RRN 900101-1234568", "KR_RRN"},
+		{"finland identity code", "HETU 131052-308T", "FI_PERSONAL_IDENTITY_CODE"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := analyze(engine, tt.text, threshold)
+			for _, result := range results {
+				if result.EntityType == tt.entity {
+					return
+				}
+			}
+			t.Fatalf("%s was not detected in %#v", tt.entity, results)
+		})
+	}
+}
+
+func TestDefaultPIIEntitiesPreserveDeveloperData(t *testing.T) {
+	engine := alcatraz.NewEngine()
+	const threshold = 0.4
+	texts := []string{
+		"request id 550e8400-e29b-41d4-a716-446655440000",
+		"released version 10.20.30 at 2026-08-26T12:34:56Z",
+		"listen on http://localhost:8080 and 127.0.0.1",
+		"docs https://platform.openai.com/docs/api-reference/responses",
+		"fixture order=123456789 account=987654321",
+		"const AWS_ACCESS_KEY_ID = AKIAIOSFODNN7EXAMPLE",
+	}
+	for _, text := range texts {
+		if results := analyze(engine, text, threshold); len(results) != 0 {
+			t.Errorf("developer data %q produced PII findings: %#v", text, results)
+		}
+	}
+}
+
+func BenchmarkDefaultPIIEntities(b *testing.B) {
+	engine := alcatraz.NewEngine()
+	const threshold = 0.4
+	text := "email alice@example.com, IBAN DE89 3704 0044 0532 0130 00, NINO AB 12 34 56 C"
+	b.ResetTimer()
+	for range b.N {
+		_ = analyze(engine, text, threshold)
+	}
+}

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -48,6 +48,14 @@ Pentect checks for secrets and personal data. Supported config formats include
 dotenv, Terraform, Kubernetes Secrets, kubeconfig, AWS, npm, PyPI, JSON, and
 other key/value formats.
 
+The built-in personal-data detector covers email addresses, phone numbers,
+payment cards, IBANs, and selected strongly formatted national identifiers:
+UK NINO, India PAN, Italian fiscal code, Spanish NIF/NIE, Singapore FIN,
+Korean RRN, and Finnish personal identity code. Names and street addresses are
+not detected by the built-in engine. URLs, IP addresses, dates, cryptocurrency
+addresses, and broad numeric identifiers remain visible by default because
+they commonly occur as non-secret operational data in source code and logs.
+
 ## Handles
 
 - Keep a useful label such as `DATABASE_URL` or `KAGGLE_API_TOKEN`.

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -51,10 +51,12 @@ other key/value formats.
 The built-in personal-data detector covers email addresses, phone numbers,
 payment cards, IBANs, and selected strongly formatted national identifiers:
 UK NINO, India PAN, Italian fiscal code, Spanish NIF/NIE, Singapore FIN,
-Korean RRN, and Finnish personal identity code. Names and street addresses are
-not detected by the built-in engine. URLs, IP addresses, dates, cryptocurrency
-addresses, and broad numeric identifiers remain visible by default because
-they commonly occur as non-secret operational data in source code and logs.
+Korean RRN, and Finnish personal identity code. Alcatraz's `PERSON`, `LOCATION`,
+and `NRP` entity types are not provided by the built-in engine, so names,
+street addresses, and those NLP-derived categories are not detected. URLs, IP
+addresses, dates, cryptocurrency addresses, and broad numeric identifiers
+remain visible by default because they commonly occur as non-secret
+operational data in source code and logs.
 
 ## Handles
 


### PR DESCRIPTION
Closes #951.

## What changed
- enable IBAN plus eight strongly formatted national identifier entities in the bundled Alcatraz helper
- keep URLs, IP addresses, dates, crypto addresses, and broad numeric identifiers disabled by default
- add positive and developer-data negative corpora, a helper benchmark, and bundled-runtime tests
- document the exact built-in coverage and the current name/address limitation
- extend release smoke coverage for the bundled standalone helper

## Local verification
- `go test ./...`
- `go test -bench BenchmarkDefaultPIIEntities -benchtime=2s ./...` (47.7 us/op on this host)
- `cargo test -p pentect-runtime --no-default-features alcatraz::tests --locked`
- `cargo clippy -p pentect-runtime --all-targets --no-default-features -- -D warnings`
- `cargo fmt --all --check`

## Selection policy
Enabled by default: EMAIL_ADDRESS, PHONE_NUMBER, CREDIT_CARD, IBAN_CODE, UK_NINO, IN_PAN, IT_FISCAL_CODE, ES_NIF, ES_NIE, SG_FIN, KR_RRN, FI_PERSONAL_IDENTITY_CODE.

Not claimed as supported: PERSON, LOCATION, and NRP constants have no registered recognizer/model in Alcatraz v0.20.2.

Kept disabled: operational/public identifiers (CRYPTO, IP_ADDRESS, URL, DATE_TIME), broad weak numeric patterns, business/vehicle/postal identifiers, and national identifiers whose shapes collide too easily with ordinary fixture numbers. These remain explicit gaps, not completed coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded personal-data detection to recognize additional identifiers, including IBANs, UK National Insurance numbers, and regional tax or identity codes.
  - Improved scanning accuracy by preserving common developer metadata such as UUIDs, version strings, timestamps, and localhost URLs.

- **Documentation**
  - Updated capabilities documentation to list supported personal-data identifiers and clarify data that remains visible by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->