### PR TITLE
chore: prepare v0.0.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.57"
+version = "0.0.58"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prepare Pentect v0.0.58 from current `main`, including the merged canonical detector, CredSweeper compatibility, Alcatraz PII expansion, cold-start, and installation reliability changes.

## Version consistency
- `pentect-cli`: 0.0.58
- npm package: 0.0.58
- Cargo.lock workspace entry: 0.0.58

## Verification
- npm tests: 8 passed
- npm pack dry run: passed
- Cargo metadata with the updated lock: passed
- license inventory check: passed
- Rust formatting and diff checks: passed

After this PR merges, tag `v0.0.58` must point exactly at the resulting `main` commit so the release workflow can publish and run installation lifecycle E2E.