### PR TITLE
Fix six isolated configuration and proxy regressions

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -646,7 +646,9 @@ impl ScopedPackageEnvironment {
             "ANTHROPIC_BASE_URL".to_string(),
             Some(std::ffi::OsString::from(anthropic_base_url)),
         )];
-        changes.extend(hidden.iter().map(|name| (name.clone(), None)));
+        changes.extend(hidden.iter().filter_map(|spec| {
+            crate::upstream::header_source_env_name(spec).map(|name| (name.to_string(), None))
+        }));
         let mut previous = Vec::with_capacity(changes.len());
         for (name, value) in changes {
             previous.push((name.clone(), std::env::var_os(&name)));

--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -335,7 +335,16 @@ fn table_has(document: &toml_edit::DocumentMut, table: &str, key: &str) -> bool 
 }
 
 fn table_bool(document: &toml_edit::DocumentMut, table: &str, key: &str) -> Option<bool> {
-    document.get(table)?.as_table_like()?.get(key)?.as_bool()
+    let value = document.get(table)?.as_table_like()?.get(key)?;
+    value.as_bool().or_else(|| {
+        value
+            .as_str()
+            .and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => Some(true),
+                "0" | "false" | "no" | "off" => Some(false),
+                _ => None,
+            })
+    })
 }
 
 fn ensure_table<'a>(
@@ -796,6 +805,17 @@ mod tests {
         assert!(migrated.contains("share = true"), "{migrated}");
         assert!(migrated.contains("required = true"), "{migrated}");
         assert!(migrated.contains("scope = \"device\""), "{migrated}");
+    }
+
+    #[test]
+    fn removed_config_string_booleans_use_runtime_semantics() {
+        let source = concat!(
+            "file_pointer_manager = { save = \"off\" }\n",
+            "log = { share = \"yes\" }\n",
+        );
+        let migrated = migrate_removed_config_keys(source).unwrap().unwrap();
+        assert!(migrated.contains("remember = false"), "{migrated}");
+        assert!(migrated.contains("share = true"), "{migrated}");
     }
 
     #[test]

--- a/crates/pentect-cli/src/upstream.rs
+++ b/crates/pentect-cli/src/upstream.rs
@@ -188,10 +188,16 @@ pub(crate) fn header_overrides_with_bearer_env(
 
 pub(crate) fn hide_header_source_env(command: &mut std::process::Command, specs: &[String]) {
     for spec in specs {
-        if let Some((_, env_name)) = spec.split_once('=') {
-            command.env_remove(env_name.trim());
+        if let Some(env_name) = header_source_env_name(spec) {
+            command.env_remove(env_name);
         }
     }
+}
+
+pub(crate) fn header_source_env_name(spec: &str) -> Option<&str> {
+    let (_, env_name) = spec.split_once('=')?;
+    let env_name = env_name.trim();
+    (!env_name.is_empty()).then_some(env_name)
 }
 
 fn is_origin_auth_header(name: &str) -> bool {
@@ -279,7 +285,8 @@ pub(crate) fn join_url(
     let mut without_query = base.clone();
     without_query.set_query(None);
     let mut joined = without_query.as_str().trim_end_matches('/').to_string();
-    if !request_path.starts_with('/') {
+    let request_path = strip_duplicate_api_version(&without_query, request_path);
+    if !request_path.starts_with('/') && !request_path.is_empty() {
         joined.push('/');
     }
     joined.push_str(request_path);
@@ -295,6 +302,24 @@ pub(crate) fn join_url(
     };
     joined.set_query(query.as_deref());
     Ok(joined)
+}
+
+fn strip_duplicate_api_version<'a>(base: &reqwest::Url, request_path: &'a str) -> &'a str {
+    let request = request_path.trim_start_matches('/');
+    let (first, remainder) = request.split_once('/').unwrap_or((request, ""));
+    let is_version = first
+        .strip_prefix('v')
+        .and_then(|suffix| suffix.as_bytes().first())
+        .is_some_and(u8::is_ascii_digit)
+        && first
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+    let base_last = base.path().trim_end_matches('/').rsplit('/').next();
+    if is_version && base_last == Some(first) {
+        remainder
+    } else {
+        request_path
+    }
 }
 
 pub(crate) fn client(protocol: &str) -> Result<reqwest::Client, String> {
@@ -389,6 +414,37 @@ mod tests {
                 .as_str(),
             "http://localhost:8080/anthropic/v1/messages"
         );
+    }
+
+    #[test]
+    fn duplicate_api_version_prefix_is_joined_once() {
+        let base = parse_base("https://gateway.example/openai/v1", "OpenAI Responses").unwrap();
+        assert_eq!(
+            join_url(
+                &base,
+                "/v1/chat/completions?stream=true",
+                "OpenAI Responses"
+            )
+            .unwrap()
+            .as_str(),
+            "https://gateway.example/openai/v1/chat/completions?stream=true"
+        );
+        assert_eq!(
+            join_url(&base, "/api/v1/chat/completions", "OpenAI Responses")
+                .unwrap()
+                .as_str(),
+            "https://gateway.example/openai/v1/api/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn header_source_env_name_extracts_only_the_environment_name() {
+        assert_eq!(
+            header_source_env_name("x-api-key= ANTHROPIC_API_KEY "),
+            Some("ANTHROPIC_API_KEY")
+        );
+        assert_eq!(header_source_env_name("x-api-key="), None);
+        assert_eq!(header_source_env_name("ANTHROPIC_API_KEY"), None);
     }
 
     #[test]

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -715,12 +715,12 @@ fn unknown_format_policy_value(value: &toml::Value) -> Result<Option<UnknownForm
         return Ok(None);
     };
     let Some(raw) = raw.as_str() else {
-        return Err("compatibility.unknown_formats must be error or ignore".to_string());
+        return Err("compatibility.unknown_formats must be error, block, or ignore".to_string());
     };
     match raw.trim().to_ascii_lowercase().as_str() {
         "ignore" => Ok(Some(UnknownFormatPolicy::Ignore)),
-        "error" => Ok(Some(UnknownFormatPolicy::Error)),
-        _ => Err("compatibility.unknown_formats must be error or ignore".to_string()),
+        "error" | "block" => Ok(Some(UnknownFormatPolicy::Error)),
+        _ => Err("compatibility.unknown_formats must be error, block, or ignore".to_string()),
     }
 }
 
@@ -1156,6 +1156,13 @@ mod tests {
         assert_eq!(
             unknown_format_policy_value(&ignore).unwrap(),
             Some(UnknownFormatPolicy::Ignore)
+        );
+        let block = "[compatibility]\nunknown_formats = \"block\""
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(
+            unknown_format_policy_value(&block).unwrap(),
+            Some(UnknownFormatPolicy::Error)
         );
         let invalid = "[compatibility]\nunknown_formats = \"allow\""
             .parse::<toml::Value>()

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -566,7 +566,13 @@ fn environment_reference_at(text: &str, start: usize) -> Option<(usize, &str)> {
             return (end > name_start).then(|| (end, &text[name_start..end]));
         }
         if bytes.get(start + 1) == Some(&b'{') {
-            let name_start = start + 2;
+            let mut name_start = start + 2;
+            if bytes
+                .get(name_start..name_start.saturating_add(4))
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"env:"))
+            {
+                name_start += 4;
+            }
             let end = env_name_end(bytes, name_start);
             if end > name_start && bytes.get(end) == Some(&b'}') {
                 return Some((end + 1, &text[name_start..end]));

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -2788,7 +2788,7 @@ fn perform_plugin_http(
 
 fn private_access_for_origin(origin: &HttpOrigin, approved: bool) -> bool {
     approved
-        && origin.host.parse::<IpAddr>().is_ok_and(|ip| match ip {
+        && origin.host.parse::<IpAddr>().map_or(true, |ip| match ip {
             IpAddr::V4(ip) => ip.is_private() || ip.is_loopback(),
             IpAddr::V6(ip) => {
                 ip.is_loopback()
@@ -4517,14 +4517,22 @@ disk = "CPU: about 5 GB"
     }
 
     #[test]
-    fn private_network_approval_does_not_apply_to_dns_names() {
-        assert!(!private_access_for_origin(
+    fn private_network_approval_applies_to_explicitly_allowed_dns_origins() {
+        assert!(private_access_for_origin(
             &HttpOrigin {
-                scheme: "https".to_string(),
-                host: "example.com".to_string(),
-                port: 443,
+                scheme: "http".to_string(),
+                host: "localhost".to_string(),
+                port: 8080,
             },
             true,
+        ));
+        assert!(!private_access_for_origin(
+            &HttpOrigin {
+                scheme: "http".to_string(),
+                host: "localhost".to_string(),
+                port: 8080,
+            },
+            false,
         ));
         assert!(private_access_for_origin(
             &HttpOrigin {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1433,6 +1433,18 @@ fn exec_injects_powershell_env_provider_references() {
 }
 
 #[test]
+fn braced_powershell_environment_reference_excludes_provider_prefix() {
+    assert_eq!(
+        environment_reference_at("${env:PENTECT_KEY_123}", 0),
+        Some((22, "PENTECT_KEY_123"))
+    );
+    assert_eq!(
+        environment_reference_at("${ENV:PENTECT_KEY_123}", 0),
+        Some((22, "PENTECT_KEY_123"))
+    );
+}
+
+#[test]
 fn auto_env_bindings_do_not_override_baseline_environment() {
     let root = temp_root("capability-reserved-env-binding");
     let session = Session::open_capability_at(&root, "t").unwrap();


### PR DESCRIPTION
## Root causes and fixes

- Parse legacy string booleans with the same accepted values as runtime config.
- Extract the environment variable from `HEADER=ENV` before hiding it from Claude Desktop package activation.
- Recognize braced PowerShell `${env:NAME}` references.
- Allow approved plugin DNS origins to resolve to private addresses while preserving denial without `private_network`.
- Accept `block` as an alias for the blocking unknown-format policy.
- Deduplicate an overlapping API-version path segment when joining custom upstream URLs.

## Regression tests

Each fix has a focused regression test. Existing custom-base-path and approved private-network request tests also pass.

Closes #1041
Closes #1038
Closes #1028
Closes #1027
Closes #1021
Closes #1002