### PR TITLE
ci: stop unrelated tests and PR cache uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
       openai_proxy: ${{ steps.filter.outputs.openai_proxy }}
       command_shims: ${{ steps.filter.outputs.command_shims }}
       runtime_log: ${{ steps.filter.outputs.runtime_log }}
-      cli_general: ${{ steps.filter.outputs.cli_general }}
-      runtime_general: ${{ steps.filter.outputs.runtime_general }}
+      cli_general: ${{ steps.filter-general.outputs.cli_general }}
+      runtime_general: ${{ steps.filter-general.outputs.runtime_general }}
       runtime_main: ${{ steps.filter.outputs.runtime_main }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -175,6 +175,16 @@ jobs:
               - 'crates/pentect-runtime/src/activity_log.rs'
               - 'crates/pentect-runtime/src/delegated_process_host.rs'
               - 'crates/pentect-runtime/src/memory_store.rs'
+            runtime_main:
+              - 'crates/pentect-runtime/src/main.rs'
+      # Negated globs require AND semantics. With paths-filter's default OR
+      # semantics, every unrelated file satisfies at least one `!pattern` and
+      # incorrectly enables both broad test suites.
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter-general
+        with:
+          predicate-quantifier: every
+          filters: |
             cli_general:
               - 'crates/pentect-cli/src/**'
               - '!crates/pentect-cli/src/codex_app.rs'
@@ -197,8 +207,6 @@ jobs:
               - '!crates/pentect-runtime/src/image.rs'
               - '!crates/pentect-runtime/src/masking.rs'
               - '!crates/pentect-runtime/src/plugin_middleware.rs'
-            runtime_main:
-              - 'crates/pentect-runtime/src/main.rs'
 
   native-ocr:
     name: Native OCR (${{ matrix.os }})
@@ -223,6 +231,8 @@ jobs:
         if: needs.changes.outputs.ocr == 'true'
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: needs.changes.outputs.ocr == 'true'
+        with:
+          save-if: ${{ github.event_name == 'push' }}
       - name: Build native OCR
         if: needs.changes.outputs.ocr == 'true'
         run: cargo build -p pentect-cli --features ocr --locked
@@ -254,6 +264,8 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: needs.changes.outputs.plugins == 'true' || needs.changes.outputs.detector == 'true'
+        with:
+          save-if: ${{ github.event_name == 'push' }}
       - name: Measure canonical engine cold construction
         if: needs.changes.outputs.detector == 'true'
         run: cargo test -p pentect-runtime --lib --locked canonical_engine_construction_stays_off_the_warm_up_path -- --nocapture
@@ -314,6 +326,8 @@ jobs:
           "Using linker: $linker"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: needs.changes.outputs.codex_app == 'true' || needs.changes.outputs.claude_app == 'true' || needs.changes.outputs.openai_proxy == 'true' || needs.changes.outputs.command_shims == 'true'
+        with:
+          save-if: ${{ github.event_name == 'push' }}
       - name: Test Codex App launcher and recovery
         if: needs.changes.outputs.codex_app == 'true'
         run: python tools/run_filtered_tests.py codex_app::tests
@@ -381,6 +395,8 @@ jobs:
           go-version-file: tools/alcatraz-helper/go.mod
           cache-dependency-path: tools/alcatraz-helper/go.sum
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name == 'push' }}
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
## Measured problem
PR #999 changed only `openai_http_proxy.rs`, but the path filter reported both `cli_general=true` and `runtime_general=true`. This ran 59 seconds of broad CLI tests and 1m58s of unrelated runtime tests. Windows and macOS also spent 40s/26s uploading Rust caches after their tests.

The cause is `paths-filter` default OR (`some`) semantics: each negated glob is independently true for unrelated files.

## Change
- evaluate the two include-plus-exclusion filters in a dedicated `predicate-quantifier: every` step
- restore Rust caches on PRs but save them only on `push`, so merged `main` remains the cache producer
- preserve all specialized, platform, full-main, and release test coverage

## Evidence
- #999 CI: https://github.com/EdamAme-x/pentect/actions/runs/33079101265
- pinned paths-filter documentation defines `every` for this exact exclusion case
- pinned rust-cache action supports `save-if` while retaining restore behavior

Related: #739