### PR TITLE
ci: fix Windows Claude release smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -607,8 +607,11 @@ jobs:
           $claudeSource = (Resolve-Path 'tools/claude-app-smoke-fixture.cs').Path
           & $csc /nologo /target:exe "/out:$claudeFixture" $claudeSource
           if ($LASTEXITCODE -ne 0) { throw 'Claude fixture compilation failed' }
-          & $env:PENTECT_SMOKE_BINARY claude app --app $claudeFixture --upstream https://api.anthropic.com
-          if ($LASTEXITCODE -ne 0) { throw 'pentect claude app failed to launch' }
+          # Root-store trust requires an interactive Windows security confirmation.
+          # The dedicated Windows CA lifecycle test exercises add/find/remove across
+          # processes; release smoke verifies the installed CLI's app contract here.
+          & $env:PENTECT_SMOKE_BINARY claude app --check --app $claudeFixture --upstream https://api.anthropic.com
+          if ($LASTEXITCODE -ne 0) { throw 'pentect claude app contract check failed' }
       - name: Verify agent CLIs and desktop app contracts (POSIX)
         if: runner.os != 'Windows'
         shell: bash


### PR DESCRIPTION
## Bug

The v0.0.59 release smoke invokes `pentect claude app` noninteractively on Windows. The newly merged trust flow correctly requires confirmation, so both direct and npm release smoke jobs stop before publication.

## Fix

Use `claude app --check` in the installed-binary release smoke. This verifies discovery and option parsing without bypassing Windows Root-store confirmation. The dedicated Windows CA lifecycle test continues to verify add/find/remove behavior across processes.

## Evidence

- failing release run: https://github.com/EdamAme-x/pentect/actions/runs/33068943185
- direct and npm installation itself completed; both failed only at the stale noninteractive Claude launch step