### PR TITLE
Reject incompatible plugin responses for streaming requests

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -448,6 +448,11 @@ async fn proxy_request_inner(
             request_coverage = Some(protected.coverage);
             reqwest::Body::from(protected.body)
         } else {
+            let request_streaming = messages_path
+                && serde_json::from_slice::<Value>(&body)
+                    .ok()
+                    .and_then(|value| value.get("stream").and_then(Value::as_bool))
+                    .unwrap_or(false);
             let mut remote_budget = crate::remote_content::RemoteRequestBudget::default();
             let body = resolve_anthropic_remote_content(body, &mut remote_budget).await?;
             hydrate_anthropic_attested_files(&body, &account_scope, state).await?;
@@ -474,6 +479,12 @@ async fn proxy_request_inner(
             .map_err(|_| "Claude request protection task failed".to_string())??;
             request_coverage = Some(protected.coverage);
             if let Some(response) = protected.local_response {
+                if request_streaming {
+                    return Ok(text_response(
+                        StatusCode::UNPROCESSABLE_ENTITY,
+                        "Plugin local responses are unavailable for streaming Anthropic requests",
+                    ));
+                }
                 return Ok(json_response(StatusCode::OK, response));
             }
             reqwest::Body::from(protected.body)

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -304,6 +304,12 @@ async fn proxy_request_inner(
             state.block_unknown_formats,
         )?;
         if let Some(response) = protected.local_response {
+            if is_stream {
+                return Ok(text_response(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "Plugin local responses are unavailable for streaming Google Cloud Code requests",
+                ));
+            }
             return Ok(json_response(StatusCode::OK, response));
         }
         reqwest::Body::from(protected.body)

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -285,6 +285,12 @@ async fn proxy_request_inner(
             state.block_unknown_formats,
         )?;
         if let Some(response) = protected.local_response {
+            if endpoint == GeminiEndpoint::StreamGenerateContent {
+                return Ok(text_response(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "Plugin local responses are unavailable for streaming Gemini requests",
+                ));
+            }
             return Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(hyper::header::CONTENT_TYPE, "application/json")

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -493,6 +493,12 @@ async fn proxy_request_inner(
             .map_err(|_| "OpenAI request protection task failed".to_string())??;
             request_coverage = Some(protected.coverage);
             if let Some(response) = protected.local_response {
+                if request_streaming {
+                    return Ok(text_response(
+                        StatusCode::UNPROCESSABLE_ENTITY,
+                        "Plugin local responses are unavailable for streaming OpenAI requests",
+                    ));
+                }
                 return Ok(json_response(StatusCode::OK, response));
             }
             reqwest::Body::from(protected.body)


### PR DESCRIPTION
Closes #1070.

## Why
Request-stage plugin `Respond` payloads are complete JSON responses. Returning them with `application/json` to clients that requested SSE caused opaque client-side stream parser failures. Guessing provider-specific stream events from an arbitrary plugin payload would be unsafe.

## Fix
- Detect streaming requests in Anthropic, OpenAI, Gemini, and Google Cloud Code paths.
- Return an explicit HTTP 422 Pentect error before upstream forwarding when a plugin attempts a local JSON response for an SSE request.
- Preserve existing local JSON responses for non-streaming requests.

## Validation
GitHub Actions is the authoritative cross-platform validation.