### PR TITLE
chore: prepare v0.0.60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.59"
+version = "0.0.60"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.59"
+version = "0.0.60"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump the CLI and npm package to v0.0.60
- supersede the v0.0.59 prerelease whose Windows smoke used the stale Claude App invocation

## Validation
- cargo/package version checks
- release metadata validation
- license validation
- npm tests (8 passed)