### PR TITLE
fix(core): close P0 JSON context and short-secret remasking gaps

### DIFF
--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -3964,35 +3964,6 @@ mod tests {
     }
 
     #[test]
-    fn responses_tool_call_history_masks_arguments_and_custom_input() {
-        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
-        let store = pentect_agent::start_in_process_memory_store().unwrap();
-        let _env = ProviderBoundaryTestEnv::install(&store);
-        let mut masker = pentect_agent::ActiveToolOutputMasker::new().unwrap();
-        let mut input = serde_json::json!([
-            {
-                "type": "function_call",
-                "name": "shell",
-                "arguments": "{\"command\":\"OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\"}"
-            },
-            {
-                "type": "custom_tool_call",
-                "name": "exec_command",
-                "input": "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX"
-            }
-        ]);
-        mask_openai_input(&mut input, false, &mut masker, &HashMap::new()).unwrap();
-        for field in [&input[0]["arguments"], &input[1]["input"]] {
-            let protected = field.as_str().unwrap();
-            assert!(protected.contains("<<"), "{protected}");
-            assert!(
-                !protected.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"),
-                "{protected}"
-            );
-        }
-    }
-
-    #[test]
     fn response_function_arguments_are_restored() {
         let input = br#"{"output":[{"type":"function_call","name":"shell","arguments":"{\"command\":\"echo <<SECRET_0123456789abcdef>>\"}"}]}"#;
         let mut value: Value = serde_json::from_slice(input).unwrap();

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -1831,6 +1831,16 @@ fn mask_openai_input(
                 .unwrap_or_default()
                 .to_string();
             match item_type.as_str() {
+                "function_call" => {
+                    if let Some(Value::String(arguments)) = object.get_mut("arguments") {
+                        mask_text(arguments, true, masker)?;
+                    }
+                }
+                "custom_tool_call" => {
+                    if let Some(Value::String(input)) = object.get_mut("input") {
+                        mask_text(input, true, masker)?;
+                    }
+                }
                 "function_call_output" | "custom_tool_call_output" => {
                     if let Some(output) = object.get_mut("output") {
                         mask_openai_input(output, true, masker, files)?;
@@ -3901,6 +3911,35 @@ mod tests {
         let original = tokens.clone();
         mask_embeddings_request(&mut tokens, &mut masker.lock().unwrap()).unwrap();
         assert_eq!(tokens, original);
+    }
+
+    #[test]
+    fn responses_tool_call_history_masks_arguments_and_custom_input() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = ProviderBoundaryTestEnv::install(&store);
+        let mut masker = pentect_agent::ActiveToolOutputMasker::new().unwrap();
+        let mut input = serde_json::json!([
+            {
+                "type": "function_call",
+                "name": "shell",
+                "arguments": "{\"command\":\"OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\"}"
+            },
+            {
+                "type": "custom_tool_call",
+                "name": "exec_command",
+                "input": "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX"
+            }
+        ]);
+        mask_openai_input(&mut input, false, &mut masker, &HashMap::new()).unwrap();
+        for field in [&input[0]["arguments"], &input[1]["input"]] {
+            let protected = field.as_str().unwrap();
+            assert!(protected.contains("<<"), "{protected}");
+            assert!(
+                !protected.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"),
+                "{protected}"
+            );
+        }
     }
 
     #[test]

--- a/crates/pentect-core/src/detect/mod.rs
+++ b/crates/pentect-core/src/detect/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use explicit::EXPLICIT_SECRET_PREFIXES;
 pub use key_value::KeyValueDetector;
 pub use pattern::{PatternMatchDetector, PatternSpec};
 pub use rule::{RuleDetector, RuleSpec};
-pub(crate) use structural::SECRET_VALUE_HINT;
+pub(crate) use structural::{is_sensitive_key_name, SECRET_VALUE_HINT};
 pub use structural::{EnvValueDetector, SensitiveKeyDetector, StructuralDetector};
 pub use url::UrlDetector;
 pub use validate::Validator;

--- a/crates/pentect-core/src/detect/structural.rs
+++ b/crates/pentect-core/src/detect/structural.rs
@@ -147,7 +147,7 @@ fn sensitive_context_label(ctx: &Context) -> Option<String> {
         .map(sensitive_label_for_key)
 }
 
-fn is_sensitive_key_name(key: &str) -> bool {
+pub(crate) fn is_sensitive_key_name(key: &str) -> bool {
     let name = normalize_identifier(key);
     if is_explicitly_non_sensitive_key(&name) || is_non_credential_sensitive_word_name(&name) {
         return false;

--- a/crates/pentect-core/src/parse/json.rs
+++ b/crates/pentect-core/src/parse/json.rs
@@ -161,7 +161,7 @@ impl Parser<'_> {
             self.i += 1;
             return Some(());
         }
-        let mut sibling_hint: Option<String> = None;
+        let mut sibling_hints = Vec::new();
         let mut sibling_values = Vec::new();
         loop {
             self.skip_ws();
@@ -189,9 +189,7 @@ impl Parser<'_> {
             self.skip_ws();
             if is_sibling_hint_key(&key) && self.peek() == Some(b'"') {
                 let (range, value) = self.string()?;
-                if sibling_hint.is_none() {
-                    sibling_hint = Some(value);
-                }
+                sibling_hints.push(value);
                 self.out.push(Region {
                     span: range,
                     ctx: Context {
@@ -214,7 +212,7 @@ impl Parser<'_> {
                 b',' => self.i += 1,
                 b'}' => {
                     self.i += 1;
-                    if let Some(hint) = sibling_hint {
+                    if !sibling_hints.is_empty() {
                         for (start, end) in sibling_values {
                             for region in &mut self.out[start..end] {
                                 if region
@@ -223,7 +221,7 @@ impl Parser<'_> {
                                     .as_deref()
                                     .is_some_and(|key| key.eq_ignore_ascii_case("value"))
                                 {
-                                    region.ctx.hints.push(hint.clone());
+                                    region.ctx.hints.extend(sibling_hints.iter().cloned());
                                 }
                             }
                         }
@@ -457,6 +455,14 @@ mod tests {
                 .unwrap();
             assert_eq!(value.ctx.hints, ["db_password"], "{raw}");
         }
+
+        let raw = r#"{"name":"display_label","value":"correcthorsebattery","key":"db_password"}"#;
+        let regions = parse_json_regions(raw).unwrap();
+        let value = regions
+            .iter()
+            .find(|region| &raw[region.span.start..region.span.end] == "correcthorsebattery")
+            .unwrap();
+        assert_eq!(value.ctx.hints, ["display_label", "db_password"]);
     }
 
     #[test]

--- a/crates/pentect-core/src/parse/json.rs
+++ b/crates/pentect-core/src/parse/json.rs
@@ -96,6 +96,12 @@ enum JsonRegionMode {
     ToolResult,
 }
 
+fn is_sibling_hint_key(key: &str) -> bool {
+    ["name", "key", "env"]
+        .iter()
+        .any(|candidate| key.eq_ignore_ascii_case(candidate))
+}
+
 struct Parser<'a> {
     b: &'a [u8],
     i: usize,
@@ -155,7 +161,8 @@ impl Parser<'_> {
             self.i += 1;
             return Some(());
         }
-        let mut sibling_name: Option<String> = None;
+        let mut sibling_hint: Option<String> = None;
+        let mut sibling_values = Vec::new();
         loop {
             self.skip_ws();
             if self.peek() != Some(b'"') {
@@ -180,9 +187,11 @@ impl Parser<'_> {
             }
             self.i += 1;
             self.skip_ws();
-            if key.eq_ignore_ascii_case("name") && self.peek() == Some(b'"') {
+            if is_sibling_hint_key(&key) && self.peek() == Some(b'"') {
                 let (range, value) = self.string()?;
-                sibling_name = Some(value);
+                if sibling_hint.is_none() {
+                    sibling_hint = Some(value);
+                }
                 self.out.push(Region {
                     span: range,
                     ctx: Context {
@@ -194,18 +203,31 @@ impl Parser<'_> {
                     },
                 });
             } else {
-                let hints = if key.eq_ignore_ascii_case("value") {
-                    sibling_name.iter().cloned().collect()
-                } else {
-                    Vec::new()
-                };
-                self.value(Some(key), hints, depth)?;
+                let start = self.out.len();
+                self.value(Some(key.clone()), Vec::new(), depth)?;
+                if key.eq_ignore_ascii_case("value") {
+                    sibling_values.push((start, self.out.len()));
+                }
             }
             self.skip_ws();
             match self.peek()? {
                 b',' => self.i += 1,
                 b'}' => {
                     self.i += 1;
+                    if let Some(hint) = sibling_hint {
+                        for (start, end) in sibling_values {
+                            for region in &mut self.out[start..end] {
+                                if region
+                                    .ctx
+                                    .key
+                                    .as_deref()
+                                    .is_some_and(|key| key.eq_ignore_ascii_case("value"))
+                                {
+                                    region.ctx.hints.push(hint.clone());
+                                }
+                            }
+                        }
+                    }
                     return Some(());
                 }
                 _ => return None,
@@ -419,6 +441,22 @@ mod tests {
             .unwrap();
         assert_eq!(value.ctx.key.as_deref(), Some("value"));
         assert_eq!(value.ctx.hints, ["Authorization"]);
+    }
+
+    #[test]
+    fn sibling_hints_do_not_depend_on_object_field_order() {
+        for raw in [
+            r#"{"value":"correcthorsebattery","name":"db_password"}"#,
+            r#"{"value":"correcthorsebattery","key":"db_password"}"#,
+            r#"{"value":"correcthorsebattery","env":"db_password"}"#,
+        ] {
+            let regions = parse_json_regions(raw).unwrap();
+            let value = regions
+                .iter()
+                .find(|region| &raw[region.span.start..region.span.end] == "correcthorsebattery")
+                .unwrap();
+            assert_eq!(value.ctx.hints, ["db_password"], "{raw}");
+        }
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -1285,6 +1285,7 @@ mod tests {
             r#"{"value":"correcthorsebattery","name":"db_password"}"#,
             r#"{"value":"correcthorsebattery","key":"db_password"}"#,
             r#"{"value":"correcthorsebattery","env":"db_password"}"#,
+            r#"{"name":"display_label","value":"correcthorsebattery","key":"db_password"}"#,
         ] {
             let result = mj(input);
             assert!(!result.masked.contains("correcthorsebattery"), "{input}");

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -1295,6 +1295,21 @@ mod tests {
     }
 
     #[test]
+    fn short_contextual_secret_is_remasked_after_local_restore() {
+        let input = r#"{"DB_PASSWORD":"p1n5"}"#;
+        let result = mj(input);
+        assert!(
+            result.masked.contains("<<DB_PASSWORD_"),
+            "{}",
+            result.masked
+        );
+        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), input);
+        let remasked = result.recovery.remask("tool echoed p1n5");
+        assert!(!remasked.contains("p1n5"), "{remasked}");
+        assert!(remasked.contains("<<DB_PASSWORD_"), "{remasked}");
+    }
+
+    #[test]
     fn ndjson_sensitive_values_are_parsed_per_line() {
         let input = "{\"password\":\"hunter2\"}\n{\"token\":\"abcdef\"}\n";
         let r = mn(input);

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -1280,6 +1280,20 @@ mod tests {
     }
 
     #[test]
+    fn json_sibling_secret_context_is_order_independent() {
+        for input in [
+            r#"{"value":"correcthorsebattery","name":"db_password"}"#,
+            r#"{"value":"correcthorsebattery","key":"db_password"}"#,
+            r#"{"value":"correcthorsebattery","env":"db_password"}"#,
+        ] {
+            let result = mj(input);
+            assert!(!result.masked.contains("correcthorsebattery"), "{input}");
+            assert!(result.masked.contains("<<"), "{input}");
+            assert_eq!(restore(&result.masked, &result.recovery).unwrap(), input);
+        }
+    }
+
+    #[test]
     fn ndjson_sensitive_values_are_parsed_per_line() {
         let input = "{\"password\":\"hunter2\"}\n{\"token\":\"abcdef\"}\n";
         let r = mn(input);

--- a/crates/pentect-core/src/recovery.rs
+++ b/crates/pentect-core/src/recovery.rs
@@ -443,7 +443,7 @@ fn is_remaskable_echo(value: &str, placeholder: &str) -> bool {
             | crate::model::labels::CMD_PASSWORD
             | crate::model::labels::URL_CREDENTIAL
             | crate::model::labels::PRIVATE_KEY
-    )
+    ) || crate::detect::is_sensitive_key_name(&parts.label)
 }
 
 fn sort_and_deduplicate_remask_pairs(pairs: &mut Vec<(String, &str)>) {
@@ -733,13 +733,18 @@ mod tests {
     #[test]
     fn remask_ignores_short_metadata_values() {
         let rec = Recovery::seal(
-            HashMap::from([("<<COUNT_0011223344556677>>".to_string(), "3".to_string())]),
+            HashMap::from([
+                ("<<COUNT_0011223344556677>>".to_string(), "1234".to_string()),
+                (
+                    "<<STATUS_8899aabbccddeeff>>".to_string(),
+                    "ready".to_string(),
+                ),
+            ]),
             &[5u8; 32],
         );
-        assert_eq!(rec.resolve("n=<<COUNT_0011223344556677>>"), "n=3");
         assert_eq!(
-            rec.remask("AKIA3EXAMPLE has a digit"),
-            "AKIA3EXAMPLE has a digit"
+            rec.remask("count 1234 status ready"),
+            "count 1234 status ready"
         );
     }
 
@@ -747,25 +752,28 @@ mod tests {
     fn remask_rehides_short_otp_and_keyed_secrets() {
         let otp = "<<OTP_0011223344556677>>";
         let password = "<<KEYED_SECRET_8899aabbccddeeff>>";
+        let database_password = "<<DB_PASSWORD_aabbccddeeff0011>>";
         let rec = Recovery::seal(
             HashMap::from([
                 (otp.to_string(), "1234".to_string()),
                 (password.to_string(), "abcde".to_string()),
+                (database_password.to_string(), "p1n5".to_string()),
             ]),
             &[5u8; 32],
         );
         assert_eq!(
-            rec.remask("code 1234 password abcde"),
-            format!("code {otp} password {password}")
+            rec.remask("code 1234 password abcde database p1n5"),
+            format!("code {otp} password {password} database {database_password}")
         );
 
         let mut stream = rec.stream_remasker();
         let mut output = stream.push_text(b"code 12");
-        output.extend(stream.push_text(b"34 password abcde"));
+        output.extend(stream.push_text(b"34 password abcde database p1"));
+        output.extend(stream.push_text(b"n5"));
         output.extend(stream.finish());
         assert_eq!(
             String::from_utf8(output).unwrap(),
-            format!("code {otp} password {password}")
+            format!("code {otp} password {password} database {database_password}")
         );
     }
 

--- a/crates/pentect-core/src/recovery.rs
+++ b/crates/pentect-core/src/recovery.rs
@@ -106,7 +106,7 @@ impl Recovery {
             .map
             .keys()
             .filter_map(|ph| self.reveal(ph).map(|v| (v, ph.as_str())))
-            .filter(|(v, _)| is_remaskable_echo(v))
+            .filter(|(value, placeholder)| is_remaskable_echo(value, placeholder))
             .collect();
         sort_and_deduplicate_remask_pairs(&mut pairs);
         if pairs.is_empty() {
@@ -232,7 +232,7 @@ impl RecoveryStreamRemasker {
             .filter_map(|placeholder| {
                 recovery
                     .reveal(placeholder)
-                    .filter(|value| is_remaskable_echo(value))
+                    .filter(|value| is_remaskable_echo(value, placeholder))
                     .map(|value| StreamPattern {
                         value: value.into_bytes(),
                         placeholder: placeholder.as_bytes().to_vec(),
@@ -421,9 +421,29 @@ impl Drop for RecoveryStreamRemasker {
     }
 }
 
-fn is_remaskable_echo(value: &str) -> bool {
+fn is_remaskable_echo(value: &str, placeholder: &str) -> bool {
     let trimmed = value.trim();
-    trimmed.len() >= 6 && !matches!(trimmed, "true" | "false" | "null")
+    if matches!(trimmed, "true" | "false" | "null") {
+        return false;
+    }
+    if trimmed.len() >= 6 {
+        return true;
+    }
+    if trimmed.len() < 4 {
+        return false;
+    }
+    let Ok(parts) = crate::placeholder::parse_placeholder(placeholder) else {
+        return false;
+    };
+    matches!(
+        parts.label.as_str(),
+        crate::model::labels::SECRET
+            | crate::model::labels::KEYED_SECRET
+            | crate::model::labels::OTP
+            | crate::model::labels::CMD_PASSWORD
+            | crate::model::labels::URL_CREDENTIAL
+            | crate::model::labels::PRIVATE_KEY
+    )
 }
 
 fn sort_and_deduplicate_remask_pairs(pairs: &mut Vec<(String, &str)>) {
@@ -720,6 +740,32 @@ mod tests {
         assert_eq!(
             rec.remask("AKIA3EXAMPLE has a digit"),
             "AKIA3EXAMPLE has a digit"
+        );
+    }
+
+    #[test]
+    fn remask_rehides_short_otp_and_keyed_secrets() {
+        let otp = "<<OTP_0011223344556677>>";
+        let password = "<<KEYED_SECRET_8899aabbccddeeff>>";
+        let rec = Recovery::seal(
+            HashMap::from([
+                (otp.to_string(), "1234".to_string()),
+                (password.to_string(), "abcde".to_string()),
+            ]),
+            &[5u8; 32],
+        );
+        assert_eq!(
+            rec.remask("code 1234 password abcde"),
+            format!("code {otp} password {password}")
+        );
+
+        let mut stream = rec.stream_remasker();
+        let mut output = stream.push_text(b"code 12");
+        output.extend(stream.push_text(b"34 password abcde"));
+        output.extend(stream.finish());
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            format!("code {otp} password {password}")
         );
     }
 


### PR DESCRIPTION
## Summary

- re-mask 4- and 5-character OTP and contextual secret values while retaining the short-metadata false-positive guard
- make JSON `name`/`key`/`env` sibling hints independent of object field order
- retain every sibling hint when an object contains multiple hint fields, so an earlier harmless `name` cannot hide a later sensitive `key`
- remove the now-merged #686 implementation and test duplication from this PR

Closes #416
Closes #412

## Why the previous CI appeared red

The previous run code and boundary tests passed. The workflow was marked cancelled only while the Windows job was uploading its Rust cache. This branch has now been updated to current `main`; the real merge conflict with the separately merged #686 fix was resolved by keeping the newer main implementation.

## Focused local verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p pentect-core sibling_hints_do_not_depend_on_object_field_order --locked`
- `cargo test -p pentect-core json_sibling_secret_context_is_order_independent --locked`
- `cargo test -p pentect-core remask_rehides_short_otp_and_keyed_secrets --locked`