### PR TITLE
Protect Claude App non-streaming JSON responses

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -1079,6 +1079,7 @@ struct ProxyState {
     masker: Arc<Mutex<pentect_agent::ActiveToolOutputMasker>>,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
     block_unknown_formats: bool,
+    restore_output: bool,
     files: Mutex<HashMap<String, crate::http_files::Coverage>>,
     file_attestations: crate::http_files::FileAttestationStore,
     pending_files: Mutex<PendingFiles>,
@@ -1140,6 +1141,7 @@ async fn run_proxy(
         )),
         plugins: Arc::new(Mutex::new(plugins)),
         block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
+        restore_output: pentect_agent::output_restore_enabled()?,
         files: Mutex::new(HashMap::new()),
         file_attestations: crate::http_files::FileAttestationStore::open_default()?,
         pending_files: Mutex::new(PendingFiles::default()),
@@ -1465,10 +1467,13 @@ async fn forward_inspected_inner(
         .unwrap_or("-");
     eprintln!("[pentect] claude-app < {status} {method} {host}{safe_path} {response_content_type}");
 
-    let transform_chat = protect_chat
+    let transform_chat_sse = protect_chat
         && status.is_success()
         && response_content_type.eq_ignore_ascii_case("text/event-stream");
-    if (transform_chat || upload_coverage.is_some() || prepare_upload)
+    let transform_chat_json = protect_chat
+        && status.is_success()
+        && response_content_type.eq_ignore_ascii_case("application/json");
+    if (transform_chat_sse || transform_chat_json || upload_coverage.is_some() || prepare_upload)
         && response_headers
             .get(hyper::header::CONTENT_ENCODING)
             .is_some_and(|encoding| {
@@ -1485,7 +1490,7 @@ async fn forward_inspected_inner(
 
     let mut builder = Response::builder().status(status);
     for (name, value) in &response_headers {
-        if !transform_chat || name != hyper::header::CONTENT_LENGTH {
+        if !(transform_chat_sse || transform_chat_json) || name != hyper::header::CONTENT_LENGTH {
             builder = builder.header(name, value);
         }
     }
@@ -1583,12 +1588,31 @@ async fn forward_inspected_inner(
             .map_err(|error| format!("could not build Claude App prepare response: {error}"));
     }
 
+    if transform_chat_json {
+        let body = read_response_capped(upstream).await?;
+        let plugins = Arc::clone(&state.plugins);
+        let block_unknown_formats = state.block_unknown_formats;
+        let restore_output = state.restore_output;
+        let body = tokio::task::spawn_blocking(move || {
+            rewrite_chat_json_response(&body, &plugins, block_unknown_formats, restore_output)
+        })
+        .await
+        .map_err(|_| "Claude App JSON response protection task failed".to_string())??;
+        return builder
+            .body(
+                Full::new(body)
+                    .map_err(|never| match never {})
+                    .boxed_unsync(),
+            )
+            .map_err(|error| format!("could not build Claude App JSON response: {error}"));
+    }
+
     let stream = upstream.bytes_stream().map(move |result| {
         result
             .map(Frame::data)
             .map_err(|error| Box::new(error) as ProxyBodyError)
     });
-    let body = if transform_chat {
+    let body = if transform_chat_sse {
         chat_sse_body(Box::pin(stream), Arc::clone(&state.plugins))
     } else {
         BodyExt::boxed_unsync(StreamBody::new(stream))
@@ -2346,6 +2370,80 @@ struct ChatStreamState {
     finished: bool,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
     resolve: Option<ChatResolver>,
+}
+
+fn rewrite_chat_json_response(
+    body: &Bytes,
+    plugins: &Mutex<pentect_agent::PluginMiddleware>,
+    block_unknown_formats: bool,
+    restore_output: bool,
+) -> Result<Bytes, String> {
+    let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
+    rewrite_chat_json_response_with(
+        body,
+        plugins,
+        block_unknown_formats,
+        restore_output,
+        &mut resolve,
+    )
+}
+
+fn rewrite_chat_json_response_with<R>(
+    body: &Bytes,
+    plugins: &Mutex<pentect_agent::PluginMiddleware>,
+    block_unknown_formats: bool,
+    restore_output: bool,
+    resolve: &mut R,
+) -> Result<Bytes, String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
+    let mut value: serde_json::Value = match serde_json::from_slice(body) {
+        Ok(value) => value,
+        Err(error) if block_unknown_formats => {
+            return Err(format!(
+                "unknown format blocked: Claude App Chat response is not valid JSON ({error})"
+            ));
+        }
+        Err(error) => {
+            eprintln!("[pentect] Claude App Chat response protection skipped: {error}");
+            return Ok(body.clone());
+        }
+    };
+    let run = plugins
+        .lock()
+        .map_err(|_| "Claude App plugin lock was poisoned".to_string())?
+        .run(
+            pentect_agent::MiddlewareStage::Response,
+            value,
+            Some(serde_json::json!({"provider": "claude", "transport": "desktop-http"})),
+        )?;
+    if block_unknown_formats && run.coverage == pentect_agent::MiddlewareCoverage::Partial {
+        return Err(
+            "unknown format blocked: a Claude App plugin reported partial response coverage"
+                .to_string(),
+        );
+    }
+    if run.stopped == Some(pentect_agent::StopOutcome::Block) {
+        return Err(format!(
+            "plugin blocked: {}",
+            run.message
+                .unwrap_or_else(|| "response blocked".to_string())
+        ));
+    }
+    value = run.payload;
+    {
+        let plugins = plugins
+            .lock()
+            .map_err(|_| "Claude App plugin lock was poisoned".to_string())?
+            .clone();
+        run_chat_tool_plugins(&mut value, &plugins)?;
+    }
+    resolve_chat_tool_calls(&mut value, resolve)?;
+    crate::claude_http_proxy::restore_anthropic_json_value(&mut value, restore_output, resolve)?;
+    serde_json::to_vec(&value)
+        .map(Bytes::from)
+        .map_err(|error| format!("could not encode Claude App Chat response: {error}"))
 }
 
 fn chat_sse_body<S>(stream: S, plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>) -> ProxyBody
@@ -3462,6 +3560,32 @@ mod tests {
         assert_eq!(
             metadata_path("/v1/code/sessions/cse_01Ni2WadyEAmYhNEa9JK4hLH/events"),
             "/v1/code/sessions/:id/events"
+        );
+    }
+
+    #[test]
+    fn nonstream_chat_response_runs_tool_and_output_restoration() {
+        let handle = "<<SECRET_0011223344556677>>";
+        let body = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "content": [
+                    {"type": "text", "text": format!("show {handle}")},
+                    {"type": "tool_use", "name": "http", "input": {
+                        "headers": {"x-token": handle}
+                    }}
+                ]
+            }))
+            .unwrap(),
+        );
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let mut resolve = |text: &str| Ok(text.replace(handle, "local-value"));
+        let rewritten =
+            rewrite_chat_json_response_with(&body, &plugins, true, true, &mut resolve).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
+        assert_eq!(value["content"][0]["text"], "show local-value");
+        assert_eq!(
+            value["content"][1]["input"]["headers"]["x-token"],
+            "local-value"
         );
     }
 

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1870,12 +1870,25 @@ fn rewrite_anthropic_json_response(body: &[u8], restore_output: bool) -> Result<
     let mut value: Value = serde_json::from_slice(body)
         .map_err(|error| format!("Claude response was not valid JSON: {error}"))?;
     let mut resolve = request_scoped_resolver();
+    restore_anthropic_json_value(&mut value, restore_output, &mut resolve)?;
+    serde_json::to_vec(&value)
+        .map_err(|error| format!("could not encode restored Claude response: {error}"))
+}
+
+pub(crate) fn restore_anthropic_json_value<R>(
+    value: &mut Value,
+    restore_output: bool,
+    resolve: &mut R,
+) -> Result<(), String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
     if let Some(content) = value.get_mut("content").and_then(Value::as_array_mut) {
         for block in content {
             if block.get("type").and_then(Value::as_str) == Some("tool_use") {
                 let tool_name = block.get("name").and_then(Value::as_str).map(str::to_owned);
                 if let Some(input) = block.get_mut("input") {
-                    resolve_tool_input_value(input, tool_name.as_deref(), &mut resolve)?;
+                    resolve_tool_input_value(input, tool_name.as_deref(), resolve)?;
                 }
             } else if restore_output && block.get("type").and_then(Value::as_str) == Some("text") {
                 if let Some(Value::String(text)) = block.get_mut("text") {
@@ -1884,8 +1897,7 @@ fn rewrite_anthropic_json_response(body: &[u8], restore_output: bool) -> Result<
             }
         }
     }
-    serde_json::to_vec(&value)
-        .map_err(|error| format!("could not encode restored Claude response: {error}"))
+    Ok(())
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary
- classify successful protected `application/json` chat responses separately from SSE
- buffer JSON responses under the existing body limit and reject unexpected compression
- run Response and ToolCall plugins before returning the response
- restore completed tool inputs and user-configured assistant output handles using the same Anthropic value restoration as the API gateway
- preserve compatibility-mode passthrough for malformed JSON

## Focused regression coverage
- non-stream text and nested tool-input restoration

Closes #1062