### PR TITLE
Protect Anthropic batch and legacy completion APIs

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -113,6 +113,8 @@ type ProxyBody = UnsyncBoxBody<Bytes, ProxyBodyError>;
 enum AnthropicEndpoint {
     Messages,
     CountTokens,
+    MessageBatches,
+    Complete,
     Files,
     Models,
     Health,
@@ -124,6 +126,8 @@ impl AnthropicEndpoint {
         match self {
             Self::Messages => "messages",
             Self::CountTokens => "count-tokens",
+            Self::MessageBatches => "message-batches",
+            Self::Complete => "complete",
             Self::Files => "files",
             Self::Models => "models",
             Self::Health => "health",
@@ -394,10 +398,18 @@ async fn proxy_request_inner(
     let credential_material = state.headers.credential_scope_material(&headers);
     let account_scope = state.file_attestations.account_scope(&credential_material);
     let messages_path = endpoint == AnthropicEndpoint::Messages;
+    let batch_create = endpoint == AnthropicEndpoint::MessageBatches
+        && method == hyper::Method::POST
+        && path_and_query
+            .split('?')
+            .next()
+            .is_some_and(|path| path.ends_with("/v1/messages/batches"));
     let protected_request = matches!(
         endpoint,
         AnthropicEndpoint::Messages | AnthropicEndpoint::CountTokens
-    );
+    ) || (endpoint == AnthropicEndpoint::Complete
+        && method == hyper::Method::POST)
+        || batch_create;
     let files_upload = endpoint == AnthropicEndpoint::Files
         && method == hyper::Method::POST
         && path_and_query
@@ -467,6 +479,7 @@ async fn proxy_request_inner(
                     &masker,
                     &plugins,
                     &files,
+                    endpoint,
                     block_unknown_formats,
                 )
             })
@@ -825,6 +838,7 @@ fn protect_anthropic_request_body(
     masker: &StdMutex<pentect_agent::ActiveToolOutputMasker>,
     plugins: &StdMutex<pentect_agent::PluginMiddleware>,
     files: &HashMap<String, crate::http_files::Coverage>,
+    endpoint: AnthropicEndpoint,
     block_unknown_formats: bool,
 ) -> Result<ProtectedJsonBody, String> {
     let mut value: Value = match serde_json::from_slice(body) {
@@ -868,7 +882,7 @@ fn protect_anthropic_request_body(
             })
             .map_err(|error| format!("could not encode plugin response: {error}"));
     }
-    let unknown_content_kind = anthropic_request_unknown_content_kind(&value);
+    let unknown_content_kind = anthropic_request_unknown_content_kind(&value, endpoint);
     let partial_schema = unknown_content_kind.is_some();
     if block_unknown_formats && (partial_schema || plugin_partial) {
         let detail = unknown_content_kind
@@ -878,15 +892,15 @@ fn protect_anthropic_request_body(
             "unknown format blocked: Anthropic request contains {detail}; set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
         ));
     }
-    warn_provider_mcp_credentials(&value);
+    warn_provider_mcp_credentials(&value, endpoint);
     // Image handling deliberately follows the existing image policy. With
     // the default image.unscanned="block", an uninspectable image is an
     // error; users can explicitly choose allow in configuration.
-    redact_anthropic_base64_images(&mut value, files)?;
+    redact_anthropic_base64_images(&mut value, files, endpoint)?;
     let mut masker = masker
         .lock()
         .map_err(|_| "Claude request masker lock was poisoned".to_string())?;
-    if let Err(error) = mask_anthropic_request(&mut value, &mut masker, files) {
+    if let Err(error) = mask_anthropic_request(&mut value, &mut masker, files, endpoint) {
         // Explicit media-policy decisions are not detector failures. Letting
         // them enter the general fail-open path would send the very PDF/image
         // that the configured policy rejected.
@@ -910,7 +924,7 @@ fn protect_anthropic_request_body(
             local_response: None,
         });
     }
-    inject_handle_contract(&mut value);
+    inject_handle_contract(&mut value, endpoint);
     match serde_json::to_vec(&value) {
         Ok(protected) => Ok(ProtectedJsonBody {
             body: Bytes::from(protected),
@@ -932,7 +946,30 @@ fn protect_anthropic_request_body(
     }
 }
 
-fn anthropic_request_unknown_content_kind(value: &Value) -> Option<&str> {
+fn anthropic_request_unknown_content_kind(
+    value: &Value,
+    endpoint: AnthropicEndpoint,
+) -> Option<&str> {
+    if endpoint == AnthropicEndpoint::MessageBatches {
+        let Some(requests) = value.get("requests").and_then(Value::as_array) else {
+            return Some("<invalid message batch>");
+        };
+        for request in requests {
+            let Some(params) = request.get("params").filter(|params| params.is_object()) else {
+                return Some("<invalid message batch request>");
+            };
+            if let Some(kind) =
+                anthropic_request_unknown_content_kind(params, AnthropicEndpoint::Messages)
+            {
+                return Some(kind);
+            }
+        }
+        return None;
+    }
+    if endpoint == AnthropicEndpoint::Complete {
+        return (!value.get("prompt").is_some_and(Value::is_string))
+            .then_some("<invalid completion prompt>");
+    }
     let mut roots = Vec::new();
     if let Some(system) = value.get("system") {
         roots.push(system);
@@ -989,8 +1026,33 @@ fn is_media_policy_rejection(error: &str) -> bool {
     error.starts_with("document blocked:") || error.starts_with("image blocked:")
 }
 
-fn warn_provider_mcp_credentials(value: &Value) {
-    if value
+fn warn_provider_mcp_credentials(value: &Value, endpoint: AnthropicEndpoint) {
+    let forwarded = if endpoint == AnthropicEndpoint::MessageBatches {
+        value
+            .get("requests")
+            .and_then(Value::as_array)
+            .is_some_and(|requests| {
+                requests.iter().any(|request| {
+                    request
+                        .get("params")
+                        .is_some_and(provider_mcp_credentials_present)
+                })
+            })
+    } else {
+        provider_mcp_credentials_present(value)
+    };
+    if forwarded && !WARNED_PROVIDER_MCP_CREDENTIALS.swap(true, Ordering::Relaxed) {
+        diagnostic(
+            "provider-mcp-credential-forwarded",
+            "credential-forwarding",
+            "messages",
+            false,
+        );
+    }
+}
+
+fn provider_mcp_credentials_present(value: &Value) -> bool {
+    value
         .get("mcp_servers")
         .and_then(Value::as_array)
         .is_some_and(|servers| {
@@ -1001,19 +1063,32 @@ fn warn_provider_mcp_credentials(value: &Value) {
                     .is_some_and(|token| !token.is_empty())
             })
         })
-        && !WARNED_PROVIDER_MCP_CREDENTIALS.swap(true, Ordering::Relaxed)
-    {
-        diagnostic(
-            "provider-mcp-credential-forwarded",
-            "credential-forwarding",
-            "messages",
-            false,
-        );
-    }
 }
 
-fn inject_handle_contract(value: &mut Value) {
+fn inject_handle_contract(value: &mut Value, endpoint: AnthropicEndpoint) {
+    if endpoint == AnthropicEndpoint::MessageBatches {
+        if let Some(requests) = value.get_mut("requests").and_then(Value::as_array_mut) {
+            for request in requests {
+                if let Some(params) = request.get_mut("params") {
+                    inject_handle_contract(params, AnthropicEndpoint::Messages);
+                }
+            }
+        }
+        return;
+    }
     if !request_contains_masked_handle(value) {
+        return;
+    }
+    if endpoint == AnthropicEndpoint::Complete {
+        if let Some(prompt) = value
+            .get_mut("prompt")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+        {
+            if !prompt.contains(HANDLE_CONTRACT) {
+                value["prompt"] = Value::String(format!("{prompt}\n\n{HANDLE_CONTRACT}"));
+            }
+        }
         return;
     }
     let contract = serde_json::json!({
@@ -1505,7 +1580,33 @@ fn mask_anthropic_request(
     value: &mut Value,
     masker: &mut pentect_agent::ActiveToolOutputMasker,
     files: &HashMap<String, crate::http_files::Coverage>,
+    endpoint: AnthropicEndpoint,
 ) -> Result<(), String> {
+    if endpoint == AnthropicEndpoint::MessageBatches {
+        let requests = value
+            .get_mut("requests")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| "message batch requires a requests array".to_string())?;
+        for request in requests {
+            let params = request
+                .get_mut("params")
+                .filter(|params| params.is_object())
+                .ok_or_else(|| "message batch request requires params".to_string())?;
+            mask_anthropic_request(params, masker, files, AnthropicEndpoint::Messages)?;
+        }
+        return Ok(());
+    }
+    if endpoint == AnthropicEndpoint::Complete {
+        let prompt = value
+            .get_mut("prompt")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "completion request requires a string prompt".to_string())?
+            .to_string();
+        let mut protected = prompt;
+        mask_string(&mut protected, false, masker)?;
+        value["prompt"] = Value::String(protected);
+        return Ok(());
+    }
     // Anthropic system content is client/provider-authored. It must be
     // protected, but prompt-only unmask markers are not trusted here.
     if let Some(system) = value.get_mut("system") {
@@ -1525,7 +1626,25 @@ fn mask_anthropic_request(
 fn redact_anthropic_base64_images(
     value: &mut Value,
     files: &HashMap<String, crate::http_files::Coverage>,
+    endpoint: AnthropicEndpoint,
 ) -> Result<(), String> {
+    if endpoint == AnthropicEndpoint::MessageBatches {
+        let requests = value
+            .get_mut("requests")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| "message batch requires a requests array".to_string())?;
+        for request in requests {
+            let params = request
+                .get_mut("params")
+                .filter(|params| params.is_object())
+                .ok_or_else(|| "message batch request requires params".to_string())?;
+            redact_anthropic_base64_images(params, files, AnthropicEndpoint::Messages)?;
+        }
+        return Ok(());
+    }
+    if endpoint == AnthropicEndpoint::Complete {
+        return Ok(());
+    }
     if let Some(system) = value.get_mut("system") {
         redact_content_images(system, files)?;
     }
@@ -2575,6 +2694,10 @@ fn classify_anthropic_endpoint(path_and_query: &str) -> AnthropicEndpoint {
         AnthropicEndpoint::Messages
     } else if path.ends_with("/v1/messages/count_tokens") {
         AnthropicEndpoint::CountTokens
+    } else if path.ends_with("/v1/messages/batches") || path.contains("/v1/messages/batches/") {
+        AnthropicEndpoint::MessageBatches
+    } else if path.ends_with("/v1/complete") {
+        AnthropicEndpoint::Complete
     } else if path.ends_with("/v1/files") || path.contains("/v1/files/") {
         AnthropicEndpoint::Files
     } else if path.ends_with("/v1/models") || path.contains("/v1/models/") {
@@ -3361,7 +3484,15 @@ mod tests {
         );
         assert_eq!(
             classify_anthropic_endpoint("/v1/messages/batches"),
-            AnthropicEndpoint::Unknown
+            AnthropicEndpoint::MessageBatches
+        );
+        assert_eq!(
+            classify_anthropic_endpoint("/v1/messages/batches/msgbatch_123/results"),
+            AnthropicEndpoint::MessageBatches
+        );
+        assert_eq!(
+            classify_anthropic_endpoint("/v1/complete"),
+            AnthropicEndpoint::Complete
         );
         assert!(enforce_known_anthropic_endpoint(AnthropicEndpoint::Unknown, true).is_err());
         assert!(enforce_known_anthropic_endpoint(AnthropicEndpoint::Unknown, false).is_ok());
@@ -3394,14 +3525,14 @@ mod tests {
             "system": "existing",
             "messages": [{"role": "user", "content": "use <<SECRET_0123456789abcdef>>"}]
         });
-        inject_handle_contract(&mut request);
+        inject_handle_contract(&mut request, AnthropicEndpoint::Messages);
         assert_eq!(request["system"][0]["text"], "existing");
         assert_eq!(request["system"][1]["text"], HANDLE_CONTRACT);
-        inject_handle_contract(&mut request);
+        inject_handle_contract(&mut request, AnthropicEndpoint::Messages);
         assert_eq!(request["system"].as_array().unwrap().len(), 2);
 
         let mut empty = serde_json::json!({"messages": []});
-        inject_handle_contract(&mut empty);
+        inject_handle_contract(&mut empty, AnthropicEndpoint::Messages);
         assert!(empty.get("system").is_none());
     }
 
@@ -3411,7 +3542,7 @@ mod tests {
             "system": "existing",
             "messages": [{"role": "user", "content": "hello"}]
         });
-        inject_handle_contract(&mut clean);
+        inject_handle_contract(&mut clean, AnthropicEndpoint::Messages);
         assert_eq!(clean["system"], "existing");
 
         let mut protected = serde_json::json!({
@@ -3421,7 +3552,7 @@ mod tests {
                 "content": "use <<SECRET_0123456789abcdef>>"
             }]
         });
-        inject_handle_contract(&mut protected);
+        inject_handle_contract(&mut protected, AnthropicEndpoint::Messages);
         assert_eq!(protected["system"][0]["text"], "existing");
         assert_eq!(protected["system"][1]["text"], HANDLE_CONTRACT);
     }
@@ -3435,15 +3566,29 @@ mod tests {
         let masker = StdMutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
         let plugins = StdMutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
         let files = HashMap::new();
-        let error = match protect_anthropic_request_body(&body, &masker, &plugins, &files, true) {
+        let error = match protect_anthropic_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Messages,
+            true,
+        ) {
             Ok(_) => panic!("unknown Anthropic block should be rejected"),
             Err(error) => error,
         };
         assert!(error.starts_with("unknown format blocked:"), "{error}");
         assert!(error.contains("future_block"), "{error}");
 
-        let allowed =
-            protect_anthropic_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        let allowed = protect_anthropic_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Messages,
+            false,
+        )
+        .unwrap();
         assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
         let allowed: Value = serde_json::from_slice(&allowed.body).unwrap();
         let original: Value = serde_json::from_slice(&body).unwrap();
@@ -3463,7 +3608,10 @@ mod tests {
                 ]
             }]
         });
-        assert_eq!(anthropic_request_unknown_content_kind(&value), None);
+        assert_eq!(
+            anthropic_request_unknown_content_kind(&value, AnthropicEndpoint::Messages),
+            None
+        );
     }
 
     #[test]
@@ -3473,11 +3621,108 @@ mod tests {
         let masker = StdMutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
         let plugins = StdMutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
         let files = HashMap::new();
-        assert!(protect_anthropic_request_body(&body, &masker, &plugins, &files, true).is_err());
-        let allowed =
-            protect_anthropic_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        assert!(protect_anthropic_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Messages,
+            true,
+        )
+        .is_err());
+        let allowed = protect_anthropic_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Messages,
+            false,
+        )
+        .unwrap();
         assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
         assert_eq!(allowed.body, body);
+    }
+
+    #[test]
+    fn batch_and_legacy_completion_prompts_are_masked_at_their_real_boundaries() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        let secret = [
+            "rpa_",
+            "ZYXWVUTS",
+            "RQPONMLK",
+            "JIHGFEDC",
+            "BA098765",
+            "4321fedcba",
+        ]
+        .concat();
+        let masker = StdMutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = StdMutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
+        let files = HashMap::new();
+
+        let batch = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "requests": [{
+                    "custom_id": "request-1",
+                    "params": {
+                        "model": "test",
+                        "max_tokens": 8,
+                        "messages": [{
+                            "role": "user",
+                            "content": format!("RUNPOD_API_KEY={secret}")
+                        }]
+                    }
+                }]
+            }))
+            .unwrap(),
+        );
+        let protected = protect_anthropic_request_body(
+            &batch,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::MessageBatches,
+            true,
+        )
+        .unwrap();
+        let protected: Value = serde_json::from_slice(&protected.body).unwrap();
+        assert!(!protected.to_string().contains(&secret));
+        assert!(first_valid_handle(
+            protected["requests"][0]["params"]["messages"][0]["content"]
+                .as_str()
+                .unwrap()
+        )
+        .is_some());
+        assert!(protected.get("system").is_none());
+        assert_eq!(
+            protected["requests"][0]["params"]["system"][0]["text"],
+            HANDLE_CONTRACT
+        );
+
+        let completion = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "test",
+                "max_tokens_to_sample": 8,
+                "prompt": format!("RUNPOD_API_KEY={secret}")
+            }))
+            .unwrap(),
+        );
+        let protected = protect_anthropic_request_body(
+            &completion,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Complete,
+            true,
+        )
+        .unwrap();
+        let protected: Value = serde_json::from_slice(&protected.body).unwrap();
+        let prompt = protected["prompt"].as_str().unwrap();
+        assert!(!prompt.contains(&secret));
+        assert!(first_valid_handle(prompt).is_some());
+        assert!(prompt.contains(HANDLE_CONTRACT));
+        assert!(protected.get("system").is_none());
     }
 
     #[test]

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1082,7 +1082,7 @@ fn inject_handle_contract(value: &mut Value, endpoint: AnthropicEndpoint) {
     if endpoint == AnthropicEndpoint::Complete {
         if let Some(prompt) = value
             .get_mut("prompt")
-            .and_then(Value::as_str)
+            .and_then(|prompt| prompt.as_str())
             .map(str::to_owned)
         {
             if !prompt.contains(HANDLE_CONTRACT) {
@@ -1599,7 +1599,7 @@ fn mask_anthropic_request(
     if endpoint == AnthropicEndpoint::Complete {
         let prompt = value
             .get_mut("prompt")
-            .and_then(Value::as_str)
+            .and_then(|prompt| prompt.as_str())
             .ok_or_else(|| "completion request requires a string prompt".to_string())?
             .to_string();
         let mut protected = prompt;

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -350,6 +350,7 @@ async fn proxy_request_inner(
     }
     let responses_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::Responses;
     let chat_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::ChatCompletions;
+    let completions_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::Completions;
     let standalone_search_path =
         method == hyper::Method::POST && endpoint == OpenAiEndpoint::StandaloneSearch;
     let embeddings_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::Embeddings;
@@ -358,12 +359,14 @@ async fn proxy_request_inner(
         OpenAiEndpoint::Responses | OpenAiEndpoint::ResponsesResource
     );
     let chat_response = endpoint == OpenAiEndpoint::ChatCompletions;
+    let completions_response = endpoint == OpenAiEndpoint::Completions;
     let protected_request = method == hyper::Method::POST
         && matches!(
             endpoint,
             OpenAiEndpoint::Responses
                 | OpenAiEndpoint::InputTokens
                 | OpenAiEndpoint::ChatCompletions
+                | OpenAiEndpoint::Completions
                 | OpenAiEndpoint::StandaloneSearch
                 | OpenAiEndpoint::Embeddings
         );
@@ -479,6 +482,8 @@ async fn proxy_request_inner(
                     &files,
                     if chat_path {
                         OpenAiRequestDialect::ChatCompletions
+                    } else if completions_path {
+                        OpenAiRequestDialect::Completions
                     } else if standalone_search_path {
                         OpenAiRequestDialect::StandaloneSearch
                     } else if embeddings_path {
@@ -548,11 +553,13 @@ async fn proxy_request_inner(
     // explicit stream flag is authoritative in that case.
     let is_event_stream = response_media_type
         .is_some_and(|value| value.eq_ignore_ascii_case("text/event-stream"))
-        || ((responses_path || chat_path) && request_streaming && response_media_type.is_none());
+        || ((responses_path || chat_path || completions_path)
+            && request_streaming
+            && response_media_type.is_none());
     let is_json_response = response_media_type.is_some_and(|value| {
         value.eq_ignore_ascii_case("application/json")
             || value.to_ascii_lowercase().ends_with("+json")
-    }) || ((responses_response || chat_response)
+    }) || ((responses_response || chat_response || completions_response)
         && !request_streaming
         && response_media_type.is_none());
     let restore_output = pentect_agent::output_restore_enabled()?;
@@ -571,7 +578,9 @@ async fn proxy_request_inner(
             .unwrap_or(crate::http_files::Coverage::None)
             .as_header(),
     );
-    if is_event_stream || (!(responses_response || chat_response) && !files_upload) {
+    if is_event_stream
+        || (!(responses_response || chat_response || completions_response) && !files_upload)
+    {
         return builder
             .body(streaming_response_body(
                 upstream,
@@ -579,6 +588,8 @@ async fn proxy_request_inner(
                     StreamTransform::Responses
                 } else if status.is_success() && chat_path && is_event_stream {
                     StreamTransform::ChatCompletions
+                } else if status.is_success() && completions_path && is_event_stream {
+                    StreamTransform::Completions
                 } else {
                     StreamTransform::None
                 },
@@ -626,25 +637,29 @@ async fn proxy_request_inner(
             }
         }
     }
-    let response_body =
-        if (responses_response || chat_response) && status.is_success() && is_json_response {
-            let response_body = run_response_plugins(response_body, &state.plugins, "openai")?;
-            let rewritten = if chat_response {
-                rewrite_chat_completions_json_response(&response_body, restore_output)
-            } else {
-                rewrite_openai_json_response(&response_body, restore_output)
-            };
-            match rewritten {
-                Ok(rewritten) => Bytes::from(rewritten),
-                Err(error) => {
-                    let _ = error;
-                    proxy_diagnostic("response-restore-skipped");
-                    response_body
-                }
-            }
+    let response_body = if (responses_response || chat_response || completions_response)
+        && status.is_success()
+        && is_json_response
+    {
+        let response_body = run_response_plugins(response_body, &state.plugins, "openai")?;
+        let rewritten = if chat_response {
+            rewrite_chat_completions_json_response(&response_body, restore_output)
+        } else if completions_response {
+            rewrite_completions_json_response(&response_body, restore_output)
         } else {
-            response_body
+            rewrite_openai_json_response(&response_body, restore_output)
         };
+        match rewritten {
+            Ok(rewritten) => Bytes::from(rewritten),
+            Err(error) => {
+                let _ = error;
+                proxy_diagnostic("response-restore-skipped");
+                response_body
+            }
+        }
+    } else {
+        response_body
+    };
     builder
         .body(full_body(response_body))
         .map_err(|error| format!("could not build OpenAI response: {error}"))
@@ -809,6 +824,7 @@ fn decode_openai_request_body(
 enum OpenAiRequestDialect {
     Responses,
     ChatCompletions,
+    Completions,
     StandaloneSearch,
     Embeddings,
 }
@@ -900,7 +916,9 @@ fn protect_openai_request_body(
     }
     if matches!(
         dialect,
-        OpenAiRequestDialect::Responses | OpenAiRequestDialect::ChatCompletions
+        OpenAiRequestDialect::Responses
+            | OpenAiRequestDialect::ChatCompletions
+            | OpenAiRequestDialect::Completions
     ) {
         inject_handle_contract(&mut value);
     }
@@ -1348,8 +1366,29 @@ fn openai_request_unknown_content_kind(
             .get("messages")
             .map(visit_chat_messages)
             .unwrap_or(Some("missing messages")),
+        OpenAiRequestDialect::Completions => completions_unknown_shape(value),
         OpenAiRequestDialect::StandaloneSearch => standalone_search_unknown_shape(value, visit),
         OpenAiRequestDialect::Embeddings => embeddings_unknown_shape(value),
+    }
+}
+
+fn completions_unknown_shape(value: &Value) -> Option<&str> {
+    let Some(prompt) = value.as_object().and_then(|object| object.get("prompt")) else {
+        return Some("missing completion prompt");
+    };
+    match prompt {
+        Value::String(_) => None,
+        Value::Array(items) if items.iter().all(Value::is_string) => None,
+        Value::Array(items) if items.iter().all(Value::is_u64) => None,
+        Value::Array(items)
+            if items.iter().all(|item| {
+                item.as_array()
+                    .is_some_and(|tokens| tokens.iter().all(Value::is_u64))
+            }) =>
+        {
+            None
+        }
+        _ => Some("unsupported completion prompt"),
     }
 }
 
@@ -1477,6 +1516,10 @@ fn inject_handle_contract(value: &mut Value) {
         inject_chat_handle_contract(value);
         return;
     }
+    if let Some(prompt) = value.get_mut("prompt") {
+        inject_completion_handle_contract(prompt);
+        return;
+    }
     match value.get_mut("instructions") {
         Some(Value::String(instructions)) if !instructions.contains(HANDLE_CONTRACT) => {
             let existing = std::mem::take(instructions);
@@ -1484,6 +1527,21 @@ fn inject_handle_contract(value: &mut Value) {
         }
         Some(Value::Null) | None => {
             value["instructions"] = Value::String(HANDLE_CONTRACT.to_string());
+        }
+        _ => {}
+    }
+}
+
+fn inject_completion_handle_contract(prompt: &mut Value) {
+    match prompt {
+        Value::String(text) if !text.contains(HANDLE_CONTRACT) => {
+            text.push_str("\n\n");
+            text.push_str(HANDLE_CONTRACT);
+        }
+        Value::Array(items) if items.iter().all(Value::is_string) => {
+            for item in items {
+                inject_completion_handle_contract(item);
+            }
         }
         _ => {}
     }
@@ -1552,6 +1610,9 @@ fn mask_openai_request(
     if let Some(messages) = value.get_mut("messages") {
         mask_chat_messages(messages, masker, files)?;
     }
+    if let Some(prompt) = value.get_mut("prompt") {
+        mask_completion_prompt(prompt, masker)?;
+    }
     // Tool descriptions and JSON Schemas are sent to the model too. MCP and
     // editor integrations commonly generate them from local state, so they
     // must cross the same masking boundary as messages. Keys are structural;
@@ -1576,6 +1637,34 @@ fn mask_openai_request(
         }
     }
     Ok(())
+}
+
+fn mask_completion_prompt(
+    prompt: &mut Value,
+    masker: &mut pentect_agent::ActiveToolOutputMasker,
+) -> Result<(), String> {
+    match prompt {
+        Value::String(text) => mask_text(text, false, masker),
+        Value::Array(items) if items.iter().all(Value::is_string) => {
+            for item in items {
+                let Value::String(text) = item else {
+                    unreachable!("completion prompt shape checked before masking")
+                };
+                mask_text(text, false, masker)?;
+            }
+            Ok(())
+        }
+        Value::Array(items)
+            if items.iter().all(Value::is_u64)
+                || items.iter().all(|item| {
+                    item.as_array()
+                        .is_some_and(|tokens| tokens.iter().all(Value::is_u64))
+                }) =>
+        {
+            Ok(())
+        }
+        _ => Err("OpenAI completion prompt has an unsupported shape".to_string()),
+    }
 }
 
 fn mask_embeddings_request(
@@ -2000,6 +2089,32 @@ fn rewrite_chat_completions_json_response(
     }
     serde_json::to_vec(&value)
         .map_err(|error| format!("could not encode restored Chat Completions response: {error}"))
+}
+
+fn rewrite_completions_json_response(body: &[u8], restore_output: bool) -> Result<Vec<u8>, String> {
+    let mut value: Value = serde_json::from_slice(body)
+        .map_err(|error| format!("OpenAI Completions response was not valid JSON: {error}"))?;
+    if restore_output {
+        let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
+        restore_completion_output_text(&mut value, &mut resolve)?;
+    }
+    serde_json::to_vec(&value)
+        .map_err(|error| format!("could not encode restored Completions response: {error}"))
+}
+
+fn restore_completion_output_text<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
+    let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    for choice in choices {
+        if let Some(Value::String(text)) = choice.get_mut("text") {
+            *text = resolve(text)?;
+        }
+    }
+    Ok(())
 }
 
 fn restore_openai_output_text<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
@@ -2447,6 +2562,7 @@ struct StreamState {
     ready: VecDeque<Result<Frame<Bytes>, ProxyBodyError>>,
     transform: StreamTransform,
     chat: ChatStreamState,
+    completions: CompletionStreamState,
     finished: bool,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
     restore_output: bool,
@@ -2459,6 +2575,7 @@ enum StreamTransform {
     None,
     Responses,
     ChatCompletions,
+    Completions,
 }
 
 fn streaming_response_body(
@@ -2473,6 +2590,7 @@ fn streaming_response_body(
         ready: VecDeque::new(),
         transform,
         chat: ChatStreamState::default(),
+        completions: CompletionStreamState::default(),
         finished: false,
         plugins,
         restore_output,
@@ -2493,8 +2611,10 @@ fn streaming_response_body(
                 }
                 Some(Ok(chunk)) => {
                     if state.pending.len().saturating_add(chunk.len()) > MAX_PENDING_SSE_BYTES {
-                        if state.transform == StreamTransform::ChatCompletions
-                            && !state.chat.calls.is_empty()
+                        if (state.transform == StreamTransform::ChatCompletions
+                            && !state.chat.calls.is_empty())
+                            || (state.transform == StreamTransform::Completions
+                                && !state.completions.output_text.is_empty())
                         {
                             state.finished = true;
                             state.ready.push_back(Err(Box::new(io::Error::new(
@@ -2535,6 +2655,11 @@ fn streaming_response_body(
                             StreamTransform::ChatCompletions => state.chat.rewrite_block(
                                 &block,
                                 &state.plugins,
+                                state.restore_output,
+                                &mut state.output_resolve,
+                            ),
+                            StreamTransform::Completions => state.completions.rewrite_block(
+                                &block,
                                 state.restore_output,
                                 &mut state.output_resolve,
                             ),
@@ -2580,6 +2705,18 @@ fn streaming_response_body(
                                 error,
                             )))),
                         }
+                    } else if state.transform == StreamTransform::Completions {
+                        match state.completions.finish_output_text("data: {}\n\n") {
+                            Ok(blocks) => {
+                                for block in blocks {
+                                    state.ready.push_back(Ok(Frame::data(block)));
+                                }
+                            }
+                            Err(error) => state.ready.push_back(Err(Box::new(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                error,
+                            )))),
+                        }
                     }
                     if !state.pending.is_empty() {
                         state
@@ -2593,6 +2730,108 @@ fn streaming_response_body(
         }
     });
     StreamBody::new(stream).boxed_unsync()
+}
+
+#[derive(Default)]
+struct CompletionStreamState {
+    output_text: HashMap<u64, crate::claude_http_proxy::OutputTextRestorer>,
+}
+
+impl CompletionStreamState {
+    fn rewrite_block(
+        &mut self,
+        block: &[u8],
+        restore_output: bool,
+        resolve: &mut HandleResolver,
+    ) -> Result<Vec<Bytes>, String> {
+        let Ok(template) = std::str::from_utf8(block) else {
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        };
+        let Some(data) = sse_data(template) else {
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        };
+        if data == "[DONE]" {
+            let mut output = self.finish_output_text(template)?;
+            output.push(Bytes::copy_from_slice(block));
+            return Ok(output);
+        }
+        let Ok(mut value) = serde_json::from_str::<Value>(data.as_ref()) else {
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        };
+        if restore_output {
+            let mut finished = Vec::new();
+            if let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) {
+                for choice in choices {
+                    let Some(choice) = choice.as_object_mut() else {
+                        continue;
+                    };
+                    let index = choice.get("index").and_then(Value::as_u64).unwrap_or(0);
+                    if let Some(Value::String(text)) = choice.get_mut("text") {
+                        *text = self
+                            .output_text
+                            .entry(index)
+                            .or_default()
+                            .push(text, resolve)?;
+                    }
+                    if choice
+                        .get("finish_reason")
+                        .is_some_and(|reason| !reason.is_null())
+                    {
+                        finished.push(index);
+                    }
+                }
+            }
+            for index in finished {
+                if let Some(mut restorer) = self.output_text.remove(&index) {
+                    let pending = restorer.finish();
+                    if !pending.is_empty() {
+                        if let Some(choice) = value
+                            .get_mut("choices")
+                            .and_then(Value::as_array_mut)
+                            .and_then(|choices| {
+                                choices.iter_mut().find(|choice| {
+                                    choice.as_object().is_some_and(|choice| {
+                                        choice.get("index").and_then(Value::as_u64).unwrap_or(0)
+                                            == index
+                                    })
+                                })
+                            })
+                        {
+                            let text = choice
+                                .as_object_mut()
+                                .expect("choice object was selected above")
+                                .entry("text")
+                                .or_insert_with(|| Value::String(String::new()));
+                            if let Value::String(text) = text {
+                                text.push_str(&pending);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(vec![encode_sse_value(template, &value)?])
+    }
+
+    fn finish_output_text(&mut self, template: &str) -> Result<Vec<Bytes>, String> {
+        let mut pending = self.output_text.drain().collect::<Vec<_>>();
+        pending.sort_by_key(|(index, _)| *index);
+        pending
+            .into_iter()
+            .filter_map(|(index, mut restorer)| {
+                let text = restorer.finish();
+                (!text.is_empty()).then_some((index, text))
+            })
+            .map(|(index, text)| {
+                encode_sse_value(
+                    template,
+                    &serde_json::json!({
+                        "choices": [{"index": index, "text": text, "finish_reason": Value::Null}]
+                    }),
+                )
+            })
+            .collect()
+    }
 }
 
 #[derive(Default)]
@@ -3142,6 +3381,7 @@ enum OpenAiEndpoint {
     InputTokens,
     StandaloneSearch,
     ChatCompletions,
+    Completions,
     Embeddings,
     FilesCollection,
     Files,
@@ -3158,6 +3398,7 @@ impl OpenAiEndpoint {
             Self::InputTokens => "input-tokens",
             Self::StandaloneSearch => "standalone-search",
             Self::ChatCompletions => "chat-completions",
+            Self::Completions => "completions",
             Self::Embeddings => "embeddings",
             Self::FilesCollection => "files-collection",
             Self::Files => "files",
@@ -3187,6 +3428,11 @@ fn classify_openai_endpoint(path_and_query: &str) -> OpenAiEndpoint {
         OpenAiEndpoint::ResponsesResource
     } else if path.ends_with("/chat/completions") {
         OpenAiEndpoint::ChatCompletions
+    } else if matches!(
+        segments.as_slice(),
+        ["completions"] | ["v1", "completions"] | ["backend-api", "codex", "completions"]
+    ) {
+        OpenAiEndpoint::Completions
     } else if matches!(
         segments.as_slice(),
         ["v1", "embeddings"] | ["backend-api", "codex", "embeddings"]
@@ -3993,6 +4239,14 @@ mod tests {
             OpenAiEndpoint::ChatCompletions
         );
         assert_eq!(
+            classify_openai_endpoint("/v1/completions"),
+            OpenAiEndpoint::Completions
+        );
+        assert_eq!(
+            classify_openai_endpoint("/completions?stream=true"),
+            OpenAiEndpoint::Completions
+        );
+        assert_eq!(
             classify_openai_endpoint("/v1/embeddings"),
             OpenAiEndpoint::Embeddings
         );
@@ -4039,6 +4293,71 @@ mod tests {
         );
         assert!(enforce_known_openai_endpoint(OpenAiEndpoint::Unknown, true).is_err());
         assert!(enforce_known_openai_endpoint(OpenAiEndpoint::Unknown, false).is_ok());
+    }
+
+    #[test]
+    fn legacy_completion_prompts_and_output_are_protected_at_their_schema_boundaries() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = ProviderBoundaryTestEnv::install(&store);
+        let secret = ["rpa_", "LEGACYOPENAI", "ZYXWVUTS", "RQPONMLK", "1234567890"].concat();
+        let mut prompt = serde_json::json!([
+            format!("RUNPOD_API_KEY={secret}"),
+            format!("repeat RUNPOD_API_KEY={secret}")
+        ]);
+        let mut masker = pentect_agent::ActiveToolOutputMasker::new().unwrap();
+
+        mask_completion_prompt(&mut prompt, &mut masker).unwrap();
+        assert!(!prompt.to_string().contains(&secret));
+        assert!(prompt
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| pentect_agent::contains_pentect_masked_handle(item.as_str().unwrap())));
+        inject_completion_handle_contract(&mut prompt);
+        assert!(prompt
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| item.as_str().unwrap().contains(HANDLE_CONTRACT)));
+
+        let mut response = serde_json::json!({
+            "choices": [{"index": 0, "text": "before <<KEYED_SECRET_test>> after"}]
+        });
+        restore_completion_output_text(&mut response, &mut |text| {
+            Ok(text.replace("<<KEYED_SECRET_test>>", "restored"))
+        })
+        .unwrap();
+        assert_eq!(response["choices"][0]["text"], "before restored after");
+    }
+
+    #[test]
+    fn legacy_completion_stream_restores_handles_split_across_deltas() {
+        let mut state = CompletionStreamState::default();
+        let mut resolve: HandleResolver =
+            Box::new(|text| Ok(text.replace("<<KEYED_SECRET_split>>", "restored")));
+        let first = state
+            .rewrite_block(
+                b"data: {\"choices\":[{\"index\":0,\"text\":\"before <<KEYED_\",\"finish_reason\":null}]}\n\n",
+                true,
+                &mut resolve,
+            )
+            .unwrap();
+        let second = state
+            .rewrite_block(
+                b"data: {\"choices\":[{\"index\":0,\"text\":\"SECRET_split>> after\",\"finish_reason\":\"stop\"}]}\n\n",
+                true,
+                &mut resolve,
+            )
+            .unwrap();
+        let output = first
+            .into_iter()
+            .chain(second)
+            .map(|bytes| String::from_utf8(bytes.to_vec()).unwrap())
+            .collect::<String>();
+        assert!(output.contains("before "), "{output}");
+        assert!(output.contains("restored after"), "{output}");
+        assert!(!output.contains("KEYED_SECRET_split"), "{output}");
     }
 
     #[test]


### PR DESCRIPTION
## Root causes

Two legacy/batch API families were missing from the provider endpoint boundaries:

- Anthropic Message Batches and legacy `/v1/complete`.
- OpenAI legacy `/v1/completions`.

Strict mode blocked them as unknown. Compatibility mode could forward their model-visible prompt fields without protection.

## Changes

- Classify Anthropic batch creation and legacy Complete requests.
- Traverse `requests[].params` using the same Messages protection boundary.
- Mask Anthropic legacy string prompts and inject the handle guidance in the schema-valid prompt field.
- Classify OpenAI legacy Completions requests at `/completions`, `/v1/completions`, and the Codex-compatible path.
- Mask OpenAI completion string and string-array prompts while preserving token-ID prompt forms.
- Restore opted-in `choices[].text` output for JSON and SSE, including handles split across stream deltas.
- Keep Request/Response plugin stages active for all newly classified routes.
- Fix the mutable JSON accessor type error found by the first CI run.

## Verification

- `cargo check -p pentect-cli --locked`
- `cargo fmt --all -- --check`
- Focused request, response, classification, and split-SSE regressions are included for GitHub Actions.

Closes #1013
Closes #1105