### PR TITLE
Fix six isolated streaming, upload, and runtime regressions

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -648,7 +648,10 @@ fn run_anthropic_tool_plugins(
             }
         }
         Value::Object(object) => {
-            if object.get("type").and_then(Value::as_str) == Some("tool_use")
+            if object
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(anthropic_tool_block_type)
                 && object.get("input").is_some()
             {
                 let run = plugins.run(
@@ -676,6 +679,10 @@ fn run_anthropic_tool_plugins(
         _ => {}
     }
     Ok(())
+}
+
+fn anthropic_tool_block_type(block_type: &str) -> bool {
+    matches!(block_type, "tool_use" | "mcp_tool_use" | "server_tool_use")
 }
 
 async fn resolve_anthropic_remote_content(
@@ -3772,6 +3779,15 @@ mod tests {
         assert!(!is_media_policy_rejection(
             "detector temporarily unavailable"
         ));
+    }
+
+    #[test]
+    fn all_anthropic_tool_use_block_types_enter_tool_middleware() {
+        for block_type in ["tool_use", "mcp_tool_use", "server_tool_use"] {
+            assert!(anthropic_tool_block_type(block_type), "{block_type}");
+        }
+        assert!(!anthropic_tool_block_type("tool_result"));
+        assert!(!anthropic_tool_block_type("mcp_tool_result"));
     }
 
     fn join_bytes(chunks: Vec<Bytes>) -> String {

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -1206,6 +1206,7 @@ fn rewrite_sse_block(
     } else {
         "\n\n"
     };
+    let line_ending = if ending == "\r\n\r\n" { "\r\n" } else { "\n" };
     let metadata = text
         .lines()
         .filter(|line| !line.starts_with("data:"))
@@ -1214,7 +1215,7 @@ fn rewrite_sse_block(
     let mut output = String::new();
     for line in metadata {
         output.push_str(line);
-        output.push('\n');
+        output.push_str(line_ending);
     }
     output.push_str("data: ");
     output.push_str(&encoded);
@@ -2074,5 +2075,22 @@ mod tests {
         let protected = std::str::from_utf8(&protected.body).unwrap();
         assert!(!protected.contains(&secret));
         assert!(protected.matches("<<").count() >= 2);
+    }
+
+    #[test]
+    fn rewritten_crlf_sse_keeps_crlf_metadata_lines() {
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
+        let rewritten = rewrite_sse_block(
+            b"event: message\r\ndata: {\"response\":{\"candidates\":[]}}\r\n\r\n",
+            &plugins,
+            true,
+        )
+        .unwrap();
+        let rewritten = std::str::from_utf8(&rewritten).unwrap();
+        assert!(
+            rewritten.starts_with("event: message\r\ndata: "),
+            "{rewritten:?}"
+        );
+        assert!(rewritten.ends_with("\r\n\r\n"), "{rewritten:?}");
     }
 }

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -799,13 +799,14 @@ fn rewrite_sse_block(
     } else {
         "\n\n"
     };
+    let line_ending = if ending == "\r\n\r\n" { "\r\n" } else { "\n" };
     let mut out = Vec::with_capacity(block.len() + 32);
     for line in text
         .lines()
         .filter(|line| !line.starts_with("data:") && !line.is_empty())
     {
         out.extend_from_slice(line.as_bytes());
-        out.push(b'\n');
+        out.extend_from_slice(line_ending.as_bytes());
     }
     out.extend_from_slice(b"data: ");
     out.extend_from_slice(&rewritten);
@@ -876,6 +877,7 @@ fn should_forward_request_header(name: &str) -> bool {
             | "connection"
             | "proxy-connection"
             | "keep-alive"
+            | "accept-encoding"
             | "transfer-encoding"
             | "upgrade"
             | "te"
@@ -1213,5 +1215,28 @@ mod tests {
             response["candidates"][0]["content"]["parts"][1]["functionCall"]["args"]["token"],
             secret
         );
+    }
+
+    #[test]
+    fn compressed_upstream_responses_are_not_requested() {
+        assert!(!should_forward_request_header("Accept-Encoding"));
+        assert!(should_forward_request_header("Accept"));
+    }
+
+    #[test]
+    fn rewritten_crlf_sse_keeps_crlf_metadata_lines() {
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
+        let rewritten = rewrite_sse_block(
+            b"event: message\r\ndata: {\"candidates\":[]}\r\n\r\n",
+            &plugins,
+            true,
+        )
+        .unwrap();
+        let rewritten = std::str::from_utf8(&rewritten).unwrap();
+        assert!(
+            rewritten.starts_with("event: message\r\ndata: "),
+            "{rewritten:?}"
+        );
+        assert!(rewritten.ends_with("\r\n\r\n"), "{rewritten:?}");
     }
 }

--- a/crates/pentect-cli/src/http_files.rs
+++ b/crates/pentect-cli/src/http_files.rs
@@ -1261,7 +1261,10 @@ pub(crate) fn supported_text_file(filename: &str, media_type: Option<&str>) -> b
                 value.as_str(),
                 "application/json"
                     | "application/jsonl"
+                    | "application/javascript"
+                    | "application/typescript"
                     | "application/x-ndjson"
+                    | "application/toml"
                     | "application/xml"
                     | "application/yaml"
                     | "application/x-yaml"
@@ -1269,8 +1272,32 @@ pub(crate) fn supported_text_file(filename: &str, media_type: Option<&str>) -> b
     }) {
         return true;
     }
-    Path::new(filename)
-        .extension()
+    let path = Path::new(filename);
+    if path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .is_some_and(|name| {
+            matches!(
+                name.to_ascii_lowercase().as_str(),
+                "dockerfile"
+                    | "makefile"
+                    | "justfile"
+                    | "procfile"
+                    | "gemfile"
+                    | "rakefile"
+                    | ".gitignore"
+                    | ".dockerignore"
+                    | ".editorconfig"
+                    | ".npmrc"
+                    | ".yarnrc"
+                    | ".prettierrc"
+                    | ".eslintrc"
+            )
+        })
+    {
+        return true;
+    }
+    path.extension()
         .and_then(|value| value.to_str())
         .is_some_and(|extension| {
             matches!(
@@ -1288,6 +1315,64 @@ pub(crate) fn supported_text_file(filename: &str, media_type: Option<&str>) -> b
                     | "yml"
                     | "env"
                     | "log"
+                    | "py"
+                    | "pyi"
+                    | "js"
+                    | "mjs"
+                    | "cjs"
+                    | "jsx"
+                    | "ts"
+                    | "mts"
+                    | "cts"
+                    | "tsx"
+                    | "rs"
+                    | "go"
+                    | "java"
+                    | "kt"
+                    | "kts"
+                    | "c"
+                    | "h"
+                    | "cc"
+                    | "cpp"
+                    | "cxx"
+                    | "hh"
+                    | "hpp"
+                    | "hxx"
+                    | "cs"
+                    | "swift"
+                    | "scala"
+                    | "sh"
+                    | "bash"
+                    | "zsh"
+                    | "fish"
+                    | "ps1"
+                    | "psm1"
+                    | "bat"
+                    | "cmd"
+                    | "toml"
+                    | "ini"
+                    | "cfg"
+                    | "conf"
+                    | "properties"
+                    | "sql"
+                    | "rb"
+                    | "php"
+                    | "pl"
+                    | "pm"
+                    | "lua"
+                    | "r"
+                    | "vue"
+                    | "svelte"
+                    | "astro"
+                    | "css"
+                    | "scss"
+                    | "sass"
+                    | "less"
+                    | "html"
+                    | "htm"
+                    | "graphql"
+                    | "gql"
+                    | "proto"
             )
         })
 }
@@ -1321,6 +1406,22 @@ mod tests {
     fn recognizes_text_files_without_trusting_only_content_type() {
         assert!(supported_text_file("secrets.env", None));
         assert!(supported_text_file("payload.bin", Some("application/json")));
+        for filename in [
+            "main.py",
+            "lib.rs",
+            "app.tsx",
+            "main.go",
+            "build.ps1",
+            "Cargo.toml",
+            "schema.sql",
+            "Dockerfile",
+            ".gitignore",
+        ] {
+            assert!(
+                supported_text_file(filename, Some("application/octet-stream")),
+                "{filename}"
+            );
+        }
         assert!(!supported_text_file("report.pdf", Some("application/pdf")));
         assert!(supported_image_file("photo.jpg", None));
         assert!(supported_image_file("upload.bin", Some("image/png")));

--- a/crates/pentect-cli/src/upstream.rs
+++ b/crates/pentect-cli/src/upstream.rs
@@ -3,6 +3,8 @@
 use std::path::Path;
 use zeroize::Zeroize;
 
+const UPSTREAM_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+
 const CA_CERT_ENV: &str = "PENTECT_UPSTREAM_CA_CERT";
 const IDENTITY_ENV: &str = "PENTECT_UPSTREAM_IDENTITY";
 const AUTHORIZATION_ENV: &str = "PENTECT_UPSTREAM_AUTHORIZATION";
@@ -326,7 +328,7 @@ pub(crate) fn client(protocol: &str) -> Result<reqwest::Client, String> {
     let mut builder = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(std::time::Duration::from_secs(10))
-        .read_timeout(std::time::Duration::from_secs(60))
+        .read_timeout(UPSTREAM_READ_TIMEOUT)
         .pool_idle_timeout(std::time::Duration::from_secs(30))
         .tcp_nodelay(true);
 
@@ -445,6 +447,11 @@ mod tests {
         );
         assert_eq!(header_source_env_name("x-api-key="), None);
         assert_eq!(header_source_env_name("ANTHROPIC_API_KEY"), None);
+    }
+
+    #[test]
+    fn upstream_read_timeout_allows_long_reasoning_gaps() {
+        assert_eq!(UPSTREAM_READ_TIMEOUT, std::time::Duration::from_secs(600));
     }
 
     #[test]

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -2131,13 +2131,13 @@ fn blur_rect(image: &mut image::RgbaImage, rect: PixelRect) {
     let tiny = image::imageops::resize(&crop, tiny_width, tiny_height, FilterType::Triangle);
     let mut redacted =
         image::imageops::resize(&tiny, rect.width, rect.height, FilterType::Triangle);
-    for pixel in redacted.pixels_mut() {
+    for (x, y, pixel) in redacted.enumerate_pixels_mut() {
         let channels = pixel.0;
         pixel.0 = [
             dim_redaction_channel(channels[0]),
             dim_redaction_channel(channels[1]),
             dim_redaction_channel(channels[2]),
-            255,
+            crop.get_pixel(x, y).0[3],
         ];
     }
     image::imageops::replace(image, &redacted, i64::from(rect.left), i64::from(rect.top));
@@ -3638,6 +3638,27 @@ mod tests {
         let outside = image.get_pixel(250, 140).0;
         assert_ne!([inside[0], inside[1], inside[2]], [220, 80, 80]);
         assert_eq!([outside[0], outside[1], outside[2]], [220, 190, 80]);
+    }
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn blur_redaction_preserves_alpha_channel() {
+        let mut image =
+            image::RgbaImage::from_fn(8, 8, |x, y| image::Rgba([120, 80, 40, (x + y * 8) as u8]));
+        let original_alpha = image.pixels().map(|pixel| pixel.0[3]).collect::<Vec<_>>();
+        blur_rect(
+            &mut image,
+            PixelRect {
+                left: 0,
+                top: 0,
+                width: 8,
+                height: 8,
+            },
+        );
+        assert_eq!(
+            image.pixels().map(|pixel| pixel.0[3]).collect::<Vec<_>>(),
+            original_alpha
+        );
     }
 
     #[cfg(feature = "ocr")]


### PR DESCRIPTION
## Root causes and fixes

- Strip client `Accept-Encoding` before Gemini upstream requests because the proxy intentionally rejects compressed upstream bodies.
- Route Anthropic `mcp_tool_use` and `server_tool_use` blocks through ToolCall middleware, matching ordinary `tool_use`.
- Preserve CRLF consistently when rewriting Cloud Code and Gemini SSE metadata.
- Preserve source alpha values during blurred OCR redaction.
- Increase the shared upstream read timeout from 60 seconds to 10 minutes for long reasoning gaps.
- Inspect common source-code, configuration, and extensionless project files uploaded with generic media types.

## Regression tests

Focused tests cover every changed behavior, including both Google SSE implementations and generic-media-type source uploads.

Closes #1059
Closes #1058
Closes #1056
Closes #1047
Closes #1030
Closes #980
Closes #417