### PR TITLE
Resolve Gemini remote fileData safely

### DIFF
--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -295,7 +295,7 @@ async fn proxy_request_inner(
             Err(error) => return Err(format!("could not read Google Cloud Code request: {error}")),
         };
         let mut remote_budget = crate::remote_content::RemoteRequestBudget::default();
-        let body = resolve_cloud_code_remote_files(body, &mut remote_budget).await?;
+        let body = resolve_google_remote_files(body, &mut remote_budget).await?;
         let protected = protect_request_body(
             &body,
             endpoint,
@@ -405,7 +405,7 @@ async fn proxy_request_inner(
         .map_err(|error| format!("could not build Google Cloud Code response: {error}"))
 }
 
-async fn resolve_cloud_code_remote_files(
+pub(crate) async fn resolve_google_remote_files(
     body: Bytes,
     budget: &mut crate::remote_content::RemoteRequestBudget,
 ) -> Result<Bytes, String> {
@@ -413,13 +413,13 @@ async fn resolve_cloud_code_remote_files(
         Ok(value) => value,
         Err(_) => return Ok(body),
     };
-    resolve_cloud_code_remote_values(&mut value, budget).await?;
+    resolve_google_remote_values(&mut value, budget).await?;
     serde_json::to_vec(&value)
         .map(Bytes::from)
         .map_err(|_| "could not encode resolved Google Cloud Code attachment".to_string())
 }
 
-fn resolve_cloud_code_remote_values<'a>(
+fn resolve_google_remote_values<'a>(
     value: &'a mut Value,
     budget: &'a mut crate::remote_content::RemoteRequestBudget,
 ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + 'a>> {
@@ -427,7 +427,7 @@ fn resolve_cloud_code_remote_values<'a>(
         match value {
             Value::Array(values) => {
                 for value in values {
-                    resolve_cloud_code_remote_values(value, budget).await?;
+                    resolve_google_remote_values(value, budget).await?;
                 }
             }
             Value::Object(object) => {
@@ -455,7 +455,7 @@ fn resolve_cloud_code_remote_values<'a>(
                     }
                 }
                 for value in object.values_mut() {
-                    resolve_cloud_code_remote_values(value, budget).await?;
+                    resolve_google_remote_values(value, budget).await?;
                 }
             }
             _ => {}
@@ -761,9 +761,7 @@ fn mask_part(
         .transpose()?
         .flatten();
     if object.contains_key("fileData") && pentect_agent::unscanned_images_should_block()? {
-        return Err(
-            "document blocked: Google Cloud Code fileData could not be scanned".to_string(),
-        );
+        return Err("document blocked: Google fileData could not be scanned".to_string());
     }
     if let Some(code) = object.get_mut("executableCode") {
         mask_value_strings(code, false, masker)?;

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -277,6 +277,10 @@ async fn proxy_request_inner(
             }
             Err(error) => return Err(format!("could not read Gemini request: {error}")),
         };
+        let mut remote_budget = crate::remote_content::RemoteRequestBudget::default();
+        let body =
+            crate::cloud_code_http_proxy::resolve_google_remote_files(body, &mut remote_budget)
+                .await?;
         let protected = protect_request_body(
             &body,
             endpoint,
@@ -1121,6 +1125,18 @@ mod tests {
             ),
             "unknown"
         );
+    }
+
+    #[tokio::test]
+    async fn remote_file_data_uses_the_bounded_google_resolver() {
+        let body = Bytes::from_static(
+            br#"{"contents":[{"role":"user","parts":[{"fileData":{"mimeType":"text/plain","fileUri":"https://127.0.0.1/private"}}]}]}"#,
+        );
+        let mut budget = crate::remote_content::RemoteRequestBudget::default();
+        let error = crate::cloud_code_http_proxy::resolve_google_remote_files(body, &mut budget)
+            .await
+            .unwrap_err();
+        assert!(error.contains("non-public address"), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1072.

## Why
Cloud Code resolved HTTPS `fileData` through the bounded remote fetcher before scanning, while the native Gemini path sent the unresolved reference into the fail-closed scanner and emitted a Cloud Code-specific error.

## Fix
- Share the bounded Google remote-file resolver with the Gemini request path.
- Preserve HTTPS-only, public-address, redirect, item, and byte limits; provider credentials are never forwarded to attachment hosts.
- Use a provider-neutral Google `fileData` scan error.
- Add a regression test proving Gemini attachment resolution reaches the SSRF-safe resolver.

## Validation
GitHub Actions is the authoritative cross-platform validation.