### PR TITLE
ci: speed up Windows test linking with lld

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,14 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/rust-toolchain
         if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true'
+      - name: Configure fast Windows test linking
+        if: runner.os == 'Windows' && (needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true')
+        shell: pwsh
+        run: |
+          $linker = (Get-Command lld-link.exe -ErrorAction Stop).Source
+          "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linker" >> $env:GITHUB_ENV
+          "CARGO_PROFILE_TEST_DEBUG=0" >> $env:GITHUB_ENV
+          "Using linker: $linker"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true'
       - name: Test Codex App launcher and recovery

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
               - 'crates/pentect-cli/src/remote_content.rs'
               - 'crates/pentect-cli/src/upstream.rs'
             claude_app:
+              - '.github/workflows/ci.yml'
               - 'crates/pentect-cli/src/claude_app_proxy.rs'
               - 'crates/pentect-cli/src/claude_http_proxy.rs'
               - 'crates/pentect-cli/src/http_files.rs'


### PR DESCRIPTION
## What changed

- use the preinstalled `lld-link.exe` for Windows desktop-boundary Rust tests
- disable test-profile debug info in that CI job
- ensure changes to the CI workflow exercise the Claude app job, so this optimization cannot merge untested

## Measured result

Before removing OpenSSL, the identical gateway step improved from 13m01s to 12m20s. This isolates the linker/debug setting at about 41 seconds saved. The larger improvement comes from #993; this PR preserves the independent linker gain without coupling it to the still-open Windows CA work in #992.

Validated in https://github.com/EdamAme-x/pentect/actions/runs/33055768163/job/98465389756