### PR TITLE
Release v0.0.62

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.61"
+version = "0.0.62"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
Bump the CLI and npm package versions to `0.0.62`.

The release tag will be created only after this PR passes CI and is merged into `main`. Package metadata remains unchanged until the release workflow generates checksums from published assets.

## Validation

- `cargo metadata --no-deps --format-version 1 --locked`
- `npm test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version to 0.0.62 across published packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->