### PR TITLE
chore: prepare v0.0.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.60"
+version = "0.0.61"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Release

Prepare Pentect v0.0.61 with the protected OpenCode in-UI provider setup fix from #1025.

## Version updates

- `pentect-cli`: 0.0.61
- npm package: 0.0.61
- lockfile: 0.0.61

## Local verification

- Cargo metadata reports 0.0.61.
- npm package tests: 8 passed.
- npm dry-run package contains the expected launcher files.
- release package metadata tests passed.
- `git diff --check` passed.