### PR TITLE
Support Windows batch command plugins

### DIFF
--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -2765,13 +2765,18 @@ fn resolve_command_executable(value: &str) -> Result<PathBuf, String> {
             value
                 .to_string_lossy()
                 .split(';')
-                .filter(|extension| {
-                    matches!(extension.to_ascii_uppercase().as_str(), ".EXE" | ".COM")
-                })
+                .filter(|extension| windows_command_extension_supported(extension))
                 .map(str::to_owned)
                 .collect::<Vec<_>>()
         })
-        .unwrap_or_else(|| vec![".EXE".to_string(), ".COM".to_string()]);
+        .unwrap_or_else(|| {
+            vec![
+                ".EXE".to_string(),
+                ".COM".to_string(),
+                ".CMD".to_string(),
+                ".BAT".to_string(),
+            ]
+        });
     #[cfg(not(windows))]
     let extensions = vec![String::new()];
     for directory in std::env::split_paths(&paths) {
@@ -2808,9 +2813,19 @@ fn supported_command_executable(path: &Path) -> bool {
         && path
             .extension()
             .and_then(|extension| extension.to_str())
-            .is_some_and(|extension| {
-                matches!(extension.to_ascii_lowercase().as_str(), "exe" | "com")
-            })
+            .is_some_and(windows_command_extension_supported)
+}
+
+#[cfg(any(windows, test))]
+fn windows_command_extension_supported(extension: &str) -> bool {
+    matches!(
+        extension
+            .strip_prefix('.')
+            .unwrap_or(extension)
+            .to_ascii_lowercase()
+            .as_str(),
+        "exe" | "com" | "cmd" | "bat"
+    )
 }
 
 fn stage_remote_command_files(
@@ -3882,6 +3897,16 @@ fn display_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn windows_command_plugins_accept_batch_shims_only() {
+        for extension in [".EXE", "com", ".CMD", "bat"] {
+            assert!(windows_command_extension_supported(extension));
+        }
+        for extension in ["ps1", ".js", "sh", ""] {
+            assert!(!windows_command_extension_supported(extension));
+        }
+    }
 
     fn python_test_executable() -> Option<&'static str> {
         ["python3", "python"].into_iter().find(|candidate| {

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -1658,13 +1658,18 @@ fn resolve_command_executable(value: &str) -> Result<PathBuf, String> {
             value
                 .to_string_lossy()
                 .split(';')
-                .filter(|extension| {
-                    matches!(extension.to_ascii_uppercase().as_str(), ".EXE" | ".COM")
-                })
+                .filter(|extension| windows_command_extension_supported(extension))
                 .map(str::to_owned)
                 .collect::<Vec<_>>()
         })
-        .unwrap_or_else(|| vec![".EXE".to_string(), ".COM".to_string()]);
+        .unwrap_or_else(|| {
+            vec![
+                ".EXE".to_string(),
+                ".COM".to_string(),
+                ".CMD".to_string(),
+                ".BAT".to_string(),
+            ]
+        });
     #[cfg(not(windows))]
     let extensions = vec![String::new()];
     for directory in std::env::split_paths(&paths) {
@@ -1701,9 +1706,19 @@ fn supported_command_executable(path: &Path) -> bool {
         && path
             .extension()
             .and_then(|extension| extension.to_str())
-            .is_some_and(|extension| {
-                matches!(extension.to_ascii_lowercase().as_str(), "exe" | "com")
-            })
+            .is_some_and(windows_command_extension_supported)
+}
+
+#[cfg(any(windows, test))]
+fn windows_command_extension_supported(extension: &str) -> bool {
+    matches!(
+        extension
+            .strip_prefix('.')
+            .unwrap_or(extension)
+            .to_ascii_lowercase()
+            .as_str(),
+        "exe" | "com" | "cmd" | "bat"
+    )
 }
 
 fn verify_plugin_approval(
@@ -3605,6 +3620,16 @@ fn plugin_id(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn windows_command_plugins_accept_batch_shims_only() {
+        for extension in [".EXE", "com", ".CMD", "bat"] {
+            assert!(windows_command_extension_supported(extension));
+        }
+        for extension in ["ps1", ".js", "sh", ""] {
+            assert!(!windows_command_extension_supported(extension));
+        }
+    }
 
     fn command_fixture(response: &str) -> Vec<String> {
         #[cfg(windows)]


### PR DESCRIPTION
Closes #1008.

## What changed
- resolve `.cmd` and `.bat` shims from Windows `PATHEXT`
- accept canonical batch-script paths during setup and runtime lock verification
- keep `.ps1`, `.js`, and arbitrary script extensions rejected
- cover both duplicated CLI and runtime extension gates

Rust `Command` applies its Windows batch-file handling and rejects arguments it cannot safely escape. Plugin command argv remains explicit and user-approved.

## Testing
- focused extension-policy regression tests in CLI and runtime
- GitHub Actions Windows plugin jobs are authoritative