### PR TITLE
fix(opencode): restore native provider and model selection

### DIFF
--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -106,7 +106,10 @@ jobs:
           $claudeSource = (Resolve-Path 'tools/claude-app-smoke-fixture.cs').Path
           & $csc /nologo /target:exe "/out:$claudeFixture" $claudeSource
           if ($LASTEXITCODE -ne 0) { throw 'Claude fixture compilation failed' }
-          & $env:PENTECT_SMOKE_BINARY claude app --yes --app $claudeFixture --upstream https://api.anthropic.com
+          # Windows root-store trust opens an OS confirmation UI. The dedicated
+          # CA lifecycle test covers add/find/remove; this headless smoke checks
+          # the installed CLI and app contract without opening that dialog.
+          & $env:PENTECT_SMOKE_BINARY claude app --check --app $claudeFixture --upstream https://api.anthropic.com
           if ($LASTEXITCODE -ne 0) { throw 'Claude Desktop contract failed' }
       - name: Start both protected desktop app contracts (POSIX)
         if: runner.os != 'Windows'

--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -138,7 +138,7 @@ jobs:
         shell: pwsh
         run: |
           & $env:PENTECT_SMOKE_BINARY uninstall
-          for ($attempt = 0; $attempt -lt 100 -and (Test-Path -LiteralPath $env:PENTECT_SMOKE_BINARY); $attempt++) {
+          for ($attempt = 0; $attempt -lt 300 -and (Test-Path -LiteralPath $env:PENTECT_SMOKE_BINARY); $attempt++) {
             Start-Sleep -Milliseconds 100
           }
           if (Test-Path -LiteralPath $env:PENTECT_SMOKE_BINARY) { throw 'uninstall did not remove Pentect' }

--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -106,7 +106,7 @@ jobs:
           $claudeSource = (Resolve-Path 'tools/claude-app-smoke-fixture.cs').Path
           & $csc /nologo /target:exe "/out:$claudeFixture" $claudeSource
           if ($LASTEXITCODE -ne 0) { throw 'Claude fixture compilation failed' }
-          & $env:PENTECT_SMOKE_BINARY claude app --app $claudeFixture --upstream https://api.anthropic.com
+          & $env:PENTECT_SMOKE_BINARY claude app --yes --app $claudeFixture --upstream https://api.anthropic.com
           if ($LASTEXITCODE -ne 0) { throw 'Claude Desktop contract failed' }
       - name: Start both protected desktop app contracts (POSIX)
         if: runner.os != 'Windows'
@@ -124,7 +124,7 @@ jobs:
 
           claude_fixture="$RUNNER_TEMP/claude-app-fixture"
           cc -std=c11 -Wall -Wextra -Werror tools/claude-app-smoke-fixture.c -o "$claude_fixture"
-          "$PENTECT_SMOKE_BINARY" claude app --app "$claude_fixture" --upstream https://api.anthropic.com
+          "$PENTECT_SMOKE_BINARY" claude app --yes --app "$claude_fixture" --upstream https://api.anthropic.com
       - name: Verify client diagnostics
         run: >-
           python tools/verify_client_smoke_log.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -629,7 +629,7 @@ jobs:
           cmp "$RUNNER_TEMP/config.before" "$CODEX_HOME/config.toml"
           claude_fixture="$RUNNER_TEMP/claude-app-fixture"
           cc -std=c11 -Wall -Wextra -Werror tools/claude-app-smoke-fixture.c -o "$claude_fixture"
-          "$PENTECT_SMOKE_BINARY" claude app --app "$claude_fixture" --upstream https://api.anthropic.com
+          "$PENTECT_SMOKE_BINARY" claude app --yes --app "$claude_fixture" --upstream https://api.anthropic.com
       - name: Verify persistent diagnostics (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -696,7 +696,7 @@ jobs:
         shell: pwsh
         run: |
           & $env:PENTECT_SMOKE_BINARY uninstall
-          for ($attempt = 0; $attempt -lt 100 -and (Test-Path -LiteralPath $env:PENTECT_SMOKE_BINARY); $attempt++) {
+          for ($attempt = 0; $attempt -lt 300 -and (Test-Path -LiteralPath $env:PENTECT_SMOKE_BINARY); $attempt++) {
             Start-Sleep -Milliseconds 100
           }
           if (Test-Path -LiteralPath $env:PENTECT_SMOKE_BINARY) { throw 'uninstall did not remove the binary' }

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1317,6 +1317,14 @@ impl AgentToolOpts {
                 "--prompt-proxy" | "--no-prompt-proxy" => {
                     return Err("prompt protection is automatic".to_string());
                 }
+                _ if *tool == client_descriptor::OPENCODE => {
+                    let (trailing_model, trailing_args) = extract_opencode_model_arg(&args[i..])?;
+                    if trailing_model.is_some() {
+                        model = trailing_model;
+                    }
+                    tool_args.extend(trailing_args);
+                    break;
+                }
                 _ => {
                     tool_args.extend(args[i..].iter().cloned());
                     break;
@@ -1335,6 +1343,40 @@ impl AgentToolOpts {
             tool_args,
         })
     }
+}
+
+fn extract_opencode_model_arg(args: &[String]) -> Result<(Option<String>, Vec<String>), String> {
+    let mut model = None;
+    let mut forwarded = Vec::with_capacity(args.len());
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--" => {
+                forwarded.extend(args[i..].iter().cloned());
+                break;
+            }
+            "--model" | "-m" => {
+                let value = args
+                    .get(i + 1)
+                    .ok_or_else(|| format!("{} requires a value", args[i]))?;
+                model = Some(value.clone());
+                i += 2;
+            }
+            value if value.starts_with("--model=") || value.starts_with("-m=") => {
+                let (_, value) = value.split_once('=').expect("matched model assignment");
+                if value.is_empty() {
+                    return Err("--model requires a value".to_string());
+                }
+                model = Some(value.to_string());
+                i += 1;
+            }
+            _ => {
+                forwarded.push(args[i].clone());
+                i += 1;
+            }
+        }
+    }
+    Ok((model, forwarded))
 }
 
 fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
@@ -3318,8 +3360,27 @@ mod tests {
         ]
         .map(str::to_string);
         let opencode = AgentToolOpts::parse(&client_descriptor::OPENCODE, &opencode_args).unwrap();
+        assert_eq!(opencode.model.as_deref(), Some("second-client-value"));
+        assert_eq!(opencode.tool_args, ["run"]);
+    }
+
+    #[test]
+    fn opencode_model_after_separator_remains_client_owned() {
+        let args = [
+            "pentect",
+            "opencode",
+            "run",
+            "--",
+            "--model",
+            "literal-prompt-text",
+        ]
+        .map(str::to_string);
+        let opencode = AgentToolOpts::parse(&client_descriptor::OPENCODE, &args).unwrap();
         assert_eq!(opencode.model, None);
-        assert_eq!(opencode.tool_args, opencode_args[2..]);
+        assert_eq!(
+            opencode.tool_args,
+            ["run", "--", "--model", "literal-prompt-text"]
+        );
     }
 
     #[test]

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -15,15 +15,18 @@ pub(crate) fn run(
     opts: &crate::AgentToolOpts,
     pentect: &Path,
 ) -> Result<std::process::ExitStatus, String> {
+    let crate::client_descriptor::Launcher::OpenAi(injection) = tool.launcher else {
+        return Err("internal OpenAI client launcher mismatch".to_string());
+    };
+    if injection == crate::client_descriptor::OpenAiInjection::InlineConfig {
+        return run_opencode(tool, opts, pentect);
+    }
     let upstream = opts
         .upstream
         .clone()
         .or_else(|| configured_upstream(tool))
         .or_else(|| tool.default_upstream.map(str::to_string))
         .ok_or_else(|| format!("{} has no configured upstream", tool.name))?;
-    let crate::client_descriptor::Launcher::OpenAi(injection) = tool.launcher else {
-        return Err("internal OpenAI client launcher mismatch".to_string());
-    };
     let args = opts.tool_args.clone();
     let model = selected_model(opts.model.as_deref())?;
     let api = ClientApi::parse(opts.api.as_deref())?;
@@ -93,10 +96,7 @@ pub(crate) fn run(
 
     match injection {
         crate::client_descriptor::OpenAiInjection::InlineConfig => {
-            let config = opencode_config(proxy.base_url(), &model, api)?;
-            command.env("OPENCODE_CONFIG_CONTENT", config);
-            command.args(args);
-            crate::run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
+            unreachable!("OpenCode is handled by run_opencode")
         }
         crate::client_descriptor::OpenAiInjection::TempExtension => {
             let extension = PiProviderFile::create()?;
@@ -150,6 +150,168 @@ pub(crate) fn run(
             )
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OpenCodeProtocol {
+    OpenAi,
+    Anthropic,
+    Gemini,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct OpenCodeRoute {
+    provider: String,
+    model: Option<String>,
+    upstream: String,
+    protocol: OpenCodeProtocol,
+    bearer_env: Option<&'static str>,
+}
+
+impl OpenCodeRoute {
+    fn resolve(opts: &crate::AgentToolOpts) -> Result<Self, String> {
+        if let Some(upstream) = opts.upstream.clone() {
+            let model = selected_model(opts.model.as_deref())?;
+            return Ok(Self {
+                provider: "pentect-gateway".to_string(),
+                model: Some(format!("pentect-gateway/{model}")),
+                upstream,
+                protocol: OpenCodeProtocol::OpenAi,
+                bearer_env: Some("OPENAI_API_KEY"),
+            });
+        }
+
+        let Some(model) = opts.model.as_deref() else {
+            return Ok(Self {
+                provider: "opencode".to_string(),
+                model: None,
+                upstream: "https://opencode.ai/zen/v1".to_string(),
+                protocol: OpenCodeProtocol::OpenAi,
+                bearer_env: Some("OPENCODE_API_KEY"),
+            });
+        };
+        validate_model(model)?;
+        let (provider, model_id) = model.split_once('/').unwrap_or(("openai", model));
+        let (upstream, protocol, bearer_env) = match provider {
+            "opencode" => (
+                "https://opencode.ai/zen/v1",
+                OpenCodeProtocol::OpenAi,
+                Some("OPENCODE_API_KEY"),
+            ),
+            "openai" => (
+                "https://api.openai.com/v1",
+                OpenCodeProtocol::OpenAi,
+                Some("OPENAI_API_KEY"),
+            ),
+            "openrouter" => (
+                "https://openrouter.ai/api/v1",
+                OpenCodeProtocol::OpenAi,
+                Some("OPENROUTER_API_KEY"),
+            ),
+            "anthropic" => (
+                "https://api.anthropic.com",
+                OpenCodeProtocol::Anthropic,
+                None,
+            ),
+            "google" => (
+                "https://generativelanguage.googleapis.com",
+                OpenCodeProtocol::Gemini,
+                None,
+            ),
+            _ => {
+                return Err(format!(
+                    "OpenCode provider '{provider}' is not routed yet; use --upstream with an OpenAI-compatible gateway"
+                ))
+            }
+        };
+        if model_id.is_empty() {
+            return Err("OpenCode model ID is empty".to_string());
+        }
+        Ok(Self {
+            provider: provider.to_string(),
+            model: Some(format!("{provider}/{model_id}")),
+            upstream: upstream.to_string(),
+            protocol,
+            bearer_env,
+        })
+    }
+}
+
+enum OpenCodeProxyGuard {
+    OpenAi(crate::openai_http_proxy::OpenAiHttpProxyGuard),
+    Anthropic(crate::claude_http_proxy::ClaudeHttpProxyGuard),
+    Gemini(crate::gemini_http_proxy::GeminiHttpProxyGuard),
+}
+
+impl OpenCodeProxyGuard {
+    fn base_url(&self) -> &str {
+        match self {
+            Self::OpenAi(proxy) => proxy.base_url(),
+            Self::Anthropic(proxy) => proxy.base_url(),
+            Self::Gemini(proxy) => proxy.base_url(),
+        }
+    }
+}
+
+fn run_opencode(
+    _tool: &'static crate::client_descriptor::ClientDescriptor,
+    opts: &crate::AgentToolOpts,
+    pentect: &Path,
+) -> Result<std::process::ExitStatus, String> {
+    let route = OpenCodeRoute::resolve(opts)?;
+    let api = ClientApi::parse(opts.api.as_deref())?;
+    if opts.dry_run {
+        crate::print_dry_run(&opts.command, &opts.tool_args);
+        return Ok(crate::success_status());
+    }
+
+    let active_plugins = crate::agent_tool_plugins(opts)?;
+    let memory_store = crate::start_memory_store(pentect)?;
+    let _parent_env = crate::agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
+    let bearer_env = route.bearer_env.filter(|name| {
+        std::env::var_os(name).is_some_and(|value| !value.is_empty())
+            && !has_authorization_override(&opts.upstream_header_env)
+    });
+    let proxy = match route.protocol {
+        OpenCodeProtocol::OpenAi => OpenCodeProxyGuard::OpenAi(
+            crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env_and_bearer_env(
+                route.upstream.clone(),
+                &opts.upstream_header_env,
+                bearer_env,
+            )?,
+        ),
+        OpenCodeProtocol::Anthropic => OpenCodeProxyGuard::Anthropic(
+            crate::claude_http_proxy::ClaudeHttpProxyGuard::start_with_header_env(
+                route.upstream.clone(),
+                &opts.upstream_header_env,
+            )?,
+        ),
+        OpenCodeProtocol::Gemini => OpenCodeProxyGuard::Gemini(
+            crate::gemini_http_proxy::GeminiHttpProxyGuard::start_with_header_env(
+                route.upstream.clone(),
+                &opts.upstream_header_env,
+            )?,
+        ),
+    };
+    let package = opts.upstream.as_ref().map(|_| api.opencode_package());
+    let config = opencode_config(
+        proxy.base_url(),
+        &route.provider,
+        route.model.as_deref(),
+        package,
+    )?;
+    let mut command = Command::new(&opts.command);
+    crate::clear_pentect_control_env(&mut command);
+    crate::upstream::hide_header_source_env(&mut command, &opts.upstream_header_env);
+    if let Some(name) = bearer_env {
+        command.env(name, "pentect-local");
+    }
+    crate::apply_plugin_env(&mut command, &active_plugins)?;
+    crate::apply_pentect_env(&mut command, pentect, Some(memory_store.token.as_str()))?;
+    crate::apply_memory_store_env(&mut command, Some(&memory_store));
+    command.env("OPENCODE_CONFIG_CONTENT", config);
+    command.args(&opts.tool_args);
+    crate::run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
 }
 
 fn has_authorization_override(specs: &[String]) -> bool {
@@ -249,7 +411,12 @@ fn validate_model(model: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn opencode_config(proxy: &str, model: &str, api: ClientApi) -> Result<String, String> {
+fn opencode_config(
+    proxy: &str,
+    provider: &str,
+    model: Option<&str>,
+    package: Option<&str>,
+) -> Result<String, String> {
     let mut root = match std::env::var("OPENCODE_CONFIG_CONTENT") {
         Ok(existing) if !existing.trim().is_empty() => serde_json::from_str::<Value>(&existing)
             .map_err(|error| format!("OPENCODE_CONFIG_CONTENT is invalid JSON: {error}"))?,
@@ -263,31 +430,35 @@ fn opencode_config(proxy: &str, model: &str, api: ClientApi) -> Result<String, S
         .or_insert_with(|| Value::Object(Map::new()))
         .as_object_mut()
         .ok_or_else(|| "OPENCODE_CONFIG_CONTENT.provider must be an object".to_string())?;
-    // Do not copy credentials for unrelated providers into the child process.
-    // This launch intentionally exposes only the ephemeral Pentect provider.
+    // Keep OpenCode's native provider identity and catalog while allowing only
+    // its Pentect-routed endpoint. Never copy provider credentials from config.
     providers.clear();
-    let api_key = "{env:OPENAI_API_KEY}";
-    providers.insert(
-        "pentect".to_string(),
-        json!({
-            "npm": api.opencode_package(),
-            "name": "Pentect",
-            "options": {"baseURL": proxy, "apiKey": api_key},
-            "models": {(model): {"name": model}}
-        }),
-    );
-    root_object.insert(
-        "model".to_string(),
-        Value::String(format!("pentect/{model}")),
-    );
-    root_object.insert(
-        "small_model".to_string(),
-        Value::String(format!("pentect/{model}")),
-    );
+    let mut provider_config = json!({"options": {"baseURL": proxy}});
+    if let Some(package) = package {
+        let provider_object = provider_config
+            .as_object_mut()
+            .expect("provider config is an object");
+        provider_object.insert("npm".to_string(), Value::String(package.to_string()));
+        if let Some(model_id) = model.and_then(|value| value.strip_prefix(&format!("{provider}/")))
+        {
+            provider_object.insert(
+                "models".to_string(),
+                json!({(model_id): {"name": model_id}}),
+            );
+        }
+    }
+    providers.insert(provider.to_string(), provider_config);
+    if let Some(model) = model {
+        root_object.insert("model".to_string(), Value::String(model.to_string()));
+        root_object.insert("small_model".to_string(), Value::String(model.to_string()));
+    } else {
+        root_object.remove("model");
+        root_object.remove("small_model");
+    }
     // OpenCode agents and lightweight background tasks may select a provider
     // independently of the main model. Restrict this launch to the ephemeral
     // provider so those requests cannot bypass the local gateway.
-    root_object.insert("enabled_providers".to_string(), json!(["pentect"]));
+    root_object.insert("enabled_providers".to_string(), json!([provider]));
     root_object.insert("disabled_providers".to_string(), json!([]));
     serde_json::to_string(&root)
         .map_err(|error| format!("could not encode temporary OpenCode config: {error}"))
@@ -371,7 +542,7 @@ mod tests {
     }
 
     #[test]
-    fn opencode_config_preserves_settings_but_drops_other_providers() {
+    fn opencode_config_preserves_settings_and_native_provider_without_credentials() {
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let old = std::env::var_os("OPENCODE_CONFIG_CONTENT");
         std::env::set_var(
@@ -381,8 +552,9 @@ mod tests {
         let value: Value = serde_json::from_str(
             &opencode_config(
                 "http://127.0.0.1/token",
-                "openai/gpt-5",
-                ClientApi::ChatCompletions,
+                "openrouter",
+                Some("openrouter/anthropic/claude-sonnet"),
+                None,
             )
             .unwrap(),
         )
@@ -392,15 +564,110 @@ mod tests {
             None => std::env::remove_var("OPENCODE_CONFIG_CONTENT"),
         }
         assert_eq!(value["theme"], "dark");
-        assert_eq!(value["model"], "pentect/openai/gpt-5");
-        assert_eq!(value["small_model"], "pentect/openai/gpt-5");
-        assert_eq!(value["enabled_providers"], serde_json::json!(["pentect"]));
+        assert_eq!(value["model"], "openrouter/anthropic/claude-sonnet");
+        assert_eq!(value["small_model"], "openrouter/anthropic/claude-sonnet");
         assert_eq!(
-            value["provider"]["pentect"]["options"]["baseURL"],
+            value["enabled_providers"],
+            serde_json::json!(["openrouter"])
+        );
+        assert_eq!(
+            value["provider"]["openrouter"]["options"]["baseURL"],
             "http://127.0.0.1/token"
         );
         assert_eq!(value["provider"].as_object().unwrap().len(), 1);
         assert!(!value.to_string().contains("must-not-survive"));
+        assert!(!value.to_string().contains("apiKey"));
+        assert!(!value.to_string().contains("pentect/"));
+    }
+
+    #[test]
+    fn opencode_default_keeps_the_native_picker_unforced() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os("OPENCODE_CONFIG_CONTENT");
+        std::env::set_var(
+            "OPENCODE_CONFIG_CONTENT",
+            r#"{"model":"other/unsafe","small_model":"other/unsafe"}"#,
+        );
+        let value: Value = serde_json::from_str(
+            &opencode_config("http://127.0.0.1/token", "opencode", None, None).unwrap(),
+        )
+        .unwrap();
+        match old {
+            Some(value) => std::env::set_var("OPENCODE_CONFIG_CONTENT", value),
+            None => std::env::remove_var("OPENCODE_CONFIG_CONTENT"),
+        }
+        assert!(value.get("model").is_none());
+        assert!(value.get("small_model").is_none());
+        assert_eq!(value["enabled_providers"], serde_json::json!(["opencode"]));
+    }
+
+    #[test]
+    fn opencode_custom_gateway_registers_its_arbitrary_model() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os("OPENCODE_CONFIG_CONTENT");
+        std::env::remove_var("OPENCODE_CONFIG_CONTENT");
+        let value: Value = serde_json::from_str(
+            &opencode_config(
+                "http://127.0.0.1/token",
+                "pentect-gateway",
+                Some("pentect-gateway/team/custom-model"),
+                Some("@ai-sdk/openai-compatible"),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        match old {
+            Some(value) => std::env::set_var("OPENCODE_CONFIG_CONTENT", value),
+            None => std::env::remove_var("OPENCODE_CONFIG_CONTENT"),
+        }
+        assert_eq!(
+            value["provider"]["pentect-gateway"]["models"]["team/custom-model"]["name"],
+            "team/custom-model"
+        );
+    }
+
+    #[test]
+    fn opencode_routes_supported_native_providers() {
+        let opts = |model: Option<&str>, upstream: Option<&str>| crate::AgentToolOpts {
+            pentect: None,
+            command: "opencode".into(),
+            plugins: Vec::new(),
+            dry_run: false,
+            upstream: upstream.map(str::to_string),
+            model: model.map(str::to_string),
+            api: None,
+            upstream_header_env: Vec::new(),
+            tool_args: Vec::new(),
+        };
+        let default = OpenCodeRoute::resolve(&opts(None, None)).unwrap();
+        assert_eq!(default.provider, "opencode");
+        assert_eq!(default.model, None);
+        assert_eq!(default.upstream, "https://opencode.ai/zen/v1");
+
+        let openrouter =
+            OpenCodeRoute::resolve(&opts(Some("openrouter/anthropic/claude-sonnet"), None))
+                .unwrap();
+        assert_eq!(openrouter.provider, "openrouter");
+        assert_eq!(openrouter.protocol, OpenCodeProtocol::OpenAi);
+        assert_eq!(
+            openrouter.model.as_deref(),
+            Some("openrouter/anthropic/claude-sonnet")
+        );
+
+        let anthropic =
+            OpenCodeRoute::resolve(&opts(Some("anthropic/claude-sonnet-4"), None)).unwrap();
+        assert_eq!(anthropic.protocol, OpenCodeProtocol::Anthropic);
+
+        let gateway = OpenCodeRoute::resolve(&opts(
+            Some("anthropic/claude-sonnet"),
+            Some("http://127.0.0.1:8080/openai/v1"),
+        ))
+        .unwrap();
+        assert_eq!(gateway.provider, "pentect-gateway");
+        assert_eq!(
+            gateway.model.as_deref(),
+            Some("pentect-gateway/anthropic/claude-sonnet")
+        );
     }
 
     #[test]

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -268,28 +268,65 @@ fn run_opencode(
     let active_plugins = crate::agent_tool_plugins(opts)?;
     let memory_store = crate::start_memory_store(pentect)?;
     let _parent_env = crate::agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
+    let mut header_env = opts.upstream_header_env.clone();
     let bearer_env = route.bearer_env.filter(|name| {
         std::env::var_os(name).is_some_and(|value| !value.is_empty())
-            && !has_authorization_override(&opts.upstream_header_env)
+            && !has_authorization_override(&header_env)
     });
+    let mut child_key_env = bearer_env.or_else(|| {
+        route
+            .bearer_env
+            .filter(|_| has_authorization_override(&header_env))
+    });
+    if route.protocol == OpenCodeProtocol::Anthropic {
+        if let Some(name) = configured_key_env(&["ANTHROPIC_API_KEY"]) {
+            child_key_env = Some(name);
+            if !has_header_override(&header_env, "x-api-key")
+                && !has_authorization_override(&header_env)
+            {
+                header_env.push(format!("x-api-key={name}"));
+            }
+        } else if has_header_override(&header_env, "x-api-key")
+            || has_authorization_override(&header_env)
+        {
+            child_key_env = Some("ANTHROPIC_API_KEY");
+        }
+    } else if route.protocol == OpenCodeProtocol::Gemini {
+        if let Some(name) = configured_key_env(&[
+            "GOOGLE_API_KEY",
+            "GOOGLE_GENERATIVE_AI_API_KEY",
+            "GEMINI_API_KEY",
+        ]) {
+            child_key_env = Some(name);
+            if !has_header_override(&header_env, "x-goog-api-key")
+                && !has_authorization_override(&header_env)
+            {
+                header_env.push(format!("x-goog-api-key={name}"));
+            }
+        } else if has_header_override(&header_env, "x-goog-api-key")
+            || has_authorization_override(&header_env)
+        {
+            child_key_env = Some("GOOGLE_API_KEY");
+        }
+    }
     let proxy = match route.protocol {
         OpenCodeProtocol::OpenAi => OpenCodeProxyGuard::OpenAi(
             crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env_and_bearer_env(
                 route.upstream.clone(),
-                &opts.upstream_header_env,
+                &header_env,
                 bearer_env,
             )?,
         ),
         OpenCodeProtocol::Anthropic => OpenCodeProxyGuard::Anthropic(
             crate::claude_http_proxy::ClaudeHttpProxyGuard::start_with_header_env(
                 route.upstream.clone(),
-                &opts.upstream_header_env,
+                &header_env,
             )?,
         ),
         OpenCodeProtocol::Gemini => OpenCodeProxyGuard::Gemini(
             crate::gemini_http_proxy::GeminiHttpProxyGuard::start_with_header_env(
                 route.upstream.clone(),
-                &opts.upstream_header_env,
+                &header_env,
             )?,
         ),
     };
@@ -302,8 +339,19 @@ fn run_opencode(
     )?;
     let mut command = Command::new(&opts.command);
     crate::clear_pentect_control_env(&mut command);
-    crate::upstream::hide_header_source_env(&mut command, &opts.upstream_header_env);
-    if let Some(name) = bearer_env {
+    crate::upstream::hide_header_source_env(&mut command, &header_env);
+    for name in [
+        "OPENAI_API_KEY",
+        "OPENCODE_API_KEY",
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_GENERATIVE_AI_API_KEY",
+        "GEMINI_API_KEY",
+    ] {
+        command.env_remove(name);
+    }
+    if let Some(name) = child_key_env {
         command.env(name, "pentect-local");
     }
     crate::apply_plugin_env(&mut command, &active_plugins)?;
@@ -314,10 +362,21 @@ fn run_opencode(
     crate::run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
 }
 
+fn configured_key_env(names: &[&'static str]) -> Option<&'static str> {
+    names
+        .iter()
+        .copied()
+        .find(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
+}
+
 fn has_authorization_override(specs: &[String]) -> bool {
+    has_header_override(specs, "authorization")
+}
+
+fn has_header_override(specs: &[String], header: &str) -> bool {
     specs.iter().any(|spec| {
         spec.split_once('=')
-            .is_some_and(|(name, _)| name.trim().eq_ignore_ascii_case("authorization"))
+            .is_some_and(|(name, _)| name.trim().eq_ignore_ascii_case(header))
     })
 }
 
@@ -430,21 +489,34 @@ fn opencode_config(
         .or_insert_with(|| Value::Object(Map::new()))
         .as_object_mut()
         .ok_or_else(|| "OPENCODE_CONFIG_CONTENT.provider must be an object".to_string())?;
-    // Keep OpenCode's native provider identity and catalog while allowing only
-    // its Pentect-routed endpoint. Never copy provider credentials from config.
+    let mut provider_config = providers
+        .remove(provider)
+        .unwrap_or_else(|| Value::Object(Map::new()));
     providers.clear();
-    let mut provider_config = json!({"options": {"baseURL": proxy}});
+    remove_provider_credentials(&mut provider_config);
+    let provider_object = provider_config
+        .as_object_mut()
+        .ok_or_else(|| format!("OPENCODE_CONFIG_CONTENT.provider.{provider} must be an object"))?;
+    let options = provider_object
+        .entry("options")
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .ok_or_else(|| {
+            format!("OPENCODE_CONFIG_CONTENT.provider.{provider}.options must be an object")
+        })?;
+    options.insert("baseURL".to_string(), Value::String(proxy.to_string()));
     if let Some(package) = package {
-        let provider_object = provider_config
-            .as_object_mut()
-            .expect("provider config is an object");
         provider_object.insert("npm".to_string(), Value::String(package.to_string()));
         if let Some(model_id) = model.and_then(|value| value.strip_prefix(&format!("{provider}/")))
         {
-            provider_object.insert(
-                "models".to_string(),
-                json!({(model_id): {"name": model_id}}),
-            );
+            let models = provider_object
+                .entry("models")
+                .or_insert_with(|| Value::Object(Map::new()))
+                .as_object_mut()
+                .ok_or_else(|| {
+                    format!("OPENCODE_CONFIG_CONTENT.provider.{provider}.models must be an object")
+                })?;
+            models.insert(model_id.to_string(), json!({"name": model_id}));
         }
     }
     providers.insert(provider.to_string(), provider_config);
@@ -462,6 +534,44 @@ fn opencode_config(
     root_object.insert("disabled_providers".to_string(), json!([]));
     serde_json::to_string(&root)
         .map_err(|error| format!("could not encode temporary OpenCode config: {error}"))
+}
+
+fn remove_provider_credentials(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            object.retain(|key, _| !is_provider_credential_key(key));
+            for value in object.values_mut() {
+                remove_provider_credentials(value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                remove_provider_credentials(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_provider_credential_key(key: &str) -> bool {
+    let normalized: String = key
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect();
+    matches!(
+        normalized.as_str(),
+        "apikey"
+            | "token"
+            | "secret"
+            | "password"
+            | "authorization"
+            | "headers"
+            | "credentials"
+            | "accesskeyid"
+            | "secretaccesskey"
+            | "sessiontoken"
+    )
 }
 
 struct PiProviderFile {
@@ -547,7 +657,7 @@ mod tests {
         let old = std::env::var_os("OPENCODE_CONFIG_CONTENT");
         std::env::set_var(
             "OPENCODE_CONFIG_CONTENT",
-            r#"{"theme":"dark","provider":{"other":{"options":{"apiKey":"must-not-survive"}}}}"#,
+            r#"{"theme":"dark","provider":{"other":{"options":{"apiKey":"other-secret"}},"openrouter":{"models":{"team-alias":{"name":"Team alias"}},"options":{"timeout":30000,"apiKey":"must-not-survive"}}}}"#,
         );
         let value: Value = serde_json::from_str(
             &opencode_config(
@@ -575,7 +685,13 @@ mod tests {
             "http://127.0.0.1/token"
         );
         assert_eq!(value["provider"].as_object().unwrap().len(), 1);
+        assert_eq!(
+            value["provider"]["openrouter"]["models"]["team-alias"]["name"],
+            "Team alias"
+        );
+        assert_eq!(value["provider"]["openrouter"]["options"]["timeout"], 30000);
         assert!(!value.to_string().contains("must-not-survive"));
+        assert!(!value.to_string().contains("other-secret"));
         assert!(!value.to_string().contains("apiKey"));
         assert!(!value.to_string().contains("pentect/"));
     }

--- a/website/src/content/docs/clients/opencode.md
+++ b/website/src/content/docs/clients/opencode.md
@@ -15,11 +15,20 @@ Without `--model`, OpenCode's native Zen provider and model picker remain
 available. Pentect keeps the original provider name and model catalog, but
 routes its requests through the local privacy gateway.
 
-Normal OpenCode arguments pass through. A model flag may appear anywhere:
+Provider setup and credentials stay under OpenCode's native provider ID. If
+`opencode auth list` shows a credential named `pentect` from an older Pentect
+release, reconnect the intended native provider once. Pentect does not guess a
+destination and copy an ambiguous stored credential automatically.
+
+Normal OpenCode arguments pass through. A model flag may appear anywhere before
+the explicit `--` separator:
 
 ```sh
 pentect opencode "Review this project" --model openai/gpt-5
 ```
+
+After `--`, `--model` and `-m` are forwarded unchanged to OpenCode and do not
+select Pentect's provider route.
 
 Pentect currently routes native `opencode`, `openai`, `openrouter`, `anthropic`,
 and `google` providers. Select one with OpenCode's `provider/model` form:

--- a/website/src/content/docs/clients/opencode.md
+++ b/website/src/content/docs/clients/opencode.md
@@ -4,18 +4,33 @@ description: Use OpenCode with Pentect.
 ---
 
 ```sh
-pentect opencode --model openai/gpt-5
+pentect opencode
 ```
 
 Pentect protects this OpenCode launch only. It does not edit `opencode.json` or
 change normal OpenCode launches. Background tasks and subagents use the same
 protected provider during the session.
 
+Without `--model`, OpenCode's native Zen provider and model picker remain
+available. Pentect keeps the original provider name and model catalog, but
+routes its requests through the local privacy gateway.
+
 Normal OpenCode arguments pass through. A model flag may appear anywhere:
 
 ```sh
 pentect opencode "Review this project" --model openai/gpt-5
 ```
+
+Pentect currently routes native `opencode`, `openai`, `openrouter`, `anthropic`,
+and `google` providers. Select one with OpenCode's `provider/model` form:
+
+```sh
+pentect opencode run --model openrouter/anthropic/claude-sonnet "Review this project"
+```
+
+Only the selected provider is enabled for that protected launch. Start a new
+Pentect launch to switch providers; this prevents background agents from
+bypassing the matching protocol gateway.
 
 Chat Completions is the default. Select Responses when the upstream supports
 it:
@@ -33,6 +48,7 @@ pentect opencode --model anthropic/claude-sonnet \
   --upstream http://127.0.0.1:8080/openai/v1
 ```
 
-If no model is given, Pentect uses `gpt-5`. Custom endpoint variables and
-gateway credentials are advanced options; see
+With a custom upstream, Pentect treats the model as an OpenAI-compatible
+gateway model ID. Custom endpoint variables and gateway credentials are
+advanced options; see
 [Custom upstreams](/clients/upstreams/).


### PR DESCRIPTION
Closes #1007.

Root cause: the OpenCode launcher deleted the native provider catalog, registered a single synthetic pentect provider, forced gpt-5, and stopped parsing Pentect model options after the first OpenCode argument.

This change:
- keeps the selected native provider ID and catalog while overriding only its base URL with a protocol-matched Pentect gateway;
- defaults bare launches to the protected OpenCode Zen provider without forcing a model;
- supports native opencode, openai, openrouter, anthropic, and google routes;
- accepts --model/-m before or after OpenCode subcommands (but not after the explicit -- separator);
- retains arbitrary OpenAI-compatible custom gateway models;
- updates the OpenCode documentation;
- fixes the scheduled Windows Claude Desktop smoke by explicitly approving the certificate in non-interactive CI.

Local verification:
- focused Rust unit tests pass;
- cargo clippy -p pentect-cli -- -D warnings passes;
- real OpenCode 1.18.20 lists the protected native Zen catalog;
- a real Zen conversation returned the requested sentinel;
- real OpenCode sent a keyed synthetic secret through a localhost upstream, where only its opaque Pentect handle was recorded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode now supports native provider and model selection, including OpenAI, OpenRouter, Anthropic, Google, and Zen.
  * OpenCode can launch without specifying a model, allowing its built-in model picker to remain available.
  * Custom upstream models are routed using their configured model IDs.

* **Bug Fixes**
  * OpenCode model options are now handled correctly in both space-separated and `=` formats.
  * Automated CLI checks no longer require interactive confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->