### PR TITLE
fix: harden Windows installation lifecycle

### DIFF
--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     env:
+      GH_TOKEN: ${{ github.token }}
       PENTECT_LOG_DIR: ${{ github.workspace }}/.pentect-client-logs
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -57,6 +58,9 @@ jobs:
           irm https://pentect.dev/install | iex
           $binary = Join-Path $env:PENTECT_INSTALL_DIR 'pentect.exe'
           if (-not (Test-Path -LiteralPath $binary)) { throw 'public installer did not produce pentect.exe' }
+          $latest = (gh release view --repo $env:GITHUB_REPOSITORY --json tagName --jq .tagName).TrimStart('v')
+          $installed = (& $binary version).Trim() -replace '^pentect\s+', ''
+          if ($installed -ne $latest) { throw "public installer installed $installed, expected $latest" }
           "PENTECT_SMOKE_BINARY=$binary" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Install latest Pentect from public endpoint (POSIX)
         if: runner.os != 'Windows'
@@ -67,6 +71,10 @@ jobs:
           curl -fsSL --proto '=https' --tlsv1.2 https://pentect.dev/install.sh |
             PENTECT_INSTALL_DIR="$install_dir" sh
           test -x "$install_dir/pentect"
+          latest=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
+          latest=${latest#v}
+          installed=$("$install_dir/pentect" version | sed 's/^pentect //')
+          test "$installed" = "$latest"
           printf 'PENTECT_SMOKE_BINARY=%s\n' "$install_dir/pentect" >> "$GITHUB_ENV"
       - name: Install current portable clients
         run: python tools/install_portable_client_smoke.py --mode latest

--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -521,20 +521,24 @@ if (-not ($parts | Where-Object { $_.TrimEnd('\') -ieq $dir.TrimEnd('\') })) {
     $key.SetValue('Path',$value,$kind)
   }
 } finally { $key.Dispose() }"#;
-    let output = Command::new("powershell.exe")
-        .args([
-            "-NoLogo",
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            SCRIPT,
-        ])
-        .env("PENTECT_DOCTOR_PATH_DIR", directory)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .output()
-        .map_err(|error| format!("could not update the user PATH: {error}"))?;
+    let output = Command::new(crate::windows_system_executable(
+        r"WindowsPowerShell\v1.0\powershell.exe",
+    ))
+    .args([
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        SCRIPT,
+    ])
+    .env("PENTECT_DOCTOR_PATH_DIR", directory)
+    .stdin(Stdio::null())
+    .stdout(Stdio::null())
+    .stderr(Stdio::piped())
+    .output()
+    .map_err(|error| format!("could not update the user PATH: {error}"))?;
     if !output.status.success() {
         let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
         return Err(if detail.is_empty() {

--- a/crates/pentect-cli/src/secure_temp.rs
+++ b/crates/pentect-cli/src/secure_temp.rs
@@ -180,7 +180,8 @@ fn cleanup_stale(directory: &Path, prefix: &str, suffix: &str) {
 pub(crate) fn restrict_to_current_user(path: &Path) -> Result<(), String> {
     use std::process::{Command, Stdio};
 
-    let identity = Command::new("whoami.exe")
+    let identity = Command::new(crate::windows_system_executable("whoami.exe"))
+        .args(["/user", "/fo", "csv", "/nh"])
         .stdin(Stdio::null())
         .stderr(Stdio::null())
         .output()
@@ -188,14 +189,10 @@ pub(crate) fn restrict_to_current_user(path: &Path) -> Result<(), String> {
     if !identity.status.success() {
         return Err("could not resolve the Windows account for ACL setup".to_string());
     }
-    let identity = String::from_utf8(identity.stdout)
-        .map_err(|_| "Windows account name is not UTF-8".to_string())?;
-    let identity = identity.trim();
-    if identity.is_empty() {
-        return Err("Windows account name is empty".to_string());
-    }
-    let grant = format!("{identity}:(F)");
-    let status = Command::new("icacls.exe")
+    let sid = windows_sid_from_whoami_output(&identity.stdout)
+        .ok_or_else(|| "could not parse the Windows account SID".to_string())?;
+    let grant = format!("*{sid}:(F)");
+    let status = Command::new(crate::windows_system_executable("icacls.exe"))
         .arg(path)
         .args(["/inheritance:r", "/grant:r", &grant])
         .stdin(Stdio::null())
@@ -209,6 +206,25 @@ pub(crate) fn restrict_to_current_user(path: &Path) -> Result<(), String> {
         .ok_or_else(|| "could not restrict temporary file ACL".to_string())
 }
 
+#[cfg(any(windows, test))]
+fn windows_sid_from_whoami_output(output: &[u8]) -> Option<String> {
+    for start in 0..output.len().saturating_sub(3) {
+        if !output[start..].starts_with(b"S-1-") {
+            continue;
+        }
+        let suffix_start = start + b"S-1-".len();
+        let end = output[suffix_start..]
+            .iter()
+            .position(|byte| !byte.is_ascii_digit() && *byte != b'-')
+            .map_or(output.len(), |length| suffix_start + length);
+        let candidate = std::str::from_utf8(&output[start..end]).ok()?;
+        if candidate.matches('-').count() >= 3 && !candidate.ends_with('-') {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
 #[cfg(not(windows))]
 pub(crate) fn restrict_to_current_user(_: &Path) -> Result<(), String> {
     Ok(())
@@ -217,6 +233,15 @@ pub(crate) fn restrict_to_current_user(_: &Path) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extracts_sid_without_decoding_the_account_name() {
+        let output = b"\x8a\xc7\x97\x9d,\"S-1-5-21-123-456-789-1001\"\r\n";
+        assert_eq!(
+            windows_sid_from_whoami_output(output).as_deref(),
+            Some("S-1-5-21-123-456-789-1001")
+        );
+    }
 
     fn directory() -> PathBuf {
         let path = std::env::temp_dir().join(format!(

--- a/crates/pentect-cli/src/uninstall.rs
+++ b/crates/pentect-cli/src/uninstall.rs
@@ -212,25 +212,29 @@ Remove-Item -LiteralPath $PSCommandPath -Force
     ));
     std::fs::write(&helper, SCRIPT)
         .map_err(|error| format!("could not create uninstall helper: {error}"))?;
-    Command::new("powershell.exe")
-        .args([
-            "-NoProfile",
-            "-NonInteractive",
-            "-WindowStyle",
-            "Hidden",
-            "-File",
-        ])
-        .arg(&helper)
-        .arg("-ParentPid")
-        .arg(std::process::id().to_string())
-        .arg("-Target")
-        .arg(executable)
-        .arg("-Marker")
-        .arg(marker)
-        .creation_flags(CREATE_NO_WINDOW)
-        .spawn()
-        .map(|_| ())
-        .map_err(|error| format!("could not start uninstall helper: {error}"))
+    Command::new(crate::windows_system_executable(
+        r"WindowsPowerShell\v1.0\powershell.exe",
+    ))
+    .args([
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-WindowStyle",
+        "Hidden",
+        "-File",
+    ])
+    .arg(&helper)
+    .arg("-ParentPid")
+    .arg(std::process::id().to_string())
+    .arg("-Target")
+    .arg(executable)
+    .arg("-Marker")
+    .arg(marker)
+    .creation_flags(CREATE_NO_WINDOW)
+    .spawn()
+    .map(|_| ())
+    .map_err(|error| format!("could not start uninstall helper: {error}"))
 }
 
 #[cfg(windows)]

--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -755,23 +755,27 @@ Remove-Item -LiteralPath $PSCommandPath -Force
     ));
     std::fs::write(&helper, SCRIPT)
         .map_err(|error| format!("could not create update cleanup helper: {error}"))?;
-    Command::new("powershell.exe")
-        .args([
-            "-NoProfile",
-            "-NonInteractive",
-            "-WindowStyle",
-            "Hidden",
-            "-File",
-        ])
-        .arg(&helper)
-        .arg("-ParentPid")
-        .arg(std::process::id().to_string())
-        .arg("-Target")
-        .arg(staged)
-        .creation_flags(CREATE_NO_WINDOW)
-        .spawn()
-        .map(|_| ())
-        .map_err(|error| format!("could not start update cleanup helper: {error}"))
+    Command::new(crate::windows_system_executable(
+        r"WindowsPowerShell\v1.0\powershell.exe",
+    ))
+    .args([
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-WindowStyle",
+        "Hidden",
+        "-File",
+    ])
+    .arg(&helper)
+    .arg("-ParentPid")
+    .arg(std::process::id().to_string())
+    .arg("-Target")
+    .arg(staged)
+    .creation_flags(CREATE_NO_WINDOW)
+    .spawn()
+    .map(|_| ())
+    .map_err(|error| format!("could not start update cleanup helper: {error}"))
 }
 
 #[cfg(test)]

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -210,6 +210,7 @@ fn restrict_identity_file(path: &Path) -> Result<(), String> {
     }
     let system32 = windows_system32()?;
     let identity = std::process::Command::new(system32.join("whoami.exe"))
+        .args(["/user", "/fo", "csv", "/nh"])
         .stdin(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .output()
@@ -217,15 +218,11 @@ fn restrict_identity_file(path: &Path) -> Result<(), String> {
     if !identity.status.success() {
         return Err("could not resolve the Windows account for ACL setup".to_string());
     }
-    let identity = String::from_utf8(identity.stdout)
-        .map_err(|_| "Windows account name is not UTF-8".to_string())?;
-    let identity = identity.trim();
-    if identity.is_empty() {
-        return Err("Windows account name is empty".to_string());
-    }
+    let sid = windows_sid_from_whoami_output(&identity.stdout)
+        .ok_or_else(|| "could not parse the Windows account SID".to_string())?;
     let status = std::process::Command::new(system32.join("icacls.exe"))
         .arg(path)
-        .args(["/inheritance:r", "/grant:r", &format!("{identity}:(F)")])
+        .args(["/inheritance:r", "/grant:r", &format!("*{sid}:(F)")])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -236,6 +233,25 @@ fn restrict_identity_file(path: &Path) -> Result<(), String> {
     }
     fs::write(&marker, expected_marker)
         .map_err(|error| format!("could not record identity key ACL setup: {error}"))
+}
+
+#[cfg(any(windows, test))]
+fn windows_sid_from_whoami_output(output: &[u8]) -> Option<String> {
+    for start in 0..output.len().saturating_sub(3) {
+        if !output[start..].starts_with(b"S-1-") {
+            continue;
+        }
+        let suffix_start = start + b"S-1-".len();
+        let end = output[suffix_start..]
+            .iter()
+            .position(|byte| !byte.is_ascii_digit() && *byte != b'-')
+            .map_or(output.len(), |length| suffix_start + length);
+        let candidate = std::str::from_utf8(&output[start..end]).ok()?;
+        if candidate.matches('-').count() >= 3 && !candidate.ends_with('-') {
+            return Some(candidate.to_string());
+        }
+    }
+    None
 }
 
 #[cfg(windows)]
@@ -976,6 +992,15 @@ fn home_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extracts_sid_without_decoding_the_account_name() {
+        let output = b"\x8a\xc7\x97\x9d,\"S-1-5-21-123-456-789-1001\"\r\n";
+        assert_eq!(
+            windows_sid_from_whoami_output(output).as_deref(),
+            Some("S-1-5-21-123-456-789-1001")
+        );
+    }
 
     fn temp_test_dir(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!(


### PR DESCRIPTION
Addresses #978, #977, and #961. Installation reports remain open pending reporter confirmation.

- pin PowerShell, whoami, and icacls to System32
- bypass PowerShell execution policy for Pentect-generated helpers
- grant ACLs by ASCII SID instead of decoding localized account names
- apply the SID fix to both secure temporary files and the startup identity key
- require the public installer smoke test to match the current stable release version

#657 is already fixed on main and remains open pending reporter confirmation.

Validation:
- targeted runtime SID regression test
- targeted CLI SID regression test
- runtime and CLI Clippy with warnings denied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installation, update, and uninstall operations by reliably locating PowerShell and applying the required execution policy.
  * Improved Windows permission handling by using account security identifiers, including support for non-UTF-8 command output.
  * Added validation to ensure binaries installed from the public endpoint match the latest release version.
  * Added regression coverage for Windows identity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->