### PR TITLE
perf: remove vendored OpenSSL from the masking engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +36,31 @@ dependencies = [
  "cfg-if",
  "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2b8006a0c83f52b62ba44a97b58bf76fe2f70a329e588f67f89691d93d498f"
+dependencies = [
+ "aead",
+ "aes 0.9.2",
+ "cipher 0.5.2",
+ "ctr",
+ "ctutils",
+ "ghash",
 ]
 
 [[package]]
@@ -183,6 +218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +328,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -424,6 +483,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cms"
+version = "0.3.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758d5272932ff167e96ec9641a04d96ab1901cccc5ea9f47c15b4cbaa6f9ea53"
+dependencies = [
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "spki 0.8.0",
+ "x509-cert",
+]
+
+[[package]]
 name = "codepage-437"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +538,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +568,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -560,6 +649,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +678,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -600,6 +712,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +732,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,7 +749,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -681,7 +811,20 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -697,6 +840,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -717,6 +871,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +888,18 @@ dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -795,7 +970,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -808,7 +983,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -924,6 +1099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flatbuffers"
 version = "24.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,21 +1156,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1113,6 +1279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1358,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
@@ -1269,7 +1450,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1565,7 +1755,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -1575,6 +1765,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding 0.4.2",
  "hybrid-array",
 ]
 
@@ -1818,9 +2009,9 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "bitflags 2.13.0",
- "cbc",
+ "cbc 0.1.2",
  "ecb",
  "encoding_rs",
  "flate2",
@@ -1832,7 +2023,7 @@ dependencies = [
  "nom 8.0.0",
  "rand 0.10.1",
  "rangemap",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
  "thiserror 2.0.18",
  "ttf-parser",
@@ -1868,7 +2059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2226,56 +2417,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
+name = "p12-keystore"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+checksum = "02686a966a6d270eb3e87178c70323a30a62741e59b37e542ff029fb774afa47"
 dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
+ "cbc 0.2.1",
+ "cms",
+ "der 0.8.1",
+ "des",
+ "hex",
+ "hmac 0.13.0",
+ "pkcs12",
+ "pkcs5",
+ "pkcs8 0.11.0",
+ "rand 0.10.1",
+ "rc2",
+ "sha1",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "x509-parser",
 ]
 
 [[package]]
@@ -2308,6 +2475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "pdf-extract"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,6 +2499,15 @@ dependencies = [
  "postscript",
  "type1-encoding-parser",
  "unicode-normalization",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2350,7 +2536,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sysinfo",
  "tokio",
  "tokio-rustls",
@@ -2371,20 +2557,26 @@ dependencies = [
  "bip39",
  "bs58",
  "chacha20",
+ "crypto-bigint",
+ "crypto-primes",
  "data-encoding",
  "fancy-regex",
  "flate2",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "memchr",
- "openssl",
+ "num-bigint",
+ "p12-keystore",
+ "pkcs1",
+ "pkcs8 0.11.0",
  "proptest",
  "prost",
  "regex",
+ "sec1",
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "toml",
  "tract-onnx",
@@ -2405,7 +2597,7 @@ dependencies = [
  "flate2",
  "getrandom 0.2.17",
  "hickory-resolver",
- "hmac",
+ "hmac 0.12.1",
  "image",
  "jiff",
  "libc",
@@ -2420,7 +2612,7 @@ dependencies = [
  "rxing",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "simd-json",
  "tokio",
  "toml",
@@ -2445,13 +2637,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
+]
+
+[[package]]
+name = "pkcs12"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8059bd79345d1d1c125656025814704bab5cdd204b1cefd5fab59b0fdd7476d2"
+dependencies = [
+ "cms",
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "digest 0.11.3",
+ "spki 0.8.0",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes 0.9.2",
+ "aes-gcm",
+ "cbc 0.2.1",
+ "der 0.8.1",
+ "pbkdf2",
+ "scrypt",
+ "sha2 0.11.0",
+ "spki 0.8.0",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2471,6 +2714,17 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2868,6 +3122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceda21af1ae61033b63175653a1af86cae399d79cd03ca80ba347eb3a6c4a7fe"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3261,6 +3524,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,6 +3565,30 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct",
+ "der 0.8.1",
+ "hybrid-array",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -3400,6 +3697,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,6 +3718,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,7 +3736,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3427,7 +3756,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -3543,7 +3872,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -4247,6 +4586,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4304,12 +4653,6 @@ dependencies = [
  "itoa",
  "ryu",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -5036,6 +5379,17 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-cert"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
+dependencies = [
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "spki 0.8.0",
+]
 
 [[package]]
 name = "x509-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,13 @@ hmac = "0.12"
 zeroize = "1"
 unicode-normalization = "0.1"
 data-encoding = "2"
-openssl = { version = "0.10.81", features = ["vendored"] }
+crypto-bigint = { version = "0.7.5", features = ["alloc"] }
+crypto-primes = "0.7.2"
+p12-keystore = "0.3.1"
+pkcs1 = { version = "0.8.0-rc.4", features = ["std"] }
+pkcs8 = { version = "0.11", features = ["std"] }
+num-bigint = "0.4"
+sec1 = "0.8"
 chacha20 = "0.10.1"
 bs58 = "0.5"
 bip39 = { version = "2.2.2", features = ["all-languages"] }

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -37,7 +37,7 @@ Pentect currently uses the upstream crate without source modifications.
 CARGO PACKAGES
 --------------
 
-499 non-workspace release dependency packages are covered below.
+532 non-workspace release dependency packages are covered below.
 Package labels show the license expression declared in Cargo metadata.
 
 DOCUMENT 1
@@ -395,33 +395,64 @@ SOFTWARE.
 DOCUMENT 5
 ~~~~~~~~~~
 Applies to:
+- aead 0.6.1 (MIT OR Apache-2.0)
 - aes 0.8.4 (MIT OR Apache-2.0)
+- aes 0.9.2 (MIT OR Apache-2.0)
+- aes-gcm 0.11.1 (Apache-2.0 OR MIT)
+- base16ct 1.0.0 (Apache-2.0 OR MIT)
 - base64ct 1.8.3 (Apache-2.0 OR MIT)
 - block-buffer 0.10.4 (MIT OR Apache-2.0)
 - block-buffer 0.12.1 (MIT OR Apache-2.0)
 - block-padding 0.3.3 (MIT OR Apache-2.0)
+- block-padding 0.4.2 (MIT OR Apache-2.0)
 - cbc 0.1.2 (MIT OR Apache-2.0)
+- cbc 0.2.1 (MIT OR Apache-2.0)
 - chacha20 0.10.1 (MIT OR Apache-2.0)
 - cipher 0.4.4 (MIT OR Apache-2.0)
 - cipher 0.5.2 (MIT OR Apache-2.0)
+- cms 0.3.0-pre.1 (Apache-2.0 OR MIT)
+- const-oid 0.10.2 (Apache-2.0 OR MIT)
 - const-oid 0.9.6 (Apache-2.0 OR MIT)
+- cpubits 0.1.1 (MIT OR Apache-2.0)
 - cpufeatures 0.2.17 (MIT OR Apache-2.0)
 - cpufeatures 0.3.0 (MIT OR Apache-2.0)
+- crypto-bigint 0.7.5 (Apache-2.0 OR MIT)
 - crypto-common 0.1.7 (MIT OR Apache-2.0)
 - crypto-common 0.2.2 (MIT OR Apache-2.0)
+- ctr 0.10.1 (MIT OR Apache-2.0)
 - der 0.7.10 (Apache-2.0 OR MIT)
+- der 0.8.1 (Apache-2.0 OR MIT)
+- der_derive 0.8.0 (Apache-2.0 OR MIT)
 - digest 0.10.7 (MIT OR Apache-2.0)
+- digest 0.11.3 (MIT OR Apache-2.0)
+- ghash 0.6.0 (Apache-2.0 OR MIT)
 - hmac 0.12.1 (MIT OR Apache-2.0)
+- hmac 0.13.0 (MIT OR Apache-2.0)
 - hybrid-array 0.4.13 (MIT OR Apache-2.0)
 - inout 0.1.4 (MIT OR Apache-2.0)
 - inout 0.2.2 (MIT OR Apache-2.0)
 - keccak 0.1.6 (Apache-2.0 OR MIT)
 - md-5 0.10.6 (MIT OR Apache-2.0)
+- pbkdf2 0.13.0 (MIT OR Apache-2.0)
+- pem-rfc7468 1.0.0 (Apache-2.0 OR MIT)
+- pkcs1 0.8.0-rc.4 (Apache-2.0 OR MIT)
+- pkcs12 0.2.0-pre.0 (Apache-2.0 OR MIT)
+- pkcs5 0.8.1 (Apache-2.0 OR MIT)
 - pkcs8 0.10.2 (Apache-2.0 OR MIT)
+- pkcs8 0.11.0 (Apache-2.0 OR MIT)
+- polyval 0.7.3 (Apache-2.0 OR MIT)
+- salsa20 0.11.0 (MIT OR Apache-2.0)
+- scrypt 0.12.0 (MIT OR Apache-2.0)
+- sec1 0.8.1 (Apache-2.0 OR MIT)
+- sha1 0.11.0 (MIT OR Apache-2.0)
 - sha2 0.10.9 (MIT OR Apache-2.0)
+- sha2 0.11.0 (MIT OR Apache-2.0)
 - sha3 0.10.9 (MIT OR Apache-2.0)
 - signature 2.2.0 (Apache-2.0 OR MIT)
 - spki 0.7.3 (Apache-2.0 OR MIT)
+- spki 0.8.0 (Apache-2.0 OR MIT)
+- universal-hash 0.6.1 (MIT OR Apache-2.0)
+- x509-cert 0.3.0 (Apache-2.0 OR MIT)
 
 Apache License
                         Version 2.0, January 2004
@@ -629,9 +660,10 @@ limitations under the License.
 DOCUMENT 6
 ~~~~~~~~~~
 Applies to:
-- aes 0.8.4 (MIT OR Apache-2.0)
+- aead 0.6.1 (MIT OR Apache-2.0)
 
-Copyright (c) 2018 Artyom Pavlov
+Copyright (c) 2019-2026 The RustCrypto Project Developers
+Copyright (c) 2019 MobileCoin, LLC
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -661,6 +693,106 @@ DEALINGS IN THE SOFTWARE.
 DOCUMENT 7
 ~~~~~~~~~~
 Applies to:
+- aes 0.8.4 (MIT OR Apache-2.0)
+
+Copyright (c) 2018 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 8
+~~~~~~~~~~
+Applies to:
+- aes 0.9.2 (MIT OR Apache-2.0)
+
+Copyright (c) 2018-2024 The RustCrypto Project Developers
+Copyright (c) 2018 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 9
+~~~~~~~~~~
+Applies to:
+- aes-gcm 0.11.1 (Apache-2.0 OR MIT)
+- chacha20 0.10.1 (MIT OR Apache-2.0)
+- ghash 0.6.0 (Apache-2.0 OR MIT)
+- polyval 0.7.3 (Apache-2.0 OR MIT)
+
+Copyright (c) 2019-2026 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 10
+~~~~~~~~~~~
+Applies to:
 - aho-corasick 1.1.4 (Unlicense OR MIT)
 - byteorder 1.5.0 (Unlicense OR MIT)
 - csv 1.4.0 (Unlicense/MIT)
@@ -679,8 +811,8 @@ This project is dual-licensed under the Unlicense and MIT licenses.
 You may use this code under the terms of either license.
 
 
-DOCUMENT 8
-~~~~~~~~~~
+DOCUMENT 11
+~~~~~~~~~~~
 Applies to:
 - aho-corasick 1.1.4 (Unlicense OR MIT)
 - byteorder 1.5.0 (Unlicense OR MIT)
@@ -717,8 +849,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 9
-~~~~~~~~~~
+DOCUMENT 12
+~~~~~~~~~~~
 Applies to:
 - Alcatraz 0.20.2 bundled PII helper (MIT)
 
@@ -745,7 +877,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 10
+DOCUMENT 13
 ~~~~~~~~~~~
 Applies to:
 - allocator-api2 0.2.21 (MIT OR Apache-2.0)
@@ -962,7 +1094,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 11
+DOCUMENT 14
 ~~~~~~~~~~~
 Applies to:
 - android_system_properties 0.1.5 (MIT/Apache-2.0)
@@ -982,7 +1114,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 12
+DOCUMENT 15
 ~~~~~~~~~~~
 Applies to:
 - android_system_properties 0.1.5 (MIT/Apache-2.0)
@@ -1009,7 +1141,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 13
+DOCUMENT 16
 ~~~~~~~~~~~
 Applies to:
 - anstream 0.6.21 (MIT OR Apache-2.0)
@@ -1020,13 +1152,10 @@ Applies to:
 - colorchoice 1.0.5 (MIT OR Apache-2.0)
 - crc32fast 1.5.0 (MIT OR Apache-2.0)
 - float-ord 0.3.2 (MIT / Apache-2.0)
-- foreign-types 0.3.2 (MIT/Apache-2.0)
-- foreign-types-shared 0.1.1 (MIT/Apache-2.0)
+- hex 0.4.3 (MIT OR Apache-2.0)
 - is_terminal_polyfill 1.70.2 (MIT OR Apache-2.0)
 - jni-sys 0.4.1 (MIT OR Apache-2.0)
 - once_cell_polyfill 1.70.2 (MIT OR Apache-2.0)
-- openssl 0.10.81 (Apache-2.0)
-- openssl-macros 0.1.1 (MIT/Apache-2.0)
 - quick-error 2.0.1 (MIT/Apache-2.0)
 - resolv-conf 0.7.6 (MIT OR Apache-2.0)
 - rustfft 6.4.1 (MIT OR Apache-2.0)
@@ -1242,7 +1371,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 14
+DOCUMENT 17
 ~~~~~~~~~~~
 Applies to:
 - anstream 0.6.21 (MIT OR Apache-2.0)
@@ -1280,7 +1409,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 15
+DOCUMENT 18
 ~~~~~~~~~~~
 Applies to:
 - anymap3 1.1.0 (BlueOak-1.0.0 OR MIT OR Apache-2.0)
@@ -1304,7 +1433,7 @@ When using this code, ensure you comply with the terms of at least one of
 these licenses.
 
 
-DOCUMENT 16
+DOCUMENT 19
 ~~~~~~~~~~~
 Applies to:
 - arrayvec 0.7.7 (MIT OR Apache-2.0)
@@ -1376,7 +1505,6 @@ Applies to:
 - oid-registry 0.8.1 (MIT OR Apache-2.0)
 - once_cell 1.21.4 (MIT OR Apache-2.0)
 - openssl-probe 0.2.1 (MIT OR Apache-2.0)
-- openssl-src 300.6.1+3.6.3 (MIT/Apache-2.0)
 - parking_lot 0.12.5 (MIT OR Apache-2.0)
 - parking_lot_core 0.9.12 (MIT OR Apache-2.0)
 - percent-encoding 2.3.2 (MIT OR Apache-2.0)
@@ -1424,7 +1552,6 @@ Applies to:
 - unicode-xid 0.2.6 (MIT OR Apache-2.0)
 - url 2.5.8 (MIT OR Apache-2.0)
 - uuid 1.24.0 (Apache-2.0 OR MIT)
-- vcpkg 0.2.15 (MIT/Apache-2.0)
 - version_check 0.9.5 (MIT/Apache-2.0)
 - wasi 0.11.1+wasi-snapshot-preview1 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
 - wasip2 1.0.3+wasi-0.2.9 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -1647,7 +1774,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 17
+DOCUMENT 20
 ~~~~~~~~~~~
 Applies to:
 - arrayvec 0.7.7 (MIT OR Apache-2.0)
@@ -1679,7 +1806,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 18
+DOCUMENT 21
 ~~~~~~~~~~~
 Applies to:
 - asn1-rs 0.7.2 (MIT OR Apache-2.0)
@@ -1716,7 +1843,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 19
+DOCUMENT 22
 ~~~~~~~~~~~
 Applies to:
 - asn1-rs-impl 0.2.0 (MIT/Apache-2.0)
@@ -1748,7 +1875,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 20
+DOCUMENT 23
 ~~~~~~~~~~~
 Applies to:
 - atomic-waker 1.1.2 (Apache-2.0 OR MIT)
@@ -1800,7 +1927,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 21
+DOCUMENT 24
 ~~~~~~~~~~~
 Applies to:
 - autocfg 1.5.1 (Apache-2.0 OR MIT)
@@ -1832,7 +1959,40 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 22
+DOCUMENT 25
+~~~~~~~~~~~
+Applies to:
+- base16ct 1.0.0 (Apache-2.0 OR MIT)
+
+Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
+Copyright (c) 2022-2025 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 26
 ~~~~~~~~~~~
 Applies to:
 - base64 0.22.1 (MIT OR Apache-2.0)
@@ -1860,7 +2020,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 23
+DOCUMENT 27
 ~~~~~~~~~~~
 Applies to:
 - base64ct 1.8.3 (Apache-2.0 OR MIT)
@@ -1893,7 +2053,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 24
+DOCUMENT 28
 ~~~~~~~~~~~
 Applies to:
 - bip39 2.2.2 (CC0-1.0)
@@ -2022,7 +2182,7 @@ express Statement of Purpose.
     this CC0 or use of the Work.
 
 
-DOCUMENT 25
+DOCUMENT 29
 ~~~~~~~~~~~
 Applies to:
 - bit-set 0.10.0 (Apache-2.0 OR MIT)
@@ -2239,7 +2399,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 26
+DOCUMENT 30
 ~~~~~~~~~~~
 Applies to:
 - bit-set 0.10.0 (Apache-2.0 OR MIT)
@@ -2271,7 +2431,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 27
+DOCUMENT 31
 ~~~~~~~~~~~
 Applies to:
 - bit-set 0.8.0 (Apache-2.0 OR MIT)
@@ -2305,7 +2465,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 28
+DOCUMENT 32
 ~~~~~~~~~~~
 Applies to:
 - bitcoin_hashes 0.14.101 (CC0-1.0)
@@ -2318,7 +2478,7 @@ This package is dedicated under Creative Commons CC0 1.0 Universal.
 Legal code: https://creativecommons.org/publicdomain/zero/1.0/legalcode
 
 
-DOCUMENT 29
+DOCUMENT 33
 ~~~~~~~~~~~
 Applies to:
 - bitflags 1.3.2 (MIT/Apache-2.0)
@@ -2362,7 +2522,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 30
+DOCUMENT 34
 ~~~~~~~~~~~
 Applies to:
 - block-buffer 0.10.4 (MIT OR Apache-2.0)
@@ -2395,10 +2555,11 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 31
+DOCUMENT 35
 ~~~~~~~~~~~
 Applies to:
 - block-buffer 0.12.1 (MIT OR Apache-2.0)
+- block-padding 0.4.2 (MIT OR Apache-2.0)
 
 Copyright (c) 2018-2025 The RustCrypto Project Developers
 
@@ -2427,7 +2588,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 32
+DOCUMENT 36
 ~~~~~~~~~~~
 Applies to:
 - block2 0.6.2 (MIT)
@@ -2459,7 +2620,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 33
+DOCUMENT 37
 ~~~~~~~~~~~
 Applies to:
 - bs58 0.5.1 (MIT/Apache-2.0)
@@ -2486,7 +2647,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 34
+DOCUMENT 38
 ~~~~~~~~~~~
 Applies to:
 - bumpalo 3.20.3 (MIT OR Apache-2.0)
@@ -2518,7 +2679,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 35
+DOCUMENT 39
 ~~~~~~~~~~~
 Applies to:
 - bytemuck 1.25.0 (Zlib OR Apache-2.0 OR MIT)
@@ -2586,7 +2747,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 36
+DOCUMENT 40
 ~~~~~~~~~~~
 Applies to:
 - bytemuck 1.25.0 (Zlib OR Apache-2.0 OR MIT)
@@ -2602,7 +2763,7 @@ The above copyright notice and this permission notice (including the next paragr
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 37
+DOCUMENT 41
 ~~~~~~~~~~~
 Applies to:
 - bytemuck 1.25.0 (Zlib OR Apache-2.0 OR MIT)
@@ -2621,7 +2782,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 38
+DOCUMENT 42
 ~~~~~~~~~~~
 Applies to:
 - bytes 1.12.0 (MIT)
@@ -2653,10 +2814,12 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 39
+DOCUMENT 43
 ~~~~~~~~~~~
 Applies to:
 - cbc 0.1.2 (MIT OR Apache-2.0)
+- cbc 0.2.1 (MIT OR Apache-2.0)
+- ctr 0.10.1 (MIT OR Apache-2.0)
 
 Copyright (c) 2018-2022 RustCrypto Developers
 Copyright (c) 2018 Artyom Pavlov
@@ -2686,7 +2849,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 40
+DOCUMENT 44
 ~~~~~~~~~~~
 Applies to:
 - cc 1.2.65 (MIT OR Apache-2.0)
@@ -2697,8 +2860,6 @@ Applies to:
 - jobserver 0.1.35 (MIT OR Apache-2.0)
 - js-sys 0.3.103 (MIT OR Apache-2.0)
 - openssl-probe 0.2.1 (MIT OR Apache-2.0)
-- openssl-src 300.6.1+3.6.3 (MIT/Apache-2.0)
-- openssl-sys 0.9.117 (MIT)
 - pkg-config 0.3.34 (MIT OR Apache-2.0)
 - socket2 0.6.4 (MIT OR Apache-2.0)
 - wasm-bindgen 0.2.126 (MIT OR Apache-2.0)
@@ -2735,7 +2896,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 41
+DOCUMENT 45
 ~~~~~~~~~~~
 Applies to:
 - cff-parser 0.2.0 (MIT OR Apache-2.0)
@@ -2762,7 +2923,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 42
+DOCUMENT 46
 ~~~~~~~~~~~
 Applies to:
 - cfg_aliases 0.1.1 (MIT)
@@ -2779,7 +2940,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 43
+DOCUMENT 47
 ~~~~~~~~~~~
 Applies to:
 - cfg_aliases 0.1.1 (MIT)
@@ -2813,39 +2974,7 @@ The `cfg_aliases!` macro uses a lot of the code from [`tectonic_cfg_support::tar
 ---
 
 
-DOCUMENT 44
-~~~~~~~~~~~
-Applies to:
-- chacha20 0.10.1 (MIT OR Apache-2.0)
-
-Copyright (c) 2019-2026 The RustCrypto Project Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-
-DOCUMENT 45
+DOCUMENT 48
 ~~~~~~~~~~~
 Applies to:
 - chrono 0.4.45 (MIT OR Apache-2.0)
@@ -3091,7 +3220,7 @@ limitations under the License.
 ~~~~
 
 
-DOCUMENT 46
+DOCUMENT 49
 ~~~~~~~~~~~
 Applies to:
 - cipher 0.4.4 (MIT OR Apache-2.0)
@@ -3123,7 +3252,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 47
+DOCUMENT 50
 ~~~~~~~~~~~
 Applies to:
 - cipher 0.5.2 (MIT OR Apache-2.0)
@@ -3155,7 +3284,303 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 48
+DOCUMENT 51
+~~~~~~~~~~~
+Applies to:
+- cmov 0.5.4 (Apache-2.0 OR MIT)
+- crypto-primes 0.7.2 (Apache-2.0 OR MIT)
+- ctutils 0.4.2 (Apache-2.0 OR MIT)
+- encoding_rs 0.8.35 ((Apache-2.0 OR MIT) AND BSD-3-Clause)
+- flagset 0.4.7 (Apache-2.0)
+- halfbrown 0.4.0 (Apache-2.0/MIT)
+- lru-slab 0.1.2 (MIT OR Apache-2.0 OR Zlib)
+- ntapi 0.4.3 (Apache-2.0 OR MIT)
+- quinn 0.11.11 (MIT OR Apache-2.0)
+- quinn-proto 0.11.16 (MIT OR Apache-2.0)
+- quinn-udp 0.5.15 (MIT OR Apache-2.0)
+- rxing-one-d-proc-derive 0.9.0 (Apache-2.0)
+- safetensors 0.7.0 (Apache-2.0)
+- serdect 0.4.3 (Apache-2.0 OR MIT)
+- simd-json 0.17.0 (Apache-2.0 OR MIT)
+- tinyvec 1.11.0 (Zlib OR Apache-2.0 OR MIT)
+- utf8_iter 1.0.4 (Apache-2.0 OR MIT)
+- value-trait 0.12.1 (Apache-2.0/MIT)
+- zeroize 1.8.2 (Apache-2.0 OR MIT)
+- zune-core 0.5.1 (MIT OR Apache-2.0 OR Zlib)
+- zune-jpeg 0.5.15 (MIT OR Apache-2.0 OR Zlib)
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+DOCUMENT 52
+~~~~~~~~~~~
+Applies to:
+- cmov 0.5.4 (Apache-2.0 OR MIT)
+- hybrid-array 0.4.13 (MIT OR Apache-2.0)
+
+Copyright (c) 2022-2026 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 53
+~~~~~~~~~~~
+Applies to:
+- cms 0.3.0-pre.1 (Apache-2.0 OR MIT)
+- cpufeatures 0.2.17 (MIT OR Apache-2.0)
+- cpufeatures 0.3.0 (MIT OR Apache-2.0)
+- der_derive 0.8.0 (Apache-2.0 OR MIT)
+
+Copyright (c) 2020-2025 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 54
 ~~~~~~~~~~~
 Applies to:
 - codepage-437 0.1.0 (MIT)
@@ -3183,7 +3608,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 49
+DOCUMENT 55
 ~~~~~~~~~~~
 Applies to:
 - color_quant 1.1.0 (MIT)
@@ -3211,7 +3636,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 50
+DOCUMENT 56
 ~~~~~~~~~~~
 Applies to:
 - combine 4.6.7 (MIT)
@@ -3239,7 +3664,41 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 51
+DOCUMENT 57
+~~~~~~~~~~~
+Applies to:
+- const-oid 0.10.2 (Apache-2.0 OR MIT)
+- der 0.8.1 (Apache-2.0 OR MIT)
+- pkcs8 0.11.0 (Apache-2.0 OR MIT)
+
+Copyright (c) 2020-2026 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 58
 ~~~~~~~~~~~
 Applies to:
 - const-oid 0.9.6 (Apache-2.0 OR MIT)
@@ -3271,7 +3730,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 52
+DOCUMENT 59
 ~~~~~~~~~~~
 Applies to:
 - core-foundation 0.10.1 (MIT OR Apache-2.0)
@@ -3306,13 +3765,12 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 53
+DOCUMENT 60
 ~~~~~~~~~~~
 Applies to:
-- cpufeatures 0.2.17 (MIT OR Apache-2.0)
-- cpufeatures 0.3.0 (MIT OR Apache-2.0)
+- cpubits 0.1.1 (MIT OR Apache-2.0)
 
-Copyright (c) 2020-2025 The RustCrypto Project Developers
+Copyright (c) 2023-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -3339,7 +3797,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 54
+DOCUMENT 61
 ~~~~~~~~~~~
 Applies to:
 - crc32fast 1.5.0 (MIT OR Apache-2.0)
@@ -3367,7 +3825,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 55
+DOCUMENT 62
 ~~~~~~~~~~~
 Applies to:
 - CredSweeper v1.17.4 detection assets (MIT)
@@ -3393,7 +3851,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 56
+DOCUMENT 63
 ~~~~~~~~~~~
 Applies to:
 - critical-section 1.2.0 (MIT OR Apache-2.0)
@@ -3425,7 +3883,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 57
+DOCUMENT 64
 ~~~~~~~~~~~
 Applies to:
 - crossbeam-channel 0.5.16 (MIT OR Apache-2.0)
@@ -3462,7 +3920,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 58
+DOCUMENT 65
 ~~~~~~~~~~~
 Applies to:
 - crossbeam-channel 0.5.16 (MIT OR Apache-2.0)
@@ -4062,7 +4520,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 59
+DOCUMENT 66
 ~~~~~~~~~~~
 Applies to:
 - crunchy 0.2.4 (MIT)
@@ -4090,7 +4548,43 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 60
+DOCUMENT 67
+~~~~~~~~~~~
+Applies to:
+- crypto-bigint 0.7.5 (Apache-2.0 OR MIT)
+- pkcs5 0.8.1 (Apache-2.0 OR MIT)
+- scrypt 0.12.0 (MIT OR Apache-2.0)
+- sec1 0.8.1 (Apache-2.0 OR MIT)
+- spki 0.8.0 (Apache-2.0 OR MIT)
+
+Copyright (c) 2021-2026 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 68
 ~~~~~~~~~~~
 Applies to:
 - crypto-common 0.1.7 (MIT OR Apache-2.0)
@@ -4122,7 +4616,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 61
+DOCUMENT 69
 ~~~~~~~~~~~
 Applies to:
 - crypto-common 0.2.2 (MIT OR Apache-2.0)
@@ -4154,7 +4648,21 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 62
+DOCUMENT 70
+~~~~~~~~~~~
+Applies to:
+- crypto-primes 0.7.2 (Apache-2.0 OR MIT)
+
+Copyright 2022-* Bogdan Opanchuk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 71
 ~~~~~~~~~~~
 Applies to:
 - ctrlc 3.5.2 (MIT/Apache-2.0)
@@ -4362,7 +4870,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 63
+DOCUMENT 72
+~~~~~~~~~~~
+Applies to:
+- ctutils 0.4.2 (Apache-2.0 OR MIT)
+
+Copyright (c) 2025-2026 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 73
 ~~~~~~~~~~~
 Applies to:
 - curve25519-dalek 4.1.3 (BSD-3-Clause)
@@ -4434,7 +4974,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 64
+DOCUMENT 74
 ~~~~~~~~~~~
 Applies to:
 - data-encoding 2.11.0 (MIT)
@@ -4463,7 +5003,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 65
+DOCUMENT 75
 ~~~~~~~~~~~
 Applies to:
 - defmt 1.1.0 (MIT OR Apache-2.0)
@@ -4496,7 +5036,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 66
+DOCUMENT 76
 ~~~~~~~~~~~
 Applies to:
 - defmt-parser 1.0.0 (MIT OR Apache-2.0)
@@ -4528,7 +5068,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 67
+DOCUMENT 77
 ~~~~~~~~~~~
 Applies to:
 - der 0.7.10 (Apache-2.0 OR MIT)
@@ -4561,7 +5101,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 68
+DOCUMENT 78
 ~~~~~~~~~~~
 Applies to:
 - deranged 0.5.8 (MIT OR Apache-2.0)
@@ -4769,7 +5309,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 69
+DOCUMENT 79
 ~~~~~~~~~~~
 Applies to:
 - deranged 0.5.8 (MIT OR Apache-2.0)
@@ -4795,7 +5335,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 70
+DOCUMENT 80
 ~~~~~~~~~~~
 Applies to:
 - derive-new 0.7.0 (MIT)
@@ -4823,11 +5363,253 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 71
+DOCUMENT 81
+~~~~~~~~~~~
+Applies to:
+- des 0.9.0 (MIT OR Apache-2.0)
+
+Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2017 Gulshan Singh
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+DOCUMENT 82
+~~~~~~~~~~~
+Applies to:
+- des 0.9.0 (MIT OR Apache-2.0)
+
+Copyright (c) 2017-2024 The RustCrypto Project Developers
+Copyright (c) 2017 Gulshan Singh, Antoni Boucher, Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 83
 ~~~~~~~~~~~
 Applies to:
 - digest 0.10.7 (MIT OR Apache-2.0)
 - hmac 0.12.1 (MIT OR Apache-2.0)
+- hmac 0.13.0 (MIT OR Apache-2.0)
 
 Copyright (c) 2017 Artyom Pavlov
 
@@ -4856,7 +5638,40 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 72
+DOCUMENT 84
+~~~~~~~~~~~
+Applies to:
+- digest 0.11.3 (MIT OR Apache-2.0)
+
+Copyright (c) 2017-2025 RustCrypto Developers
+Copyright (c) 2017 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 85
 ~~~~~~~~~~~
 Applies to:
 - dispatch2 0.3.1 (Zlib OR Apache-2.0 OR MIT)
@@ -4888,7 +5703,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 73
+DOCUMENT 86
 ~~~~~~~~~~~
 Applies to:
 - downcast-rs 1.2.1 (MIT/Apache-2.0)
@@ -4921,7 +5736,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 74
+DOCUMENT 87
 ~~~~~~~~~~~
 Applies to:
 - dyn-eq 0.1.3 (MPL-2.0)
@@ -5301,7 +6116,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 
 
-DOCUMENT 75
+DOCUMENT 88
 ~~~~~~~~~~~
 Applies to:
 - ecb 0.1.2 (MIT)
@@ -5329,7 +6144,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 76
+DOCUMENT 89
 ~~~~~~~~~~~
 Applies to:
 - ed25519 2.2.3 (Apache-2.0 OR MIT)
@@ -5537,7 +6352,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 77
+DOCUMENT 90
 ~~~~~~~~~~~
 Applies to:
 - ed25519 2.2.3 (Apache-2.0 OR MIT)
@@ -5570,7 +6385,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 78
+DOCUMENT 91
 ~~~~~~~~~~~
 Applies to:
 - ed25519-dalek 2.2.0 (BSD-3-Clause)
@@ -5605,7 +6420,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 79
+DOCUMENT 92
 ~~~~~~~~~~~
 Applies to:
 - either 1.16.0 (MIT OR Apache-2.0)
@@ -5640,7 +6455,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 80
+DOCUMENT 93
 ~~~~~~~~~~~
 Applies to:
 - encoding_rs 0.8.35 ((Apache-2.0 OR MIT) AND BSD-3-Clause)
@@ -5664,230 +6479,7 @@ Test code within encoding_rs is dedicated to the Public Domain when so
 designated (see the individual files for PD/CC0-dedicated sections).
 
 
-DOCUMENT 81
-~~~~~~~~~~~
-Applies to:
-- encoding_rs 0.8.35 ((Apache-2.0 OR MIT) AND BSD-3-Clause)
-- halfbrown 0.4.0 (Apache-2.0/MIT)
-- lru-slab 0.1.2 (MIT OR Apache-2.0 OR Zlib)
-- ntapi 0.4.3 (Apache-2.0 OR MIT)
-- quinn 0.11.11 (MIT OR Apache-2.0)
-- quinn-proto 0.11.16 (MIT OR Apache-2.0)
-- quinn-udp 0.5.15 (MIT OR Apache-2.0)
-- rxing-one-d-proc-derive 0.9.0 (Apache-2.0)
-- safetensors 0.7.0 (Apache-2.0)
-- simd-json 0.17.0 (Apache-2.0 OR MIT)
-- tinyvec 1.11.0 (Zlib OR Apache-2.0 OR MIT)
-- utf8_iter 1.0.4 (Apache-2.0 OR MIT)
-- value-trait 0.12.1 (Apache-2.0/MIT)
-- zeroize 1.8.2 (Apache-2.0 OR MIT)
-- zune-core 0.5.1 (MIT OR Apache-2.0 OR Zlib)
-- zune-jpeg 0.5.15 (MIT OR Apache-2.0 OR Zlib)
-
-Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
-DOCUMENT 82
+DOCUMENT 94
 ~~~~~~~~~~~
 Applies to:
 - encoding_rs 0.8.35 ((Apache-2.0 OR MIT) AND BSD-3-Clause)
@@ -5920,7 +6512,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 83
+DOCUMENT 95
 ~~~~~~~~~~~
 Applies to:
 - encoding_rs 0.8.35 ((Apache-2.0 OR MIT) AND BSD-3-Clause)
@@ -5953,7 +6545,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 84
+DOCUMENT 96
 ~~~~~~~~~~~
 Applies to:
 - equivalent 1.0.2 (Apache-2.0 OR MIT)
@@ -5985,7 +6577,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 85
+DOCUMENT 97
 ~~~~~~~~~~~
 Applies to:
 - errno 0.3.14 (MIT OR Apache-2.0)
@@ -6017,7 +6609,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 86
+DOCUMENT 98
 ~~~~~~~~~~~
 Applies to:
 - euclid 0.20.14 (MIT / Apache-2.0)
@@ -6029,7 +6621,7 @@ option. All files in the project carrying such notice may not be
 copied, modified, or distributed except according to those terms.
 
 
-DOCUMENT 87
+DOCUMENT 99
 ~~~~~~~~~~~
 Applies to:
 - fancy-regex 0.18.0 (MIT)
@@ -6057,8 +6649,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 88
-~~~~~~~~~~~
+DOCUMENT 100
+~~~~~~~~~~~~
 Applies to:
 - fdeflate 0.3.7 (MIT OR Apache-2.0)
 - half 2.7.1 (MIT OR Apache-2.0)
@@ -6256,8 +6848,8 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 89
-~~~~~~~~~~~
+DOCUMENT 101
+~~~~~~~~~~~~
 Applies to:
 - fdeflate 0.3.7 (MIT OR Apache-2.0)
 - image 0.25.10 (MIT OR Apache-2.0)
@@ -6290,8 +6882,8 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 90
-~~~~~~~~~~~
+DOCUMENT 102
+~~~~~~~~~~~~
 Applies to:
 - fiat-crypto 0.2.9 (MIT OR Apache-2.0 OR BSD-1-Clause)
 
@@ -6304,8 +6896,8 @@ the BSD 1-Clause License <LICENSE-BSD-1> or
 <https://spdx.org/licenses/BSD-1-Clause.html>, at your option.
 
 
-DOCUMENT 91
-~~~~~~~~~~~
+DOCUMENT 103
+~~~~~~~~~~~~
 Applies to:
 - fiat-crypto 0.2.9 (MIT OR Apache-2.0 OR BSD-1-Clause)
 
@@ -6326,8 +6918,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 92
-~~~~~~~~~~~
+DOCUMENT 104
+~~~~~~~~~~~~
 Applies to:
 - fiat-crypto 0.2.9 (MIT OR Apache-2.0 OR BSD-1-Clause)
 
@@ -6356,8 +6948,8 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 93
-~~~~~~~~~~~
+DOCUMENT 105
+~~~~~~~~~~~~
 Applies to:
 - fiat-crypto 0.2.9 (MIT OR Apache-2.0 OR BSD-1-Clause)
 
@@ -6384,8 +6976,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 94
-~~~~~~~~~~~
+DOCUMENT 106
+~~~~~~~~~~~~
 Applies to:
 - filedescriptor 0.8.3 (MIT)
 - portable-pty 0.9.0 (MIT)
@@ -6413,8 +7005,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 95
-~~~~~~~~~~~
+DOCUMENT 107
+~~~~~~~~~~~~
 Applies to:
 - flatbuffers 24.12.23 (Apache-2.0)
 
@@ -6581,8 +7173,8 @@ such warranty or additional liability.
 END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 96
-~~~~~~~~~~~
+DOCUMENT 108
+~~~~~~~~~~~~
 Applies to:
 - flate2 1.1.9 (MIT OR Apache-2.0)
 
@@ -6613,8 +7205,8 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 97
-~~~~~~~~~~~
+DOCUMENT 109
+~~~~~~~~~~~~
 Applies to:
 - float-cmp 0.10.0 (MIT)
 
@@ -6639,8 +7231,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 
-DOCUMENT 98
-~~~~~~~~~~~
+DOCUMENT 110
+~~~~~~~~~~~~
 Applies to:
 - float-ord 0.3.2 (MIT / Apache-2.0)
 
@@ -6665,8 +7257,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 99
-~~~~~~~~~~~
+DOCUMENT 111
+~~~~~~~~~~~~
 Applies to:
 - foldhash 0.1.5 (Zlib)
 - foldhash 0.2.0 (Zlib)
@@ -6692,34 +7284,7 @@ the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 100
-~~~~~~~~~~~~
-Applies to:
-- foreign-types 0.3.2 (MIT/Apache-2.0)
-- foreign-types-shared 0.1.1 (MIT/Apache-2.0)
-
-Copyright (c) 2017 The foreign-types Developers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-DOCUMENT 101
+DOCUMENT 112
 ~~~~~~~~~~~~
 Applies to:
 - form_urlencoded 1.2.2 (MIT OR Apache-2.0)
@@ -6751,7 +7316,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 102
+DOCUMENT 113
 ~~~~~~~~~~~~
 Applies to:
 - futures-channel 0.3.32 (MIT OR Apache-2.0)
@@ -6966,7 +7531,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 103
+DOCUMENT 114
 ~~~~~~~~~~~~
 Applies to:
 - futures-channel 0.3.32 (MIT OR Apache-2.0)
@@ -7005,7 +7570,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 104
+DOCUMENT 115
 ~~~~~~~~~~~~
 Applies to:
 - generic-array 0.14.7 (MIT)
@@ -7033,7 +7598,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 105
+DOCUMENT 116
 ~~~~~~~~~~~~
 Applies to:
 - getrandom 0.2.17 (MIT OR Apache-2.0)
@@ -7242,7 +7807,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 106
+DOCUMENT 117
 ~~~~~~~~~~~~
 Applies to:
 - getrandom 0.2.17 (MIT OR Apache-2.0)
@@ -7275,7 +7840,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 107
+DOCUMENT 118
 ~~~~~~~~~~~~
 Applies to:
 - getrandom 0.4.2 (MIT OR Apache-2.0)
@@ -7308,7 +7873,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 108
+DOCUMENT 119
 ~~~~~~~~~~~~
 Applies to:
 - gif 0.14.2 (MIT OR Apache-2.0)
@@ -7336,7 +7901,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 109
+DOCUMENT 120
 ~~~~~~~~~~~~
 Applies to:
 - half 2.7.1 (MIT OR Apache-2.0)
@@ -7364,7 +7929,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 110
+DOCUMENT 121
 ~~~~~~~~~~~~
 Applies to:
 - halfbrown 0.4.0 (Apache-2.0/MIT)
@@ -7394,7 +7959,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 111
+DOCUMENT 122
 ~~~~~~~~~~~~
 Applies to:
 - hashbrown 0.15.5 (MIT OR Apache-2.0)
@@ -7428,7 +7993,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 112
+DOCUMENT 123
 ~~~~~~~~~~~~
 Applies to:
 - heck 0.5.0 (MIT OR Apache-2.0)
@@ -7465,7 +8030,34 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 113
+DOCUMENT 124
+~~~~~~~~~~~~
+Applies to:
+- hex 0.4.3 (MIT OR Apache-2.0)
+
+Copyright (c) 2013-2014 The Rust Project Developers.
+Copyright (c) 2015-2020 The rust-hex Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+DOCUMENT 125
 ~~~~~~~~~~~~
 Applies to:
 - hickory-net 0.26.1 (MIT OR Apache-2.0)
@@ -7675,7 +8267,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 114
+DOCUMENT 126
 ~~~~~~~~~~~~
 Applies to:
 - hickory-net 0.26.1 (MIT OR Apache-2.0)
@@ -7704,7 +8296,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 115
+DOCUMENT 127
 ~~~~~~~~~~~~
 Applies to:
 - http 1.4.2 (MIT OR Apache-2.0)
@@ -7912,7 +8504,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 116
+DOCUMENT 128
 ~~~~~~~~~~~~
 Applies to:
 - http 1.4.2 (MIT OR Apache-2.0)
@@ -7944,7 +8536,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 117
+DOCUMENT 129
 ~~~~~~~~~~~~
 Applies to:
 - http-body 1.0.1 (MIT)
@@ -7976,7 +8568,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 118
+DOCUMENT 130
 ~~~~~~~~~~~~
 Applies to:
 - http-body-util 0.1.3 (MIT)
@@ -8008,7 +8600,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 119
+DOCUMENT 131
 ~~~~~~~~~~~~
 Applies to:
 - httparse 1.10.1 (MIT OR Apache-2.0)
@@ -8035,7 +8627,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 120
+DOCUMENT 132
 ~~~~~~~~~~~~
 Applies to:
 - httpdate 1.0.3 (MIT OR Apache-2.0)
@@ -8243,7 +8835,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 121
+DOCUMENT 133
 ~~~~~~~~~~~~
 Applies to:
 - httpdate 1.0.3 (MIT OR Apache-2.0)
@@ -8269,39 +8861,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 122
-~~~~~~~~~~~~
-Applies to:
-- hybrid-array 0.4.13 (MIT OR Apache-2.0)
-
-Copyright (c) 2022-2026 The RustCrypto Project Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-
-DOCUMENT 123
+DOCUMENT 134
 ~~~~~~~~~~~~
 Applies to:
 - hyper 1.10.1 (MIT)
@@ -8327,7 +8887,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 124
+DOCUMENT 135
 ~~~~~~~~~~~~
 Applies to:
 - hyper-rustls 0.27.9 (Apache-2.0 OR ISC OR MIT)
@@ -8351,7 +8911,7 @@ ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 
-DOCUMENT 125
+DOCUMENT 136
 ~~~~~~~~~~~~
 Applies to:
 - hyper-rustls 0.27.9 (Apache-2.0 OR ISC OR MIT)
@@ -8385,7 +8945,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 126
+DOCUMENT 137
 ~~~~~~~~~~~~
 Applies to:
 - hyper-util 0.1.20 (MIT)
@@ -8411,7 +8971,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 127
+DOCUMENT 138
 ~~~~~~~~~~~~
 Applies to:
 - iana-time-zone 0.1.65 (MIT OR Apache-2.0)
@@ -8620,7 +9180,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 128
+DOCUMENT 139
 ~~~~~~~~~~~~
 Applies to:
 - iana-time-zone 0.1.65 (MIT OR Apache-2.0)
@@ -8653,7 +9213,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 129
+DOCUMENT 140
 ~~~~~~~~~~~~
 Applies to:
 - icu_collections 2.2.0 (Unicode-3.0)
@@ -8723,7 +9283,7 @@ Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
 ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.
 
 
-DOCUMENT 130
+DOCUMENT 141
 ~~~~~~~~~~~~
 Applies to:
 - idna 1.1.0 (MIT OR Apache-2.0)
@@ -8757,7 +9317,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 131
+DOCUMENT 142
 ~~~~~~~~~~~~
 Applies to:
 - idna_adapter 1.2.2 (Apache-2.0 OR MIT)
@@ -8789,7 +9349,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 132
+DOCUMENT 143
 ~~~~~~~~~~~~
 Applies to:
 - indexmap 2.14.0 (Apache-2.0 OR MIT)
@@ -8821,7 +9381,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 133
+DOCUMENT 144
 ~~~~~~~~~~~~
 Applies to:
 - inout 0.1.4 (MIT OR Apache-2.0)
@@ -8854,7 +9414,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 134
+DOCUMENT 145
 ~~~~~~~~~~~~
 Applies to:
 - inout 0.2.2 (MIT OR Apache-2.0)
@@ -8887,7 +9447,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 135
+DOCUMENT 146
 ~~~~~~~~~~~~
 Applies to:
 - ipconfig 0.3.4 (MIT/Apache-2.0)
@@ -8919,7 +9479,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 136
+DOCUMENT 147
 ~~~~~~~~~~~~
 Applies to:
 - ipnet 2.12.0 (MIT OR Apache-2.0)
@@ -9128,7 +9688,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 137
+DOCUMENT 148
 ~~~~~~~~~~~~
 Applies to:
 - ipnet 2.12.0 (MIT OR Apache-2.0)
@@ -9142,7 +9702,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 138
+DOCUMENT 149
 ~~~~~~~~~~~~
 Applies to:
 - jni 0.22.4 (MIT OR Apache-2.0)
@@ -9174,7 +9734,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 139
+DOCUMENT 150
 ~~~~~~~~~~~~
 Applies to:
 - jni-macros 0.22.4 (MIT OR Apache-2.0)
@@ -9206,7 +9766,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 140
+DOCUMENT 151
 ~~~~~~~~~~~~
 Applies to:
 - jni-sys 0.4.1 (MIT OR Apache-2.0)
@@ -9232,7 +9792,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 141
+DOCUMENT 152
 ~~~~~~~~~~~~
 Applies to:
 - jni-sys-macros 0.4.1 (MIT OR Apache-2.0)
@@ -9264,7 +9824,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 142
+DOCUMENT 153
 ~~~~~~~~~~~~
 Applies to:
 - junction 2.0.0 (MIT)
@@ -9292,7 +9852,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 143
+DOCUMENT 154
 ~~~~~~~~~~~~
 Applies to:
 - keccak 0.1.6 (Apache-2.0 OR MIT)
@@ -9324,7 +9884,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 144
+DOCUMENT 155
 ~~~~~~~~~~~~
 Applies to:
 - lazy_static 1.5.0 (MIT OR Apache-2.0)
@@ -9358,7 +9918,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 145
+DOCUMENT 156
 ~~~~~~~~~~~~
 Applies to:
 - libc 0.2.186 (MIT OR Apache-2.0)
@@ -9390,7 +9950,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 146
+DOCUMENT 157
 ~~~~~~~~~~~~
 Applies to:
 - libm 0.2.16 (MIT)
@@ -9655,7 +10215,7 @@ have been licensed under extremely permissive terms.
 Copyright notices are retained in src/* files where relevant.
 
 
-DOCUMENT 147
+DOCUMENT 158
 ~~~~~~~~~~~~
 Applies to:
 - linux-raw-sys 0.12.1 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -9691,7 +10251,7 @@ is licensed under:
 at your option.
 
 
-DOCUMENT 148
+DOCUMENT 159
 ~~~~~~~~~~~~
 Applies to:
 - linux-raw-sys 0.12.1 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -9924,7 +10484,7 @@ the License, but only in their entirety and only with respect to the Combined
 Software.
 
 
-DOCUMENT 149
+DOCUMENT 160
 ~~~~~~~~~~~~
 Applies to:
 - lock_api 0.4.14 (MIT OR Apache-2.0)
@@ -9959,7 +10519,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 150
+DOCUMENT 161
 ~~~~~~~~~~~~
 Applies to:
 - lopdf 0.42.0 (MIT)
@@ -9988,7 +10548,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 151
+DOCUMENT 162
 ~~~~~~~~~~~~
 Applies to:
 - lru-slab 0.1.2 (MIT OR Apache-2.0 OR Zlib)
@@ -10002,7 +10562,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 152
+DOCUMENT 163
 ~~~~~~~~~~~~
 Applies to:
 - lru-slab 0.1.2 (MIT OR Apache-2.0 OR Zlib)
@@ -10028,7 +10588,7 @@ the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 153
+DOCUMENT 164
 ~~~~~~~~~~~~
 Applies to:
 - matrixmultiply 0.3.10 (MIT/Apache-2.0)
@@ -10062,7 +10622,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 154
+DOCUMENT 165
 ~~~~~~~~~~~~
 Applies to:
 - md-5 0.10.6 (MIT OR Apache-2.0)
@@ -10097,7 +10657,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 155
+DOCUMENT 166
 ~~~~~~~~~~~~
 Applies to:
 - memmap2 0.9.11 (MIT OR Apache-2.0)
@@ -10305,7 +10865,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 156
+DOCUMENT 167
 ~~~~~~~~~~~~
 Applies to:
 - memmap2 0.9.11 (MIT OR Apache-2.0)
@@ -10338,7 +10898,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 157
+DOCUMENT 168
 ~~~~~~~~~~~~
 Applies to:
 - minimal-lexical 0.2.1 (MIT/Apache-2.0)
@@ -10382,7 +10942,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 158
+DOCUMENT 169
 ~~~~~~~~~~~~
 Applies to:
 - miniz_oxide 0.8.9 (MIT OR Zlib OR Apache-2.0)
@@ -10414,7 +10974,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 159
+DOCUMENT 170
 ~~~~~~~~~~~~
 Applies to:
 - miniz_oxide 0.8.9 (MIT OR Zlib OR Apache-2.0)
@@ -10445,7 +11005,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 160
+DOCUMENT 171
 ~~~~~~~~~~~~
 Applies to:
 - miniz_oxide 0.8.9 (MIT OR Zlib OR Apache-2.0)
@@ -10466,7 +11026,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 161
+DOCUMENT 172
 ~~~~~~~~~~~~
 Applies to:
 - mio 1.2.1 (MIT)
@@ -10492,7 +11052,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 162
+DOCUMENT 173
 ~~~~~~~~~~~~
 Applies to:
 - moka 0.12.15 ((MIT OR Apache-2.0) AND Apache-2.0)
@@ -10700,7 +11260,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 163
+DOCUMENT 174
 ~~~~~~~~~~~~
 Applies to:
 - moka 0.12.15 ((MIT OR Apache-2.0) AND Apache-2.0)
@@ -10728,7 +11288,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 164
+DOCUMENT 175
 ~~~~~~~~~~~~
 Applies to:
 - moka 0.12.15 ((MIT OR Apache-2.0) AND Apache-2.0)
@@ -10749,7 +11309,7 @@ These files were ported from the Java Caffeine library and are not dual-licensed
 Please refer to the LICENSE-APACHE file for more details on the Apache License 2.0.
 
 
-DOCUMENT 165
+DOCUMENT 176
 ~~~~~~~~~~~~
 Applies to:
 - moxcms 0.8.1 (BSD-3-Clause OR Apache-2.0)
@@ -10958,7 +11518,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 166
+DOCUMENT 177
 ~~~~~~~~~~~~
 Applies to:
 - moxcms 0.8.1 (BSD-3-Clause OR Apache-2.0)
@@ -10992,7 +11552,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 167
+DOCUMENT 178
 ~~~~~~~~~~~~
 Applies to:
 - ndarray 0.17.2 (MIT OR Apache-2.0)
@@ -11026,7 +11586,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 168
+DOCUMENT 179
 ~~~~~~~~~~~~
 Applies to:
 - ndk-context 0.1.1 (MIT OR Apache-2.0)
@@ -11058,7 +11618,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 169
+DOCUMENT 180
 ~~~~~~~~~~~~
 Applies to:
 - nix 0.28.0 (MIT)
@@ -11087,7 +11647,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 170
+DOCUMENT 181
 ~~~~~~~~~~~~
 Applies to:
 - nom 7.1.3 (MIT)
@@ -11115,7 +11675,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 171
+DOCUMENT 182
 ~~~~~~~~~~~~
 Applies to:
 - nom-language 0.1.0 (MIT)
@@ -11147,7 +11707,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 172
+DOCUMENT 183
 ~~~~~~~~~~~~
 Applies to:
 - ntapi 0.4.3 (Apache-2.0 OR MIT)
@@ -11171,7 +11731,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 173
+DOCUMENT 184
 ~~~~~~~~~~~~
 Applies to:
 - num-conv 0.2.2 (MIT OR Apache-2.0)
@@ -11197,7 +11757,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 174
+DOCUMENT 185
 ~~~~~~~~~~~~
 Applies to:
 - objc2 0.6.4 (MIT)
@@ -11229,7 +11789,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 175
+DOCUMENT 186
 ~~~~~~~~~~~~
 Applies to:
 - objc2-core-foundation 0.3.2 (Zlib OR Apache-2.0 OR MIT)
@@ -11261,7 +11821,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 176
+DOCUMENT 187
 ~~~~~~~~~~~~
 Applies to:
 - objc2-encode 4.1.0 (MIT)
@@ -11293,7 +11853,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 177
+DOCUMENT 188
 ~~~~~~~~~~~~
 Applies to:
 - objc2-foundation 0.3.2 (MIT)
@@ -11325,7 +11885,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 178
+DOCUMENT 189
 ~~~~~~~~~~~~
 Applies to:
 - objc2-io-kit 0.3.2 (Zlib OR Apache-2.0 OR MIT)
@@ -11357,7 +11917,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 179
+DOCUMENT 190
 ~~~~~~~~~~~~
 Applies to:
 - objc2-vision 0.3.2 (Zlib OR Apache-2.0 OR MIT)
@@ -11389,7 +11949,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 180
+DOCUMENT 191
 ~~~~~~~~~~~~
 Applies to:
 - ocrs 0.12.2 (MIT OR Apache-2.0)
@@ -11421,7 +11981,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 181
+DOCUMENT 192
 ~~~~~~~~~~~~
 Applies to:
 - Ocrs bundled RTen models (CC-BY-SA-4.0 attribution)
@@ -11442,34 +12002,18 @@ Files:
   SHA-256: e484866d4cce403175bd8d00b128feb08ab42e208de30e42cd9889d8f1735a6e
 
 
-DOCUMENT 182
+DOCUMENT 193
 ~~~~~~~~~~~~
 Applies to:
-- openssl 0.10.81 (Apache-2.0)
+- p12-keystore 0.3.1 (MIT/Apache-2.0)
 
-Copyright 2011-2017 Google Inc.
-          2013 Jack Lloyd
-          2013-2014 Steven Fackler
+Package: p12-keystore 0.3.1
+Authors: Dmitry Pankratov <dmitry@pankratov.net>
+Source: https://github.com/ancwrd1/p12-keystore
+Declared license expression: MIT/Apache-2.0
+MIT License
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-
-DOCUMENT 183
-~~~~~~~~~~~~
-Applies to:
-- openssl-macros 0.1.1 (MIT/Apache-2.0)
-
-Copyright (c) 2022 Steven Fackler
+The package did not include a separate copyright notice; see its author and source metadata above.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -11490,7 +12034,40 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 184
+DOCUMENT 194
+~~~~~~~~~~~~
+Applies to:
+- pbkdf2 0.13.0 (MIT OR Apache-2.0)
+
+Copyright (c) 2017 Artyom Pavlov
+Copyright (c) 2018-2023 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 195
 ~~~~~~~~~~~~
 Applies to:
 - pdf-extract 0.12.0 (MIT)
@@ -11522,7 +12099,73 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 185
+DOCUMENT 196
+~~~~~~~~~~~~
+Applies to:
+- pem-rfc7468 1.0.0 (Apache-2.0 OR MIT)
+- pkcs1 0.8.0-rc.4 (Apache-2.0 OR MIT)
+- x509-cert 0.3.0 (Apache-2.0 OR MIT)
+
+Copyright (c) 2021-2025 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 197
+~~~~~~~~~~~~
+Applies to:
+- pkcs12 0.2.0-pre.0 (Apache-2.0 OR MIT)
+
+Copyright (c) 2022-2025 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 198
 ~~~~~~~~~~~~
 Applies to:
 - png 0.18.1 (MIT OR Apache-2.0)
@@ -11554,7 +12197,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 186
+DOCUMENT 199
 ~~~~~~~~~~~~
 Applies to:
 - postscript 0.14.1 (Apache-2.0/MIT)
@@ -11610,7 +12253,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 
-DOCUMENT 187
+DOCUMENT 200
 ~~~~~~~~~~~~
 Applies to:
 - powerfmt 0.2.0 (MIT OR Apache-2.0)
@@ -11818,7 +12461,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 188
+DOCUMENT 201
 ~~~~~~~~~~~~
 Applies to:
 - powerfmt 0.2.0 (MIT OR Apache-2.0)
@@ -11844,7 +12487,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 189
+DOCUMENT 202
 ~~~~~~~~~~~~
 Applies to:
 - prefix-trie 0.8.4 (MIT OR Apache-2.0)
@@ -11858,7 +12501,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 190
+DOCUMENT 203
 ~~~~~~~~~~~~
 Applies to:
 - primal-check 0.3.4 (MIT OR Apache-2.0)
@@ -11890,7 +12533,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 191
+DOCUMENT 204
 ~~~~~~~~~~~~
 Applies to:
 - proc-macro-error-attr2 2.0.0 (MIT OR Apache-2.0)
@@ -12099,7 +12742,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 192
+DOCUMENT 205
 ~~~~~~~~~~~~
 Applies to:
 - proc-macro-error-attr2 2.0.0 (MIT OR Apache-2.0)
@@ -12128,7 +12771,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 193
+DOCUMENT 206
 ~~~~~~~~~~~~
 Applies to:
 - quick-error 2.0.1 (MIT/Apache-2.0)
@@ -12154,7 +12797,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 194
+DOCUMENT 207
 ~~~~~~~~~~~~
 Applies to:
 - quick-xml 0.41.0 (MIT)
@@ -12184,7 +12827,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 195
+DOCUMENT 208
 ~~~~~~~~~~~~
 Applies to:
 - quinn 0.11.11 (MIT OR Apache-2.0)
@@ -12200,7 +12843,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 196
+DOCUMENT 209
 ~~~~~~~~~~~~
 Applies to:
 - r-efi 6.0.0 (MIT OR Apache-2.0 OR LGPL-2.1-or-later)
@@ -12232,7 +12875,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 197
+DOCUMENT 210
 ~~~~~~~~~~~~
 Applies to:
 - rand 0.10.1 (MIT OR Apache-2.0)
@@ -12254,7 +12897,7 @@ The Rand project includes code from the Rust project
 published under these same licenses.
 
 
-DOCUMENT 198
+DOCUMENT 211
 ~~~~~~~~~~~~
 Applies to:
 - rand 0.10.1 (MIT OR Apache-2.0)
@@ -12437,7 +13080,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 199
+DOCUMENT 212
 ~~~~~~~~~~~~
 Applies to:
 - rand 0.10.1 (MIT OR Apache-2.0)
@@ -12471,7 +13114,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 200
+DOCUMENT 213
 ~~~~~~~~~~~~
 Applies to:
 - rand_core 0.10.1 (MIT OR Apache-2.0)
@@ -12487,7 +13130,7 @@ licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
 <LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
 
 
-DOCUMENT 201
+DOCUMENT 214
 ~~~~~~~~~~~~
 Applies to:
 - rand_core 0.10.1 (MIT OR Apache-2.0)
@@ -12684,7 +13327,7 @@ APPENDIX: How to apply the Apache License to your work.
    identification within third-party archives.
 
 
-DOCUMENT 202
+DOCUMENT 215
 ~~~~~~~~~~~~
 Applies to:
 - rand_core 0.10.1 (MIT OR Apache-2.0)
@@ -12716,7 +13359,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 203
+DOCUMENT 216
 ~~~~~~~~~~~~
 Applies to:
 - rand_distr 0.6.0 (MIT OR Apache-2.0)
@@ -12748,7 +13391,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 204
+DOCUMENT 217
 ~~~~~~~~~~~~
 Applies to:
 - rand_pcg 0.10.2 (MIT OR Apache-2.0)
@@ -12781,7 +13424,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 205
+DOCUMENT 218
 ~~~~~~~~~~~~
 Applies to:
 - rangemap 1.7.1 (MIT/Apache-2.0)
@@ -12978,7 +13621,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 206
+DOCUMENT 219
 ~~~~~~~~~~~~
 Applies to:
 - rangemap 1.7.1 (MIT/Apache-2.0)
@@ -12992,7 +13635,248 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 207
+DOCUMENT 220
+~~~~~~~~~~~~
+Applies to:
+- rc2 0.9.0 (MIT OR Apache-2.0)
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Damian Czaja
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+DOCUMENT 221
+~~~~~~~~~~~~
+Applies to:
+- rc2 0.9.0 (MIT OR Apache-2.0)
+
+Copyright (c) 2017-2024 The RustCrypto Project Developers
+Copyright (c) 2017 Damian Czaja
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 222
 ~~~~~~~~~~~~
 Applies to:
 - rcgen 0.14.8 (MIT OR Apache-2.0)
@@ -13213,7 +14097,7 @@ Apache License, version 2.0
    END OF TERMS AND CONDITIONS
 
 
-DOCUMENT 208
+DOCUMENT 223
 ~~~~~~~~~~~~
 Applies to:
 - redox_syscall 0.5.18 (MIT)
@@ -13242,7 +14126,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 209
+DOCUMENT 224
 ~~~~~~~~~~~~
 Applies to:
 - reqwest 0.12.28 (MIT OR Apache-2.0)
@@ -13450,7 +14334,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 210
+DOCUMENT 225
 ~~~~~~~~~~~~
 Applies to:
 - reqwest 0.12.28 (MIT OR Apache-2.0)
@@ -13476,7 +14360,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 211
+DOCUMENT 226
 ~~~~~~~~~~~~
 Applies to:
 - resolv-conf 0.7.6 (MIT OR Apache-2.0)
@@ -13502,7 +14386,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 212
+DOCUMENT 227
 ~~~~~~~~~~~~
 Applies to:
 - ring 0.17.14 (Apache-2.0 AND ISC)
@@ -13518,7 +14402,7 @@ See src/polyfill/once_cell/LICENSE-APACHE and src/polyfill/once_cell/LICENSE-MIT
 for the license to code that was sourced from the once_cell project.
 
 
-DOCUMENT 213
+DOCUMENT 228
 ~~~~~~~~~~~~
 Applies to:
 - ring 0.17.14 (Apache-2.0 AND ISC)
@@ -13796,7 +14680,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 214
+DOCUMENT 229
 ~~~~~~~~~~~~
 Applies to:
 - ring 0.17.14 (Apache-2.0 AND ISC)
@@ -13816,7 +14700,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-DOCUMENT 215
+DOCUMENT 230
 ~~~~~~~~~~~~
 Applies to:
 - rten 0.24.0 (MIT OR Apache-2.0)
@@ -13848,7 +14732,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 216
+DOCUMENT 231
 ~~~~~~~~~~~~
 Applies to:
 - rten-base 0.24.0 (MIT OR Apache-2.0)
@@ -13880,7 +14764,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 217
+DOCUMENT 232
 ~~~~~~~~~~~~
 Applies to:
 - rten-gemm 0.24.0 (MIT OR Apache-2.0)
@@ -13912,7 +14796,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 218
+DOCUMENT 233
 ~~~~~~~~~~~~
 Applies to:
 - rten-imageproc 0.24.0 (MIT OR Apache-2.0)
@@ -13944,7 +14828,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 219
+DOCUMENT 234
 ~~~~~~~~~~~~
 Applies to:
 - rten-model-file 0.24.0 (MIT OR Apache-2.0)
@@ -13976,7 +14860,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 220
+DOCUMENT 235
 ~~~~~~~~~~~~
 Applies to:
 - rten-shape-inference 0.24.0 (MIT OR Apache-2.0)
@@ -14008,7 +14892,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 221
+DOCUMENT 236
 ~~~~~~~~~~~~
 Applies to:
 - rten-simd 0.24.0 (MIT OR Apache-2.0)
@@ -14040,7 +14924,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 222
+DOCUMENT 237
 ~~~~~~~~~~~~
 Applies to:
 - rten-tensor 0.24.0 (MIT OR Apache-2.0)
@@ -14072,7 +14956,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 223
+DOCUMENT 238
 ~~~~~~~~~~~~
 Applies to:
 - rten-vecmath 0.24.0 (MIT OR Apache-2.0)
@@ -14104,7 +14988,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 224
+DOCUMENT 239
 ~~~~~~~~~~~~
 Applies to:
 - rustfft 6.4.1 (MIT OR Apache-2.0)
@@ -14131,7 +15015,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 225
+DOCUMENT 240
 ~~~~~~~~~~~~
 Applies to:
 - rustix 1.1.4 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -14167,7 +15051,7 @@ is licensed under:
 at your option.
 
 
-DOCUMENT 226
+DOCUMENT 241
 ~~~~~~~~~~~~
 Applies to:
 - rustls-native-certs 0.8.4 (Apache-2.0 OR ISC OR MIT)
@@ -14183,7 +15067,7 @@ respectively.  You may use this software under the terms of any
 of these licenses, at your option.
 
 
-DOCUMENT 227
+DOCUMENT 242
 ~~~~~~~~~~~~
 Applies to:
 - rustls-pki-types 1.15.0 (MIT OR Apache-2.0)
@@ -14391,7 +15275,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 228
+DOCUMENT 243
 ~~~~~~~~~~~~
 Applies to:
 - rustls-pki-types 1.15.0 (MIT OR Apache-2.0)
@@ -14423,7 +15307,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 229
+DOCUMENT 244
 ~~~~~~~~~~~~
 Applies to:
 - rustls-webpki 0.103.13 (ISC)
@@ -14449,7 +15333,7 @@ The files under third-party/chromium are licensed as described in
 third-party/chromium/LICENSE.
 
 
-DOCUMENT 230
+DOCUMENT 245
 ~~~~~~~~~~~~
 Applies to:
 - rxing 0.9.1 (Apache-2.0)
@@ -14657,7 +15541,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 231
+DOCUMENT 246
 ~~~~~~~~~~~~
 Applies to:
 - ryu 1.0.23 (Apache-2.0 OR BSL-1.0)
@@ -14687,7 +15571,40 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 232
+DOCUMENT 247
+~~~~~~~~~~~~
+Applies to:
+- salsa20 0.11.0 (MIT OR Apache-2.0)
+
+Copyright (c) 2019-2026 The RustCrypto Project Developers
+Copyright (c) 2019 Eric McCorkle
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 248
 ~~~~~~~~~~~~
 Applies to:
 - same-file 1.0.6 (Unlicense/MIT)
@@ -14716,7 +15633,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 233
+DOCUMENT 249
 ~~~~~~~~~~~~
 Applies to:
 - scan_fmt 0.2.6 (MIT)
@@ -14744,7 +15661,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 234
+DOCUMENT 250
 ~~~~~~~~~~~~
 Applies to:
 - schannel 0.1.29 (MIT)
@@ -14758,7 +15675,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 235
+DOCUMENT 251
 ~~~~~~~~~~~~
 Applies to:
 - scopeguard 1.2.0 (MIT OR Apache-2.0)
@@ -14790,7 +15707,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 236
+DOCUMENT 252
 ~~~~~~~~~~~~
 Applies to:
 - security-framework 3.7.0 (MIT OR Apache-2.0)
@@ -14818,7 +15735,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 237
+DOCUMENT 253
 ~~~~~~~~~~~~
 Applies to:
 - serde_urlencoded 0.7.1 (MIT/Apache-2.0)
@@ -14850,7 +15767,35 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 238
+DOCUMENT 254
+~~~~~~~~~~~~
+Applies to:
+- serdect 0.4.3 (Apache-2.0 OR MIT)
+
+MIT License
+
+Copyright (c) 2022-2025 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+DOCUMENT 255
 ~~~~~~~~~~~~
 Applies to:
 - serial2 0.2.37 (BSD-2-Clause OR Apache-2.0)
@@ -14870,7 +15815,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 239
+DOCUMENT 256
 ~~~~~~~~~~~~
 Applies to:
 - serial2 0.2.37 (BSD-2-Clause OR Apache-2.0)
@@ -14901,7 +15846,43 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 240
+DOCUMENT 257
+~~~~~~~~~~~~
+Applies to:
+- sha1 0.11.0 (MIT OR Apache-2.0)
+- sha2 0.11.0 (MIT OR Apache-2.0)
+
+Copyright (c) 2016-2026 The RustCrypto Project Developers
+Copyright (c) 2016 Artyom Pavlov
+Copyright (c) 2009-2013 Mozilla Foundation
+Copyright (c) 2006-2009 Graydon Hoare
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 258
 ~~~~~~~~~~~~
 Applies to:
 - sha3 0.10.9 (MIT OR Apache-2.0)
@@ -14936,7 +15917,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 241
+DOCUMENT 259
 ~~~~~~~~~~~~
 Applies to:
 - shared_library 0.1.9 (Apache-2.0/MIT)
@@ -14968,7 +15949,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 242
+DOCUMENT 260
 ~~~~~~~~~~~~
 Applies to:
 - shell-words 1.1.1 (MIT/Apache-2.0)
@@ -15176,7 +16157,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 243
+DOCUMENT 261
 ~~~~~~~~~~~~
 Applies to:
 - shell-words 1.1.1 (MIT/Apache-2.0)
@@ -15208,7 +16189,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 244
+DOCUMENT 262
 ~~~~~~~~~~~~
 Applies to:
 - shlex 2.0.1 (MIT OR Apache-2.0)
@@ -15228,7 +16209,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 245
+DOCUMENT 263
 ~~~~~~~~~~~~
 Applies to:
 - shlex 2.0.1 (MIT OR Apache-2.0)
@@ -15256,7 +16237,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 246
+DOCUMENT 264
 ~~~~~~~~~~~~
 Applies to:
 - signal-hook-registry 1.4.8 (MIT OR Apache-2.0)
@@ -15288,7 +16269,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 247
+DOCUMENT 265
 ~~~~~~~~~~~~
 Applies to:
 - simd-adler32 0.3.9 (MIT)
@@ -15316,7 +16297,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 248
+DOCUMENT 266
 ~~~~~~~~~~~~
 Applies to:
 - slab 0.4.12 (MIT)
@@ -15348,7 +16329,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 249
+DOCUMENT 267
 ~~~~~~~~~~~~
 Applies to:
 - smallvec 1.15.2 (MIT OR Apache-2.0)
@@ -15380,7 +16361,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 250
+DOCUMENT 268
 ~~~~~~~~~~~~
 Applies to:
 - spin 0.9.8 (MIT)
@@ -15408,7 +16389,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 251
+DOCUMENT 269
 ~~~~~~~~~~~~
 Applies to:
 - spki 0.7.3 (Apache-2.0 OR MIT)
@@ -15440,7 +16421,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 252
+DOCUMENT 270
 ~~~~~~~~~~~~
 Applies to:
 - stable_deref_trait 1.2.1 (MIT OR Apache-2.0)
@@ -15472,7 +16453,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 253
+DOCUMENT 271
 ~~~~~~~~~~~~
 Applies to:
 - string-interner 0.19.0 (MIT/Apache-2.0)
@@ -15495,7 +16476,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 254
+DOCUMENT 272
 ~~~~~~~~~~~~
 Applies to:
 - string-interner 0.19.0 (MIT/Apache-2.0)
@@ -15524,7 +16505,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 255
+DOCUMENT 273
 ~~~~~~~~~~~~
 Applies to:
 - stringprep 0.1.5 (MIT/Apache-2.0)
@@ -15550,7 +16531,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 256
+DOCUMENT 274
 ~~~~~~~~~~~~
 Applies to:
 - subtle 2.6.1 (BSD-3-Clause)
@@ -15586,7 +16567,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 257
+DOCUMENT 275
 ~~~~~~~~~~~~
 Applies to:
 - synstructure 0.13.2 (MIT)
@@ -15600,7 +16581,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 258
+DOCUMENT 276
 ~~~~~~~~~~~~
 Applies to:
 - sysinfo 0.37.2 (MIT)
@@ -15628,7 +16609,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 259
+DOCUMENT 277
 ~~~~~~~~~~~~
 Applies to:
 - system-configuration 0.7.0 (MIT OR Apache-2.0)
@@ -15661,7 +16642,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 260
+DOCUMENT 278
 ~~~~~~~~~~~~
 Applies to:
 - tagptr 0.2.0 (MIT/Apache-2.0)
@@ -15681,7 +16662,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 261
+DOCUMENT 279
 ~~~~~~~~~~~~
 Applies to:
 - tagptr 0.2.0 (MIT/Apache-2.0)
@@ -15709,7 +16690,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 262
+DOCUMENT 280
 ~~~~~~~~~~~~
 Applies to:
 - tar 0.4.46 (MIT OR Apache-2.0)
@@ -15741,7 +16722,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 263
+DOCUMENT 281
 ~~~~~~~~~~~~
 Applies to:
 - time 0.3.54 (MIT OR Apache-2.0)
@@ -15769,7 +16750,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 264
+DOCUMENT 282
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec 1.11.0 (Zlib OR Apache-2.0 OR MIT)
@@ -15781,7 +16762,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 265
+DOCUMENT 283
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec_macros 0.1.1 (MIT OR Apache-2.0 OR Zlib)
@@ -15989,7 +16970,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 266
+DOCUMENT 284
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec_macros 0.1.1 (MIT OR Apache-2.0 OR Zlib)
@@ -16017,7 +16998,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 267
+DOCUMENT 285
 ~~~~~~~~~~~~
 Applies to:
 - tinyvec_macros 0.1.1 (MIT OR Apache-2.0 OR Zlib)
@@ -16043,7 +17024,7 @@ freely, subject to the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 
 
-DOCUMENT 268
+DOCUMENT 286
 ~~~~~~~~~~~~
 Applies to:
 - tokio 1.52.3 (MIT)
@@ -16072,7 +17053,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 269
+DOCUMENT 287
 ~~~~~~~~~~~~
 Applies to:
 - tokio-macros 2.7.0 (MIT)
@@ -16101,7 +17082,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 270
+DOCUMENT 288
 ~~~~~~~~~~~~
 Applies to:
 - tokio-rustls 0.26.4 (MIT OR Apache-2.0)
@@ -16309,7 +17290,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 271
+DOCUMENT 289
 ~~~~~~~~~~~~
 Applies to:
 - tokio-rustls 0.26.4 (MIT OR Apache-2.0)
@@ -16341,7 +17322,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 272
+DOCUMENT 290
 ~~~~~~~~~~~~
 Applies to:
 - tower 0.5.3 (MIT)
@@ -16375,7 +17356,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 273
+DOCUMENT 291
 ~~~~~~~~~~~~
 Applies to:
 - tower-http 0.6.11 (MIT)
@@ -16407,7 +17388,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 274
+DOCUMENT 292
 ~~~~~~~~~~~~
 Applies to:
 - tracing 0.1.44 (MIT)
@@ -16440,7 +17421,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 275
+DOCUMENT 293
 ~~~~~~~~~~~~
 Applies to:
 - tract-core 0.23.3 (MIT OR Apache-2.0)
@@ -16467,7 +17448,7 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
 
 
-DOCUMENT 276
+DOCUMENT 294
 ~~~~~~~~~~~~
 Applies to:
 - tract-extra 0.23.3 (MIT OR Apache-2.0)
@@ -16499,7 +17480,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 277
+DOCUMENT 295
 ~~~~~~~~~~~~
 Applies to:
 - tract-transformers 0.23.3 (MIT OR Apache-2.0)
@@ -16531,7 +17512,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 278
+DOCUMENT 296
 ~~~~~~~~~~~~
 Applies to:
 - transpose 0.2.3 (MIT OR Apache-2.0)
@@ -16739,7 +17720,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 279
+DOCUMENT 297
 ~~~~~~~~~~~~
 Applies to:
 - transpose 0.2.3 (MIT OR Apache-2.0)
@@ -16771,7 +17752,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 280
+DOCUMENT 298
 ~~~~~~~~~~~~
 Applies to:
 - try-lock 0.2.5 (MIT)
@@ -16798,7 +17779,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 281
+DOCUMENT 299
 ~~~~~~~~~~~~
 Applies to:
 - type1-encoding-parser 0.1.1 (MIT)
@@ -16830,7 +17811,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 282
+DOCUMENT 300
 ~~~~~~~~~~~~
 Applies to:
 - typenum 1.20.1 (MIT OR Apache-2.0)
@@ -16838,7 +17819,7 @@ Applies to:
 MIT OR Apache-2.0
 
 
-DOCUMENT 283
+DOCUMENT 301
 ~~~~~~~~~~~~
 Applies to:
 - typenum 1.20.1 (MIT OR Apache-2.0)
@@ -17046,7 +18027,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-DOCUMENT 284
+DOCUMENT 302
 ~~~~~~~~~~~~
 Applies to:
 - typenum 1.20.1 (MIT OR Apache-2.0)
@@ -17074,7 +18055,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 285
+DOCUMENT 303
 ~~~~~~~~~~~~
 Applies to:
 - unicode-bidi 0.3.18 (MIT OR Apache-2.0)
@@ -17089,7 +18070,7 @@ carrying such notice may not be copied, modified, or distributed except
 according to those terms.
 
 
-DOCUMENT 286
+DOCUMENT 304
 ~~~~~~~~~~~~
 Applies to:
 - unicode-ident 1.0.24 ((MIT OR Apache-2.0) AND Unicode-3.0)
@@ -17135,7 +18116,7 @@ dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
 
 
-DOCUMENT 287
+DOCUMENT 305
 ~~~~~~~~~~~~
 Applies to:
 - unicode-normalization 0.1.25 (MIT OR Apache-2.0)
@@ -17152,7 +18133,39 @@ notice may not be copied, modified, or distributed except
 according to those terms.
 
 
-DOCUMENT 288
+DOCUMENT 306
+~~~~~~~~~~~~
+Applies to:
+- universal-hash 0.6.1 (MIT OR Apache-2.0)
+
+Copyright (c) 2019-2025 RustCrypto Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+DOCUMENT 307
 ~~~~~~~~~~~~
 Applies to:
 - untrusted 0.9.0 (ISC)
@@ -17172,7 +18185,7 @@ Applies to:
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-DOCUMENT 289
+DOCUMENT 308
 ~~~~~~~~~~~~
 Applies to:
 - utf8_iter 1.0.4 (Apache-2.0 OR MIT)
@@ -17221,7 +18234,7 @@ licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
 <LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
 
 
-DOCUMENT 290
+DOCUMENT 309
 ~~~~~~~~~~~~
 Applies to:
 - utf8parse 0.2.2 (Apache-2.0 OR MIT)
@@ -17253,7 +18266,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 291
+DOCUMENT 310
 ~~~~~~~~~~~~
 Applies to:
 - uuid 1.24.0 (Apache-2.0 OR MIT)
@@ -17286,39 +18299,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 292
-~~~~~~~~~~~~
-Applies to:
-- vcpkg 0.2.15 (MIT/Apache-2.0)
-
-Copyright (c) 2017 Jim McGrath
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-
-DOCUMENT 293
+DOCUMENT 311
 ~~~~~~~~~~~~
 Applies to:
 - version_check 0.9.5 (MIT/Apache-2.0)
@@ -17344,7 +18325,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 294
+DOCUMENT 312
 ~~~~~~~~~~~~
 Applies to:
 - want 0.3.1 (MIT)
@@ -17370,7 +18351,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 295
+DOCUMENT 313
 ~~~~~~~~~~~~
 Applies to:
 - wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17402,7 +18383,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 296
+DOCUMENT 314
 ~~~~~~~~~~~~
 Applies to:
 - wasm-encoder 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17434,7 +18415,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 297
+DOCUMENT 315
 ~~~~~~~~~~~~
 Applies to:
 - wasm-metadata 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17466,7 +18447,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 298
+DOCUMENT 316
 ~~~~~~~~~~~~
 Applies to:
 - wasmi 1.1.0 (MIT/Apache-2.0)
@@ -17498,7 +18479,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 299
+DOCUMENT 317
 ~~~~~~~~~~~~
 Applies to:
 - wasmi_collections 1.1.0 (MIT/Apache-2.0)
@@ -17530,7 +18511,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 300
+DOCUMENT 318
 ~~~~~~~~~~~~
 Applies to:
 - wasmi_core 1.1.0 (MIT/Apache-2.0)
@@ -17562,7 +18543,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 301
+DOCUMENT 319
 ~~~~~~~~~~~~
 Applies to:
 - wasmi_ir 1.1.0 (MIT/Apache-2.0)
@@ -17594,7 +18575,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 302
+DOCUMENT 320
 ~~~~~~~~~~~~
 Applies to:
 - wasmparser 0.239.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17626,7 +18607,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 303
+DOCUMENT 321
 ~~~~~~~~~~~~
 Applies to:
 - wasmparser 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -17658,7 +18639,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 304
+DOCUMENT 322
 ~~~~~~~~~~~~
 Applies to:
 - web-time 1.1.0 (MIT OR Apache-2.0)
@@ -17866,7 +18847,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 305
+DOCUMENT 323
 ~~~~~~~~~~~~
 Applies to:
 - web-time 1.1.0 (MIT OR Apache-2.0)
@@ -17894,7 +18875,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 306
+DOCUMENT 324
 ~~~~~~~~~~~~
 Applies to:
 - weezl 0.1.12 (MIT OR Apache-2.0)
@@ -17922,7 +18903,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 307
+DOCUMENT 325
 ~~~~~~~~~~~~
 Applies to:
 - winapi 0.3.9 (MIT/Apache-2.0)
@@ -17948,7 +18929,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 308
+DOCUMENT 326
 ~~~~~~~~~~~~
 Applies to:
 - winapi-i686-pc-windows-gnu 0.4.0 (MIT/Apache-2.0)
@@ -17980,7 +18961,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 309
+DOCUMENT 327
 ~~~~~~~~~~~~
 Applies to:
 - winapi-x86_64-pc-windows-gnu 0.4.0 (MIT/Apache-2.0)
@@ -18012,7 +18993,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 310
+DOCUMENT 328
 ~~~~~~~~~~~~
 Applies to:
 - windows 0.61.3 (MIT OR Apache-2.0)
@@ -18251,7 +19232,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 311
+DOCUMENT 329
 ~~~~~~~~~~~~
 Applies to:
 - windows 0.61.3 (MIT OR Apache-2.0)
@@ -18310,7 +19291,7 @@ MIT License
     SOFTWARE
 
 
-DOCUMENT 312
+DOCUMENT 330
 ~~~~~~~~~~~~
 Applies to:
 - winnow 0.7.15 (MIT)
@@ -18335,7 +19316,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 313
+DOCUMENT 331
 ~~~~~~~~~~~~
 Applies to:
 - winreg 0.10.1 (MIT)
@@ -18361,7 +19342,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-DOCUMENT 314
+DOCUMENT 332
 ~~~~~~~~~~~~
 Applies to:
 - wit-component 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -18393,7 +19374,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 315
+DOCUMENT 333
 ~~~~~~~~~~~~
 Applies to:
 - wit-parser 0.244.0 (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
@@ -18425,7 +19406,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 316
+DOCUMENT 334
 ~~~~~~~~~~~~
 Applies to:
 - xattr 1.6.1 (MIT OR Apache-2.0)
@@ -18457,7 +19438,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 317
+DOCUMENT 335
 ~~~~~~~~~~~~
 Applies to:
 - yasna 0.6.0 (MIT OR Apache-2.0)
@@ -18471,7 +19452,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 318
+DOCUMENT 336
 ~~~~~~~~~~~~
 Applies to:
 - zerocopy 0.8.52 (BSD-2-Clause OR Apache-2.0 OR MIT)
@@ -18680,7 +19661,7 @@ Apache License
    limitations under the License.
 
 
-DOCUMENT 319
+DOCUMENT 337
 ~~~~~~~~~~~~
 Applies to:
 - zerocopy 0.8.52 (BSD-2-Clause OR Apache-2.0 OR MIT)
@@ -18712,7 +19693,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 320
+DOCUMENT 338
 ~~~~~~~~~~~~
 Applies to:
 - zerocopy 0.8.52 (BSD-2-Clause OR Apache-2.0 OR MIT)
@@ -18745,7 +19726,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 321
+DOCUMENT 339
 ~~~~~~~~~~~~
 Applies to:
 - zeroize 1.8.2 (Apache-2.0 OR MIT)
@@ -18773,7 +19754,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 322
+DOCUMENT 340
 ~~~~~~~~~~~~
 Applies to:
 - zstd 0.13.3 (MIT)
@@ -18790,7 +19771,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-DOCUMENT 323
+DOCUMENT 341
 ~~~~~~~~~~~~
 Applies to:
 - zstd-safe 7.2.4 (MIT OR Apache-2.0)
@@ -18799,7 +19780,7 @@ Applies to:
 MIT or Apache-2.0
 
 
-DOCUMENT 324
+DOCUMENT 342
 ~~~~~~~~~~~~
 Applies to:
 - zstd-sys 2.0.16+zstd.1.5.7 (MIT/Apache-2.0)
@@ -18838,7 +19819,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-DOCUMENT 325
+DOCUMENT 343
 ~~~~~~~~~~~~
 Applies to:
 - zune-core 0.5.1 (MIT OR Apache-2.0 OR Zlib)
@@ -18867,7 +19848,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-DOCUMENT 326
+DOCUMENT 344
 ~~~~~~~~~~~~
 Applies to:
 - zune-core 0.5.1 (MIT OR Apache-2.0 OR Zlib)

--- a/crates/pentect-core/Cargo.toml
+++ b/crates/pentect-core/Cargo.toml
@@ -27,7 +27,13 @@ chacha20 = { workspace = true }
 zeroize = { workspace = true }
 unicode-normalization = { workspace = true }
 data-encoding = { workspace = true }
-openssl = { workspace = true }
+crypto-bigint = { workspace = true }
+crypto-primes = { workspace = true }
+p12-keystore = { workspace = true }
+pkcs1 = { workspace = true }
+pkcs8 = { workspace = true }
+num-bigint = { workspace = true }
+sec1 = { workspace = true }
 bs58 = { workspace = true }
 bip39 = { workspace = true }
 flate2 = { workspace = true }

--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -5,14 +5,18 @@ use crate::model::{
 };
 use crate::normalize::NormalizedView;
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
+use crypto_bigint::BoxedUint;
+use crypto_primes::{is_prime, Flavor};
 use data_encoding::{BASE32, BASE64, BASE64URL, BASE64URL_NOPAD, BASE64_NOPAD};
 use fancy_regex::Regex as FancyRegex;
-use openssl::encrypt::{Decrypter, Encrypter};
-use openssl::hash::MessageDigest;
-use openssl::pkcs12::Pkcs12;
-use openssl::pkey::{Id, PKey, Private};
-use openssl::provider::Provider;
-use openssl::rsa::Padding;
+use num_bigint::BigUint;
+use p12_keystore::{KeyStore, Pkcs12ImportPolicy};
+use pkcs1::{der::Decode, RsaPrivateKey};
+use pkcs8::der::{
+    asn1::{AnyRef, OctetStringRef, UintRef},
+    Reader, Tag, Tagged,
+};
+use pkcs8::PrivateKeyInfoRef;
 use regex::Regex as RustRegex;
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -55,11 +59,6 @@ static CREDSWEEPER_BASE32: LazyLock<data_encoding::Encoding> = LazyLock::new(|| 
     specification
         .encoding()
         .expect("CredSweeper-compatible base32 specification")
-});
-static OPENSSL_PKCS12_PROVIDERS: LazyLock<Option<(Provider, Provider)>> = LazyLock::new(|| {
-    let default = Provider::load(None, "default").ok()?;
-    let legacy = Provider::load(None, "legacy").ok()?;
-    Some((default, legacy))
 });
 
 #[derive(Clone)]
@@ -3648,60 +3647,205 @@ fn value_base64_encoded_pem_filtered(value: &str) -> bool {
     true
 }
 
-fn load_der_private_key(data: &[u8]) -> Option<PKey<Private>> {
-    PKey::private_key_from_der(data).ok().or_else(|| {
-        LazyLock::force(&OPENSSL_PKCS12_PROVIDERS).as_ref()?;
-        Pkcs12::from_der(data).ok()?.parse2("").ok()?.pkey
+enum CredSweeperPrivateKey {
+    Rsa,
+    SupportedNonRsa,
+}
+
+fn rsa_private_key_is_valid(data: &[u8]) -> bool {
+    let Ok(key) = RsaPrivateKey::from_der(data) else {
+        return false;
+    };
+    let one = BigUint::from(1_u8);
+    let modulus = BigUint::from_bytes_be(key.modulus.as_bytes());
+    let public_exponent = BigUint::from_bytes_be(key.public_exponent.as_bytes());
+    let private_exponent = BigUint::from_bytes_be(key.private_exponent.as_bytes());
+    let prime1 = BigUint::from_bytes_be(key.prime1.as_bytes());
+    let prime2 = BigUint::from_bytes_be(key.prime2.as_bytes());
+    let mut primes = vec![prime1.clone(), prime2.clone()];
+    if public_exponent <= one || private_exponent <= one || primes.iter().any(|prime| prime <= &one)
+    {
+        return false;
+    }
+    // SHA-1 OAEP with CredSweeper's 20-byte probe needs a 62-byte modulus.
+    if key.modulus.as_bytes().len() < 62 {
+        return false;
+    }
+    let exponent_product = &private_exponent * &public_exponent;
+    if BigUint::from_bytes_be(key.exponent1.as_bytes()) != &private_exponent % (&prime1 - &one)
+        || BigUint::from_bytes_be(key.exponent2.as_bytes()) != &private_exponent % (&prime2 - &one)
+        || (BigUint::from_bytes_be(key.coefficient.as_bytes()) * &prime2) % &prime1 != one
+    {
+        return false;
+    }
+    let mut prime_product = &prime1 * &prime2;
+    if let Some(other_primes) = key.other_prime_infos {
+        for info in other_primes {
+            let prime = BigUint::from_bytes_be(info.prime.as_bytes());
+            if prime <= one
+                || BigUint::from_bytes_be(info.exponent.as_bytes())
+                    != &private_exponent % (&prime - &one)
+                || (BigUint::from_bytes_be(info.coefficient.as_bytes()) * &prime_product) % &prime
+                    != one
+            {
+                return false;
+            }
+            prime_product *= &prime;
+            primes.push(prime);
+        }
+    }
+    prime_product == modulus
+        && primes
+            .iter()
+            .all(|prime| &exponent_product % (prime - &one) == one)
+        && primes.iter().all(|prime| {
+            let bytes = prime.to_bytes_be();
+            is_prime(
+                Flavor::Any,
+                &BoxedUint::from_be_slice_vartime(bytes.as_slice()),
+            )
+        })
+}
+
+fn der_positive_integer(data: &[u8]) -> bool {
+    AnyRef::try_from(data)
+        .and_then(|value| value.decode_as::<UintRef<'_>>())
+        .is_ok_and(|value| !value.is_empty() && value.as_bytes().iter().any(|byte| *byte != 0))
+}
+
+fn rfc8410_private_key(info: &PrivateKeyInfoRef<'_>, expected_len: usize) -> bool {
+    if info.algorithm.parameters.is_some() {
+        return false;
+    }
+    AnyRef::try_from(info.private_key.as_bytes())
+        .and_then(|value| value.decode_as::<&OctetStringRef>())
+        .is_ok_and(|key| key.as_bytes().len() == expected_len)
+}
+
+fn parameter_children(params: AnyRef<'_>) -> Option<Vec<AnyRef<'_>>> {
+    params
+        .sequence(|reader| {
+            let mut children = Vec::new();
+            while !reader.is_finished() {
+                children.push(reader.decode::<AnyRef<'_>>()?);
+            }
+            Ok::<_, pkcs8::der::Error>(children)
+        })
+        .ok()
+}
+
+fn any_positive_integer(value: AnyRef<'_>) -> bool {
+    value.decode_as::<UintRef<'_>>().is_ok_and(|integer| {
+        !integer.is_empty() && integer.as_bytes().iter().any(|byte| *byte != 0)
     })
 }
 
-fn rsa_private_key_roundtrip(key: &PKey<Private>) -> bool {
-    const DATA: &[u8] = b"CredSweeperRSAProbe";
-    let Ok(mut encrypter) = Encrypter::new(key) else {
-        return false;
-    };
-    if encrypter.set_rsa_padding(Padding::PKCS1_OAEP).is_err()
-        || encrypter.set_rsa_oaep_md(MessageDigest::sha1()).is_err()
-        || encrypter.set_rsa_mgf1_md(MessageDigest::sha1()).is_err()
-    {
-        return false;
-    }
-    let Ok(encrypted_len) = encrypter.encrypt_len(DATA) else {
-        return false;
-    };
-    let mut encrypted = vec![0u8; encrypted_len];
-    let Ok(encrypted_len) = encrypter.encrypt(DATA, &mut encrypted) else {
-        return false;
-    };
-    encrypted.truncate(encrypted_len);
-
-    let Ok(mut decrypter) = Decrypter::new(key) else {
-        return false;
-    };
-    if decrypter.set_rsa_padding(Padding::PKCS1_OAEP).is_err()
-        || decrypter.set_rsa_oaep_md(MessageDigest::sha1()).is_err()
-        || decrypter.set_rsa_mgf1_md(MessageDigest::sha1()).is_err()
-    {
-        return false;
-    }
-    let Ok(decrypted_len) = decrypter.decrypt_len(&encrypted) else {
-        return false;
-    };
-    let mut decrypted = vec![0u8; decrypted_len];
-    let Ok(decrypted_len) = decrypter.decrypt(&encrypted, &mut decrypted) else {
-        return false;
-    };
-    decrypted.truncate(decrypted_len);
-    decrypted == DATA
+fn dsa_parameters_valid(params: AnyRef<'_>) -> bool {
+    parameter_children(params).is_some_and(|children| {
+        children.len() == 3 && children.into_iter().all(any_positive_integer)
+    })
 }
 
-fn private_key_is_valid(key: &PKey<Private>) -> bool {
-    match key.id() {
-        Id::RSA | Id::RSA_PSS => rsa_private_key_roundtrip(key),
-        Id::EC | Id::DSA | Id::DH | Id::DHX | Id::ED448 | Id::ED25519 | Id::X448 | Id::X25519 => {
-            true
+fn dh_parameters_valid(params: AnyRef<'_>) -> bool {
+    parameter_children(params).is_some_and(|children| {
+        (2..=3).contains(&children.len()) && children.into_iter().all(any_positive_integer)
+    })
+}
+
+fn dhx_validation_parameters_valid(value: AnyRef<'_>) -> bool {
+    parameter_children(value).is_some_and(|children| {
+        children.len() == 2
+            && children[0].tag() == Tag::BitString
+            && any_positive_integer(children[1])
+    })
+}
+
+fn dhx_parameters_valid(params: AnyRef<'_>) -> bool {
+    parameter_children(params).is_some_and(|children| {
+        if !(3..=5).contains(&children.len())
+            || !children[..3].iter().copied().all(any_positive_integer)
+        {
+            return false;
         }
-        _ => false,
+        match &children[3..] {
+            [] => true,
+            [fourth] => any_positive_integer(*fourth) || dhx_validation_parameters_valid(*fourth),
+            [fourth, fifth] => {
+                any_positive_integer(*fourth) && dhx_validation_parameters_valid(*fifth)
+            }
+            _ => false,
+        }
+    })
+}
+
+fn integer_key_with_parameters(
+    info: &PrivateKeyInfoRef<'_>,
+    parameters_valid: fn(AnyRef<'_>) -> bool,
+) -> bool {
+    info.algorithm.parameters.is_some_and(parameters_valid)
+        && der_positive_integer(info.private_key.as_bytes())
+}
+
+fn load_pkcs8_private_key(data: &[u8]) -> Option<CredSweeperPrivateKey> {
+    let info = PrivateKeyInfoRef::try_from(data).ok()?;
+    match info.algorithm.oid.to_string().as_str() {
+        // rsaEncryption and RSASSA-PSS. OpenSSL validates the embedded PKCS#1
+        // structure for both before CredSweeper performs its RSA probe.
+        "1.2.840.113549.1.1.1" | "1.2.840.113549.1.1.10"
+            if rsa_private_key_is_valid(info.private_key.as_bytes()) =>
+        {
+            Some(CredSweeperPrivateKey::Rsa)
+        }
+        // Keep parsing here rather than accepting a recognized OID by itself:
+        // cryptography.load_der_private_key(), used by CredSweeper, rejects
+        // malformed key bodies before classifying the private-key family.
+        "1.2.840.10045.2.1" => sec1::EcPrivateKey::try_from(info.private_key.as_bytes())
+            .ok()
+            .filter(|key| !key.private_key.is_empty())
+            .and(info.algorithm.parameters.as_ref())
+            .filter(|params| params.tag() == Tag::ObjectIdentifier)
+            .map(|_| CredSweeperPrivateKey::SupportedNonRsa),
+        "1.2.840.10040.4.1" if integer_key_with_parameters(&info, dsa_parameters_valid) => {
+            Some(CredSweeperPrivateKey::SupportedNonRsa)
+        }
+        "1.2.840.113549.1.3.1" if integer_key_with_parameters(&info, dh_parameters_valid) => {
+            Some(CredSweeperPrivateKey::SupportedNonRsa)
+        }
+        "1.2.840.10046.2.1" if integer_key_with_parameters(&info, dhx_parameters_valid) => {
+            Some(CredSweeperPrivateKey::SupportedNonRsa)
+        }
+        "1.3.101.110" if rfc8410_private_key(&info, 32) => {
+            Some(CredSweeperPrivateKey::SupportedNonRsa)
+        }
+        "1.3.101.111" if rfc8410_private_key(&info, 56) => {
+            Some(CredSweeperPrivateKey::SupportedNonRsa)
+        }
+        "1.3.101.112" if rfc8410_private_key(&info, 32) => {
+            Some(CredSweeperPrivateKey::SupportedNonRsa)
+        }
+        "1.3.101.113" if rfc8410_private_key(&info, 57) => {
+            Some(CredSweeperPrivateKey::SupportedNonRsa)
+        }
+        _ => None,
+    }
+}
+
+fn load_der_private_key(data: &[u8]) -> Option<CredSweeperPrivateKey> {
+    if rsa_private_key_is_valid(data) {
+        return Some(CredSweeperPrivateKey::Rsa);
+    }
+    if let Some(key) = load_pkcs8_private_key(data) {
+        return Some(key);
+    }
+    let store = KeyStore::from_pkcs12(data, "", Pkcs12ImportPolicy::Raw).ok()?;
+    let (_, chain) = store.private_key_chain()?;
+    load_pkcs8_private_key(chain.key().as_der())
+}
+
+fn private_key_is_valid(key: &CredSweeperPrivateKey) -> bool {
+    match key {
+        CredSweeperPrivateKey::Rsa => true,
+        CredSweeperPrivateKey::SupportedNonRsa => true,
     }
 }
 
@@ -6730,6 +6874,94 @@ fn normalize_label(rule: &str) -> String {
 mod tests {
     use super::*;
     use crate::detect::region;
+    use p12_keystore::{KeyStoreEntry, PrivateKey, PrivateKeyChain};
+
+    fn rsa_pkcs8_fixture() -> Vec<u8> {
+        BASE64
+            .decode(b"MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALT7bjP4S78u42idmuYyxhZrAini+XRpVhl+PMWKFyhZm+Xm2w+Yb9K6T1Ve9s3NwoxLqZDkXH8t0VGMfMxQfyIYfcTDqjXlg2p2BhdnZ59NeB+OrGw8hI4IaqPs371xVxXzE/v7LMRrIKmVra/i+lu+KVtIrsUfFoqx+gMUEsOBAgMBAAECgYANK3K0g2/3pJDVzwozkCRMA1Nv+t1ONFAYoNAJS+gtfn/Stf7g3qXcfsRBIRzykvOCRAs9yPBWLN5bgc6fC4iEskccmvVGntEyKkkNzF39CNjLBX8nlJkFTY7LxDDSjCj9LCZp343yTvV8tsChXE1+eMoeBE/K/1EmTP/GkacDVQJBAOK1Dt3kEF2ygi7bzILSUWPqk0XNt9kAnNsKMFhp/9CzwM87Zt6fEbG4tyffv7qcUj4jsSXn0h8pXKrnDTBUppMCQQDMXeTBp1td2R8POAe3cyRtL4H2aHGESBgeLhUM1STopdZyneixavl6xb5YsJGvOCav0cQziRffOjsr1zzio0YbAkBmg58UYWOxKt5JWCTzZy1ctB8ianLfErLbLZFM+amu8wmV6/OJaX6z0aYoxrnJJZTe+n7JeDmA09BOi6pgF3c3AkEAy58Z1+F55W35xl4bQitVNfzJzsuNnzF95kQf8SNFnQ/vNVAkkvF1FWCFITT8UsrtsOyeQoLr6BzK7AmOvnnT1QJAW8Pdg05dND79yAjMnowqcvsJEoi6nD1wN9Iq5CrHcGrRLV26vH5a+O1J6Zlz7UdEe6XpJ6mxax1UjICw4AXAOA==")
+            .expect("PKCS#8 RSA fixture")
+    }
+
+    fn rsa_fixture_der() -> Vec<u8> {
+        let pkcs8 = rsa_pkcs8_fixture();
+        PrivateKeyInfoRef::try_from(pkcs8.as_slice())
+            .expect("PKCS#8 fixture")
+            .private_key
+            .as_bytes()
+            .to_vec()
+    }
+
+    #[test]
+    fn private_key_loader_accepts_pkcs1_and_pkcs8_rsa() {
+        let pkcs1 = rsa_fixture_der();
+        let pkcs8 = rsa_pkcs8_fixture();
+        assert!(load_der_private_key(&pkcs1).is_some());
+        assert!(load_der_private_key(&pkcs8).is_some());
+    }
+
+    #[test]
+    fn private_key_loader_rejects_malformed_rsa_der() {
+        let mut pkcs1 = rsa_fixture_der();
+        pkcs1.truncate(pkcs1.len() / 2);
+        assert!(load_der_private_key(&pkcs1).is_none());
+
+        let mut invalid_crt = rsa_fixture_der();
+        *invalid_crt.last_mut().expect("RSA coefficient") ^= 1;
+        assert!(load_der_private_key(&invalid_crt).is_none());
+    }
+
+    #[test]
+    fn private_key_loader_accepts_empty_password_pkcs12() {
+        let pkcs8 = rsa_pkcs8_fixture();
+        let chain = PrivateKeyChain::new(
+            [1_u8, 2, 3, 4].as_slice(),
+            PrivateKey::from_der(&pkcs8).expect("private key"),
+            [],
+        );
+        let mut store = KeyStore::new();
+        store.add_entry("test", KeyStoreEntry::PrivateKeyChain(chain));
+        let p12 = store.writer("").write().expect("PKCS#12 fixture");
+        let key = load_der_private_key(&p12).expect("load PKCS#12");
+        assert!(private_key_is_valid(&key));
+    }
+
+    #[test]
+    fn private_key_loader_validates_rfc8410_key_body() {
+        // RFC 8410 section 10.3 Ed25519 PKCS#8 fixture.
+        let mut ed25519 = data_encoding::HEXLOWER
+            .decode(b"302e020100300506032b65700422042017ed9c73e9db649ec189a612831c5fc570238207c1aa9dfbd2c53e3ff5e5ea85")
+            .expect("Ed25519 fixture");
+        assert!(load_der_private_key(&ed25519).is_some());
+
+        let nested_octet = ed25519
+            .windows(2)
+            .rposition(|bytes| bytes == [0x04, 0x20])
+            .expect("nested private-key OCTET STRING");
+        ed25519[nested_octet] = 0x05;
+        assert!(load_der_private_key(&ed25519).is_none());
+    }
+
+    #[test]
+    fn dsa_and_dh_parameter_parsers_reject_wrong_tags_and_extra_fields() {
+        let dsa = AnyRef::try_from(&[0x30, 9, 2, 1, 2, 2, 1, 3, 2, 1, 5][..]).unwrap();
+        assert!(dsa_parameters_valid(dsa));
+        let dsa_wrong_tag = AnyRef::try_from(&[0x30, 9, 2, 1, 2, 4, 1, 3, 2, 1, 5][..]).unwrap();
+        assert!(!dsa_parameters_valid(dsa_wrong_tag));
+
+        let dh = AnyRef::try_from(&[0x30, 6, 2, 1, 2, 2, 1, 3][..]).unwrap();
+        assert!(dh_parameters_valid(dh));
+        let dh_extra =
+            AnyRef::try_from(&[0x30, 12, 2, 1, 2, 2, 1, 3, 2, 1, 5, 2, 1, 7][..]).unwrap();
+        assert!(!dh_parameters_valid(dh_extra));
+
+        let dhx_with_validation = AnyRef::try_from(
+            &[
+                0x30, 17, 2, 1, 2, 2, 1, 3, 2, 1, 5, 0x30, 6, 3, 1, 0, 2, 1, 7,
+            ][..],
+        )
+        .unwrap();
+        assert!(dhx_parameters_valid(dhx_with_validation));
+    }
 
     #[test]
     fn embedded_assets_are_present() {
@@ -7359,8 +7591,7 @@ mod tests {
 
     #[test]
     fn value_base64_key_loads_and_checks_private_keys() {
-        let rsa = openssl::rsa::Rsa::generate(1024).unwrap();
-        let der = rsa.private_key_to_der().unwrap();
+        let der = rsa_fixture_der();
         let encoded = BASE64.encode(&der);
         assert!(!value_base64_key_filtered(&encoded));
 
@@ -7376,8 +7607,7 @@ mod tests {
 
     #[test]
     fn value_base64_key_ignores_captured_source_punctuation_like_python() {
-        let rsa = openssl::rsa::Rsa::generate(1024).expect("RSA fixture");
-        let encoded = BASE64.encode(&rsa.private_key_to_der().expect("DER fixture"));
+        let encoded = BASE64.encode(&rsa_fixture_der());
         assert!(!value_base64_key_filtered(&format!("{encoded}\"`,")));
     }
 
@@ -7723,8 +7953,7 @@ mod tests {
             "n7fzJc3_WG59VEOBTkayzuSMM780OJQuZjN_KbH8lOZG25ZoA7T4Bxcc0xQn5oZE5uSCI",
             "wg91oCt0JvxPcpmqzaJZg1nirjcWZ-oBtVk7gCAWq-B3qhfF3izlbkosrzjHajIcY33HBh",
         );
-        let rsa = openssl::rsa::Rsa::generate(1024).unwrap();
-        let base64_key = BASE64.encode(&rsa.private_key_to_der().unwrap());
+        let base64_key = BASE64.encode(&rsa_fixture_der());
         let raw = format!(
             "aws {aws_id} {aws_secret}\n\
              google 123-abcdeabcdeabcdeabcdeabcdeabcdeab.apps.googleusercontent.com {google_secret}\n\


### PR DESCRIPTION
## Why

Windows release builds spend most of their time building and statically linking vendored OpenSSL. Pentect only used OpenSSL for CredSweeper-compatible private-key validation. Issue #657 requested Perl for AUR specifically because vendored OpenSSL needed it; removing vendored OpenSSL removes that packaging requirement at its source.

## What changed

- replace OpenSSL RSA/PKCS#8/PKCS#12 handling with maintained pure-Rust format and math crates
- keep Pentect-owned code limited to the CredSweeper compatibility adapter; do not reimplement cryptographic primitives
- validate RSA prime factors, CRT values, modulus, exponents, and SHA-1 OAEP size requirements without performing private-key operations
- structurally validate EC, DSA, DH/DHX, and RFC 8410 key families
- preserve empty-password PKCS#12 support
- remove `openssl`, `openssl-sys`, `openssl-src`, and the advisory-affected `rsa` crate from the dependency graph
- regenerate third-party notices

## Verification

- `cargo test -p pentect-core detect::credsweeper::tests` (106 passed)
- focused PKCS#1, PKCS#8, PKCS#12, malformed DER/CRT, RFC 8410, DSA, and DH tests
- `cargo clippy -p pentect-core --all-targets -- -D warnings`
- `python tools/check_credsweeper_port_inventory.py` (43 filters, 0 unverified)
- `python tools/generate_licenses.py --check`
- `cargo tree -i openssl` and `cargo tree -i rsa` confirm both are absent

Closes #657
Progresses #739