### PR TITLE
Highlight sensitive plugin environment access

### DIFF
--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -3036,6 +3036,13 @@ fn print_permissions(permissions: &PermissionsConfig) {
     }
     if !permissions.env.is_empty() {
         println!("permission-env: {}", permissions.env.join(", "));
+        let sensitive = sensitive_env_permissions(&permissions.env);
+        if !sensitive.is_empty() {
+            println!(
+                "WARNING: credential-like environment access: {}",
+                sensitive.join(", ")
+            );
+        }
     }
     for argv in &permissions.run {
         println!("permission-run: {}", display_command(argv));
@@ -3043,6 +3050,36 @@ fn print_permissions(permissions: &PermissionsConfig) {
     if permissions.storage {
         println!("permission-storage: enabled");
     }
+}
+
+fn sensitive_env_permissions(names: &[String]) -> Vec<&str> {
+    names
+        .iter()
+        .filter(|name| {
+            let upper = name.to_ascii_uppercase();
+            upper == "PASSWORD"
+                || upper == "PASSWD"
+                || upper == "API_KEY"
+                || upper == "SECRET"
+                || upper == "TOKEN"
+                || upper == "CREDENTIAL"
+                || upper == "CREDENTIALS"
+                || upper == "PRIVATE_KEY"
+                || upper == "ACCESS_KEY"
+                || upper.ends_with("_PASSWORD")
+                || upper.ends_with("_PASSWD")
+                || upper.contains("_API_KEY")
+                || upper.ends_with("_SECRET")
+                || upper.contains("_SECRET_")
+                || upper.ends_with("_TOKEN")
+                || upper.contains("_TOKEN_")
+                || upper.ends_with("_CREDENTIAL")
+                || upper.ends_with("_CREDENTIALS")
+                || upper.ends_with("_PRIVATE_KEY")
+                || upper.ends_with("_ACCESS_KEY")
+        })
+        .map(String::as_str)
+        .collect()
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -4790,5 +4827,26 @@ pattern = "token-[0-9]+"
 
         let _ = std::fs::remove_dir_all(data_dir);
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn credential_like_environment_permissions_are_highlighted() {
+        let names = vec![
+            "PATH".to_string(),
+            "OPENAI_API_KEY".to_string(),
+            "GITHUB_TOKEN".to_string(),
+            "AWS_SECRET_ACCESS_KEY".to_string(),
+            "DATABASE_PASSWORD".to_string(),
+            "PUBLIC_ENDPOINT".to_string(),
+        ];
+        assert_eq!(
+            sensitive_env_permissions(&names),
+            [
+                "OPENAI_API_KEY",
+                "GITHUB_TOKEN",
+                "AWS_SECRET_ACCESS_KEY",
+                "DATABASE_PASSWORD"
+            ]
+        );
     }
 }


### PR DESCRIPTION
Closes #1040.

## Why
Environment permissions were already explicitly approved, but credential-like names were displayed with the same weight as benign variables, making a dangerous approval easy to skim past.

## Fix
- Add a prominent warning listing only credential-like requested environment variables.
- Cover common API key, token, secret, credential, private/access key, and password naming patterns.
- Keep explicit user approval and `--yes` semantics unchanged; this is an informed-consent UX improvement, not a new hardcoded denylist.
- Add classification regression coverage.

## Validation
GitHub Actions is the authoritative cross-platform validation.