### PR TITLE
fix(opencode): preserve native first-time authentication

### DIFF
--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -258,6 +258,22 @@ fn run_opencode(
     opts: &crate::AgentToolOpts,
     pentect: &Path,
 ) -> Result<std::process::ExitStatus, String> {
+    // Authentication does not carry conversation content. Let OpenCode own this
+    // flow so its complete native provider catalog remains available and the
+    // credential is stored under the real provider ID. Injecting the protected
+    // conversation config here would restrict first-time setup to the currently
+    // routed provider.
+    if is_opencode_auth_command(&opts.tool_args) {
+        if opts.dry_run {
+            crate::print_dry_run(&opts.command, &opts.tool_args);
+            return Ok(crate::success_status());
+        }
+        let mut command = Command::new(&opts.command);
+        crate::clear_pentect_control_env(&mut command);
+        command.args(&opts.tool_args);
+        return crate::run_native_command_with_guards(command, &opts.command, ());
+    }
+
     let route = OpenCodeRoute::resolve(opts)?;
     let api = ClientApi::parse(opts.api.as_deref())?;
     if opts.dry_run {
@@ -360,6 +376,10 @@ fn run_opencode(
     command.env("OPENCODE_CONFIG_CONTENT", config);
     command.args(&opts.tool_args);
     crate::run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
+}
+
+fn is_opencode_auth_command(args: &[String]) -> bool {
+    args.first().is_some_and(|arg| arg == "auth")
 }
 
 fn configured_key_env(names: &[&'static str]) -> Option<&'static str> {
@@ -784,6 +804,23 @@ mod tests {
             gateway.model.as_deref(),
             Some("pentect-gateway/anthropic/claude-sonnet")
         );
+    }
+
+    #[test]
+    fn opencode_auth_commands_bypass_conversation_provider_injection() {
+        assert!(is_opencode_auth_command(&[
+            "auth".to_string(),
+            "login".to_string()
+        ]));
+        assert!(is_opencode_auth_command(&[
+            "auth".to_string(),
+            "list".to_string()
+        ]));
+        assert!(!is_opencode_auth_command(&[]));
+        assert!(!is_opencode_auth_command(&[
+            "run".to_string(),
+            "auth".to_string()
+        ]));
     }
 
     #[test]

--- a/website/src/content/docs/clients/opencode.md
+++ b/website/src/content/docs/clients/opencode.md
@@ -20,6 +20,18 @@ Provider setup and credentials stay under OpenCode's native provider ID. If
 release, reconnect the intended native provider once. Pentect does not guess a
 destination and copy an ambiguous stored credential automatically.
 
+Run OpenCode's native authentication flow through Pentect before the first
+protected conversation when the provider requires an account:
+
+```sh
+pentect opencode auth login
+```
+
+Authentication commands retain OpenCode's complete provider list and do not
+install Pentect's temporary conversation routing. They exchange credentials,
+not conversation content. Subsequent `pentect opencode` launches protect AI
+traffic normally.
+
 Normal OpenCode arguments pass through. A model flag may appear anywhere before
 the explicit `--` separator:
 


### PR DESCRIPTION
## What was broken

The previous #1007 fix protected authenticated conversations, but fresh-profile verification exposed an incomplete first-run path: Pentect injected its conversation-only `enabled_providers` restriction into `opencode auth login`. OpenCode therefore showed only OpenCode Zen and Other instead of its native provider catalog.

## Fix

- Run `opencode auth ...` through OpenCode’s native authentication path without temporary conversation routing.
- Keep all normal conversation commands on Pentect’s protected proxy path.
- Document the first-time authentication command and why it is separate.
- Add focused regression coverage for auth-command detection.

Authentication commands exchange credentials rather than AI conversation content, so bypassing conversation routing here restores native provider setup without allowing prompts to bypass Pentect.

## Verification

- Fresh isolated HOME/XDG profile in tmux.
- Before fix: `pentect opencode auth login` showed only OpenCode Zen and Other.
- After fix: native list included OpenCode Zen, OpenAI, GitHub Copilot, Google, Anthropic, OpenRouter, Vercel AI Gateway, and more.
- Selected OpenRouter and stored a test credential; `pentect opencode auth list` reported `OpenRouter api`, not `pentect`.
- Ran an authenticated OpenRouter conversation through the protected Pentect route successfully.
- `cargo test -p pentect-cli openai_clients::tests`
- `cargo clippy -p pentect-cli -- -D warnings`
- `git diff --check`

Closes #1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authenticating OpenCode through Pentect using `auth login` and `auth list`.
  * Authentication commands now run without conversation routing or provider configuration changes.

* **Documentation**
  * Added guidance for completing OpenCode authentication before starting protected conversations.
  * Clarified that provider settings remain available during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->