### PR TITLE
Support parallel Claude tool streams

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1150,21 +1150,20 @@ fn streaming_response_body(
 struct SseStreamTransformer<R> {
     resolve: R,
     pending: Vec<u8>,
-    active_tool: Option<ActiveToolStream>,
+    tool_buffer: Option<ToolStreamBuffer>,
     passthrough: bool,
     plugins: Option<Arc<StdMutex<pentect_agent::PluginMiddleware>>>,
     restore_output: bool,
     output_text: HashMap<(u64, &'static str), OutputTextRestorer>,
 }
 
-struct ActiveToolStream {
-    index: u64,
-    name: Option<String>,
+struct ToolStreamBuffer {
+    active: HashSet<u64>,
     bytes: Vec<u8>,
 }
 
 enum SseToolBoundary {
-    Start { index: u64, name: Option<String> },
+    Start { index: u64 },
     Stop(u64),
     Other,
 }
@@ -1181,7 +1180,7 @@ where
         Self {
             resolve,
             pending: Vec::new(),
-            active_tool: None,
+            tool_buffer: None,
             passthrough: false,
             plugins,
             restore_output,
@@ -1208,10 +1207,10 @@ where
 
     fn finish(&mut self) -> Vec<Bytes> {
         let mut output = self.finish_output_text();
-        if let Some(mut tool) = self.active_tool.take() {
-            tool.bytes.append(&mut self.pending);
-            if !tool.bytes.is_empty() {
-                output.push(Bytes::from(tool.bytes));
+        if let Some(mut tools) = self.tool_buffer.take() {
+            tools.bytes.append(&mut self.pending);
+            if !tools.bytes.is_empty() {
+                output.push(Bytes::from(tools.bytes));
             }
         } else if !self.pending.is_empty() {
             output.push(Bytes::from(std::mem::take(&mut self.pending)));
@@ -1244,39 +1243,57 @@ where
     }
 
     fn process_block(&mut self, block: Vec<u8>, output: &mut Vec<Bytes>) -> Result<(), String> {
-        if let Some(active) = &mut self.active_tool {
+        if self.tool_buffer.is_some() {
             match sse_control_event(&block) {
                 SseControlEvent::Ping => {
                     output.push(Bytes::from(block));
                     return Ok(());
                 }
                 SseControlEvent::Error => {
-                    let active = self.active_tool.take().expect("active tool exists");
-                    output.push(Bytes::from(active.bytes));
+                    let tools = self.tool_buffer.take().expect("tool buffer exists");
+                    output.push(Bytes::from(tools.bytes));
                     output.push(Bytes::from(block));
                     self.passthrough = true;
                     return Ok(());
                 }
                 SseControlEvent::Other => {}
             }
-            if active.bytes.len().saturating_add(block.len()) > MAX_PENDING_SSE_BYTES {
+            if self
+                .tool_buffer
+                .as_ref()
+                .expect("tool buffer exists")
+                .bytes
+                .len()
+                .saturating_add(block.len())
+                > MAX_PENDING_SSE_BYTES
+            {
                 diagnostic("sse-tool-limit", "limit", "messages", false);
-                let active = self.active_tool.take().expect("active tool exists");
-                output.push(Bytes::from(active.bytes));
+                let tools = self.tool_buffer.take().expect("tool buffer exists");
+                output.push(Bytes::from(tools.bytes));
                 output.push(Bytes::from(block));
                 self.passthrough = true;
                 return Ok(());
             }
             let boundary = sse_tool_boundary(&block);
-            active.bytes.extend_from_slice(&block);
-            if matches!(boundary, SseToolBoundary::Stop(index) if index == active.index) {
-                let active = self.active_tool.take().expect("active tool exists");
-                let rewritten = std::str::from_utf8(&active.bytes)
+            let tools = self.tool_buffer.as_mut().expect("tool buffer exists");
+            match boundary {
+                SseToolBoundary::Start { index } => {
+                    tools.active.insert(index);
+                }
+                SseToolBoundary::Stop(index) => {
+                    tools.active.remove(&index);
+                }
+                SseToolBoundary::Other => {}
+            }
+            tools.bytes.extend_from_slice(&block);
+            if tools.active.is_empty() {
+                let tools = self.tool_buffer.take().expect("tool buffer exists");
+                let rewritten = std::str::from_utf8(&tools.bytes)
                     .map_err(|error| format!("Claude tool SSE was not UTF-8: {error}"))
                     .and_then(|text| {
                         rewrite_anthropic_sse_with_tool_name(
                             text,
-                            active.name.as_deref(),
+                            None,
                             &mut self.resolve,
                             self.plugins.as_deref(),
                         )
@@ -1287,10 +1304,9 @@ where
         }
 
         match sse_tool_boundary(&block) {
-            SseToolBoundary::Start { index, name } => {
-                self.active_tool = Some(ActiveToolStream {
-                    index,
-                    name,
+            SseToolBoundary::Start { index } => {
+                self.tool_buffer = Some(ToolStreamBuffer {
+                    active: HashSet::from([index]),
                     bytes: block,
                 });
             }
@@ -1312,9 +1328,9 @@ where
     fn fail_open_with(&mut self, chunk: &[u8]) -> Vec<Bytes> {
         let mut output = self.finish_output_text();
         let mut bytes = self
-            .active_tool
+            .tool_buffer
             .take()
-            .map_or_else(Vec::new, |active| active.bytes);
+            .map_or_else(Vec::new, |tools| tools.bytes);
         bytes.append(&mut self.pending);
         bytes.extend_from_slice(chunk);
         self.passthrough = true;
@@ -1476,14 +1492,7 @@ fn sse_tool_boundary(block: &[u8]) -> SseToolBoundary {
             .and_then(Value::as_str)
             == Some("tool_use")
     {
-        SseToolBoundary::Start {
-            index,
-            name: data
-                .get("content_block")
-                .and_then(|content| content.get("name"))
-                .and_then(Value::as_str)
-                .map(str::to_owned),
-        }
+        SseToolBoundary::Start { index }
     } else if event_type == Some("content_block_stop") {
         SseToolBoundary::Stop(index)
     } else {
@@ -3279,7 +3288,7 @@ mod tests {
         assert_eq!(blocks[0].data.as_ref().unwrap()["index"], 4);
         assert!(matches!(
             sse_tool_boundary(start.as_bytes()),
-            SseToolBoundary::Start { index: 4, .. }
+            SseToolBoundary::Start { index: 4 }
         ));
 
         let ping = "event: message\ndata: {\"type\":\ndata: \"ping\"}\n\n";
@@ -3610,6 +3619,47 @@ mod tests {
         let output = join_bytes(output);
         assert!(output.contains("actual-secret"));
         assert!(!output.contains("<<SECRET_deadbeefdeadbeef>>"));
+    }
+
+    #[test]
+    fn parallel_tool_blocks_are_buffered_and_resolved_by_index() {
+        let before_last_stop = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tool_1\",\"name\":\"Bash\",\"input\":{}}}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tool_2\",\"name\":\"Bash\",\"input\":{}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"echo <<SECRET_one>>\\\"}\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"echo <<SECRET_two>>\\\"}\"}}\n\n",
+            "event: content_block_stop\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":2}\n\n"
+        );
+        let last_stop = concat!(
+            "event: content_block_stop\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n"
+        );
+        let mut transformer = SseStreamTransformer::new(
+            |text: &str| {
+                Ok(text
+                    .replace("<<SECRET_one>>", "first")
+                    .replace("<<SECRET_two>>", "second"))
+            },
+            None,
+            false,
+        );
+        assert!(transformer
+            .push(before_last_stop.as_bytes())
+            .unwrap()
+            .is_empty());
+        let output = join_bytes(transformer.push(last_stop.as_bytes()).unwrap());
+        assert!(output.contains("echo first"), "{output}");
+        assert!(output.contains("echo second"), "{output}");
+        assert!(!output.contains("<<SECRET_"), "{output}");
+        assert!(
+            output.find("tool_1").unwrap() < output.find("tool_2").unwrap(),
+            "{output}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the single active Claude tool slot with an ordered shared buffer and an active-index set
- keep interleaved tool events in original SSE order until every overlapping tool block completes
- inspect and restore each completed tool input using its own index and tool name
- preserve existing ping passthrough, limits, EOF behavior, and fail-closed restoration errors

## Focused regression coverage
- two interleaved tool blocks completing out of order restore independently without leaking handles or reordering their starts

Closes #1045