### PR TITLE
chore: prepare v0.0.59

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.58"
+version = "0.0.59"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the Pentect CLI and npm package to v0.0.59
- release the current main state, including the OpenSSL removal, Windows CI acceleration, and Claude Desktop Windows trust flow

## Validation

- cargo metadata version check
- npm package tests
- package metadata check
- third-party license check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application package version from 0.0.58 to 0.0.59.
  * Updated the CLI package version from 0.0.58 to 0.0.59.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->