### PR TITLE
fix: count blocked images individually

### DIFF
--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -81,6 +81,7 @@ struct PrivacyMetrics {
     scope: &'static str,
     masked_text_occurrences: u64,
     redacted_image_occurrences: u64,
+    blocked_image_occurrences: u64,
     restoration_operations: u64,
     blocked_occurrences: u64,
     warning_occurrences: u64,
@@ -388,6 +389,7 @@ pub(crate) fn print_metrics(json: bool) -> Result<(), String> {
     println!("Pentect privacy metrics (retained local logs)");
     println!("Masked occurrences: {}", metrics.masked_text_occurrences);
     println!("Redacted images: {}", metrics.redacted_image_occurrences);
+    println!("Blocked images: {}", metrics.blocked_image_occurrences);
     println!(
         "Local restoration operations: {}",
         metrics.restoration_operations
@@ -499,6 +501,11 @@ fn aggregate_metric_event(event: &ActivityEvent, metrics: &mut PrivacyMetrics) {
         }
         "block" => {
             metrics.blocked_occurrences = metrics.blocked_occurrences.saturating_add(event.count);
+        }
+        "block-image" => {
+            metrics.blocked_image_occurrences = metrics
+                .blocked_image_occurrences
+                .saturating_add(event.count);
         }
         "warning" => {
             metrics.warning_occurrences = metrics.warning_occurrences.saturating_add(event.count);
@@ -1543,7 +1550,12 @@ mod tests {
             &ActivityEvent::new("block", "image", 1, BTreeMap::new(), None),
             &mut metrics,
         );
+        aggregate_metric_event(
+            &ActivityEvent::new("block-image", "image", 3, BTreeMap::new(), None),
+            &mut metrics,
+        );
         assert_eq!(metrics.blocked_occurrences, 1);
+        assert_eq!(metrics.blocked_image_occurrences, 3);
     }
 
     #[test]

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -193,6 +193,18 @@ pub(crate) fn skip_text_masking_for_image_field(key: &str, text: &str) -> bool {
     ) && looks_like_base64_image_field_value(text)
 }
 
+pub(crate) fn count_image_results(value: &Value) -> usize {
+    match value {
+        Value::String(text) => {
+            usize::from(looks_like_image_reference(text) || looks_like_base64_image(text))
+        }
+        Value::Array(items) => items.iter().map(count_image_results).sum(),
+        Value::Object(map) if object_marks_image(map) => 1,
+        Value::Object(map) => map.values().map(count_image_results).sum(),
+        Value::Number(_) | Value::Bool(_) | Value::Null => 0,
+    }
+}
+
 pub(crate) fn inspect_tool_images_for_secrets(
     value: &Value,
     key: &[u8; 32],
@@ -3726,6 +3738,17 @@ mod tests {
         )
         .unwrap()
         .is_some());
+    }
+
+    #[test]
+    fn image_result_count_counts_each_image_object_once() {
+        let value = serde_json::json!({
+            "content": [
+                {"type": "image", "data": "not-loaded-while-counting"},
+                {"type": "image_url", "image_url": {"url": "https://example.invalid/two.png"}}
+            ]
+        });
+        assert_eq!(count_image_results(&value), 2);
     }
 
     #[test]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -4322,7 +4322,7 @@ fn image_tool_result_block_reason(
     let cfg = config::image_ocr_config()?;
     if matches!(cfg.mode, config::ImageOcrMode::Off) {
         if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Block) {
-            record_image_block();
+            record_image_block(image_ocr::count_image_results(value));
             return Ok(Some("image blocked: OCR is off.".to_string()));
         }
         return Ok(None);
@@ -4336,27 +4336,28 @@ fn image_tool_result_block_reason(
             BTreeMap::new(),
             None,
         );
-        record_image_block();
+        record_image_block(inspection.secret_images);
         return Ok(Some("image blocked: secret text detected.".to_string()));
     }
     if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Allow) {
         return Ok(None);
     }
     if inspection.unscanned_images > 0 {
-        record_image_block();
+        record_image_block(inspection.unscanned_images);
         return Ok(Some(
             "image blocked: image could not be fetched or scanned.".to_string(),
         ));
     }
     if inspection.ocr_failures > 0 {
-        record_image_block();
+        record_image_block(inspection.ocr_failures);
         return Ok(Some("image blocked: image scan failed.".to_string()));
     }
     Ok(None)
 }
 
-fn record_image_block() {
+fn record_image_block(images: usize) {
     activity_log::record_summary("block", "image", 1, BTreeMap::new(), None);
+    activity_log::record_summary("block-image", "image", images as u64, BTreeMap::new(), None);
 }
 
 fn unsupported_tool_result_reason(value: &Value) -> Option<String> {

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -87,6 +87,9 @@ pentect pi --model gpt-5
 | `pentect log [--json \| --path]` | Show persistent diagnostics and follow protection events |
 | `pentect metrics [--json]` | Show local counts by secret type and protection surface |
 
+Image statistics distinguish blocked operations from blocked images: one tool
+operation containing three blocked images counts as one operation and three images.
+
 ### `mask`
 
 Mask UTF-8 standard input. It infers structured formats from content when no


### PR DESCRIPTION
Follow-up to #986.

- keeps blocked operations as operation counts
- adds a separate blocked image count
- counts every blocked image, including multiple images in one tool result
- documents the distinction

Validation:
- targeted activity-log regression test
- targeted image-count regression test
- runtime Clippy with CI flags