### PR TITLE
Fail closed on partial ToolCall plugin coverage

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -2559,6 +2559,7 @@ fn run_chat_tool_plugins(
                     serde_json::Value::Object(object.clone()),
                     Some(serde_json::json!({"provider": "claude", "transport": "desktop-http"})),
                 )?;
+                crate::plugins::enforce_tool_plugin_coverage(run.coverage, "Claude App")?;
                 if run.stopped == Some(pentect_agent::StopOutcome::Block) {
                     return Err(format!(
                         "plugin blocked: {}",

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -659,6 +659,7 @@ fn run_anthropic_tool_plugins(
                     Value::Object(object.clone()),
                     Some(serde_json::json!({"provider": "anthropic", "transport": "http"})),
                 )?;
+                crate::plugins::enforce_tool_plugin_coverage(run.coverage, "Claude")?;
                 if run.stopped == Some(pentect_agent::StopOutcome::Block) {
                     return Err(format!(
                         "plugin blocked: {}",
@@ -1429,9 +1430,9 @@ fn sse_control_event(block: &[u8]) -> SseControlEvent {
             .as_str()
             .map(str::to_owned)
     });
-    match event.or(data_type.as_deref()) {
-        Some("ping") => SseControlEvent::Ping,
-        Some("error") => SseControlEvent::Error,
+    match (event, data_type.as_deref()) {
+        (Some("ping"), _) | (_, Some("ping")) => SseControlEvent::Ping,
+        (Some("error"), _) | (_, Some("error")) => SseControlEvent::Error,
         _ => SseControlEvent::Other,
     }
 }

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2018,6 +2018,7 @@ where
                         Some(serde_json::json!({"provider": "anthropic", "transport": "http_sse"})),
                     )
                     .map_err(|error| format!("plugin middleware: {error}"))?;
+                crate::plugins::enforce_tool_plugin_coverage(run.coverage, "Claude")?;
                 if run.stopped == Some(pentect_agent::StopOutcome::Block) {
                     return Err(format!(
                         "plugin middleware: blocked: {}",

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -3642,9 +3642,9 @@ mod tests {
             "event: content_block_start\n",
             "data: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tool_2\",\"name\":\"Bash\",\"input\":{}}}\n\n",
             "event: content_block_delta\n",
-            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"echo <<SECRET_one>>\\\"}\"}}\n\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"echo <<SECRET_1111111111111111>>\\\"}\"}}\n\n",
             "event: content_block_delta\n",
-            "data: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"echo <<SECRET_two>>\\\"}\"}}\n\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"echo <<SECRET_2222222222222222>>\\\"}\"}}\n\n",
             "event: content_block_stop\n",
             "data: {\"type\":\"content_block_stop\",\"index\":2}\n\n"
         );
@@ -3655,8 +3655,8 @@ mod tests {
         let mut transformer = SseStreamTransformer::new(
             |text: &str| {
                 Ok(text
-                    .replace("<<SECRET_one>>", "first")
-                    .replace("<<SECRET_two>>", "second"))
+                    .replace("<<SECRET_1111111111111111>>", "first")
+                    .replace("<<SECRET_2222222222222222>>", "second"))
             },
             None,
             false,

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -1021,6 +1021,7 @@ fn run_tool_plugins(
                     call.clone(),
                     Some(serde_json::json!({"provider": "google-cloud-code", "transport": "http"})),
                 )?;
+                crate::plugins::enforce_tool_plugin_coverage(run.coverage, "Google Cloud Code")?;
                 if run.stopped == Some(pentect_agent::StopOutcome::Block) {
                     return Err(format!(
                         "plugin blocked: {}",

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -616,6 +616,7 @@ fn run_tool_plugins(
                     call.clone(),
                     Some(serde_json::json!({"provider": "gemini", "transport": "http"})),
                 )?;
+                crate::plugins::enforce_tool_plugin_coverage(run.coverage, "Gemini")?;
                 if run.stopped == Some(pentect_agent::StopOutcome::Block) {
                     return Err(format!(
                         "plugin blocked: {}",

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -730,6 +730,7 @@ fn run_openai_tool_plugins(
                     Value::Object(object.clone()),
                     Some(serde_json::json!({"provider": "openai", "transport": "http"})),
                 )?;
+                crate::plugins::enforce_tool_plugin_coverage(run.coverage, "OpenAI")?;
                 if run.stopped == Some(pentect_agent::StopOutcome::Block) {
                     return Err(format!(
                         "plugin blocked: {}",

--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -35,6 +35,30 @@ const MAX_REMOTE_PLUGIN_CACHE_ENTRIES: usize = 256;
 const MAX_PROJECT_PLUGIN_LOCK_BYTES: u64 = 1024 * 1024;
 static PROJECT_LOCK_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
+pub(crate) fn enforce_tool_plugin_coverage(
+    coverage: pentect_agent::MiddlewareCoverage,
+    provider: &str,
+) -> std::result::Result<(), String> {
+    enforce_tool_plugin_coverage_with_policy(
+        coverage,
+        pentect_agent::unknown_formats_should_block()?,
+        provider,
+    )
+}
+
+fn enforce_tool_plugin_coverage_with_policy(
+    coverage: pentect_agent::MiddlewareCoverage,
+    block_unknown_formats: bool,
+    provider: &str,
+) -> std::result::Result<(), String> {
+    if block_unknown_formats && coverage == pentect_agent::MiddlewareCoverage::Partial {
+        return Err(format!(
+            "unknown format blocked: a {provider} ToolCall plugin reported partial coverage; set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to allow it"
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum PluginScope {
     User,
@@ -2675,5 +2699,27 @@ label = "INLINE_SECRET"
         assert!(packs.is_empty());
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn partial_tool_plugin_coverage_only_blocks_in_strict_mode() {
+        assert!(enforce_tool_plugin_coverage_with_policy(
+            pentect_agent::MiddlewareCoverage::Partial,
+            true,
+            "fixture"
+        )
+        .is_err());
+        assert!(enforce_tool_plugin_coverage_with_policy(
+            pentect_agent::MiddlewareCoverage::Partial,
+            false,
+            "fixture"
+        )
+        .is_ok());
+        assert!(enforce_tool_plugin_coverage_with_policy(
+            pentect_agent::MiddlewareCoverage::Full,
+            true,
+            "fixture"
+        )
+        .is_ok());
     }
 }

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -431,9 +431,13 @@ impl PluginMiddleware {
                     if plugin.required {
                         return Err(error);
                     }
-                    coverage = MiddlewareCoverage::Partial;
-                    eprintln!("[pentect] optional {error}");
-                    continue;
+                    eprintln!("[pentect] optional {error}; blocking instead");
+                    return Ok(MiddlewareRun {
+                        payload,
+                        coverage,
+                        stopped: Some(StopOutcome::Block),
+                        message: response.message.or(Some(error)),
+                    });
                 }
                 Some(outcome)
             } else {
@@ -3951,6 +3955,36 @@ mod tests {
             )
             .unwrap_err();
         assert!(error.contains("mismatched protocol response"), "{error}");
+    }
+
+    #[test]
+    fn optional_non_request_respond_falls_back_to_block() {
+        let Some(command) = python_protocol_fixture(
+            "import json,sys; r=json.loads(sys.stdin.readline()); print(json.dumps({'schema':'pentect.plugin.v1','id':r['id'],'type':'result','action':'stop','outcome':'respond'}), flush=True)",
+        ) else {
+            return;
+        };
+        let middleware = PluginMiddleware {
+            plugins: vec![PluginBinary {
+                name: "optional-respond".to_string(),
+                program: PluginProgram::Command(
+                    CommandProgram::new(command, std::env::current_dir().unwrap(), 4096).unwrap(),
+                ),
+                hooks: BTreeSet::from([MiddlewareStage::ToolCall]),
+                required: false,
+                command_config: Some(json!({})),
+                timeout: Duration::from_secs(5),
+                startup_timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+                max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
+                max_output_bytes: 4096,
+                max_spans: DEFAULT_MAX_SPANS,
+            }],
+        };
+        let result = middleware
+            .run(MiddlewareStage::ToolCall, json!({"input": {}}), None)
+            .unwrap();
+        assert_eq!(result.stopped, Some(StopOutcome::Block));
+        assert!(result.message.unwrap().contains("can only respond"));
     }
 
     fn invalid_command_plugin(required: bool) -> PluginBinary {


### PR DESCRIPTION
## Summary
- enforce partial ToolCall coverage consistently across Claude, Claude App, OpenAI, Gemini, and Google Cloud Code
- block partial ToolCall coverage when strict unknown-format policy is enabled
- preserve compatibility-mode behavior when unknown formats are explicitly allowed
- convert an optional plugin’s invalid non-Request `stop/respond` result into `stop/block` instead of discarding the stop request

## Focused regression coverage
- strict versus compatibility handling for partial ToolCall coverage
- optional non-Request respond fallback to block

Closes #1066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call protection across supported AI providers by detecting incomplete plugin coverage before processing tool results.
  * Requests now correctly fail when configured blocking rules cannot be fully applied.
  * Optional plugins that respond during tool-call processing now block the operation immediately.
  * Improved handling of streaming `ping` and `error` events, including mismatched event labels and payload types.
  * Added support for permissive behavior when unknown formats are configured to be ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->