### PR TITLE
Protect Claude App tool input fields

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -2184,7 +2184,14 @@ fn mask_chat_value(
                 || kind.contains("tool_result")
                 || kind.contains("tool_output")
                 || kind.contains("function_output");
+            let tool_call = kind.contains("tool_use")
+                || kind.contains("tool_call")
+                || kind.contains("function_call");
             for (key, nested) in object {
+                if tool_call && matches!(key.as_str(), "input" | "arguments") {
+                    crate::claude_http_proxy::mask_value_strings(nested, masker)?;
+                    continue;
+                }
                 if matches!(
                     key.as_str(),
                     "signature" | "thinking_signature" | "attestation"
@@ -3401,6 +3408,15 @@ mod tests {
                     "type": "tool_result",
                     "tool_use_id": "tool-stable-id",
                     "content": {"token": secret, "status": "ok"}
+                }, {
+                    "type": "tool_use",
+                    "name": "configure_service",
+                    "input": {
+                        "token": secret,
+                        "authorization": secret,
+                        "id": secret,
+                        "name": secret
+                    }
                 }]}],
                 "client_context": {"locale": "ja-JP", "revision": 7}
             }))
@@ -3433,6 +3449,12 @@ mod tests {
             value["messages"][0]["content"][0]["content"]["token"],
             secret
         );
+        let tool_input = &value["messages"][0]["content"][1]["input"];
+        for key in ["token", "authorization", "id", "name"] {
+            let protected = tool_input[key].as_str().unwrap();
+            assert!(!protected.contains(&secret), "{key} was not protected");
+            assert!(protected.contains("<<"), "{key} has no handle");
+        }
 
         let telemetry = Bytes::from(
             serde_json::to_vec(&serde_json::json!({

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1835,7 +1835,7 @@ pub(crate) fn mask_string(
     Ok(())
 }
 
-fn mask_value_strings(
+pub(crate) fn mask_value_strings(
     value: &mut Value,
     masker: &mut pentect_agent::ActiveToolOutputMasker,
 ) -> Result<(), String> {


### PR DESCRIPTION
Closes #1082.

## Why
Claude App protocol metadata exclusions were recursively applied inside free-form tool input objects, so fields named `token`, `authorization`, `id`, or `name` bypassed masking.

## Fix
- Route `tool_use`/`tool_call` input and arguments through the same full string masking helper used by the Anthropic API proxy.
- Keep metadata exclusions at the protocol envelope level.
- Add regression coverage for all reported field names.

## Validation
- GitHub Actions is the authoritative cross-platform validation.