### PR TITLE
fix: support current Claude Desktop on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
         run: python tools/run_filtered_tests.py claude_app_proxy::tests
       - name: Test Claude Desktop temporary certificate lifecycle
         if: needs.changes.outputs.claude_app == 'true' && runner.os == 'Windows'
-        run: cargo test -p pentect-cli windows_user_ca_round_trip --locked -- --ignored
+        run: cargo test -p pentect-cli --no-default-features windows_user_ca_round_trip --locked -- --ignored
       - name: Test OpenAI gateway
         if: needs.changes.outputs.openai_proxy == 'true'
         run: python tools/run_filtered_tests.py openai_http_proxy::tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
       - name: Test Claude Desktop gateway
         if: needs.changes.outputs.claude_app == 'true'
         run: python tools/run_filtered_tests.py claude_app_proxy::tests
-      - name: Test Claude Desktop temporary certificate lifecycle
+      - name: Test Claude Desktop certificate-store lifecycle
         if: needs.changes.outputs.claude_app == 'true' && runner.os == 'Windows'
         run: cargo test -p pentect-cli --no-default-features windows_user_ca_round_trip --locked -- --ignored --nocapture
       - name: Test OpenAI gateway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,14 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/rust-toolchain
         if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true'
+      - name: Configure fast Windows test linking
+        if: runner.os == 'Windows' && (needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true')
+        shell: pwsh
+        run: |
+          $linker = (Get-Command lld-link.exe -ErrorAction Stop).Source
+          "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linker" >> $env:GITHUB_ENV
+          "CARGO_PROFILE_TEST_DEBUG=0" >> $env:GITHUB_ENV
+          "Using linker: $linker"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true'
       - name: Test Codex App launcher and recovery

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
         run: python tools/run_filtered_tests.py claude_app_proxy::tests
       - name: Test Claude Desktop temporary certificate lifecycle
         if: needs.changes.outputs.claude_app == 'true' && runner.os == 'Windows'
-        run: cargo test -p pentect-cli --no-default-features windows_user_ca_round_trip --locked -- --ignored
+        run: cargo test -p pentect-cli windows_user_ca_round_trip --locked -- --ignored
       - name: Test OpenAI gateway
         if: needs.changes.outputs.openai_proxy == 'true'
         run: python tools/run_filtered_tests.py openai_http_proxy::tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
               - 'crates/pentect-cli/src/remote_content.rs'
               - 'crates/pentect-cli/src/upstream.rs'
             claude_app:
+              - '.github/workflows/ci.yml'
               - 'crates/pentect-cli/src/claude_app_proxy.rs'
               - 'crates/pentect-cli/src/claude_http_proxy.rs'
               - 'crates/pentect-cli/src/http_files.rs'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,9 @@ jobs:
       - name: Test Claude Desktop gateway
         if: needs.changes.outputs.claude_app == 'true'
         run: python tools/run_filtered_tests.py claude_app_proxy::tests
+      - name: Test Claude Desktop temporary certificate lifecycle
+        if: needs.changes.outputs.claude_app == 'true' && runner.os == 'Windows'
+        run: cargo test -p pentect-cli --no-default-features windows_user_ca_round_trip --locked -- --ignored
       - name: Test OpenAI gateway
         if: needs.changes.outputs.openai_proxy == 'true'
         run: python tools/run_filtered_tests.py openai_http_proxy::tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
     needs: changes
     if: always()
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
         run: python tools/run_filtered_tests.py claude_app_proxy::tests
       - name: Test Claude Desktop temporary certificate lifecycle
         if: needs.changes.outputs.claude_app == 'true' && runner.os == 'Windows'
-        run: cargo test -p pentect-cli --no-default-features windows_user_ca_round_trip --locked -- --ignored
+        run: cargo test -p pentect-cli --no-default-features windows_user_ca_round_trip --locked -- --ignored --nocapture
       - name: Test OpenAI gateway
         if: needs.changes.outputs.openai_proxy == 'true'
         run: python tools/run_filtered_tests.py openai_http_proxy::tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,6 +2350,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "sysinfo",
  "tokio",
@@ -3408,6 +3409,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -37,7 +37,7 @@ Pentect currently uses the upstream crate without source modifications.
 CARGO PACKAGES
 --------------
 
-499 non-workspace release dependency packages are covered below.
+500 non-workspace release dependency packages are covered below.
 Package labels show the license expression declared in Cargo metadata.
 
 DOCUMENT 1
@@ -418,6 +418,7 @@ Applies to:
 - keccak 0.1.6 (Apache-2.0 OR MIT)
 - md-5 0.10.6 (MIT OR Apache-2.0)
 - pkcs8 0.10.2 (Apache-2.0 OR MIT)
+- sha1 0.10.7 (MIT OR Apache-2.0)
 - sha2 0.10.9 (MIT OR Apache-2.0)
 - sha3 0.10.9 (MIT OR Apache-2.0)
 - signature 2.2.0 (Apache-2.0 OR MIT)
@@ -10066,6 +10067,7 @@ DOCUMENT 154
 ~~~~~~~~~~~~
 Applies to:
 - md-5 0.10.6 (MIT OR Apache-2.0)
+- sha1 0.10.7 (MIT OR Apache-2.0)
 - sha2 0.10.9 (MIT OR Apache-2.0)
 
 Copyright (c) 2006-2009 Graydon Hoare

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -51,7 +51,6 @@ sha1 = "0.10"
 windows = { version = "0.61.3", features = [
     "Win32_Security_Cryptography",
     "Win32_System_Com",
-    "Win32_System_Registry",
     "Win32_UI_Shell",
 ] }
 windows-sys = { version = "0.61.2", features = [

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -47,7 +47,9 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 [target.'cfg(windows)'.dependencies]
 junction = "2.0.0"
 quick-xml = "0.41"
+sha1 = "0.10"
 windows = { version = "0.61.3", features = [
+    "Win32_Security_Cryptography",
     "Win32_System_Com",
     "Win32_UI_Shell",
 ] }

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -51,6 +51,7 @@ sha1 = "0.10"
 windows = { version = "0.61.3", features = [
     "Win32_Security_Cryptography",
     "Win32_System_Com",
+    "Win32_System_Registry",
     "Win32_UI_Shell",
 ] }
 windows-sys = { version = "0.61.2", features = [

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -50,6 +50,7 @@ quick-xml = "0.41"
 sha1 = "0.10"
 windows = { version = "0.61.3", features = [
     "Win32_Security_Cryptography",
+    "Win32_Security_Cryptography_UI",
     "Win32_System_Com",
     "Win32_UI_Shell",
 ] }

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -50,8 +50,8 @@ quick-xml = "0.41"
 sha1 = "0.10"
 windows = { version = "0.61.3", features = [
     "Win32_Security_Cryptography",
-    "Win32_Security_Cryptography_UI",
     "Win32_System_Com",
+    "Win32_System_Registry",
     "Win32_UI_Shell",
 ] }
 windows-sys = { version = "0.61.2", features = [

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -401,7 +401,7 @@ impl WindowsUserCaGuard {
         )?;
         write_windows_ca_journal(serial)?;
         let status = Command::new(crate::windows_system_executable("certutil.exe"))
-            .args(["-user", "-addstore", "Root"])
+            .args(["-f", "-user", "-addstore", "Root"])
             .arg(certificate.path())
             .stdin(Stdio::null())
             .stdout(Stdio::null())

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -3441,6 +3441,39 @@ mod tests {
     }
 
     #[cfg(windows)]
+    fn assert_windows_ca_visibility_in_fresh_process(thumbprint: &str, expected: bool) {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--ignored",
+                "--exact",
+                "claude_app_proxy::tests::windows_user_ca_presence_probe",
+                "--nocapture",
+            ])
+            .env("PENTECT_TEST_WINDOWS_CA_THUMBPRINT", thumbprint)
+            .env(
+                "PENTECT_TEST_WINDOWS_CA_EXPECTED",
+                if expected { "1" } else { "0" },
+            )
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "fresh-process CA visibility probe failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "helper launched by windows_user_ca_round_trip"]
+    fn windows_user_ca_presence_probe() {
+        let thumbprint = std::env::var("PENTECT_TEST_WINDOWS_CA_THUMBPRINT").unwrap();
+        let expected = std::env::var("PENTECT_TEST_WINDOWS_CA_EXPECTED").unwrap() == "1";
+        assert_eq!(windows_user_ca_present(&thumbprint).unwrap(), expected);
+    }
+
+    #[cfg(windows)]
     #[test]
     #[ignore = "mutates the ephemeral test user's CurrentUser Root store"]
     fn windows_user_ca_round_trip() {
@@ -3464,13 +3497,13 @@ mod tests {
         eprintln!("windows CA round trip: installing");
         let guard =
             WindowsUserCaGuard::install(authority.issuer.der(), &authority.thumbprint).unwrap();
-        eprintln!("windows CA round trip: checking presence");
-        assert!(windows_user_ca_present(&authority.thumbprint).unwrap());
+        eprintln!("windows CA round trip: checking presence from a fresh process");
+        assert_windows_ca_visibility_in_fresh_process(&authority.thumbprint, true);
         assert!(windows_ca_cleanup_pending().unwrap());
         eprintln!("windows CA round trip: removing");
         drop(guard);
-        eprintln!("windows CA round trip: checking final absence");
-        assert!(!windows_user_ca_present(&authority.thumbprint).unwrap());
+        eprintln!("windows CA round trip: checking final absence from a fresh process");
+        assert_windows_ca_visibility_in_fresh_process(&authority.thumbprint, false);
         assert!(!windows_ca_cleanup_pending().unwrap());
 
         match previous {

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -298,7 +298,8 @@ fn write_windows_ca_journal(thumbprint: &str) -> Result<(), String> {
         format!("could not create Claude Desktop CA cleanup directory: {error}")
     })?;
     crate::secure_temp::restrict_to_current_user(parent)?;
-    std::fs::write(&path, thumbprint)
+    let journal = format!("{thumbprint}\n{}\n", std::process::id());
+    std::fs::write(&path, journal)
         .map_err(|error| format!("could not write Claude Desktop CA cleanup journal: {error}"))?;
     crate::secure_temp::restrict_to_current_user(&path)
 }
@@ -321,6 +322,64 @@ fn validate_ca_thumbprint(thumbprint: &str) -> Result<(), String> {
         return Err("Claude Desktop CA cleanup journal is invalid".to_string());
     }
     Ok(())
+}
+
+#[cfg(windows)]
+struct WindowsCaJournal {
+    thumbprint: String,
+    owner: Option<u32>,
+}
+
+#[cfg(windows)]
+fn parse_windows_ca_journal(content: &str) -> Result<WindowsCaJournal, String> {
+    let mut lines = content.lines();
+    let thumbprint = lines
+        .next()
+        .ok_or_else(|| "Claude Desktop CA cleanup journal is invalid".to_string())?;
+    validate_ca_thumbprint(thumbprint)?;
+    let owner = lines
+        .next()
+        .map(|value| {
+            value
+                .parse::<u32>()
+                .ok()
+                .filter(|owner| *owner != 0)
+                .ok_or_else(|| "Claude Desktop CA cleanup journal is invalid".to_string())
+        })
+        .transpose()?;
+    if lines.next().is_some() {
+        return Err("Claude Desktop CA cleanup journal is invalid".to_string());
+    }
+    Ok(WindowsCaJournal {
+        thumbprint: thumbprint.to_string(),
+        owner,
+    })
+}
+
+#[cfg(windows)]
+fn windows_ca_owner_is_running(owner: Option<u32>) -> bool {
+    let Some(owner) = owner else {
+        return false;
+    };
+    let pid = sysinfo::Pid::from_u32(owner);
+    let mut system = sysinfo::System::new();
+    system.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[pid]),
+        true,
+        sysinfo::ProcessRefreshKind::nothing(),
+    );
+    system.process(pid).is_some()
+}
+
+#[cfg(windows)]
+fn read_windows_ca_journal() -> Result<Option<WindowsCaJournal>, String> {
+    match std::fs::read_to_string(windows_ca_journal_path()?) {
+        Ok(content) => parse_windows_ca_journal(&content).map(Some),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!(
+            "could not read Claude Desktop CA cleanup journal: {error}"
+        )),
+    }
 }
 
 #[cfg(windows)]
@@ -441,24 +500,23 @@ fn windows_user_ca_present(thumbprint: &str) -> Result<bool, String> {
 
 #[cfg(windows)]
 pub(crate) fn windows_ca_cleanup_pending() -> Result<bool, String> {
-    Ok(windows_ca_journal_path()?.is_file())
+    let Some(journal) = read_windows_ca_journal()? else {
+        return Ok(false);
+    };
+    Ok(!windows_ca_owner_is_running(journal.owner))
 }
 
 #[cfg(windows)]
 pub(crate) fn cleanup_stale_windows_user_ca() -> Result<(), String> {
-    let path = windows_ca_journal_path()?;
-    let thumbprint = match std::fs::read_to_string(&path) {
-        Ok(thumbprint) => thumbprint,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => {
-            return Err(format!(
-                "could not read Claude Desktop CA cleanup journal: {error}"
-            ))
-        }
+    let Some(journal) = read_windows_ca_journal()? else {
+        return Ok(());
     };
-    let thumbprint = thumbprint.trim();
-    validate_ca_thumbprint(thumbprint)?;
-    remove_windows_user_ca(thumbprint)?;
+    if windows_ca_owner_is_running(journal.owner) {
+        return Err(
+            "Claude Desktop protection is active; refusing to remove its certificate".to_string(),
+        );
+    }
+    remove_windows_user_ca(&journal.thumbprint)?;
     remove_windows_ca_journal()?;
     eprintln!("[pentect] Removed a stale temporary Claude Desktop certificate");
     Ok(())
@@ -3407,7 +3465,13 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_ca_journal_accepts_only_sha1_thumbprints() {
-        assert!(validate_ca_thumbprint("00112233445566778899AABBCCDDEEFF00112233").is_ok());
+        let thumbprint = "00112233445566778899AABBCCDDEEFF00112233";
+        assert!(validate_ca_thumbprint(thumbprint).is_ok());
+        let current = parse_windows_ca_journal(&format!("{thumbprint}\n1234\n")).unwrap();
+        assert_eq!(current.owner, Some(1234));
+        let legacy = parse_windows_ca_journal(thumbprint).unwrap();
+        assert_eq!(legacy.owner, None);
+        assert!(parse_windows_ca_journal(&format!("{thumbprint}\n1234\nextra")).is_err());
         for invalid in [
             "",
             "0011",
@@ -3469,10 +3533,19 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    #[ignore = "mutates the ephemeral test user's CurrentUser Root store"]
+    #[ignore = "mutates an ephemeral current-user certificate test store"]
     fn windows_user_ca_round_trip() {
-        std::thread::spawn(|| {
-            std::thread::sleep(Duration::from_secs(30));
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let finished = Arc::new(AtomicBool::new(false));
+        let watchdog = Arc::clone(&finished);
+        std::thread::spawn(move || {
+            for _ in 0..300 {
+                std::thread::sleep(Duration::from_millis(100));
+                if watchdog.load(Ordering::Relaxed) {
+                    return;
+                }
+            }
             eprintln!("windows CA round trip exceeded 30 seconds");
             std::process::abort();
         });
@@ -3496,7 +3569,11 @@ mod tests {
             WindowsUserCaGuard::install(authority.issuer.der(), &authority.thumbprint).unwrap();
         eprintln!("windows CA round trip: checking presence from a fresh process");
         assert_windows_ca_visibility_in_fresh_process(&authority.thumbprint, true);
-        assert!(windows_ca_cleanup_pending().unwrap());
+        assert!(windows_ca_journal_path().unwrap().is_file());
+        assert!(!windows_ca_cleanup_pending().unwrap());
+        let active_cleanup = cleanup_stale_windows_user_ca().unwrap_err();
+        assert!(active_cleanup.contains("protection is active"));
+        assert_windows_ca_visibility_in_fresh_process(&authority.thumbprint, true);
         eprintln!("windows CA round trip: removing");
         drop(guard);
         eprintln!("windows CA round trip: checking final absence from a fresh process");
@@ -3513,6 +3590,7 @@ mod tests {
             None => std::env::remove_var("PENTECT_TEST_WINDOWS_CA_STORE"),
         }
         let _ = std::fs::remove_dir_all(state);
+        finished.store(true, Ordering::Relaxed);
     }
 
     #[cfg(windows)]

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -324,14 +324,6 @@ fn validate_ca_thumbprint(thumbprint: &str) -> Result<(), String> {
 }
 
 #[cfg(windows)]
-fn windows_ca_registry_path(thumbprint: &str) -> Result<windows::core::HSTRING, String> {
-    validate_ca_thumbprint(thumbprint)?;
-    Ok(windows::core::HSTRING::from(format!(
-        "Software\\Microsoft\\SystemCertificates\\Root\\Certificates\\{thumbprint}"
-    )))
-}
-
-#[cfg(windows)]
 fn open_windows_user_root_store(
 ) -> Result<windows::Win32::Security::Cryptography::HCERTSTORE, String> {
     use windows::core::w;
@@ -397,17 +389,41 @@ fn find_windows_user_ca(thumbprint: &str) -> Result<bool, String> {
 
 #[cfg(windows)]
 fn remove_windows_user_ca(thumbprint: &str) -> Result<(), String> {
-    use windows::Win32::Foundation::ERROR_FILE_NOT_FOUND;
-    use windows::Win32::System::Registry::{RegDeleteTreeW, HKEY_CURRENT_USER};
+    use windows::Win32::Security::Cryptography::{
+        CertCloseStore, CertDeleteCertificateFromStore, CertFindCertificateInStore,
+        CERT_FIND_SHA1_HASH, CRYPT_INTEGER_BLOB, X509_ASN_ENCODING,
+    };
 
-    let path = windows_ca_registry_path(thumbprint)?;
-    let status = unsafe { RegDeleteTreeW(HKEY_CURRENT_USER, &path) };
-    if status == ERROR_FILE_NOT_FOUND {
+    validate_ca_thumbprint(thumbprint)?;
+    let mut hash = data_encoding::HEXUPPER
+        .decode(thumbprint.as_bytes())
+        .map_err(|_| "Claude Desktop CA cleanup journal is invalid".to_string())?;
+    let blob = CRYPT_INTEGER_BLOB {
+        cbData: hash.len() as u32,
+        pbData: hash.as_mut_ptr(),
+    };
+    let store = open_windows_user_root_store()?;
+    let context = unsafe {
+        CertFindCertificateInStore(
+            store,
+            X509_ASN_ENCODING,
+            0,
+            CERT_FIND_SHA1_HASH,
+            Some(&blob as *const _ as *const std::ffi::c_void),
+            None,
+        )
+    };
+    if context.is_null() {
+        unsafe { CertCloseStore(Some(store), 0) }
+            .map_err(|error| format!("could not close the current-user Root store: {error}"))?;
         return Ok(());
     }
-    status
-        .ok()
-        .map_err(|error| format!("could not remove temporary Claude Desktop certificate: {error}"))
+    let deleted = unsafe { CertDeleteCertificateFromStore(context) };
+    let closed = unsafe { CertCloseStore(Some(store), 0) };
+    deleted.map_err(|error| {
+        format!("could not remove temporary Claude Desktop certificate: {error}")
+    })?;
+    closed.map_err(|error| format!("could not close the current-user Root store: {error}"))
 }
 
 #[cfg(windows)]
@@ -449,12 +465,7 @@ struct WindowsUserCaGuard {
 impl WindowsUserCaGuard {
     fn install(certificate_der: &[u8], thumbprint: &str) -> Result<Self, String> {
         use windows::Win32::Security::Cryptography::{
-            CertCreateCertificateContext, CertFreeCertificateContext,
-            CertSerializeCertificateStoreElement, X509_ASN_ENCODING,
-        };
-        use windows::Win32::System::Registry::{
-            RegCloseKey, RegCreateKeyExW, RegSetValueExW, HKEY, HKEY_CURRENT_USER, KEY_SET_VALUE,
-            REG_BINARY, REG_OPTION_NON_VOLATILE,
+            CertAddEncodedCertificateToStore, CertCloseStore, CERT_STORE_ADD_NEW, X509_ASN_ENCODING,
         };
 
         validate_ca_thumbprint(thumbprint)?;
@@ -468,77 +479,34 @@ impl WindowsUserCaGuard {
         eprintln!("windows CA install: writing cleanup journal");
         write_windows_ca_journal(thumbprint)?;
         #[cfg(test)]
-        eprintln!("windows CA install: serializing certificate");
-        let context = unsafe { CertCreateCertificateContext(X509_ASN_ENCODING, certificate_der) };
-        if context.is_null() {
-            let error = windows::core::Error::from_win32();
+        eprintln!("windows CA install: opening CurrentUser Root store");
+        let store = open_windows_user_root_store().map_err(|error| {
             let _ = remove_windows_ca_journal();
-            return Err(format!(
-                "could not parse temporary Claude Desktop certificate: {error}"
-            ));
-        }
-        let mut serialized_length = 0_u32;
-        let serialized_result = unsafe {
-            CertSerializeCertificateStoreElement(context, 0, None, &mut serialized_length)
-        };
-        let mut serialized = vec![0_u8; serialized_length as usize];
-        let serialized_result = serialized_result.and_then(|()| unsafe {
-            CertSerializeCertificateStoreElement(
-                context,
-                0,
-                Some(serialized.as_mut_ptr()),
-                &mut serialized_length,
-            )
+            error
         });
-        let _ = unsafe { CertFreeCertificateContext(Some(context)) };
-        if let Err(error) = serialized_result {
-            let _ = remove_windows_ca_journal();
-            return Err(format!(
-                "could not serialize temporary Claude Desktop certificate: {error}"
-            ));
-        }
-        serialized.truncate(serialized_length as usize);
+        let store = store?;
 
         #[cfg(test)]
-        eprintln!("windows CA install: writing CurrentUser Root registry entry");
-        let path = windows_ca_registry_path(thumbprint)?;
-        let mut key = HKEY::default();
+        eprintln!("windows CA install: adding certificate through certificate store API");
         let add = unsafe {
-            RegCreateKeyExW(
-                HKEY_CURRENT_USER,
-                &path,
-                None,
-                windows::core::PCWSTR::null(),
-                REG_OPTION_NON_VOLATILE,
-                KEY_SET_VALUE,
-                None,
-                &mut key,
+            CertAddEncodedCertificateToStore(
+                Some(store),
+                X509_ASN_ENCODING,
+                certificate_der,
+                CERT_STORE_ADD_NEW,
                 None,
             )
-        }
-        .ok()
-        .and_then(|()| unsafe {
-            RegSetValueExW(
-                key,
-                windows::core::w!("Blob"),
-                None,
-                REG_BINARY,
-                Some(&serialized),
-            )
-            .ok()
-        });
-        if !key.is_invalid() {
-            let _ = unsafe { RegCloseKey(key) };
-        }
+        };
+        let close = unsafe { CertCloseStore(Some(store), 0) };
         if let Err(error) = add {
-            let _ = remove_windows_user_ca(thumbprint);
             let _ = remove_windows_ca_journal();
             return Err(format!(
                 "could not trust temporary Claude Desktop certificate: {error}"
             ));
         }
+        close.map_err(|error| format!("could not close the current-user Root store: {error}"))?;
         #[cfg(test)]
-        eprintln!("windows CA install: registry write finished");
+        eprintln!("windows CA install: certificate store update finished");
         Ok(Self {
             thumbprint: thumbprint.to_string(),
         })

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -351,9 +351,7 @@ fn open_windows_user_root_store(
 }
 
 #[cfg(windows)]
-fn find_windows_user_ca(
-    thumbprint: &str,
-) -> Result<Option<*const windows::Win32::Security::Cryptography::CERT_CONTEXT>, String> {
+fn find_windows_user_ca(thumbprint: &str) -> Result<bool, String> {
     use windows::Win32::Security::Cryptography::{
         CertCloseStore, CertFindCertificateInStore, CERT_FIND_SHA1_HASH, CRYPT_INTEGER_BLOB,
         X509_ASN_ENCODING,
@@ -378,31 +376,59 @@ fn find_windows_user_ca(
             None,
         )
     };
+    let found = !context.is_null();
+    if found {
+        let _ = unsafe {
+            windows::Win32::Security::Cryptography::CertFreeCertificateContext(Some(context))
+        };
+    }
     let close = unsafe { CertCloseStore(Some(store), 0) };
     close.map_err(|error| format!("could not close the current-user Root store: {error}"))?;
-    Ok((!context.is_null()).then_some(context))
+    Ok(found)
 }
 
 #[cfg(windows)]
 fn remove_windows_user_ca(thumbprint: &str) -> Result<(), String> {
-    use windows::Win32::Security::Cryptography::CertDeleteCertificateFromStore;
-
-    let Some(context) = find_windows_user_ca(thumbprint)? else {
-        return Ok(());
+    use windows::Win32::Security::Cryptography::{
+        CertCloseStore, CertDeleteCertificateFromStore, CertFindCertificateInStore,
+        CERT_FIND_SHA1_HASH, CRYPT_INTEGER_BLOB, X509_ASN_ENCODING,
     };
-    unsafe { CertDeleteCertificateFromStore(context) }
-        .map_err(|error| format!("could not remove temporary Claude Desktop certificate: {error}"))
+
+    validate_ca_thumbprint(thumbprint)?;
+    let mut hash = data_encoding::HEXUPPER
+        .decode(thumbprint.as_bytes())
+        .map_err(|_| "Claude Desktop CA cleanup journal is invalid".to_string())?;
+    let blob = CRYPT_INTEGER_BLOB {
+        cbData: hash.len() as u32,
+        pbData: hash.as_mut_ptr(),
+    };
+    let store = open_windows_user_root_store()?;
+    let context = unsafe {
+        CertFindCertificateInStore(
+            store,
+            X509_ASN_ENCODING,
+            0,
+            CERT_FIND_SHA1_HASH,
+            Some(&blob as *const _ as *const std::ffi::c_void),
+            None,
+        )
+    };
+    if context.is_null() {
+        unsafe { CertCloseStore(Some(store), 0) }
+            .map_err(|error| format!("could not close the current-user Root store: {error}"))?;
+        return Ok(());
+    }
+    let deleted = unsafe { CertDeleteCertificateFromStore(context) };
+    let closed = unsafe { CertCloseStore(Some(store), 0) };
+    deleted.map_err(|error| {
+        format!("could not remove temporary Claude Desktop certificate: {error}")
+    })?;
+    closed.map_err(|error| format!("could not close the current-user Root store: {error}"))
 }
 
 #[cfg(windows)]
 fn windows_user_ca_present(thumbprint: &str) -> Result<bool, String> {
-    use windows::Win32::Security::Cryptography::CertFreeCertificateContext;
-
-    let Some(context) = find_windows_user_ca(thumbprint)? else {
-        return Ok(false);
-    };
-    let _ = unsafe { CertFreeCertificateContext(Some(context)) };
-    Ok(true)
+    find_windows_user_ca(thumbprint)
 }
 
 #[cfg(windows)]
@@ -443,11 +469,17 @@ impl WindowsUserCaGuard {
         };
 
         validate_ca_thumbprint(thumbprint)?;
+        #[cfg(test)]
+        eprintln!("windows CA install: writing cleanup journal");
         write_windows_ca_journal(thumbprint)?;
+        #[cfg(test)]
+        eprintln!("windows CA install: opening Root store");
         let store = open_windows_user_root_store().map_err(|error| {
             let _ = remove_windows_ca_journal();
             error
         })?;
+        #[cfg(test)]
+        eprintln!("windows CA install: adding certificate");
         let add = unsafe {
             CertAddEncodedCertificateToStore(
                 Some(store),
@@ -457,6 +489,8 @@ impl WindowsUserCaGuard {
                 None,
             )
         };
+        #[cfg(test)]
+        eprintln!("windows CA install: closing Root store");
         let close = unsafe { CertCloseStore(Some(store), 0) };
         if let Err(error) = add {
             let _ = remove_windows_ca_journal();

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -324,6 +324,14 @@ fn validate_ca_thumbprint(thumbprint: &str) -> Result<(), String> {
 }
 
 #[cfg(windows)]
+fn windows_ca_registry_path(thumbprint: &str) -> Result<windows::core::HSTRING, String> {
+    validate_ca_thumbprint(thumbprint)?;
+    Ok(windows::core::HSTRING::from(format!(
+        "Software\\Microsoft\\SystemCertificates\\Root\\Certificates\\{thumbprint}"
+    )))
+}
+
+#[cfg(windows)]
 fn open_windows_user_root_store(
 ) -> Result<windows::Win32::Security::Cryptography::HCERTSTORE, String> {
     use windows::core::w;
@@ -389,41 +397,17 @@ fn find_windows_user_ca(thumbprint: &str) -> Result<bool, String> {
 
 #[cfg(windows)]
 fn remove_windows_user_ca(thumbprint: &str) -> Result<(), String> {
-    use windows::Win32::Security::Cryptography::{
-        CertCloseStore, CertDeleteCertificateFromStore, CertFindCertificateInStore,
-        CERT_FIND_SHA1_HASH, CRYPT_INTEGER_BLOB, X509_ASN_ENCODING,
-    };
+    use windows::Win32::Foundation::ERROR_FILE_NOT_FOUND;
+    use windows::Win32::System::Registry::{RegDeleteTreeW, HKEY_CURRENT_USER};
 
-    validate_ca_thumbprint(thumbprint)?;
-    let mut hash = data_encoding::HEXUPPER
-        .decode(thumbprint.as_bytes())
-        .map_err(|_| "Claude Desktop CA cleanup journal is invalid".to_string())?;
-    let blob = CRYPT_INTEGER_BLOB {
-        cbData: hash.len() as u32,
-        pbData: hash.as_mut_ptr(),
-    };
-    let store = open_windows_user_root_store()?;
-    let context = unsafe {
-        CertFindCertificateInStore(
-            store,
-            X509_ASN_ENCODING,
-            0,
-            CERT_FIND_SHA1_HASH,
-            Some(&blob as *const _ as *const std::ffi::c_void),
-            None,
-        )
-    };
-    if context.is_null() {
-        unsafe { CertCloseStore(Some(store), 0) }
-            .map_err(|error| format!("could not close the current-user Root store: {error}"))?;
+    let path = windows_ca_registry_path(thumbprint)?;
+    let status = unsafe { RegDeleteTreeW(HKEY_CURRENT_USER, &path) };
+    if status == ERROR_FILE_NOT_FOUND {
         return Ok(());
     }
-    let deleted = unsafe { CertDeleteCertificateFromStore(context) };
-    let closed = unsafe { CertCloseStore(Some(store), 0) };
-    deleted.map_err(|error| {
-        format!("could not remove temporary Claude Desktop certificate: {error}")
-    })?;
-    closed.map_err(|error| format!("could not close the current-user Root store: {error}"))
+    status
+        .ok()
+        .map_err(|error| format!("could not remove temporary Claude Desktop certificate: {error}"))
 }
 
 #[cfg(windows)]
@@ -464,65 +448,97 @@ struct WindowsUserCaGuard {
 #[cfg(windows)]
 impl WindowsUserCaGuard {
     fn install(certificate_der: &[u8], thumbprint: &str) -> Result<Self, String> {
-        use windows::Win32::Security::Cryptography::UI::{
-            CryptUIWizImport, CRYPTUI_WIZ_IMPORT_ALLOW_CERT, CRYPTUI_WIZ_IMPORT_SRC_INFO,
-            CRYPTUI_WIZ_IMPORT_SRC_INFO_0, CRYPTUI_WIZ_IMPORT_SUBJECT_CERT_CONTEXT,
-            CRYPTUI_WIZ_NO_UI,
-        };
         use windows::Win32::Security::Cryptography::{
-            CertCloseStore, CertCreateCertificateContext, CertFreeCertificateContext,
-            X509_ASN_ENCODING,
+            CertCreateCertificateContext, CertFreeCertificateContext,
+            CertSerializeCertificateStoreElement, X509_ASN_ENCODING,
+        };
+        use windows::Win32::System::Registry::{
+            RegCloseKey, RegCreateKeyExW, RegSetValueExW, HKEY, HKEY_CURRENT_USER, KEY_SET_VALUE,
+            REG_BINARY, REG_OPTION_NON_VOLATILE,
         };
 
         validate_ca_thumbprint(thumbprint)?;
+        if windows_user_ca_present(thumbprint)? {
+            return Err(
+                "temporary Claude Desktop certificate already exists in CurrentUser Root"
+                    .to_string(),
+            );
+        }
         #[cfg(test)]
         eprintln!("windows CA install: writing cleanup journal");
         write_windows_ca_journal(thumbprint)?;
         #[cfg(test)]
-        eprintln!("windows CA install: opening Root store");
-        let store = open_windows_user_root_store().map_err(|error| {
-            let _ = remove_windows_ca_journal();
-            error
-        })?;
-        #[cfg(test)]
-        eprintln!("windows CA install: adding certificate");
+        eprintln!("windows CA install: serializing certificate");
         let context = unsafe { CertCreateCertificateContext(X509_ASN_ENCODING, certificate_der) };
         if context.is_null() {
             let error = windows::core::Error::from_win32();
-            let _ = unsafe { CertCloseStore(Some(store), 0) };
             let _ = remove_windows_ca_journal();
             return Err(format!(
                 "could not parse temporary Claude Desktop certificate: {error}"
             ));
         }
-        let source = CRYPTUI_WIZ_IMPORT_SRC_INFO {
-            dwSize: std::mem::size_of::<CRYPTUI_WIZ_IMPORT_SRC_INFO>() as u32,
-            dwSubjectChoice: CRYPTUI_WIZ_IMPORT_SUBJECT_CERT_CONTEXT,
-            Anonymous: CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {
-                pCertContext: context,
-            },
-            ..Default::default()
+        let mut serialized_length = 0_u32;
+        let serialized_result = unsafe {
+            CertSerializeCertificateStoreElement(context, 0, None, &mut serialized_length)
         };
+        let mut serialized = vec![0_u8; serialized_length as usize];
+        let serialized_result = serialized_result.and_then(|()| unsafe {
+            CertSerializeCertificateStoreElement(
+                context,
+                0,
+                Some(serialized.as_mut_ptr()),
+                &mut serialized_length,
+            )
+        });
+        let _ = unsafe { CertFreeCertificateContext(Some(context)) };
+        if let Err(error) = serialized_result {
+            let _ = remove_windows_ca_journal();
+            return Err(format!(
+                "could not serialize temporary Claude Desktop certificate: {error}"
+            ));
+        }
+        serialized.truncate(serialized_length as usize);
+
+        #[cfg(test)]
+        eprintln!("windows CA install: writing CurrentUser Root registry entry");
+        let path = windows_ca_registry_path(thumbprint)?;
+        let mut key = HKEY::default();
         let add = unsafe {
-            CryptUIWizImport(
-                CRYPTUI_WIZ_NO_UI | CRYPTUI_WIZ_IMPORT_ALLOW_CERT,
+            RegCreateKeyExW(
+                HKEY_CURRENT_USER,
+                &path,
                 None,
                 windows::core::PCWSTR::null(),
-                Some(&source),
-                Some(store),
+                REG_OPTION_NON_VOLATILE,
+                KEY_SET_VALUE,
+                None,
+                &mut key,
+                None,
             )
-        };
-        let _ = unsafe { CertFreeCertificateContext(Some(context)) };
-        #[cfg(test)]
-        eprintln!("windows CA install: closing Root store");
-        let close = unsafe { CertCloseStore(Some(store), 0) };
+        }
+        .ok()
+        .and_then(|()| unsafe {
+            RegSetValueExW(
+                key,
+                windows::core::w!("Blob"),
+                None,
+                REG_BINARY,
+                Some(&serialized),
+            )
+            .ok()
+        });
+        if !key.is_invalid() {
+            let _ = unsafe { RegCloseKey(key) };
+        }
         if let Err(error) = add {
+            let _ = remove_windows_user_ca(thumbprint);
             let _ = remove_windows_ca_journal();
             return Err(format!(
                 "could not trust temporary Claude Desktop certificate: {error}"
             ));
         }
-        close.map_err(|error| format!("could not close the current-user Root store: {error}"))?;
+        #[cfg(test)]
+        eprintln!("windows CA install: registry write finished");
         Ok(Self {
             thumbprint: thumbprint.to_string(),
         })

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -3370,6 +3370,11 @@ mod tests {
     #[test]
     #[ignore = "mutates the ephemeral test user's CurrentUser Root store"]
     fn windows_user_ca_round_trip() {
+        std::thread::spawn(|| {
+            std::thread::sleep(Duration::from_secs(30));
+            eprintln!("windows CA round trip exceeded 30 seconds");
+            std::process::abort();
+        });
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let previous = std::env::var_os("LOCALAPPDATA");
         let state = std::env::temp_dir().join(format!(
@@ -3380,12 +3385,17 @@ mod tests {
         std::env::set_var("LOCALAPPDATA", &state);
 
         let authority = CertificateAuthority::new().unwrap();
+        eprintln!("windows CA round trip: checking initial absence");
         assert!(!windows_user_ca_present(&authority.thumbprint).unwrap());
+        eprintln!("windows CA round trip: installing");
         let guard =
             WindowsUserCaGuard::install(authority.issuer.der(), &authority.thumbprint).unwrap();
+        eprintln!("windows CA round trip: checking presence");
         assert!(windows_user_ca_present(&authority.thumbprint).unwrap());
         assert!(windows_ca_cleanup_pending().unwrap());
+        eprintln!("windows CA round trip: removing");
         drop(guard);
+        eprintln!("windows CA round trip: checking final absence");
         assert!(!windows_user_ca_present(&authority.thumbprint).unwrap());
         assert!(!windows_ca_cleanup_pending().unwrap());
 

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -19,6 +19,8 @@ use rcgen::{
     BasicConstraints, CertificateParams, CertifiedIssuer, DistinguishedName, DnType, IsCa, KeyPair,
     KeyUsagePurpose,
 };
+#[cfg(windows)]
+use sha1::{Digest as Sha1Digest, Sha1};
 #[cfg(not(windows))]
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
@@ -130,7 +132,8 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     )?;
     let proxy = ClaudeAppProxyGuard::start()?;
     #[cfg(windows)]
-    let _trusted_ca = WindowsUserCaGuard::install(proxy.root_certificate_der(), proxy.ca_serial())?;
+    let _trusted_ca =
+        WindowsUserCaGuard::install(proxy.root_certificate_der(), proxy.ca_thumbprint())?;
     let user_data_dir = claude_user_data_dir()?;
     #[cfg(windows)]
     if let Some(package) = find_windows_claude_package()
@@ -142,10 +145,10 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         let process = activate_windows_package(&package.aumid, &arguments)?;
         drop(environment);
         let process_id = process.id();
-        let ca_serial = proxy.ca_serial().to_string();
+        let ca_thumbprint = proxy.ca_thumbprint().to_string();
         if let Err(error) = ctrlc::set_handler(move || {
             terminate_child_process(process_id);
-            let _ = remove_windows_user_ca(&ca_serial);
+            let _ = remove_windows_user_ca(&ca_thumbprint);
             let _ = remove_windows_ca_journal();
             std::process::exit(130);
         }) {
@@ -179,12 +182,12 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         .map_err(|error| format!("could not start Claude Desktop: {error}"))?;
     let child_id = child.id();
     #[cfg(windows)]
-    let ca_serial = proxy.ca_serial().to_string();
+    let ca_thumbprint = proxy.ca_thumbprint().to_string();
     if let Err(error) = ctrlc::set_handler(move || {
         terminate_child_process(child_id);
         #[cfg(windows)]
         {
-            let _ = remove_windows_user_ca(&ca_serial);
+            let _ = remove_windows_user_ca(&ca_thumbprint);
             let _ = remove_windows_ca_journal();
         }
         std::process::exit(130);
@@ -282,11 +285,11 @@ fn windows_ca_journal_path() -> Result<PathBuf, String> {
     let root = std::env::var_os("LOCALAPPDATA")
         .map(PathBuf::from)
         .ok_or_else(|| "LOCALAPPDATA is unavailable for Claude Desktop CA cleanup".to_string())?;
-    Ok(root.join("Pentect").join("claude-app-temporary-ca.serial"))
+    Ok(root.join("Pentect").join("claude-app-temporary-ca.sha1"))
 }
 
 #[cfg(windows)]
-fn write_windows_ca_journal(serial: &str) -> Result<(), String> {
+fn write_windows_ca_journal(thumbprint: &str) -> Result<(), String> {
     let path = windows_ca_journal_path()?;
     let parent = path
         .parent()
@@ -295,7 +298,7 @@ fn write_windows_ca_journal(serial: &str) -> Result<(), String> {
         format!("could not create Claude Desktop CA cleanup directory: {error}")
     })?;
     crate::secure_temp::restrict_to_current_user(parent)?;
-    std::fs::write(&path, serial)
+    std::fs::write(&path, thumbprint)
         .map_err(|error| format!("could not write Claude Desktop CA cleanup journal: {error}"))?;
     crate::secure_temp::restrict_to_current_user(&path)
 }
@@ -313,45 +316,68 @@ fn remove_windows_ca_journal() -> Result<(), String> {
 }
 
 #[cfg(windows)]
-fn validate_ca_serial(serial: &str) -> Result<(), String> {
-    if serial.len() != 32 || !serial.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+fn validate_ca_thumbprint(thumbprint: &str) -> Result<(), String> {
+    if thumbprint.len() != 40 || !thumbprint.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err("Claude Desktop CA cleanup journal is invalid".to_string());
     }
     Ok(())
 }
 
 #[cfg(windows)]
-fn remove_windows_user_ca(serial: &str) -> Result<(), String> {
-    validate_ca_serial(serial)?;
-    if !windows_user_ca_present(serial)? {
-        return Ok(());
-    }
-    let status = Command::new(crate::windows_system_executable("certutil.exe"))
-        .args(["-user", "-delstore", "Root", serial])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map_err(|error| {
-            format!("could not remove temporary Claude Desktop certificate: {error}")
-        })?;
-    status.success().then_some(()).ok_or_else(|| {
-        "could not remove temporary Claude Desktop certificate; run `pentect claude app` again to retry cleanup"
-            .to_string()
-    })
+fn find_windows_user_ca(
+    thumbprint: &str,
+) -> Result<Option<*const windows::Win32::Security::Cryptography::CERT_CONTEXT>, String> {
+    use windows::core::w;
+    use windows::Win32::Security::Cryptography::{
+        CertCloseStore, CertFindCertificateInStore, CertOpenSystemStoreW, CERT_FIND_SHA1_HASH,
+        CRYPT_INTEGER_BLOB, X509_ASN_ENCODING,
+    };
+
+    validate_ca_thumbprint(thumbprint)?;
+    let mut hash = data_encoding::HEXUPPER
+        .decode(thumbprint.as_bytes())
+        .map_err(|_| "Claude Desktop CA cleanup journal is invalid".to_string())?;
+    let blob = CRYPT_INTEGER_BLOB {
+        cbData: hash.len() as u32,
+        pbData: hash.as_mut_ptr(),
+    };
+    let store = unsafe { CertOpenSystemStoreW(None, w!("ROOT")) }
+        .map_err(|error| format!("could not open the current-user Root store: {error}"))?;
+    let context = unsafe {
+        CertFindCertificateInStore(
+            store,
+            X509_ASN_ENCODING,
+            0,
+            CERT_FIND_SHA1_HASH,
+            Some(&blob as *const _ as *const std::ffi::c_void),
+            None,
+        )
+    };
+    let close = unsafe { CertCloseStore(Some(store), 0) };
+    close.map_err(|error| format!("could not close the current-user Root store: {error}"))?;
+    Ok((!context.is_null()).then_some(context))
 }
 
 #[cfg(windows)]
-fn windows_user_ca_present(serial: &str) -> Result<bool, String> {
-    validate_ca_serial(serial)?;
-    Command::new(crate::windows_system_executable("certutil.exe"))
-        .args(["-user", "-store", "Root", serial])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .map_err(|error| format!("could not inspect temporary Claude Desktop certificate: {error}"))
+fn remove_windows_user_ca(thumbprint: &str) -> Result<(), String> {
+    use windows::Win32::Security::Cryptography::CertDeleteCertificateFromStore;
+
+    let Some(context) = find_windows_user_ca(thumbprint)? else {
+        return Ok(());
+    };
+    unsafe { CertDeleteCertificateFromStore(context) }
+        .map_err(|error| format!("could not remove temporary Claude Desktop certificate: {error}"))
+}
+
+#[cfg(windows)]
+fn windows_user_ca_present(thumbprint: &str) -> Result<bool, String> {
+    use windows::Win32::Security::Cryptography::CertFreeCertificateContext;
+
+    let Some(context) = find_windows_user_ca(thumbprint)? else {
+        return Ok(false);
+    };
+    let _ = unsafe { CertFreeCertificateContext(Some(context)) };
+    Ok(true)
 }
 
 #[cfg(windows)]
@@ -362,8 +388,8 @@ pub(crate) fn windows_ca_cleanup_pending() -> Result<bool, String> {
 #[cfg(windows)]
 pub(crate) fn cleanup_stale_windows_user_ca() -> Result<(), String> {
     let path = windows_ca_journal_path()?;
-    let serial = match std::fs::read_to_string(&path) {
-        Ok(serial) => serial,
+    let thumbprint = match std::fs::read_to_string(&path) {
+        Ok(thumbprint) => thumbprint,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => {
             return Err(format!(
@@ -371,9 +397,9 @@ pub(crate) fn cleanup_stale_windows_user_ca() -> Result<(), String> {
             ))
         }
     };
-    let serial = serial.trim();
-    validate_ca_serial(serial)?;
-    remove_windows_user_ca(serial)?;
+    let thumbprint = thumbprint.trim();
+    validate_ca_thumbprint(thumbprint)?;
+    remove_windows_user_ca(thumbprint)?;
     remove_windows_ca_journal()?;
     eprintln!("[pentect] Removed a stale temporary Claude Desktop certificate");
     Ok(())
@@ -381,62 +407,58 @@ pub(crate) fn cleanup_stale_windows_user_ca() -> Result<(), String> {
 
 #[cfg(windows)]
 struct WindowsUserCaGuard {
-    serial: String,
+    thumbprint: String,
 }
 
 #[cfg(windows)]
 impl WindowsUserCaGuard {
-    fn install(certificate_der: &[u8], serial: &str) -> Result<Self, String> {
-        validate_ca_serial(serial)?;
-        let directory = crate::secure_temp::SecureTempDirectory::create(
-            "pentect-claude-ca-",
-            "Claude Desktop certificate",
-        )?;
-        let certificate = crate::secure_temp::SecureTempFile::create(
-            directory.path(),
-            "root-",
-            ".cer",
-            certificate_der,
-            "Claude Desktop certificate",
-        )?;
-        write_windows_ca_journal(serial)?;
-        let status = Command::new(crate::windows_system_executable("certutil.exe"))
-            .args(["-f", "-user", "-addstore", "Root"])
-            .arg(certificate.path())
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map_err(|error| {
-                format!("could not trust temporary Claude Desktop certificate: {error}")
-            });
-        match status {
-            Ok(status) if status.success() => Ok(Self {
-                serial: serial.to_string(),
-            }),
-            Ok(_) => {
-                let _ = remove_windows_ca_journal();
-                Err("Windows rejected the temporary Claude Desktop certificate".to_string())
-            }
-            Err(error) => {
-                let _ = remove_windows_ca_journal();
-                Err(error)
-            }
+    fn install(certificate_der: &[u8], thumbprint: &str) -> Result<Self, String> {
+        use windows::core::w;
+        use windows::Win32::Security::Cryptography::{
+            CertAddEncodedCertificateToStore, CertCloseStore, CertOpenSystemStoreW,
+            CERT_STORE_ADD_NEW, X509_ASN_ENCODING,
+        };
+
+        validate_ca_thumbprint(thumbprint)?;
+        write_windows_ca_journal(thumbprint)?;
+        let store = unsafe { CertOpenSystemStoreW(None, w!("ROOT")) }.map_err(|error| {
+            let _ = remove_windows_ca_journal();
+            format!("could not open the current-user Root store: {error}")
+        })?;
+        let add = unsafe {
+            CertAddEncodedCertificateToStore(
+                Some(store),
+                X509_ASN_ENCODING,
+                certificate_der,
+                CERT_STORE_ADD_NEW,
+                None,
+            )
+        };
+        let close = unsafe { CertCloseStore(Some(store), 0) };
+        if let Err(error) = add {
+            let _ = remove_windows_ca_journal();
+            return Err(format!(
+                "could not trust temporary Claude Desktop certificate: {error}"
+            ));
         }
+        close.map_err(|error| format!("could not close the current-user Root store: {error}"))?;
+        Ok(Self {
+            thumbprint: thumbprint.to_string(),
+        })
     }
 }
 
 #[cfg(windows)]
 impl Drop for WindowsUserCaGuard {
     fn drop(&mut self) {
-        if let Err(error) = remove_windows_user_ca(&self.serial) {
+        if let Err(error) = remove_windows_user_ca(&self.thumbprint) {
             eprintln!("[pentect] {error}");
             return;
         }
         if let Err(error) = remove_windows_ca_journal() {
             eprintln!("[pentect] {error}");
         }
-        self.serial.zeroize();
+        self.thumbprint.zeroize();
     }
 }
 
@@ -719,7 +741,7 @@ struct ClaudeAppProxyGuard {
     #[cfg(windows)]
     root_certificate_der: Vec<u8>,
     #[cfg(windows)]
-    ca_serial: String,
+    ca_thumbprint: String,
     shutdown: Option<oneshot::Sender<()>>,
     thread: Option<thread::JoinHandle<()>>,
 }
@@ -732,7 +754,7 @@ impl ClaudeAppProxyGuard {
         #[cfg(windows)]
         let root_certificate_der = authority.issuer.der().to_vec();
         #[cfg(windows)]
-        let ca_serial = authority.serial.clone();
+        let ca_thumbprint = authority.thumbprint.clone();
         let (ready_tx, ready_rx) = mpsc::channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let thread = thread::spawn(move || {
@@ -765,7 +787,7 @@ impl ClaudeAppProxyGuard {
             #[cfg(windows)]
             root_certificate_der,
             #[cfg(windows)]
-            ca_serial,
+            ca_thumbprint,
             shutdown: Some(shutdown_tx),
             thread: Some(thread),
         })
@@ -786,8 +808,8 @@ impl ClaudeAppProxyGuard {
     }
 
     #[cfg(windows)]
-    fn ca_serial(&self) -> &str {
-        &self.ca_serial
+    fn ca_thumbprint(&self) -> &str {
+        &self.ca_thumbprint
     }
 }
 
@@ -805,7 +827,7 @@ impl Drop for ClaudeAppProxyGuard {
         #[cfg(windows)]
         {
             self.root_certificate_der.zeroize();
-            self.ca_serial.zeroize();
+            self.ca_thumbprint.zeroize();
         }
     }
 }
@@ -815,7 +837,7 @@ struct CertificateAuthority {
     #[cfg(not(windows))]
     spki_hash: String,
     #[cfg(windows)]
-    serial: String,
+    thumbprint: String,
 }
 
 impl CertificateAuthority {
@@ -835,24 +857,16 @@ impl CertificateAuthority {
             KeyUsagePurpose::KeyCertSign,
             KeyUsagePurpose::DigitalSignature,
         ];
-        #[cfg(windows)]
-        let serial = {
-            let mut serial = [0_u8; 16];
-            getrandom::getrandom(&mut serial).map_err(|error| {
-                format!("OS CSPRNG unavailable for Claude App CA serial: {error}")
-            })?;
-            serial[0] &= 0x7f;
-            params.serial_number = Some(rcgen::SerialNumber::from_slice(&serial));
-            data_encoding::HEXUPPER.encode(&serial)
-        };
         let issuer = CertifiedIssuer::self_signed(params, key)
             .map_err(|error| format!("could not sign Claude App proxy CA: {error}"))?;
+        #[cfg(windows)]
+        let thumbprint = data_encoding::HEXUPPER.encode(&Sha1::digest(issuer.der()));
         Ok(Self {
             issuer,
             #[cfg(not(windows))]
             spki_hash,
             #[cfg(windows)]
-            serial,
+            thumbprint,
         })
     }
 
@@ -3305,9 +3319,9 @@ mod tests {
         assert!(!authority.spki_hash.is_empty());
         #[cfg(windows)]
         {
-            assert_eq!(authority.serial.len(), 32);
+            assert_eq!(authority.thumbprint.len(), 40);
             assert!(authority
-                .serial
+                .thumbprint
                 .bytes()
                 .all(|byte| byte.is_ascii_hexdigit()));
             assert!(!authority.issuer.der().is_empty());
@@ -3317,15 +3331,15 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn windows_ca_journal_accepts_only_generated_serial_shape() {
-        assert!(validate_ca_serial("00112233445566778899AABBCCDDEEFF").is_ok());
+    fn windows_ca_journal_accepts_only_sha1_thumbprints() {
+        assert!(validate_ca_thumbprint("00112233445566778899AABBCCDDEEFF00112233").is_ok());
         for invalid in [
             "",
             "0011",
-            "00112233445566778899AABBCCDDEEFG",
-            "00112233445566778899AABBCCDDEEFF --force",
+            "00112233445566778899AABBCCDDEEFF0011223G",
+            "00112233445566778899AABBCCDDEEFF00112233 --force",
         ] {
-            assert!(validate_ca_serial(invalid).is_err(), "{invalid}");
+            assert!(validate_ca_thumbprint(invalid).is_err(), "{invalid}");
         }
     }
 
@@ -3343,12 +3357,13 @@ mod tests {
         std::env::set_var("LOCALAPPDATA", &state);
 
         let authority = CertificateAuthority::new().unwrap();
-        assert!(!windows_user_ca_present(&authority.serial).unwrap());
-        let guard = WindowsUserCaGuard::install(authority.issuer.der(), &authority.serial).unwrap();
-        assert!(windows_user_ca_present(&authority.serial).unwrap());
+        assert!(!windows_user_ca_present(&authority.thumbprint).unwrap());
+        let guard =
+            WindowsUserCaGuard::install(authority.issuer.der(), &authority.thumbprint).unwrap();
+        assert!(windows_user_ca_present(&authority.thumbprint).unwrap());
         assert!(windows_ca_cleanup_pending().unwrap());
         drop(guard);
-        assert!(!windows_user_ca_present(&authority.serial).unwrap());
+        assert!(!windows_user_ca_present(&authority.thumbprint).unwrap());
         assert!(!windows_ca_cleanup_pending().unwrap());
 
         match previous {

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -486,12 +486,15 @@ impl WindowsUserCaGuard {
         })?;
         #[cfg(test)]
         eprintln!("windows CA install: adding certificate");
-        let context = unsafe { CertCreateCertificateContext(X509_ASN_ENCODING, certificate_der) }
-            .map_err(|error| {
+        let context = unsafe { CertCreateCertificateContext(X509_ASN_ENCODING, certificate_der) };
+        if context.is_null() {
+            let error = windows::core::Error::from_win32();
             let _ = unsafe { CertCloseStore(Some(store), 0) };
             let _ = remove_windows_ca_journal();
-            format!("could not parse temporary Claude Desktop certificate: {error}")
-        })?;
+            return Err(format!(
+                "could not parse temporary Claude Desktop certificate: {error}"
+            ));
+        }
         let source = CRYPTUI_WIZ_IMPORT_SRC_INFO {
             dwSize: std::mem::size_of::<CRYPTUI_WIZ_IMPORT_SRC_INFO>() as u32,
             dwSubjectChoice: CRYPTUI_WIZ_IMPORT_SUBJECT_CERT_CONTEXT,

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -324,13 +324,39 @@ fn validate_ca_thumbprint(thumbprint: &str) -> Result<(), String> {
 }
 
 #[cfg(windows)]
+fn open_windows_user_root_store(
+) -> Result<windows::Win32::Security::Cryptography::HCERTSTORE, String> {
+    use windows::core::w;
+    use windows::Win32::Security::Cryptography::{
+        CertOpenStore, CERT_OPEN_STORE_FLAGS, CERT_STORE_MAXIMUM_ALLOWED_FLAG,
+        CERT_STORE_OPEN_EXISTING_FLAG, CERT_STORE_PROV_SYSTEM_REGISTRY_W,
+        CERT_SYSTEM_STORE_CURRENT_USER, X509_ASN_ENCODING,
+    };
+
+    let flags = CERT_OPEN_STORE_FLAGS(
+        CERT_SYSTEM_STORE_CURRENT_USER
+            | CERT_STORE_MAXIMUM_ALLOWED_FLAG.0
+            | CERT_STORE_OPEN_EXISTING_FLAG.0,
+    );
+    unsafe {
+        CertOpenStore(
+            CERT_STORE_PROV_SYSTEM_REGISTRY_W,
+            X509_ASN_ENCODING,
+            None,
+            flags,
+            Some(w!("ROOT").as_ptr() as *const std::ffi::c_void),
+        )
+    }
+    .map_err(|error| format!("could not open the current-user Root store: {error}"))
+}
+
+#[cfg(windows)]
 fn find_windows_user_ca(
     thumbprint: &str,
 ) -> Result<Option<*const windows::Win32::Security::Cryptography::CERT_CONTEXT>, String> {
-    use windows::core::w;
     use windows::Win32::Security::Cryptography::{
-        CertCloseStore, CertFindCertificateInStore, CertOpenSystemStoreW, CERT_FIND_SHA1_HASH,
-        CRYPT_INTEGER_BLOB, X509_ASN_ENCODING,
+        CertCloseStore, CertFindCertificateInStore, CERT_FIND_SHA1_HASH, CRYPT_INTEGER_BLOB,
+        X509_ASN_ENCODING,
     };
 
     validate_ca_thumbprint(thumbprint)?;
@@ -341,8 +367,7 @@ fn find_windows_user_ca(
         cbData: hash.len() as u32,
         pbData: hash.as_mut_ptr(),
     };
-    let store = unsafe { CertOpenSystemStoreW(None, w!("ROOT")) }
-        .map_err(|error| format!("could not open the current-user Root store: {error}"))?;
+    let store = open_windows_user_root_store()?;
     let context = unsafe {
         CertFindCertificateInStore(
             store,
@@ -413,17 +438,15 @@ struct WindowsUserCaGuard {
 #[cfg(windows)]
 impl WindowsUserCaGuard {
     fn install(certificate_der: &[u8], thumbprint: &str) -> Result<Self, String> {
-        use windows::core::w;
         use windows::Win32::Security::Cryptography::{
-            CertAddEncodedCertificateToStore, CertCloseStore, CertOpenSystemStoreW,
-            CERT_STORE_ADD_NEW, X509_ASN_ENCODING,
+            CertAddEncodedCertificateToStore, CertCloseStore, CERT_STORE_ADD_NEW, X509_ASN_ENCODING,
         };
 
         validate_ca_thumbprint(thumbprint)?;
         write_windows_ca_journal(thumbprint)?;
-        let store = unsafe { CertOpenSystemStoreW(None, w!("ROOT")) }.map_err(|error| {
+        let store = open_windows_user_root_store().map_err(|error| {
             let _ = remove_windows_ca_journal();
-            format!("could not open the current-user Root store: {error}")
+            error
         })?;
         let add = unsafe {
             CertAddEncodedCertificateToStore(

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -464,10 +464,6 @@ struct WindowsUserCaGuard {
 #[cfg(windows)]
 impl WindowsUserCaGuard {
     fn install(certificate_der: &[u8], thumbprint: &str) -> Result<Self, String> {
-        use windows::Win32::Security::Cryptography::{
-            CertAddEncodedCertificateToStore, CertCloseStore, CERT_STORE_ADD_NEW, X509_ASN_ENCODING,
-        };
-
         validate_ca_thumbprint(thumbprint)?;
         if windows_user_ca_present(thumbprint)? {
             return Err(
@@ -475,36 +471,42 @@ impl WindowsUserCaGuard {
                     .to_string(),
             );
         }
+        let directory = crate::secure_temp::SecureTempDirectory::create(
+            "pentect-claude-ca-",
+            "Claude Desktop certificate",
+        )?;
+        let certificate = crate::secure_temp::SecureTempFile::create(
+            directory.path(),
+            "root-",
+            ".cer",
+            certificate_der,
+            "Claude Desktop certificate",
+        )?;
         #[cfg(test)]
         eprintln!("windows CA install: writing cleanup journal");
         write_windows_ca_journal(thumbprint)?;
         #[cfg(test)]
-        eprintln!("windows CA install: opening CurrentUser Root store");
-        let store = open_windows_user_root_store().map_err(|error| {
-            let _ = remove_windows_ca_journal();
-            error
-        });
-        let store = store?;
-
-        #[cfg(test)]
-        eprintln!("windows CA install: adding certificate through certificate store API");
-        let add = unsafe {
-            CertAddEncodedCertificateToStore(
-                Some(store),
-                X509_ASN_ENCODING,
-                certificate_der,
-                CERT_STORE_ADD_NEW,
-                None,
-            )
+        eprintln!("windows CA install: importing certificate with certutil");
+        let status = Command::new(crate::windows_system_executable("certutil.exe"))
+            .args(["-f", "-user", "-addstore", "Root"])
+            .arg(certificate.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        let status = match status {
+            Ok(status) => status,
+            Err(error) => {
+                let _ = remove_windows_ca_journal();
+                return Err(format!(
+                    "could not trust temporary Claude Desktop certificate: {error}"
+                ));
+            }
         };
-        let close = unsafe { CertCloseStore(Some(store), 0) };
-        if let Err(error) = add {
+        if !status.success() {
             let _ = remove_windows_ca_journal();
-            return Err(format!(
-                "could not trust temporary Claude Desktop certificate: {error}"
-            ));
+            return Err("Windows rejected the temporary Claude Desktop certificate".to_string());
         }
-        close.map_err(|error| format!("could not close the current-user Root store: {error}"))?;
         #[cfg(test)]
         eprintln!("windows CA install: certificate store update finished");
         Ok(Self {

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -326,75 +326,36 @@ fn validate_ca_thumbprint(thumbprint: &str) -> Result<(), String> {
 #[cfg(windows)]
 fn open_windows_user_root_store(
 ) -> Result<windows::Win32::Security::Cryptography::HCERTSTORE, String> {
-    use windows::core::w;
     use windows::Win32::Security::Cryptography::{
         CertOpenStore, CERT_OPEN_STORE_FLAGS, CERT_STORE_MAXIMUM_ALLOWED_FLAG,
         CERT_STORE_OPEN_EXISTING_FLAG, CERT_STORE_PROV_SYSTEM_REGISTRY_W,
         CERT_SYSTEM_STORE_CURRENT_USER, X509_ASN_ENCODING,
     };
 
-    let flags = CERT_OPEN_STORE_FLAGS(
-        CERT_SYSTEM_STORE_CURRENT_USER
-            | CERT_STORE_MAXIMUM_ALLOWED_FLAG.0
-            | CERT_STORE_OPEN_EXISTING_FLAG.0,
-    );
+    #[cfg(test)]
+    let test_store = std::env::var_os("PENTECT_TEST_WINDOWS_CA_STORE")
+        .map(|name| windows::core::HSTRING::from(name.to_string_lossy().as_ref()));
+    #[cfg(not(test))]
+    let test_store: Option<windows::core::HSTRING> = None;
+    let store_name = test_store
+        .as_ref()
+        .cloned()
+        .unwrap_or_else(|| windows::core::HSTRING::from("ROOT"));
+    let mut raw_flags = CERT_SYSTEM_STORE_CURRENT_USER | CERT_STORE_MAXIMUM_ALLOWED_FLAG.0;
+    if test_store.is_none() {
+        raw_flags |= CERT_STORE_OPEN_EXISTING_FLAG.0;
+    }
+    let flags = CERT_OPEN_STORE_FLAGS(raw_flags);
     unsafe {
         CertOpenStore(
             CERT_STORE_PROV_SYSTEM_REGISTRY_W,
             X509_ASN_ENCODING,
             None,
             flags,
-            Some(w!("ROOT").as_ptr() as *const std::ffi::c_void),
+            Some(store_name.as_ptr() as *const std::ffi::c_void),
         )
     }
     .map_err(|error| format!("could not open the current-user Root store: {error}"))
-}
-
-#[cfg(windows)]
-fn open_windows_user_root_registry_store() -> Result<
-    (
-        windows::Win32::Security::Cryptography::HCERTSTORE,
-        windows::Win32::System::Registry::HKEY,
-    ),
-    String,
-> {
-    use windows::Win32::Security::Cryptography::{
-        CertOpenStore, CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE, CERT_STORE_PROV_REG,
-    };
-    use windows::Win32::System::Registry::{
-        RegCloseKey, RegOpenKeyExW, HKEY, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE,
-    };
-
-    let mut key = HKEY::default();
-    unsafe {
-        RegOpenKeyExW(
-            HKEY_CURRENT_USER,
-            windows::core::w!("Software\\Microsoft\\SystemCertificates\\Root"),
-            None,
-            KEY_READ | KEY_WRITE,
-            &mut key,
-        )
-    }
-    .ok()
-    .map_err(|error| format!("could not open the current-user Root registry store: {error}"))?;
-    let store = unsafe {
-        CertOpenStore(
-            CERT_STORE_PROV_REG,
-            CERT_QUERY_ENCODING_TYPE(0),
-            None,
-            CERT_OPEN_STORE_FLAGS(0),
-            Some(key.0 as *const std::ffi::c_void),
-        )
-    };
-    match store {
-        Ok(store) => Ok((store, key)),
-        Err(error) => {
-            let _ = unsafe { RegCloseKey(key) };
-            Err(format!(
-                "could not open the current-user Root registry certificate provider: {error}"
-            ))
-        }
-    }
 }
 
 #[cfg(windows)]
@@ -514,7 +475,6 @@ impl WindowsUserCaGuard {
         use windows::Win32::Security::Cryptography::{
             CertAddEncodedCertificateToStore, CertCloseStore, CERT_STORE_ADD_NEW, X509_ASN_ENCODING,
         };
-        use windows::Win32::System::Registry::RegCloseKey;
 
         validate_ca_thumbprint(thumbprint)?;
         if windows_user_ca_present(thumbprint)? {
@@ -527,16 +487,16 @@ impl WindowsUserCaGuard {
         eprintln!("windows CA install: writing cleanup journal");
         write_windows_ca_journal(thumbprint)?;
         #[cfg(test)]
-        eprintln!("windows CA install: opening registry certificate provider");
-        let (store, key) = match open_windows_user_root_registry_store() {
-            Ok(handles) => handles,
+        eprintln!("windows CA install: opening current-user certificate store");
+        let store = match open_windows_user_root_store() {
+            Ok(store) => store,
             Err(error) => {
                 let _ = remove_windows_ca_journal();
                 return Err(error);
             }
         };
         #[cfg(test)]
-        eprintln!("windows CA install: adding certificate through registry provider");
+        eprintln!("windows CA install: adding certificate through system store provider");
         let add = unsafe {
             CertAddEncodedCertificateToStore(
                 Some(store),
@@ -547,7 +507,6 @@ impl WindowsUserCaGuard {
             )
         };
         let close_store = unsafe { CertCloseStore(Some(store), 0) };
-        let close_key = unsafe { RegCloseKey(key) };
         if let Err(error) = add {
             let _ = remove_windows_ca_journal();
             return Err(format!(
@@ -556,9 +515,6 @@ impl WindowsUserCaGuard {
         }
         close_store
             .map_err(|error| format!("could not close the Root certificate provider: {error}"))?;
-        close_key
-            .ok()
-            .map_err(|error| format!("could not close the Root registry store: {error}"))?;
         #[cfg(test)]
         eprintln!("windows CA install: certificate store update finished");
         Ok(Self {
@@ -3496,6 +3452,22 @@ mod tests {
     }
 
     #[cfg(windows)]
+    fn remove_windows_test_ca_store(name: &str) {
+        use windows::Win32::Security::Cryptography::{
+            CertUnregisterSystemStore, CERT_SYSTEM_STORE_CURRENT_USER,
+        };
+
+        let name = windows::core::HSTRING::from(name);
+        let removed = unsafe {
+            CertUnregisterSystemStore(
+                name.as_ptr() as *const std::ffi::c_void,
+                CERT_SYSTEM_STORE_CURRENT_USER,
+            )
+        };
+        assert!(removed.as_bool(), "could not remove temporary test store");
+    }
+
+    #[cfg(windows)]
     #[test]
     #[ignore = "mutates the ephemeral test user's CurrentUser Root store"]
     fn windows_user_ca_round_trip() {
@@ -3512,6 +3484,9 @@ mod tests {
         ));
         std::fs::create_dir_all(&state).unwrap();
         std::env::set_var("LOCALAPPDATA", &state);
+        let previous_store = std::env::var_os("PENTECT_TEST_WINDOWS_CA_STORE");
+        let store_name = format!("PentectClaudeCaTest-{}", std::process::id());
+        std::env::set_var("PENTECT_TEST_WINDOWS_CA_STORE", &store_name);
 
         let authority = CertificateAuthority::new().unwrap();
         eprintln!("windows CA round trip: checking initial absence");
@@ -3527,10 +3502,15 @@ mod tests {
         eprintln!("windows CA round trip: checking final absence from a fresh process");
         assert_windows_ca_visibility_in_fresh_process(&authority.thumbprint, false);
         assert!(!windows_ca_cleanup_pending().unwrap());
+        remove_windows_test_ca_store(&store_name);
 
         match previous {
             Some(value) => std::env::set_var("LOCALAPPDATA", value),
             None => std::env::remove_var("LOCALAPPDATA"),
+        }
+        match previous_store {
+            Some(value) => std::env::set_var("PENTECT_TEST_WINDOWS_CA_STORE", value),
+            None => std::env::remove_var("PENTECT_TEST_WINDOWS_CA_STORE"),
         }
         let _ = std::fs::remove_dir_all(state);
     }

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -464,8 +464,14 @@ struct WindowsUserCaGuard {
 #[cfg(windows)]
 impl WindowsUserCaGuard {
     fn install(certificate_der: &[u8], thumbprint: &str) -> Result<Self, String> {
+        use windows::Win32::Security::Cryptography::UI::{
+            CryptUIWizImport, CRYPTUI_WIZ_IMPORT_ALLOW_CERT, CRYPTUI_WIZ_IMPORT_SRC_INFO,
+            CRYPTUI_WIZ_IMPORT_SRC_INFO_0, CRYPTUI_WIZ_IMPORT_SUBJECT_CERT_CONTEXT,
+            CRYPTUI_WIZ_NO_UI,
+        };
         use windows::Win32::Security::Cryptography::{
-            CertAddEncodedCertificateToStore, CertCloseStore, CERT_STORE_ADD_NEW, X509_ASN_ENCODING,
+            CertCloseStore, CertCreateCertificateContext, CertFreeCertificateContext,
+            X509_ASN_ENCODING,
         };
 
         validate_ca_thumbprint(thumbprint)?;
@@ -480,15 +486,30 @@ impl WindowsUserCaGuard {
         })?;
         #[cfg(test)]
         eprintln!("windows CA install: adding certificate");
+        let context = unsafe { CertCreateCertificateContext(X509_ASN_ENCODING, certificate_der) }
+            .map_err(|error| {
+            let _ = unsafe { CertCloseStore(Some(store), 0) };
+            let _ = remove_windows_ca_journal();
+            format!("could not parse temporary Claude Desktop certificate: {error}")
+        })?;
+        let source = CRYPTUI_WIZ_IMPORT_SRC_INFO {
+            dwSize: std::mem::size_of::<CRYPTUI_WIZ_IMPORT_SRC_INFO>() as u32,
+            dwSubjectChoice: CRYPTUI_WIZ_IMPORT_SUBJECT_CERT_CONTEXT,
+            Anonymous: CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {
+                pCertContext: context,
+            },
+            ..Default::default()
+        };
         let add = unsafe {
-            CertAddEncodedCertificateToStore(
-                Some(store),
-                X509_ASN_ENCODING,
-                certificate_der,
-                CERT_STORE_ADD_NEW,
+            CryptUIWizImport(
+                CRYPTUI_WIZ_NO_UI | CRYPTUI_WIZ_IMPORT_ALLOW_CERT,
                 None,
+                windows::core::PCWSTR::null(),
+                Some(&source),
+                Some(store),
             )
         };
+        let _ = unsafe { CertFreeCertificateContext(Some(context)) };
         #[cfg(test)]
         eprintln!("windows CA install: closing Root store");
         let close = unsafe { CertCloseStore(Some(store), 0) };

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -351,6 +351,53 @@ fn open_windows_user_root_store(
 }
 
 #[cfg(windows)]
+fn open_windows_user_root_registry_store() -> Result<
+    (
+        windows::Win32::Security::Cryptography::HCERTSTORE,
+        windows::Win32::System::Registry::HKEY,
+    ),
+    String,
+> {
+    use windows::Win32::Security::Cryptography::{
+        CertOpenStore, CERT_OPEN_STORE_FLAGS, CERT_STORE_PROV_REG,
+    };
+    use windows::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, HKEY, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE,
+    };
+
+    let mut key = HKEY::default();
+    unsafe {
+        RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            windows::core::w!("Software\\Microsoft\\SystemCertificates\\Root"),
+            None,
+            KEY_READ | KEY_WRITE,
+            &mut key,
+        )
+    }
+    .ok()
+    .map_err(|error| format!("could not open the current-user Root registry store: {error}"))?;
+    let store = unsafe {
+        CertOpenStore(
+            CERT_STORE_PROV_REG,
+            0,
+            None,
+            CERT_OPEN_STORE_FLAGS(0),
+            Some(key.0 as *const std::ffi::c_void),
+        )
+    };
+    match store {
+        Ok(store) => Ok((store, key)),
+        Err(error) => {
+            let _ = unsafe { RegCloseKey(key) };
+            Err(format!(
+                "could not open the current-user Root registry certificate provider: {error}"
+            ))
+        }
+    }
+}
+
+#[cfg(windows)]
 fn find_windows_user_ca(thumbprint: &str) -> Result<bool, String> {
     use windows::Win32::Security::Cryptography::{
         CertCloseStore, CertFindCertificateInStore, CERT_FIND_SHA1_HASH, CRYPT_INTEGER_BLOB,
@@ -464,6 +511,11 @@ struct WindowsUserCaGuard {
 #[cfg(windows)]
 impl WindowsUserCaGuard {
     fn install(certificate_der: &[u8], thumbprint: &str) -> Result<Self, String> {
+        use windows::Win32::Security::Cryptography::{
+            CertAddEncodedCertificateToStore, CertCloseStore, CERT_STORE_ADD_NEW, X509_ASN_ENCODING,
+        };
+        use windows::Win32::System::Registry::RegCloseKey;
+
         validate_ca_thumbprint(thumbprint)?;
         if windows_user_ca_present(thumbprint)? {
             return Err(
@@ -471,42 +523,42 @@ impl WindowsUserCaGuard {
                     .to_string(),
             );
         }
-        let directory = crate::secure_temp::SecureTempDirectory::create(
-            "pentect-claude-ca-",
-            "Claude Desktop certificate",
-        )?;
-        let certificate = crate::secure_temp::SecureTempFile::create(
-            directory.path(),
-            "root-",
-            ".cer",
-            certificate_der,
-            "Claude Desktop certificate",
-        )?;
         #[cfg(test)]
         eprintln!("windows CA install: writing cleanup journal");
         write_windows_ca_journal(thumbprint)?;
         #[cfg(test)]
-        eprintln!("windows CA install: importing certificate with certutil");
-        let status = Command::new(crate::windows_system_executable("certutil.exe"))
-            .args(["-f", "-user", "-addstore", "Root"])
-            .arg(certificate.path())
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-        let status = match status {
-            Ok(status) => status,
+        eprintln!("windows CA install: opening registry certificate provider");
+        let (store, key) = match open_windows_user_root_registry_store() {
+            Ok(handles) => handles,
             Err(error) => {
                 let _ = remove_windows_ca_journal();
-                return Err(format!(
-                    "could not trust temporary Claude Desktop certificate: {error}"
-                ));
+                return Err(error);
             }
         };
-        if !status.success() {
+        #[cfg(test)]
+        eprintln!("windows CA install: adding certificate through registry provider");
+        let add = unsafe {
+            CertAddEncodedCertificateToStore(
+                Some(store),
+                X509_ASN_ENCODING,
+                certificate_der,
+                CERT_STORE_ADD_NEW,
+                None,
+            )
+        };
+        let close_store = unsafe { CertCloseStore(Some(store), 0) };
+        let close_key = unsafe { RegCloseKey(key) };
+        if let Err(error) = add {
             let _ = remove_windows_ca_journal();
-            return Err("Windows rejected the temporary Claude Desktop certificate".to_string());
+            return Err(format!(
+                "could not trust temporary Claude Desktop certificate: {error}"
+            ));
         }
+        close_store
+            .map_err(|error| format!("could not close the Root certificate provider: {error}"))?;
+        close_key
+            .ok()
+            .map_err(|error| format!("could not close the Root registry store: {error}"))?;
         #[cfg(test)]
         eprintln!("windows CA install: certificate store update finished");
         Ok(Self {

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -1,9 +1,10 @@
 //! Explicit HTTPS gateway for the unmodified Claude Desktop application.
 //!
-//! The root CA and its signing key exist only in memory. Claude Desktop is
-//! launched with Chromium's SPKI allow-list, so this does not modify the OS
-//! certificate store. Chat completion bodies are protected in memory and are
-//! never logged. Claude Code children inherit the Anthropic HTTP gateway.
+//! The root CA signing key exists only in memory. On Windows, Claude Desktop is
+//! launched after explicit user consent with the public root certificate in the
+//! current-user trust store; the certificate is removed when the session ends.
+//! Other platforms use Chromium's SPKI allow-list. Chat completion bodies are
+//! protected in memory and are never logged.
 
 use futures_util::StreamExt;
 use http_body_util::combinators::UnsyncBoxBody;
@@ -12,15 +13,20 @@ use hyper::body::{Bytes, Frame, Incoming};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
+#[cfg(not(windows))]
+use rcgen::PublicKeyData;
 use rcgen::{
     BasicConstraints, CertificateParams, CertifiedIssuer, DistinguishedName, DnType, IsCa, KeyPair,
-    KeyUsagePurpose, PublicKeyData,
+    KeyUsagePurpose,
 };
+#[cfg(not(windows))]
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
 use std::convert::Infallible;
 use std::error::Error;
 use std::io;
+#[cfg(windows)]
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::{Command, Stdio};
@@ -62,6 +68,8 @@ pub(crate) fn check_mode(args: &[String]) -> Result<bool, String> {
 
 fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     let options = ClaudeAppOptions::parse(args)?;
+    #[cfg(not(windows))]
+    let _ = options.assume_yes;
     let app = options.app.unwrap_or_else(default_claude_app_path);
     if options.check {
         let installed = app.is_file();
@@ -77,7 +85,7 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         );
         println!("Protection: supported Claude Desktop Chat and attachment routes");
         println!(
-            "Compatibility: the app must accept Pentect's required certificate-pin switch; Claude Desktop 1.34493.1 is known incompatible"
+            "Compatibility: Windows uses an explicitly approved, session-only current-user certificate; other platforms require Chromium's certificate-pin switch"
         );
         let upstream = options
             .upstream
@@ -103,6 +111,16 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         );
     }
 
+    #[cfg(windows)]
+    {
+        cleanup_stale_windows_user_ca()?;
+        if !options.assume_yes && !confirm_windows_user_ca_install()? {
+            return Err(
+                "Claude Desktop protection was cancelled; no certificate was installed".to_string(),
+            );
+        }
+    }
+
     let anthropic = crate::claude_http_proxy::ClaudeHttpProxyGuard::start_with_header_env(
         options
             .upstream
@@ -111,6 +129,8 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         &options.upstream_header_env,
     )?;
     let proxy = ClaudeAppProxyGuard::start()?;
+    #[cfg(windows)]
+    let _trusted_ca = WindowsUserCaGuard::install(proxy.root_certificate_der(), proxy.ca_serial())?;
     let user_data_dir = claude_user_data_dir()?;
     #[cfg(windows)]
     if let Some(package) = find_windows_claude_package()
@@ -122,8 +142,11 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         let process = activate_windows_package(&package.aumid, &arguments)?;
         drop(environment);
         let process_id = process.id();
+        let ca_serial = proxy.ca_serial().to_string();
         if let Err(error) = ctrlc::set_handler(move || {
             terminate_child_process(process_id);
+            let _ = remove_windows_user_ca(&ca_serial);
+            let _ = remove_windows_ca_journal();
             std::process::exit(130);
         }) {
             terminate_child_process(process_id);
@@ -155,8 +178,15 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
         .spawn()
         .map_err(|error| format!("could not start Claude Desktop: {error}"))?;
     let child_id = child.id();
+    #[cfg(windows)]
+    let ca_serial = proxy.ca_serial().to_string();
     if let Err(error) = ctrlc::set_handler(move || {
         terminate_child_process(child_id);
+        #[cfg(windows)]
+        {
+            let _ = remove_windows_user_ca(&ca_serial);
+            let _ = remove_windows_ca_journal();
+        }
         std::process::exit(130);
     }) {
         terminate_child_process(child_id);
@@ -184,19 +214,29 @@ fn run_claude_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
 fn claude_desktop_early_exit_error(status: impl std::fmt::Display, packaged: bool) -> String {
     let installation = if packaged { " package" } else { "" };
     format!(
-        "Claude Desktop{installation} exited while Pentect was attaching its required local-proxy certificate pin ({status}). Claude Desktop 1.34493.1 is known to reject this Chromium switch. Pentect will not bypass certificate verification or install a system CA, so this app build cannot be protected; use `pentect claude` for Claude Code or a Claude Desktop build explicitly listed as compatible"
+        "Claude Desktop{installation} exited before Pentect could attach protection ({status}); the temporary current-user certificate will be removed"
     )
 }
 
 fn claude_chromium_arguments(proxy: &ClaudeAppProxyGuard, user_data_dir: &Path) -> Vec<String> {
-    vec![
+    let arguments = vec![
         format!("--proxy-server={}", proxy.proxy_url()),
-        format!(
-            "--ignore-certificate-errors-spki-list={}",
-            proxy.spki_hash()
-        ),
         format!("--user-data-dir={}", user_data_dir.display()),
-    ]
+    ];
+    #[cfg(not(windows))]
+    {
+        arguments
+            .into_iter()
+            .chain(std::iter::once(format!(
+                "--ignore-certificate-errors-spki-list={}",
+                proxy.spki_hash()
+            )))
+            .collect()
+    }
+    #[cfg(windows)]
+    {
+        arguments
+    }
 }
 
 fn print_gateway_ready(proxy: &ClaudeAppProxyGuard) {
@@ -207,6 +247,197 @@ fn print_gateway_ready(proxy: &ClaudeAppProxyGuard) {
     eprintln!(
         "[pentect] Supported Claude Desktop Chat and attachment traffic is protected; bodies are not logged"
     );
+}
+
+#[cfg(windows)]
+fn confirm_windows_user_ca_install() -> Result<bool, String> {
+    if !std::io::stdin().is_terminal() {
+        return Err(
+            "input is not interactive; rerun `pentect claude app --yes` to approve the temporary current-user certificate"
+                .to_string(),
+        );
+    }
+    println!(
+        "Pentect needs to temporarily trust a session-specific certificate for this Windows user so Claude Desktop traffic can be protected."
+    );
+    println!(
+        "The private key stays in this Pentect process. The public certificate is removed when Claude Desktop exits."
+    );
+    print!("Continue? [y/N] ");
+    std::io::stdout()
+        .flush()
+        .map_err(|error| format!("could not show Claude Desktop certificate prompt: {error}"))?;
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .map_err(|error| format!("could not read Claude Desktop certificate prompt: {error}"))?;
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+#[cfg(windows)]
+fn windows_ca_journal_path() -> Result<PathBuf, String> {
+    let root = std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .ok_or_else(|| "LOCALAPPDATA is unavailable for Claude Desktop CA cleanup".to_string())?;
+    Ok(root.join("Pentect").join("claude-app-temporary-ca.serial"))
+}
+
+#[cfg(windows)]
+fn write_windows_ca_journal(serial: &str) -> Result<(), String> {
+    let path = windows_ca_journal_path()?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Claude Desktop CA cleanup path has no parent".to_string())?;
+    std::fs::create_dir_all(parent).map_err(|error| {
+        format!("could not create Claude Desktop CA cleanup directory: {error}")
+    })?;
+    crate::secure_temp::restrict_to_current_user(parent)?;
+    std::fs::write(&path, serial)
+        .map_err(|error| format!("could not write Claude Desktop CA cleanup journal: {error}"))?;
+    crate::secure_temp::restrict_to_current_user(&path)
+}
+
+#[cfg(windows)]
+fn remove_windows_ca_journal() -> Result<(), String> {
+    let path = windows_ca_journal_path()?;
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "could not remove Claude Desktop CA cleanup journal: {error}"
+        )),
+    }
+}
+
+#[cfg(windows)]
+fn validate_ca_serial(serial: &str) -> Result<(), String> {
+    if serial.len() != 32 || !serial.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err("Claude Desktop CA cleanup journal is invalid".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn remove_windows_user_ca(serial: &str) -> Result<(), String> {
+    validate_ca_serial(serial)?;
+    if !windows_user_ca_present(serial)? {
+        return Ok(());
+    }
+    let status = Command::new(crate::windows_system_executable("certutil.exe"))
+        .args(["-user", "-delstore", "Root", serial])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| {
+            format!("could not remove temporary Claude Desktop certificate: {error}")
+        })?;
+    status.success().then_some(()).ok_or_else(|| {
+        "could not remove temporary Claude Desktop certificate; run `pentect claude app` again to retry cleanup"
+            .to_string()
+    })
+}
+
+#[cfg(windows)]
+fn windows_user_ca_present(serial: &str) -> Result<bool, String> {
+    validate_ca_serial(serial)?;
+    Command::new(crate::windows_system_executable("certutil.exe"))
+        .args(["-user", "-store", "Root", serial])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .map_err(|error| format!("could not inspect temporary Claude Desktop certificate: {error}"))
+}
+
+#[cfg(windows)]
+pub(crate) fn windows_ca_cleanup_pending() -> Result<bool, String> {
+    Ok(windows_ca_journal_path()?.is_file())
+}
+
+#[cfg(windows)]
+pub(crate) fn cleanup_stale_windows_user_ca() -> Result<(), String> {
+    let path = windows_ca_journal_path()?;
+    let serial = match std::fs::read_to_string(&path) {
+        Ok(serial) => serial,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "could not read Claude Desktop CA cleanup journal: {error}"
+            ))
+        }
+    };
+    let serial = serial.trim();
+    validate_ca_serial(serial)?;
+    remove_windows_user_ca(serial)?;
+    remove_windows_ca_journal()?;
+    eprintln!("[pentect] Removed a stale temporary Claude Desktop certificate");
+    Ok(())
+}
+
+#[cfg(windows)]
+struct WindowsUserCaGuard {
+    serial: String,
+}
+
+#[cfg(windows)]
+impl WindowsUserCaGuard {
+    fn install(certificate_der: &[u8], serial: &str) -> Result<Self, String> {
+        validate_ca_serial(serial)?;
+        let directory = crate::secure_temp::SecureTempDirectory::create(
+            "pentect-claude-ca-",
+            "Claude Desktop certificate",
+        )?;
+        let certificate = crate::secure_temp::SecureTempFile::create(
+            directory.path(),
+            "root-",
+            ".cer",
+            certificate_der,
+            "Claude Desktop certificate",
+        )?;
+        write_windows_ca_journal(serial)?;
+        let status = Command::new(crate::windows_system_executable("certutil.exe"))
+            .args(["-user", "-addstore", "Root"])
+            .arg(certificate.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map_err(|error| {
+                format!("could not trust temporary Claude Desktop certificate: {error}")
+            });
+        match status {
+            Ok(status) if status.success() => Ok(Self {
+                serial: serial.to_string(),
+            }),
+            Ok(_) => {
+                let _ = remove_windows_ca_journal();
+                Err("Windows rejected the temporary Claude Desktop certificate".to_string())
+            }
+            Err(error) => {
+                let _ = remove_windows_ca_journal();
+                Err(error)
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsUserCaGuard {
+    fn drop(&mut self) {
+        if let Err(error) = remove_windows_user_ca(&self.serial) {
+            eprintln!("[pentect] {error}");
+            return;
+        }
+        if let Err(error) = remove_windows_ca_journal() {
+            eprintln!("[pentect] {error}");
+        }
+        self.serial.zeroize();
+    }
 }
 
 #[cfg(windows)]
@@ -411,6 +642,7 @@ struct ClaudeAppOptions {
     upstream: Option<String>,
     upstream_header_env: Vec<String>,
     check: bool,
+    assume_yes: bool,
 }
 
 impl ClaudeAppOptions {
@@ -419,6 +651,7 @@ impl ClaudeAppOptions {
         let mut upstream = None;
         let mut upstream_header_env = Vec::new();
         let mut check = false;
+        let mut assume_yes = false;
         let mut index = if args.get(1).is_some_and(|arg| arg == "claude")
             && args.get(2).is_some_and(|arg| arg == "app")
         {
@@ -437,6 +670,10 @@ impl ClaudeAppOptions {
                 }
                 "--check" | "--dry-run" => {
                     check = true;
+                    index += 1;
+                }
+                "--yes" => {
+                    assume_yes = true;
                     index += 1;
                 }
                 "--upstream" => {
@@ -470,13 +707,19 @@ impl ClaudeAppOptions {
             upstream,
             upstream_header_env,
             check,
+            assume_yes,
         })
     }
 }
 
 struct ClaudeAppProxyGuard {
     proxy_url: String,
+    #[cfg(not(windows))]
     spki_hash: String,
+    #[cfg(windows)]
+    root_certificate_der: Vec<u8>,
+    #[cfg(windows)]
+    ca_serial: String,
     shutdown: Option<oneshot::Sender<()>>,
     thread: Option<thread::JoinHandle<()>>,
 }
@@ -484,7 +727,12 @@ struct ClaudeAppProxyGuard {
 impl ClaudeAppProxyGuard {
     fn start() -> Result<Self, String> {
         let authority = CertificateAuthority::new()?;
+        #[cfg(not(windows))]
         let spki_hash = authority.spki_hash.clone();
+        #[cfg(windows)]
+        let root_certificate_der = authority.issuer.der().to_vec();
+        #[cfg(windows)]
+        let ca_serial = authority.serial.clone();
         let (ready_tx, ready_rx) = mpsc::channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let thread = thread::spawn(move || {
@@ -512,7 +760,12 @@ impl ClaudeAppProxyGuard {
             .map_err(|_| "Claude App proxy did not start within 30 seconds".to_string())??;
         Ok(Self {
             proxy_url,
+            #[cfg(not(windows))]
             spki_hash,
+            #[cfg(windows)]
+            root_certificate_der,
+            #[cfg(windows)]
+            ca_serial,
             shutdown: Some(shutdown_tx),
             thread: Some(thread),
         })
@@ -522,8 +775,19 @@ impl ClaudeAppProxyGuard {
         &self.proxy_url
     }
 
+    #[cfg(not(windows))]
     fn spki_hash(&self) -> &str {
         &self.spki_hash
+    }
+
+    #[cfg(windows)]
+    fn root_certificate_der(&self) -> &[u8] {
+        &self.root_certificate_der
+    }
+
+    #[cfg(windows)]
+    fn ca_serial(&self) -> &str {
+        &self.ca_serial
     }
 }
 
@@ -536,21 +800,31 @@ impl Drop for ClaudeAppProxyGuard {
             let _ = thread.join();
         }
         self.proxy_url.zeroize();
+        #[cfg(not(windows))]
         self.spki_hash.zeroize();
+        #[cfg(windows)]
+        {
+            self.root_certificate_der.zeroize();
+            self.ca_serial.zeroize();
+        }
     }
 }
 
 struct CertificateAuthority {
     issuer: CertifiedIssuer<'static, KeyPair>,
+    #[cfg(not(windows))]
     spki_hash: String,
+    #[cfg(windows)]
+    serial: String,
 }
 
 impl CertificateAuthority {
     fn new() -> Result<Self, String> {
         let key = KeyPair::generate()
             .map_err(|error| format!("could not generate Claude App proxy CA key: {error}"))?;
-        let spki = key.subject_public_key_info();
-        let spki_hash = data_encoding::BASE64.encode(&Sha256::digest(spki));
+        #[cfg(not(windows))]
+        let spki_hash =
+            data_encoding::BASE64.encode(&Sha256::digest(key.subject_public_key_info()));
         let mut params = CertificateParams::new(Vec::<String>::new())
             .map_err(|error| format!("could not create Claude App proxy CA: {error}"))?;
         let mut distinguished_name = DistinguishedName::new();
@@ -561,9 +835,25 @@ impl CertificateAuthority {
             KeyUsagePurpose::KeyCertSign,
             KeyUsagePurpose::DigitalSignature,
         ];
+        #[cfg(windows)]
+        let serial = {
+            let mut serial = [0_u8; 16];
+            getrandom::getrandom(&mut serial).map_err(|error| {
+                format!("OS CSPRNG unavailable for Claude App CA serial: {error}")
+            })?;
+            serial[0] &= 0x7f;
+            params.serial_number = Some(rcgen::SerialNumber::from_slice(&serial));
+            data_encoding::HEXUPPER.encode(&serial)
+        };
         let issuer = CertifiedIssuer::self_signed(params, key)
             .map_err(|error| format!("could not sign Claude App proxy CA: {error}"))?;
-        Ok(Self { issuer, spki_hash })
+        Ok(Self {
+            issuer,
+            #[cfg(not(windows))]
+            spki_hash,
+            #[cfg(windows)]
+            serial,
+        })
     }
 
     fn server_config(&self, host: &str) -> Result<Arc<ServerConfig>, String> {
@@ -2527,13 +2817,12 @@ mod tests {
         for packaged in [false, true] {
             let error = claude_desktop_early_exit_error("exit code: 1", packaged);
             assert!(
-                error.contains("required local-proxy certificate pin"),
+                error.contains("exited before Pentect could attach"),
                 "{error}"
             );
-            assert!(error.contains("1.34493.1 is known to reject"), "{error}");
-            assert!(error.contains("cannot be protected"), "{error}");
-            assert!(error.contains("`pentect claude`"), "{error}");
+            assert!(error.contains("certificate will be removed"), "{error}");
             assert!(!error.contains("update Claude Desktop"), "{error}");
+            assert!(!error.contains("ignore-certificate-errors"), "{error}");
         }
     }
 
@@ -2624,10 +2913,12 @@ mod tests {
             "--app".to_string(),
             "Claude.exe".to_string(),
             "--dry-run".to_string(),
+            "--yes".to_string(),
         ];
         let options = ClaudeAppOptions::parse(&args).unwrap();
         assert_eq!(options.app, Some(PathBuf::from("Claude.exe")));
         assert!(options.check);
+        assert!(options.assume_yes);
     }
 
     #[test]
@@ -3010,8 +3301,61 @@ mod tests {
     #[test]
     fn ephemeral_ca_builds_host_certificate() {
         let authority = CertificateAuthority::new().unwrap();
+        #[cfg(not(windows))]
         assert!(!authority.spki_hash.is_empty());
+        #[cfg(windows)]
+        {
+            assert_eq!(authority.serial.len(), 32);
+            assert!(authority
+                .serial
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit()));
+            assert!(!authority.issuer.der().is_empty());
+        }
         authority.server_config("claude.ai").unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_ca_journal_accepts_only_generated_serial_shape() {
+        assert!(validate_ca_serial("00112233445566778899AABBCCDDEEFF").is_ok());
+        for invalid in [
+            "",
+            "0011",
+            "00112233445566778899AABBCCDDEEFG",
+            "00112233445566778899AABBCCDDEEFF --force",
+        ] {
+            assert!(validate_ca_serial(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "mutates the ephemeral test user's CurrentUser Root store"]
+    fn windows_user_ca_round_trip() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("LOCALAPPDATA");
+        let state = std::env::temp_dir().join(format!(
+            "pentect-claude-ca-round-trip-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&state).unwrap();
+        std::env::set_var("LOCALAPPDATA", &state);
+
+        let authority = CertificateAuthority::new().unwrap();
+        assert!(!windows_user_ca_present(&authority.serial).unwrap());
+        let guard = WindowsUserCaGuard::install(authority.issuer.der(), &authority.serial).unwrap();
+        assert!(windows_user_ca_present(&authority.serial).unwrap());
+        assert!(windows_ca_cleanup_pending().unwrap());
+        drop(guard);
+        assert!(!windows_user_ca_present(&authority.serial).unwrap());
+        assert!(!windows_ca_cleanup_pending().unwrap());
+
+        match previous {
+            Some(value) => std::env::set_var("LOCALAPPDATA", value),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
+        let _ = std::fs::remove_dir_all(state);
     }
 
     #[cfg(windows)]

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -359,7 +359,7 @@ fn open_windows_user_root_registry_store() -> Result<
     String,
 > {
     use windows::Win32::Security::Cryptography::{
-        CertOpenStore, CERT_OPEN_STORE_FLAGS, CERT_STORE_PROV_REG,
+        CertOpenStore, CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE, CERT_STORE_PROV_REG,
     };
     use windows::Win32::System::Registry::{
         RegCloseKey, RegOpenKeyExW, HKEY, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE,
@@ -380,7 +380,7 @@ fn open_windows_user_root_registry_store() -> Result<
     let store = unsafe {
         CertOpenStore(
             CERT_STORE_PROV_REG,
-            0,
+            CERT_QUERY_ENCODING_TYPE(0),
             None,
             CERT_OPEN_STORE_FLAGS(0),
             Some(key.0 as *const std::ffi::c_void),

--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -46,7 +46,11 @@ struct Check {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Repair {
     AddToPath(PathBuf),
-    MigrateConfig { path: PathBuf },
+    MigrateConfig {
+        path: PathBuf,
+    },
+    #[cfg(windows)]
+    RemoveClaudeDesktopCa,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -88,6 +92,8 @@ fn parse_args(args: &[String]) -> Result<DoctorOptions, String> {
 
 fn run_checks() -> Vec<Check> {
     let mut checks = vec![check_pentect_binary(), check_path()];
+    #[cfg(windows)]
+    checks.push(check_claude_desktop_ca());
     checks.extend(check_configs());
     checks.extend([
         check_memory_store(),
@@ -97,6 +103,19 @@ fn run_checks() -> Vec<Check> {
         check_command("claude"),
     ]);
     checks
+}
+
+#[cfg(windows)]
+fn check_claude_desktop_ca() -> Check {
+    match crate::claude_app_proxy::windows_ca_cleanup_pending() {
+        Ok(false) => Check::ok("claude-app-ca", "no stale temporary certificate"),
+        Ok(true) => Check::repairable_warn(
+            "claude-app-ca",
+            "a previous Claude Desktop session left a temporary certificate",
+            Repair::RemoveClaudeDesktopCa,
+        ),
+        Err(error) => Check::warn("claude-app-ca", error),
+    }
 }
 
 fn check_pentect_binary() -> Check {
@@ -474,6 +493,10 @@ impl Repair {
                 "back up '{}' and migrate its removed setting names",
                 path.display()
             ),
+            #[cfg(windows)]
+            Self::RemoveClaudeDesktopCa => {
+                "remove the stale temporary Claude Desktop certificate".to_string()
+            }
         }
     }
 
@@ -481,6 +504,11 @@ impl Repair {
         match self {
             Self::AddToPath(directory) => add_to_user_path(directory),
             Self::MigrateConfig { path } => migrate_config_file(path),
+            #[cfg(windows)]
+            Self::RemoveClaudeDesktopCa => {
+                crate::claude_app_proxy::cleanup_stale_windows_user_ca()?;
+                Ok("removed the stale temporary Claude Desktop certificate".to_string())
+            }
         }
     }
 }

--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -98,7 +98,9 @@ the Pentect process, and Pentect removes the certificate when Claude Desktop
 exits. If Pentect or Claude crashes, the next `pentect claude app` launch
 removes the stale certificate before doing anything else; `pentect doctor
 --fix` can also remove it. Declining makes no trust-store change. Use `--yes`
-only in reviewed automation.
+only to skip Pentect's own prompt. Windows can still show its security
+confirmation for the Root store; Pentect does not bypass it, so this launch
+path is not suitable for unattended automation.
 :::
 
 Desktop protection affects only the launch started by Pentect. Test app

--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -91,14 +91,14 @@ credentials, and troubleshooting.
 
 ## Claude Desktop
 
-::: danger
-Claude Desktop `1.34493.1` on Windows rejects the certificate-pin switch that
-Pentect requires for its ephemeral local CA, so that build cannot be protected
-with `pentect claude app`. Pentect will not bypass certificate verification or
-install a system CA. Version `1.24012.9` is an older observed-compatible point,
-not a guaranteed version ceiling. Use `pentect claude` for Claude Code and see
-the [compatibility matrix](/reference/compatibility/#desktop-testing) before
-using Desktop mode.
+::: warning
+On Windows, `pentect claude app` asks before adding a session-specific public
+CA certificate to the current user's trust store. Its private key remains in
+the Pentect process, and Pentect removes the certificate when Claude Desktop
+exits. If Pentect or Claude crashes, the next `pentect claude app` launch
+removes the stale certificate before doing anything else; `pentect doctor
+--fix` can also remove it. Declining makes no trust-store change. Use `--yes`
+only in reviewed automation.
 :::
 
 Desktop protection affects only the launch started by Pentect. Test app
@@ -107,6 +107,7 @@ discovery first. If Pentect cannot find the app, pass its path:
 ```sh
 pentect claude app --check
 pentect claude app --app /path/to/claude
+pentect claude app
 ```
 
 Run `pentect log` in another terminal and test with a fake secret. Check that it

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -63,6 +63,11 @@ launched client process. Use `--plugins SOURCE` to add a plugin for one launch.
 App commands also support
 `--app PATH` and `--check`.
 
+On Windows, `pentect claude app` separately confirms the session-only
+current-user certificate needed for Claude Desktop HTTPS protection. Its
+`--yes` option skips that prompt in reviewed automation; it does not make the
+certificate permanent or machine-wide.
+
 Codex and Claude arguments are forwarded directly:
 
 ```sh

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -65,8 +65,8 @@ App commands also support
 
 On Windows, `pentect claude app` separately confirms the session-only
 current-user certificate needed for Claude Desktop HTTPS protection. Its
-`--yes` option skips that prompt in reviewed automation; it does not make the
-certificate permanent or machine-wide.
+`--yes` option skips Pentect's prompt; it does not bypass a Windows Root-store
+security confirmation, or make the certificate permanent or machine-wide.
 
 Codex and Claude arguments are forwarded directly:
 

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -15,7 +15,7 @@ drift is visible before the next release.
 | OpenCode `1.18.20` | Real launch on Linux and all installer platforms | `pentect opencode` |
 | Pi `0.84.2` | Real launch, npm extension, and provider discovery | `pentect pi` or `@pentect/pi` |
 | ChatGPT desktop app, Codex mode | Executable launch contract and Responses protocol tests | `pentect codex app` |
-| Claude Desktop | Protocol tests; `1.24012.9` was manually launch-tested, while `1.34493.1` is known incompatible | `pentect claude app` only on an explicitly compatible build |
+| Claude Desktop | Protocol tests; Windows current-user trust-store launch path awaiting real-account release verification | `pentect claude app` with explicit certificate confirmation |
 
 ## Not implemented
 
@@ -90,14 +90,14 @@ that local handles are not printed.
 | Claude Desktop | Protocol support exists, but current build compatibility is restricted as described below |
 | Other app modes | Not claimed unless listed here |
 
-Claude Desktop `1.34493.1` on Windows deliberately rejects the Chromium
-certificate-pin switch required by Pentect's ephemeral local CA. Pentect does
-not weaken certificate verification or install that CA into the system trust
-store, so this build cannot use `pentect claude app`. Claude Desktop
-`1.24012.9` is an observed compatible point from a manual smoke test, not a
-guaranteed version range. Do not update or downgrade solely from an inferred
-range; check this page for an explicitly tested build. Use `pentect claude` for
-Claude Code.
+Current Claude Desktop builds on Windows reject Chromium's certificate-pin
+switch. Pentect instead asks before installing a session-specific public CA in
+the current user's trust store, launches Claude with its local proxy setting,
+and removes the certificate on exit. The CA private key stays process-local.
+Crash residue is journaled and removed before the next protected launch. This
+path still requires a real-account release verification before it is listed as
+fully supported; use `pentect claude` for Claude Code when Desktop coverage is
+not acceptable.
 
 ## Not covered
 

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -94,6 +94,8 @@ Current Claude Desktop builds on Windows reject Chromium's certificate-pin
 switch. Pentect instead asks before installing a session-specific public CA in
 the current user's trust store, launches Claude with its local proxy setting,
 and removes the certificate on exit. The CA private key stays process-local.
+Windows may also show its own Root-store security confirmation, which Pentect
+does not suppress or bypass.
 Crash residue is journaled and removed before the next protected launch. This
 path still requires a real-account release verification before it is listed as
 fully supported; use `pentect claude` for Claude Code when Desktop coverage is


### PR DESCRIPTION
## Summary

- ask for explicit consent when `pentect claude app` needs a temporary Windows current-user trust anchor
- keep the CA private key process-local and install only the public certificate
- remove Chromium certificate-bypass arguments on Windows while retaining the local proxy
- remove the certificate on normal exit, launch failure, and Ctrl+C
- journal crash residue and clean it on the next protected launch or through `pentect doctor --fix`
- add a Windows CI test that performs an actual CurrentUser Root add/query/delete round trip
- document the prompt, `--yes` automation path, cleanup behavior, and current verification status

Addresses #352

## Local verification

- `cargo check -p pentect-cli --no-default-features`
- `cargo test -p pentect-cli --no-default-features claude_app_proxy::tests -- --skip windows_user_ca_round_trip`
- `cargo clippy -p pentect-cli --no-default-features --all-targets -- -D warnings`

The real Windows certificate-store round trip is intentionally executed only by the Windows GitHub Actions job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows support for securely launching Claude Desktop with a temporary, session-specific certificate.
  * Added consent prompts and a `--yes` option for approved automation workflows.
  * Added automatic cleanup and crash recovery for temporary certificates.
  * Added diagnostic and repair options for removing leftover certificates.

* **Bug Fixes**
  * Improved certificate cleanup after interrupted or completed sessions.

* **Documentation**
  * Updated Windows setup, compatibility, testing, and command-line guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->