### PR TITLE
Skip memory store probe for metadata commands

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -312,7 +312,8 @@ fn run(args: Vec<String>) -> Option<i32> {
     {
         panic!("forced test panic with payload that must not be persisted");
     }
-    let inherited_env_is_trusted = pentect_agent::active_memory_store_ready();
+    let inherited_env_is_trusted =
+        command_uses_agent_runtime(&args) && pentect_agent::active_memory_store_ready();
     update::start_update_notification(&args);
     if is_memory_store_server(&args) || !supports_process_host(&args) {
         return dispatch(args, inherited_env_is_trusted);
@@ -325,6 +326,29 @@ fn run(args: Vec<String>) -> Option<i32> {
     drop(_process_host_env);
     drop(process_host);
     exit_code
+}
+
+fn command_uses_agent_runtime(args: &[String]) -> bool {
+    matches!(
+        (
+            args.get(1).map(String::as_str),
+            args.get(2).map(String::as_str),
+        ),
+        (
+            Some(
+                "exec"
+                    | "resolve"
+                    | "log"
+                    | "hook"
+                    | "bridge"
+                    | "memory-store"
+                    | "purge"
+                    | "__agent-script"
+                    | "__agent-stream"
+            ),
+            _
+        ) | (Some("agent"), Some(_))
+    )
 }
 
 fn catch_cli_exit(operation: impl FnOnce() -> Option<i32>) -> Option<i32> {
@@ -3026,6 +3050,26 @@ fn required_value(args: &[String], i: &mut usize, flag: &str) -> Result<String, 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn metadata_and_client_commands_skip_memory_store_probe() {
+        let args = |values: &[&str]| {
+            values
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+        };
+        assert!(!command_uses_agent_runtime(&args(&[
+            "pentect",
+            "--version"
+        ])));
+        assert!(!command_uses_agent_runtime(&args(&["pentect", "help"])));
+        assert!(!command_uses_agent_runtime(&args(&["pentect", "codex"])));
+        assert!(command_uses_agent_runtime(&args(&["pentect", "exec"])));
+        assert!(command_uses_agent_runtime(&args(&[
+            "pentect", "agent", "hook"
+        ])));
+    }
 
     fn command_test_directory(name: &str) -> PathBuf {
         let nonce = std::time::SystemTime::now()


### PR DESCRIPTION
## Summary
- only probe inherited memory-store credentials for commands that actually dispatch into the agent runtime
- avoid a stale/unreachable memory-store timeout on `pentect --version`, help, client launchers, and other non-agent commands
- keep inherited-store validation unchanged for exec/resolve/log/hook/bridge and explicit agent commands

## Verification
- current v0.0.62 spends about 0.30s on `--version` in this environment because it performs the unconditional probe
- focused dispatch classification test covers metadata, client, direct-agent, and nested-agent commands

Closes #1036