### PR TITLE
Guide safe stdin use for pentect mask

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -984,8 +984,11 @@ fn validate_mask_args(args: &[String]) -> Result<(), String> {
             flag if flag.starts_with("--") => {
                 return Err(format!("unknown option: {flag}"));
             }
-            value => {
-                return Err(format!("unexpected argument for mask: {value}"));
+            _ => {
+                return Err(
+                    "pentect mask reads standard input only; pipe input to it or use `pentect mask < FILE`. Positional values are refused because command-line arguments may be recorded"
+                        .to_string(),
+                );
             }
         }
     }
@@ -3050,6 +3053,21 @@ fn required_value(args: &[String], i: &mut usize, flag: &str) -> Result<String, 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mask_positional_error_guides_without_echoing_the_value() {
+        let secret = "should-never-appear-in-an-error";
+        let args = vec![
+            "pentect".to_string(),
+            "mask".to_string(),
+            secret.to_string(),
+        ];
+        let error = validate_mask_args(&args).unwrap_err();
+        assert!(!error.contains(secret), "{error}");
+        assert!(error.contains("standard input"), "{error}");
+        assert!(error.contains("pentect mask < FILE"), "{error}");
+        assert!(error.contains("may be recorded"), "{error}");
+    }
 
     #[test]
     fn metadata_and_client_commands_skip_memory_store_probe() {


### PR DESCRIPTION
Closes #960.

## What changed
- keep `pentect mask` stdin-only so secrets are not encouraged into shell history or process listings
- stop echoing rejected positional values in the error message
- explain the stdin-only reason and provide a redirection example
- add a regression test proving a positional secret cannot appear in the diagnostic

## Testing
- `cargo fmt --all -- --check`
- focused parser regression test runs in GitHub Actions