### PR TITLE
fix(claude-app): keep the CA journal out of the install root

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -285,7 +285,14 @@ fn windows_ca_journal_path() -> Result<PathBuf, String> {
     let root = std::env::var_os("LOCALAPPDATA")
         .map(PathBuf::from)
         .ok_or_else(|| "LOCALAPPDATA is unavailable for Claude Desktop CA cleanup".to_string())?;
-    Ok(root.join("Pentect").join("claude-app-temporary-ca.sha1"))
+    // The journal lives in its own directory. `write_windows_ca_journal`
+    // restricts the containing directory to the current user, so it must never
+    // be the shared install root: that would strip the inheritable
+    // SYSTEM/Administrators entries from `bin`, `plugins`, and `runtime`.
+    Ok(root
+        .join("Pentect")
+        .join("claude-app-ca")
+        .join("claude-app-temporary-ca.sha1"))
 }
 
 #[cfg(windows)]
@@ -306,14 +313,18 @@ fn write_windows_ca_journal(thumbprint: &str) -> Result<(), String> {
 
 #[cfg(windows)]
 fn remove_windows_ca_journal() -> Result<(), String> {
-    let path = windows_ca_journal_path()?;
-    match std::fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(format!(
-            "could not remove Claude Desktop CA cleanup journal: {error}"
-        )),
+    for path in [windows_ca_journal_path()?, legacy_windows_ca_journal_path()?] {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "could not remove Claude Desktop CA cleanup journal: {error}"
+                ))
+            }
+        }
     }
+    Ok(())
 }
 
 #[cfg(windows)]
@@ -371,15 +382,31 @@ fn windows_ca_owner_is_running(owner: Option<u32>) -> bool {
     system.process(pid).is_some()
 }
 
+// Releases before the journal moved into its own directory wrote it directly
+// into the install root. Read that location too so a certificate left behind by
+// an older build is still cleaned up after an upgrade.
+#[cfg(windows)]
+fn legacy_windows_ca_journal_path() -> Result<PathBuf, String> {
+    let root = std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .ok_or_else(|| "LOCALAPPDATA is unavailable for Claude Desktop CA cleanup".to_string())?;
+    Ok(root.join("Pentect").join("claude-app-temporary-ca.sha1"))
+}
+
 #[cfg(windows)]
 fn read_windows_ca_journal() -> Result<Option<WindowsCaJournal>, String> {
-    match std::fs::read_to_string(windows_ca_journal_path()?) {
-        Ok(content) => parse_windows_ca_journal(&content).map(Some),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(format!(
-            "could not read Claude Desktop CA cleanup journal: {error}"
-        )),
+    for path in [windows_ca_journal_path()?, legacy_windows_ca_journal_path()?] {
+        match std::fs::read_to_string(&path) {
+            Ok(content) => return parse_windows_ca_journal(&content).map(Some),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(format!(
+                    "could not read Claude Desktop CA cleanup journal: {error}"
+                ))
+            }
+        }
     }
+    Ok(None)
 }
 
 #[cfg(windows)]

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -313,7 +313,10 @@ fn write_windows_ca_journal(thumbprint: &str) -> Result<(), String> {
 
 #[cfg(windows)]
 fn remove_windows_ca_journal() -> Result<(), String> {
-    for path in [windows_ca_journal_path()?, legacy_windows_ca_journal_path()?] {
+    for path in [
+        windows_ca_journal_path()?,
+        legacy_windows_ca_journal_path()?,
+    ] {
         match std::fs::remove_file(&path) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -395,7 +398,10 @@ fn legacy_windows_ca_journal_path() -> Result<PathBuf, String> {
 
 #[cfg(windows)]
 fn read_windows_ca_journal() -> Result<Option<WindowsCaJournal>, String> {
-    for path in [windows_ca_journal_path()?, legacy_windows_ca_journal_path()?] {
+    for path in [
+        windows_ca_journal_path()?,
+        legacy_windows_ca_journal_path()?,
+    ] {
         match std::fs::read_to_string(&path) {
             Ok(content) => return parse_windows_ca_journal(&content).map(Some),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -313,18 +313,18 @@ fn write_windows_ca_journal(thumbprint: &str) -> Result<(), String> {
 
 #[cfg(windows)]
 fn remove_windows_ca_journal() -> Result<(), String> {
-    for path in [
-        windows_ca_journal_path()?,
-        legacy_windows_ca_journal_path()?,
-    ] {
-        match std::fs::remove_file(&path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(format!(
-                    "could not remove Claude Desktop CA cleanup journal: {error}"
-                ))
-            }
+    remove_windows_ca_journal_at(&windows_ca_journal_path()?)
+}
+
+#[cfg(windows)]
+fn remove_windows_ca_journal_at(path: &std::path::Path) -> Result<(), String> {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "could not remove Claude Desktop CA cleanup journal: {error}"
+            ))
         }
     }
     Ok(())
@@ -397,13 +397,14 @@ fn legacy_windows_ca_journal_path() -> Result<PathBuf, String> {
 }
 
 #[cfg(windows)]
-fn read_windows_ca_journal() -> Result<Option<WindowsCaJournal>, String> {
+fn read_windows_ca_journals() -> Result<Vec<(PathBuf, WindowsCaJournal)>, String> {
+    let mut journals = Vec::new();
     for path in [
         windows_ca_journal_path()?,
         legacy_windows_ca_journal_path()?,
     ] {
         match std::fs::read_to_string(&path) {
-            Ok(content) => return parse_windows_ca_journal(&content).map(Some),
+            Ok(content) => journals.push((path, parse_windows_ca_journal(&content)?)),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
             Err(error) => {
                 return Err(format!(
@@ -412,7 +413,7 @@ fn read_windows_ca_journal() -> Result<Option<WindowsCaJournal>, String> {
             }
         }
     }
-    Ok(None)
+    Ok(journals)
 }
 
 #[cfg(windows)]
@@ -533,25 +534,30 @@ fn windows_user_ca_present(thumbprint: &str) -> Result<bool, String> {
 
 #[cfg(windows)]
 pub(crate) fn windows_ca_cleanup_pending() -> Result<bool, String> {
-    let Some(journal) = read_windows_ca_journal()? else {
-        return Ok(false);
-    };
-    Ok(!windows_ca_owner_is_running(journal.owner))
+    Ok(read_windows_ca_journals()?
+        .iter()
+        .any(|(_, journal)| !windows_ca_owner_is_running(journal.owner)))
 }
 
 #[cfg(windows)]
 pub(crate) fn cleanup_stale_windows_user_ca() -> Result<(), String> {
-    let Some(journal) = read_windows_ca_journal()? else {
+    let journals = read_windows_ca_journals()?;
+    if journals.is_empty() {
         return Ok(());
-    };
-    if windows_ca_owner_is_running(journal.owner) {
+    }
+    if journals
+        .iter()
+        .any(|(_, journal)| windows_ca_owner_is_running(journal.owner))
+    {
         return Err(
             "Claude Desktop protection is active; refusing to remove its certificate".to_string(),
         );
     }
-    remove_windows_user_ca(&journal.thumbprint)?;
-    remove_windows_ca_journal()?;
-    eprintln!("[pentect] Removed a stale temporary Claude Desktop certificate");
+    for (path, journal) in journals {
+        remove_windows_user_ca(&journal.thumbprint)?;
+        remove_windows_ca_journal_at(&path)?;
+    }
+    eprintln!("[pentect] Removed stale temporary Claude Desktop certificates");
     Ok(())
 }
 
@@ -3612,6 +3618,47 @@ mod tests {
         eprintln!("windows CA round trip: checking final absence from a fresh process");
         assert_windows_ca_visibility_in_fresh_process(&authority.thumbprint, false);
         assert!(!windows_ca_cleanup_pending().unwrap());
+
+        // An upgrade can leave a legacy journal while a newer session writes
+        // the current journal. Each journal must remain paired with, and clean
+        // up, its own certificate.
+        let legacy_authority = CertificateAuthority::new().unwrap();
+        let legacy_guard = WindowsUserCaGuard::install(
+            legacy_authority.issuer.der(),
+            &legacy_authority.thumbprint,
+        )
+        .unwrap();
+        std::fs::rename(
+            windows_ca_journal_path().unwrap(),
+            legacy_windows_ca_journal_path().unwrap(),
+        )
+        .unwrap();
+        let current_authority = CertificateAuthority::new().unwrap();
+        let current_guard = WindowsUserCaGuard::install(
+            current_authority.issuer.der(),
+            &current_authority.thumbprint,
+        )
+        .unwrap();
+        std::fs::write(
+            legacy_windows_ca_journal_path().unwrap(),
+            &legacy_authority.thumbprint,
+        )
+        .unwrap();
+        std::fs::write(
+            windows_ca_journal_path().unwrap(),
+            &current_authority.thumbprint,
+        )
+        .unwrap();
+        std::mem::forget(legacy_guard);
+        std::mem::forget(current_guard);
+
+        assert_windows_ca_visibility_in_fresh_process(&legacy_authority.thumbprint, true);
+        assert_windows_ca_visibility_in_fresh_process(&current_authority.thumbprint, true);
+        cleanup_stale_windows_user_ca().unwrap();
+        assert_windows_ca_visibility_in_fresh_process(&legacy_authority.thumbprint, false);
+        assert_windows_ca_visibility_in_fresh_process(&current_authority.thumbprint, false);
+        assert!(!legacy_windows_ca_journal_path().unwrap().exists());
+        assert!(!windows_ca_journal_path().unwrap().exists());
         remove_windows_test_ca_store(&store_name);
 
         match previous {


### PR DESCRIPTION
Fixes #1000.

## Problem

`write_windows_ca_journal` calls `restrict_to_current_user` on the journal's containing directory. That helper clears inheritance and grants a single explicit ACE (`icacls /inheritance:r /grant:r *<SID>:(F)`) — correct for an isolated temp file, which is how it's used everywhere else in the codebase.

The journal lived directly in `%LOCALAPPDATA%\Pentect`, so `path.parent()` was the shared install root. Every `pentect claude app` launch therefore stripped the inheritable SYSTEM/Administrators entries from `bin`, `plugins`, and `runtime`.

On my machine those subdirectories ended up with an empty effective ACL — not even the owning user could list them — and the bundled Alcatraz detector failed on every single request:

```
[pentect] warning/alcatraz detector-unavailable: could not create
'...\Pentect\runtime\alcatraz\0.20.2\<hash>': アクセスが拒否されました。 (os error 5)
```

`icacls "%LOCALAPPDATA%\Pentect" /reset /T` restored it and the warnings stopped immediately.

## Change

Move the journal into its own `claude-app-ca` subdirectory, so the restriction only ever applies to a directory that exists solely for it. `read_windows_ca_journal` and `remove_windows_ca_journal` also check the previous location, so a certificate left behind by an older build is still cleaned up after an upgrade rather than being orphaned in the user's certificate store.

## Verification

Reproduced both behaviors against scratch directories with the normal Windows-default ACL, using the exact `icacls` invocation `restrict_to_current_user` performs:

```
### old: restrict the install root
root:  DESKTOP-XXXXXXXX\user:(F)
bin:   (empty — no ACEs at all)

### new: restrict only claude-app-ca
root:           NT AUTHORITY\SYSTEM:(I)(OI)(CI)(F)
                BUILTIN\Administrators:(I)(OI)(CI)(F)
                DESKTOP-XXXXXXXX\user:(I)(OI)(CI)(F)
bin:            (same — untouched)
claude-app-ca:  DESKTOP-XXXXXXXX\user:(F)
```

`cargo build --release -p pentect-cli` is clean (no new warnings). `pentect claude app --check` still reports the app and the certificate-based compatibility line as before. The existing `windows_ca_round_trip` test asserts through `windows_ca_journal_path()`, so it follows the new location automatically — I was not able to run the Windows-gated test suite locally, so please confirm it in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows certificate cleanup during upgrades.
  - Certificates and cleanup records from both current and older installations are now detected and removed.
  - Prevents legacy certificate data from being left behind after updating the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->