### PR TITLE
feat: add local privacy metrics command

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -150,6 +150,12 @@ const COMMANDS: &[CommandSpec] = &[
         audience: CommandAudience::Public,
     },
     CommandSpec {
+        name: "metrics",
+        usage: "pentect metrics [--json]",
+        summary: "Show local value-free protection statistics",
+        audience: CommandAudience::Public,
+    },
+    CommandSpec {
         name: "resolve",
         usage: "pentect resolve [PATH...]",
         summary: "Write real values for known handles",
@@ -352,7 +358,7 @@ fn dispatch(args: Vec<String>, inherited_env_is_trusted: bool) -> Option<i32> {
         Some("plugins") => plugins_cmd::cmd_plugins(&args),
         Some("provider") => return Some(cmd_provider(&args)),
         Some(
-            "exec" | "resolve" | "log" | "hook" | "bridge" | "memory-store" | "purge"
+            "exec" | "resolve" | "log" | "metrics" | "hook" | "bridge" | "memory-store" | "purge"
             | "__agent-script" | "__agent-stream",
         ) => return Some(cmd_agent_from(1, &args, inherited_env_is_trusted)),
         Some("agent") => return Some(cmd_agent_from(2, &args, inherited_env_is_trusted)),
@@ -3091,6 +3097,7 @@ mod tests {
                 "help",
                 "log",
                 "mask",
+                "metrics",
                 "opencode",
                 "pi",
                 "plugins",

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -4,7 +4,7 @@ use pentect_core::MaskResult;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
@@ -73,6 +73,21 @@ pub(crate) struct ActivityEvent {
 struct LabelCount {
     name: String,
     count: u64,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct PrivacyMetrics {
+    enabled: bool,
+    scope: &'static str,
+    masked_text_occurrences: u64,
+    redacted_image_occurrences: u64,
+    restoration_operations: u64,
+    blocked_occurrences: u64,
+    warning_occurrences: u64,
+    by_secret_type: BTreeMap<String, u64>,
+    by_surface: BTreeMap<String, u64>,
+    records_read: u64,
+    records_skipped: u64,
 }
 
 struct ActivitySource {
@@ -357,6 +372,179 @@ pub(crate) fn persistent_log_path() -> PathBuf {
         .join(".pentect")
         .join("logs")
         .join("pentect.log")
+}
+
+pub(crate) fn print_metrics(json: bool) -> Result<(), String> {
+    let metrics = read_metrics(&persistent_log_path())?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&metrics)
+                .map_err(|error| format!("could not encode privacy metrics: {error}"))?
+        );
+        return Ok(());
+    }
+
+    println!("Pentect privacy metrics (retained local logs)");
+    println!("Masked occurrences: {}", metrics.masked_text_occurrences);
+    println!("Redacted images: {}", metrics.redacted_image_occurrences);
+    println!(
+        "Local restoration operations: {}",
+        metrics.restoration_operations
+    );
+    println!("Blocked operations: {}", metrics.blocked_occurrences);
+    println!("Warnings: {}", metrics.warning_occurrences);
+    print_metric_group(
+        "Secret types (text masks and image redactions)",
+        &metrics.by_secret_type,
+    );
+    print_metric_group("Protection surfaces", &metrics.by_surface);
+    if metrics.records_skipped > 0 {
+        println!(
+            "Skipped unreadable records: {} (counts may be incomplete)",
+            metrics.records_skipped
+        );
+    }
+    println!("No secret values, handles, paths, URLs, or account identifiers are included.");
+    Ok(())
+}
+
+fn print_metric_group(title: &str, values: &BTreeMap<String, u64>) {
+    println!("{title}:");
+    if values.is_empty() {
+        println!("  (none)");
+        return;
+    }
+    let mut values = values.iter().collect::<Vec<_>>();
+    values.sort_by(|(left_name, left_count), (right_name, right_count)| {
+        right_count
+            .cmp(left_count)
+            .then_with(|| left_name.cmp(right_name))
+    });
+    for (name, count) in values {
+        println!("  {name}: {count}");
+    }
+}
+
+fn read_metrics(path: &Path) -> Result<PrivacyMetrics, String> {
+    let mut metrics = PrivacyMetrics {
+        enabled: true,
+        scope: "retained_local_logs",
+        ..PrivacyMetrics::default()
+    };
+    for generation in (1..=LOG_ROTATIONS).rev() {
+        aggregate_metrics_file(&rotated_log_path(path, generation), &mut metrics)?;
+    }
+    aggregate_metrics_file(path, &mut metrics)?;
+    Ok(metrics)
+}
+
+fn aggregate_metrics_file(path: &Path, metrics: &mut PrivacyMetrics) -> Result<(), String> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("could not read persistent activity log: {error}")),
+    };
+    for line in BufReader::new(file).lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(_) => {
+                metrics.records_skipped = metrics.records_skipped.saturating_add(1);
+                continue;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event = match serde_json::from_str::<ActivityEvent>(&line) {
+            Ok(event) => event,
+            Err(_) => {
+                metrics.records_skipped = metrics.records_skipped.saturating_add(1);
+                continue;
+            }
+        };
+        metrics.records_read = metrics.records_read.saturating_add(1);
+        aggregate_metric_event(&event, metrics);
+    }
+    Ok(())
+}
+
+fn aggregate_metric_event(event: &ActivityEvent, metrics: &mut PrivacyMetrics) {
+    match event.action.as_str() {
+        "mask" | "redact" => {
+            if event.action == "mask" {
+                metrics.masked_text_occurrences =
+                    metrics.masked_text_occurrences.saturating_add(event.count);
+            } else {
+                metrics.redacted_image_occurrences = metrics
+                    .redacted_image_occurrences
+                    .saturating_add(event.count);
+            }
+            increment_metric(
+                &mut metrics.by_surface,
+                safe_metric_dimension(&event.surface),
+                event.count,
+            );
+            for label in &event.labels {
+                increment_metric(
+                    &mut metrics.by_secret_type,
+                    safe_metric_dimension(&label.name),
+                    label.count,
+                );
+            }
+        }
+        "resolve" => {
+            metrics.restoration_operations =
+                metrics.restoration_operations.saturating_add(event.count);
+        }
+        "block" => {
+            metrics.blocked_occurrences = metrics.blocked_occurrences.saturating_add(event.count);
+        }
+        "warning" => {
+            metrics.warning_occurrences = metrics.warning_occurrences.saturating_add(event.count);
+            if is_block_event(event.event.as_deref()) {
+                metrics.blocked_occurrences =
+                    metrics.blocked_occurrences.saturating_add(event.count);
+            }
+        }
+        "diagnostic" => {
+            if is_block_event(event.event.as_deref()) {
+                metrics.blocked_occurrences =
+                    metrics.blocked_occurrences.saturating_add(event.count);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_block_event(event: Option<&str>) -> bool {
+    matches!(
+        event,
+        Some(
+            "request-rejected"
+                | "scan-failure-blocked"
+                | "scan-unavailable-blocked"
+                | "unknown-content-block"
+        )
+    )
+}
+
+fn increment_metric(values: &mut BTreeMap<String, u64>, name: String, count: u64) {
+    let value = values.entry(name).or_default();
+    *value = value.saturating_add(count);
+}
+
+fn safe_metric_dimension(value: &str) -> String {
+    if !value.is_empty()
+        && value.len() <= 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+    {
+        value.to_string()
+    } else {
+        "OTHER".to_string()
+    }
 }
 
 pub(crate) fn record_mask_result(surface: &str, result: &MaskResult, target: Option<&Path>) {
@@ -1253,6 +1441,88 @@ fn display_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn privacy_metrics_count_occurrences_without_retaining_sensitive_fields() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-metrics-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("pentect.log");
+
+        let masked = ActivityEvent::new(
+            "mask",
+            "prompt",
+            3,
+            BTreeMap::from([
+                ("AWS_AKID".to_string(), 2),
+                ("EMAIL_ADDRESS".to_string(), 1),
+            ]),
+            Some("private-project/.env".to_string()),
+        );
+        let redacted = ActivityEvent::new(
+            "redact",
+            "image",
+            1,
+            BTreeMap::from([("AWS_AKID".to_string(), 1)]),
+            None,
+        );
+        let restored = ActivityEvent::new("resolve", "tool", 2, BTreeMap::new(), None);
+        let warning = ActivityEvent::diagnostic(
+            "openai",
+            "request-failed",
+            Some("connect"),
+            None,
+            None,
+            None,
+            Some(true),
+            None,
+        );
+        std::fs::write(
+            rotated_log_path(&path, 1),
+            format!("{}\n", serde_json::to_string(&masked).unwrap()),
+        )
+        .unwrap();
+        std::fs::write(
+            &path,
+            [redacted, restored, warning]
+                .iter()
+                .map(|event| serde_json::to_string(event).unwrap())
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\nnot-json\n",
+        )
+        .unwrap();
+
+        let metrics = read_metrics(&path).unwrap();
+        assert!(metrics.enabled);
+        assert_eq!(metrics.masked_text_occurrences, 3);
+        assert_eq!(metrics.redacted_image_occurrences, 1);
+        assert_eq!(metrics.restoration_operations, 2);
+        assert_eq!(metrics.warning_occurrences, 1);
+        assert_eq!(metrics.by_secret_type["AWS_AKID"], 3);
+        assert_eq!(metrics.by_secret_type["EMAIL_ADDRESS"], 1);
+        assert_eq!(metrics.by_surface["prompt"], 3);
+        assert_eq!(metrics.by_surface["image"], 1);
+        assert_eq!(metrics.records_skipped, 1);
+
+        let output = serde_json::to_string(&metrics).unwrap();
+        assert!(!output.contains("private-project"));
+        assert!(!output.contains(".env"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn privacy_metric_dimensions_collapse_untrusted_values() {
+        assert_eq!(safe_metric_dimension("AWS_AKID"), "AWS_AKID");
+        assert_eq!(safe_metric_dimension("secret\u{1b}[31m"), "OTHER");
+        assert_eq!(safe_metric_dimension(&"x".repeat(65)), "OTHER");
+    }
 
     #[test]
     fn activity_event_contains_metadata_only() {

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -482,13 +482,13 @@ fn aggregate_metric_event(event: &ActivityEvent, metrics: &mut PrivacyMetrics) {
             }
             increment_metric(
                 &mut metrics.by_surface,
-                safe_metric_dimension(&event.surface),
+                safe_metric_surface(&event.surface).to_string(),
                 event.count,
             );
             for label in &event.labels {
                 increment_metric(
                     &mut metrics.by_secret_type,
-                    safe_metric_dimension(&label.name),
+                    safe_metric_secret_type(&label.name).to_string(),
                     label.count,
                 );
             }
@@ -531,16 +531,25 @@ fn increment_metric(values: &mut BTreeMap<String, u64>, name: String, count: u64
     *value = value.saturating_add(count);
 }
 
-fn safe_metric_dimension(value: &str) -> String {
-    if !value.is_empty()
-        && value.len() <= 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
-    {
-        value.to_string()
-    } else {
-        "OTHER".to_string()
+fn safe_metric_surface(value: &str) -> &str {
+    match value {
+        "prompt" | "output" | "tool" | "read" | "image" => value,
+        _ => "OTHER",
+    }
+}
+
+fn safe_metric_secret_type(value: &str) -> &str {
+    match value {
+        "ACCESS_TOKEN" | "ANTHROPIC_API_KEY" | "API_KEY" | "AWS_AKID" | "AWS_MULTI"
+        | "AWS_S3_BUCKET" | "BASE64_PRIVATE_KEY" | "BASIC_AUTH" | "BEARER_TOKEN" | "CREDENTIAL"
+        | "CREDENTIALS" | "CREDIT_CARD" | "EMAIL_ADDRESS" | "GITHUB_PAT" | "GITHUB_TOKEN"
+        | "GOOGLE_API_KEY" | "HUGGINGFACE_TOKEN" | "IBAN_CODE" | "KEYED_SECRET"
+        | "LIKELY_SECRET" | "OPENAI_API_KEY" | "PASSWORD" | "PEM_PRIVATE_KEY" | "PHONE_NUMBER"
+        | "PRIVATE_KEY" | "SECRET" | "SESSION_TOKEN" | "SLACK_TOKEN" | "SLACK_WEBHOOK"
+        | "STRIPE_SECRET_KEY" | "TELEGRAM_BOT_TOKEN" | "TOKEN" | "UK_NINO" | "URL_CREDENTIAL" => {
+            value
+        }
+        _ => "OTHER",
     }
 }
 
@@ -1516,9 +1525,25 @@ mod tests {
 
     #[test]
     fn privacy_metric_dimensions_collapse_untrusted_values() {
-        assert_eq!(safe_metric_dimension("AWS_AKID"), "AWS_AKID");
-        assert_eq!(safe_metric_dimension("secret\u{1b}[31m"), "OTHER");
-        assert_eq!(safe_metric_dimension(&"x".repeat(65)), "OTHER");
+        assert_eq!(safe_metric_secret_type("AWS_AKID"), "AWS_AKID");
+        assert_eq!(safe_metric_secret_type("accountIdentifier456"), "OTHER");
+        assert_eq!(safe_metric_secret_type("secret\u{1b}[31m"), "OTHER");
+        assert_eq!(safe_metric_surface("prompt"), "prompt");
+        assert_eq!(safe_metric_surface("private-plugin"), "OTHER");
+    }
+
+    #[test]
+    fn image_detection_count_does_not_inflate_blocked_operations() {
+        let mut metrics = PrivacyMetrics::default();
+        aggregate_metric_event(
+            &ActivityEvent::new("detect", "image", 3, BTreeMap::new(), None),
+            &mut metrics,
+        );
+        aggregate_metric_event(
+            &ActivityEvent::new("block", "image", 1, BTreeMap::new(), None),
+            &mut metrics,
+        );
+        assert_eq!(metrics.blocked_occurrences, 1);
     }
 
     #[test]

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -507,11 +507,8 @@ fn aggregate_metric_event(event: &ActivityEvent, metrics: &mut PrivacyMetrics) {
                     metrics.blocked_occurrences.saturating_add(event.count);
             }
         }
-        "diagnostic" => {
-            if is_block_event(event.event.as_deref()) {
-                metrics.blocked_occurrences =
-                    metrics.blocked_occurrences.saturating_add(event.count);
-            }
+        "diagnostic" if is_block_event(event.event.as_deref()) => {
+            metrics.blocked_occurrences = metrics.blocked_occurrences.saturating_add(event.count);
         }
         _ => {}
     }

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -420,6 +420,12 @@ pub(crate) fn activity_share_enabled() -> Result<bool, String> {
     Ok(project.or(global).unwrap_or(true))
 }
 
+pub(crate) fn metrics_enabled() -> Result<bool, String> {
+    let project = read_metrics_enabled(project_config_path())?;
+    let global = read_metrics_enabled(global_config_path()?)?;
+    Ok(project.or(global).unwrap_or(true))
+}
+
 pub(crate) fn update_check_enabled() -> Result<bool, String> {
     let project = read_update_check(project_config_path())?;
     let global = read_update_check(global_config_path()?)?;
@@ -674,6 +680,10 @@ fn read_activity_share(path: PathBuf) -> Result<Option<bool>, String> {
     parse_config_file(&path)?.map_or(Ok(None), |value| activity_share_value(&value))
 }
 
+fn read_metrics_enabled(path: PathBuf) -> Result<Option<bool>, String> {
+    parse_config_file(&path)?.map_or(Ok(None), |value| metrics_enabled_value(&value))
+}
+
 fn read_unknown_format_policy(path: PathBuf) -> Result<Option<UnknownFormatPolicy>, String> {
     parse_config_file(&path)?.map_or(Ok(None), |value| unknown_format_policy_value(&value))
 }
@@ -711,6 +721,19 @@ fn activity_share_value(value: &toml::Value) -> Result<Option<bool>, String> {
         }
     }
     Ok(None)
+}
+
+fn metrics_enabled_value(value: &toml::Value) -> Result<Option<bool>, String> {
+    let Some(raw) = value.get("metrics") else {
+        return Ok(None);
+    };
+    let Some(table) = raw.as_table() else {
+        return Err("metrics config must be a table".to_string());
+    };
+    table
+        .get("enabled")
+        .map(|raw| config_bool(raw, "metrics.enabled"))
+        .transpose()
 }
 
 fn config_bool(value: &toml::Value, field: &str) -> Result<bool, String> {
@@ -1321,6 +1344,20 @@ unknown_min_bytes = 32
 
         let value = "[log]\nshare = true".parse::<toml::Value>().unwrap();
         assert!(activity_share_value(&value).is_err());
+    }
+
+    #[test]
+    fn metrics_enabled_defaults_on_and_accepts_boolean_like_values() {
+        let disabled = "[metrics]\nenabled = false".parse::<toml::Value>().unwrap();
+        assert_eq!(metrics_enabled_value(&disabled).unwrap(), Some(false));
+
+        let enabled = "[metrics]\nenabled = \"on\""
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(metrics_enabled_value(&enabled).unwrap(), Some(true));
+
+        let invalid = "[metrics]\nenabled = 3".parse::<toml::Value>().unwrap();
+        assert!(metrics_enabled_value(&invalid).is_err());
     }
 
     #[test]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -4321,10 +4321,11 @@ fn image_tool_result_block_reason(
     }
     let cfg = config::image_ocr_config()?;
     if matches!(cfg.mode, config::ImageOcrMode::Off) {
-        return Ok(
-            matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Block)
-                .then_some("image blocked: OCR is off.".to_string()),
-        );
+        if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Block) {
+            record_image_block();
+            return Ok(Some("image blocked: OCR is off.".to_string()));
+        }
+        return Ok(None);
     }
     let inspection = image_ocr::inspect_tool_images_for_secrets(value, &session.key, &cfg)?;
     if inspection.secret_images > 0 {
@@ -4335,20 +4336,27 @@ fn image_tool_result_block_reason(
             BTreeMap::new(),
             None,
         );
+        record_image_block();
         return Ok(Some("image blocked: secret text detected.".to_string()));
     }
     if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Allow) {
         return Ok(None);
     }
     if inspection.unscanned_images > 0 {
+        record_image_block();
         return Ok(Some(
             "image blocked: image could not be fetched or scanned.".to_string(),
         ));
     }
     if inspection.ocr_failures > 0 {
+        record_image_block();
         return Ok(Some("image blocked: image scan failed.".to_string()));
     }
     Ok(None)
+}
+
+fn record_image_block() {
+    activity_log::record_summary("block", "image", 1, BTreeMap::new(), None);
 }
 
 fn unsupported_tool_result_reason(value: &Value) -> Option<String> {

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -856,7 +856,7 @@ fn cmd_metrics(args: &[String]) -> i32 {
     };
     if !enabled {
         if json {
-            println!("{}", r#"{"enabled":false}"#);
+            println!("{{\"enabled\":false}}");
         } else {
             println!("Pentect privacy metrics are disabled (metrics.enabled = false).");
         }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -111,6 +111,7 @@ pub fn run_from(args: Vec<String>) -> i32 {
         Some("exec") => cmd_exec(&args),
         Some("resolve") => cmd_resolve(&args),
         Some("log") => cmd_log(&args),
+        Some("metrics") => cmd_metrics(&args),
         Some("hook") => cmd_hook(&args),
         Some("bridge") => cmd_bridge(&args),
         Some("memory-store") => cmd_memory_store(&args),
@@ -817,11 +818,13 @@ fn usage() {
          pentect view <HANDLE>\n\
          pentect resolve [PATH...]\n\
          pentect log [--json | --path]\n\
+         pentect metrics [--json]\n\
          \n\
          exec: masked output\n\
          view: handle\n\
          resolve: write handles\n\
-         log: gateway history and live events"
+         log: gateway history and live events\n\
+         metrics: local value-free protection statistics"
     );
 }
 
@@ -836,6 +839,30 @@ fn cmd_log(args: &[String]) -> i32 {
         _ => return die("log [--json | --path]"),
     };
     match activity_log::follow(json) {
+        Ok(()) => 0,
+        Err(error) => die(&error),
+    }
+}
+
+fn cmd_metrics(args: &[String]) -> i32 {
+    let json = match args.get(2).map(String::as_str) {
+        None => false,
+        Some("--json") if args.len() == 3 => true,
+        _ => return die("metrics [--json]"),
+    };
+    let enabled = match config::metrics_enabled() {
+        Ok(enabled) => enabled,
+        Err(error) => return die(&error),
+    };
+    if !enabled {
+        if json {
+            println!("{}", r#"{"enabled":false}"#);
+        } else {
+            println!("Pentect privacy metrics are disabled (metrics.enabled = false).");
+        }
+        return 0;
+    }
+    match activity_log::print_metrics(json) {
         Ok(()) => 0,
         Err(error) => die(&error),
     }

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -84,6 +84,7 @@ unknown-handle behavior.
 | `pentect view HANDLE` | Show handle details without revealing the real value |
 | `pentect resolve [PATH...]` | Restore known handles from stdin or selected files |
 | `pentect log [--json \| --path]` | Show persistent diagnostics and follow protection events without secret values |
+| `pentect metrics [--json]` | Show local value-free counts by secret type and protection surface |
 | `pentect doctor [--json]` | Check the installation and supported clients |
 | `pentect doctor --fix` | Offer repairable configuration changes |
 | `pentect update [VERSION]` | Install a checksummed GitHub Release binary |

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -85,6 +85,7 @@ pentect pi --model gpt-5
 | `pentect exec "COMMAND"` | Restore known handles, run the command, and mask its output |
 | `pentect view HANDLE` | Show handle details without revealing its value |
 | `pentect log [--json \| --path]` | Show persistent diagnostics and follow protection events |
+| `pentect metrics [--json]` | Show local counts by secret type and protection surface |
 
 ### `mask`
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -37,6 +37,7 @@ ignored.
 | `image.unscanned` | `block` | Stop when image or document content cannot be checked |
 | `files.remember` | `true` | Remember safe local file-to-handle information |
 | `activity.share` | `true` | Share events with compatible local Pentect processes |
+| `metrics.enabled` | `true` | Allow on-demand local privacy statistics |
 | `agent.required` | `false` | Require supported agents to start through Pentect |
 | `output.restore` | `true` | Restore known handles in assistant text shown by supported clients |
 | `update.check` | `true` | Check in the background for a newer Pentect release |
@@ -148,10 +149,17 @@ remember = true
 
 [activity]
 share = true
+
+[metrics]
+enabled = true
 ```
 
 `files.remember` keeps local information that helps restore handles from files.
 `activity.share` lets compatible Pentect processes share protection events.
+`metrics.enabled` controls the local `pentect metrics` summary and defaults to
+`true`. Metrics are calculated on demand from retained diagnostic logs and are
+never sent externally. Setting it to `false` disables the summary; diagnostic
+logging and rotation continue independently so crashes remain diagnosable.
 
 Project values normally override user values. `agent.required` is stricter: if
 either file sets it to `true`, the effective value is true.

--- a/website/src/content/docs/start/commands.md
+++ b/website/src/content/docs/start/commands.md
@@ -106,6 +106,8 @@ when a command can consume a handle without creating a plaintext file.
 | View persistent diagnostics | `pentect log` | Values, bodies, headers, and URLs are not logged |
 | Locate the log file | `pentect log --path` | Prints the local path |
 | Machine-readable diagnostics | `pentect log --json` | Suitable for support tooling |
+| View local protection statistics | `pentect metrics` | Counts occurrences; never shows values, handles, paths, URLs, or account identifiers |
+| Machine-readable statistics | `pentect metrics --json` | Local JSON; no telemetry is sent |
 | Check readiness | `pentect doctor` | Does not change configuration |
 | Offer safe repairs | `pentect doctor --fix` | Confirms changes interactively |
 | Check for an update | `pentect update --check` | Does not install |


### PR DESCRIPTION
## What
- add `pentect metrics` and `pentect metrics --json`
- count masked occurrences by secret type and protection surface from retained local logs
- report image redactions, local restoration operations, blocked operations, and warnings
- add `metrics.enabled` (default `true`) to disable on-demand statistics
- document the command and privacy boundary

## Privacy boundary
Metrics are computed locally on demand. Output excludes secret values, handles, paths, URLs, request bodies, account identifiers, and unbounded dimensions. Untrusted labels collapse to `OTHER`. No telemetry is sent. Diagnostic logging remains independent when metrics are disabled so crash investigation still works.

## Semantics
Counts are occurrences, not unique secrets. Secret-type totals include text masks and image redactions.

## Tests
- runtime aggregation and malicious-dimension tests
- configuration parsing tests
- public CLI command snapshot tests
- real human and JSON command smoke checks

Implements the local metrics portion of #250; external telemetry and false-positive submission remain out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `pentect metrics` to display local, value-free protection statistics.
  - Added optional `--json` output for machine-readable results.
  - Reports masking, redaction, restoration, blocked operations, warnings, and summary breakdowns.
  - Safely handles malformed records and untrusted metric labels.
  - Metrics remain local and can be disabled with `metrics.enabled`.

- **Documentation**
  - Documented the new command, JSON output, privacy behavior, and configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->