### PR TITLE
fix(openai): mask Responses tool-call history arguments

### DIFF
--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -1831,6 +1831,16 @@ fn mask_openai_input(
                 .unwrap_or_default()
                 .to_string();
             match item_type.as_str() {
+                "function_call" | "custom_tool_call" => {
+                    // Previous assistant tool calls are sent back to the model as
+                    // conversation history. Their locally restored arguments can
+                    // contain secrets, so protect both Responses API call shapes.
+                    for key in ["arguments", "input"] {
+                        if let Some(Value::String(arguments)) = object.get_mut(key) {
+                            mask_text(arguments, true, masker)?;
+                        }
+                    }
+                }
                 "function_call_output" | "custom_tool_call_output" => {
                     if let Some(output) = object.get_mut("output") {
                         mask_openai_input(output, true, masker, files)?;
@@ -3689,6 +3699,56 @@ mod tests {
             request.matches("<<").count() >= 2,
             "expected prompt handles did not reach upstream"
         );
+    }
+
+    #[test]
+    fn provider_boundary_masks_responses_tool_call_history() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = ProviderBoundaryTestEnv::install(&store);
+        let secret = ["rpa_", "TOOLHISTORY", "ZYXWVUTS", "RQPONMLK", "1234567890"].concat();
+        let (upstream, captured, thread) = mock_chat_upstream();
+        let proxy = OpenAiHttpProxyGuard::start(upstream).unwrap();
+
+        reqwest::blocking::Client::new()
+            .post(format!("{}/responses", proxy.base_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(
+                serde_json::to_vec(&serde_json::json!({
+                    "model": "test",
+                    "input": [
+                        {
+                            "type": "function_call",
+                            "name": "shell",
+                            "arguments": serde_json::json!({
+                                "command": format!("export RUNPOD_API_KEY={secret}")
+                            }).to_string()
+                        },
+                        {
+                            "type": "custom_tool_call",
+                            "name": "exec_command",
+                            "input": format!("curl -H 'Authorization: Bearer {secret}' localhost")
+                        }
+                    ],
+                    "stream": false
+                }))
+                .unwrap(),
+            )
+            .send()
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+
+        let (_, request) = captured
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .unwrap();
+        thread.join().unwrap();
+        assert!(!request.contains(&secret), "tool history reached upstream");
+        let protected: Value = serde_json::from_str(&request).unwrap();
+        for (index, key) in [(0, "arguments"), (1, "input")] {
+            let value = protected["input"][index][key].as_str().unwrap();
+            assert!(value.contains("<<"), "unmasked {key}: {value}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Bug
Responses API history items of type `function_call` and `custom_tool_call` bypassed request masking because `mask_openai_input` did not inspect `arguments` or `input`. Locally restored credentials could therefore reach the OpenAI upstream in cleartext on later turns.

## Fix
- mask `arguments` and `input` for both tool-call item types as external content
- add a localhost upstream-recorder regression covering standard and custom calls

## Validation
- `cargo test -p pentect-cli provider_boundary_masks_responses_tool_call_history -- --nocapture`
- recorder received handles for both fields and no plaintext synthetic secret

Closes #686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for restored conversation history by masking tool-call arguments before they are sent upstream.
  * Covered both standard function calls and custom tool calls to prevent unmask markers from being transmitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->