### PR TITLE
Harden proxy stream boundaries

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1270,7 +1270,7 @@ where
             active.bytes.extend_from_slice(&block);
             if matches!(boundary, SseToolBoundary::Stop(index) if index == active.index) {
                 let active = self.active_tool.take().expect("active tool exists");
-                match std::str::from_utf8(&active.bytes)
+                let rewritten = std::str::from_utf8(&active.bytes)
                     .map_err(|error| format!("Claude tool SSE was not UTF-8: {error}"))
                     .and_then(|text| {
                         rewrite_anthropic_sse_with_tool_name(
@@ -1279,16 +1279,8 @@ where
                             &mut self.resolve,
                             self.plugins.as_deref(),
                         )
-                    }) {
-                    Ok(rewritten) => output.push(Bytes::from(rewritten)),
-                    Err(error) => {
-                        if error.starts_with("plugin middleware:") {
-                            return Err(error);
-                        }
-                        diagnostic("sse-restore-skipped", "protection", "messages", false);
-                        output.push(Bytes::from(active.bytes));
-                    }
-                }
+                    })?;
+                output.push(Bytes::from(rewritten));
             }
             return Ok(());
         }
@@ -3557,6 +3549,22 @@ mod tests {
         let output = join_bytes(output);
         assert!(output.contains("actual-secret"));
         assert!(!output.contains("<<SECRET_deadbeefdeadbeef>>"));
+    }
+
+    #[test]
+    fn streaming_tool_restore_failure_aborts_without_emitting_unresolved_input() {
+        let input = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"use <<SECRET_deadbeefdeadbeef>>\\\"}\"}}\n\n",
+            "event: content_block_stop\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n"
+        );
+        let mut transformer =
+            SseStreamTransformer::new(|_| Err("memory store unavailable".to_string()), None, false);
+        let error = transformer.push(input.as_bytes()).unwrap_err();
+        assert!(error.contains("memory store unavailable"), "{error}");
     }
 
     #[test]

--- a/crates/pentect-cli/src/upstream.rs
+++ b/crates/pentect-cli/src/upstream.rs
@@ -227,7 +227,8 @@ fn sensitive_header_value(
 fn reject_unsafe_override_header(name: &reqwest::header::HeaderName) -> Result<(), String> {
     if matches!(
         name.as_str(),
-        "connection"
+        "accept-encoding"
+            | "connection"
             | "content-length"
             | "host"
             | "proxy-authenticate"
@@ -512,6 +513,9 @@ mod tests {
         std::env::remove_var("PENTECT_TEST_MISSING_KEY");
         assert!(header_overrides(&["x-bf-vk=PENTECT_TEST_MISSING_KEY".to_string()]).is_err());
         assert!(header_overrides(&["host=PENTECT_TEST_MISSING_KEY".to_string()]).is_err());
+        assert!(
+            header_overrides(&["accept-encoding=PENTECT_TEST_MISSING_KEY".to_string()]).is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject `accept-encoding` in environment-backed upstream header overrides so callers cannot re-enable compressed upstream bodies that the inspection proxies intentionally disable
- abort Claude tool streams when buffered tool-input restoration fails instead of emitting unresolved buffered SSE bytes

## Focused regression coverage
- transport-header override rejection
- Claude tool-stream restoration failure

Closes #1067
Closes #1069