### PR TITLE
Batch runtime and provider reliability fixes

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -448,6 +448,11 @@ async fn proxy_request_inner(
             request_coverage = Some(protected.coverage);
             reqwest::Body::from(protected.body)
         } else {
+            let request_streaming = messages_path
+                && serde_json::from_slice::<Value>(&body)
+                    .ok()
+                    .and_then(|value| value.get("stream").and_then(Value::as_bool))
+                    .unwrap_or(false);
             let mut remote_budget = crate::remote_content::RemoteRequestBudget::default();
             let body = resolve_anthropic_remote_content(body, &mut remote_budget).await?;
             hydrate_anthropic_attested_files(&body, &account_scope, state).await?;
@@ -474,6 +479,12 @@ async fn proxy_request_inner(
             .map_err(|_| "Claude request protection task failed".to_string())??;
             request_coverage = Some(protected.coverage);
             if let Some(response) = protected.local_response {
+                if request_streaming {
+                    return Ok(text_response(
+                        StatusCode::UNPROCESSABLE_ENTITY,
+                        "Plugin local responses are unavailable for streaming Anthropic requests",
+                    ));
+                }
                 return Ok(json_response(StatusCode::OK, response));
             }
             reqwest::Body::from(protected.body)

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -113,6 +113,8 @@ type ProxyBody = UnsyncBoxBody<Bytes, ProxyBodyError>;
 enum AnthropicEndpoint {
     Messages,
     CountTokens,
+    MessageBatches,
+    Complete,
     Files,
     Models,
     Health,
@@ -124,6 +126,8 @@ impl AnthropicEndpoint {
         match self {
             Self::Messages => "messages",
             Self::CountTokens => "count-tokens",
+            Self::MessageBatches => "message-batches",
+            Self::Complete => "complete",
             Self::Files => "files",
             Self::Models => "models",
             Self::Health => "health",
@@ -394,10 +398,18 @@ async fn proxy_request_inner(
     let credential_material = state.headers.credential_scope_material(&headers);
     let account_scope = state.file_attestations.account_scope(&credential_material);
     let messages_path = endpoint == AnthropicEndpoint::Messages;
+    let batch_create = endpoint == AnthropicEndpoint::MessageBatches
+        && method == hyper::Method::POST
+        && path_and_query
+            .split('?')
+            .next()
+            .is_some_and(|path| path.ends_with("/v1/messages/batches"));
     let protected_request = matches!(
         endpoint,
         AnthropicEndpoint::Messages | AnthropicEndpoint::CountTokens
-    );
+    ) || (endpoint == AnthropicEndpoint::Complete
+        && method == hyper::Method::POST)
+        || batch_create;
     let files_upload = endpoint == AnthropicEndpoint::Files
         && method == hyper::Method::POST
         && path_and_query
@@ -467,6 +479,7 @@ async fn proxy_request_inner(
                     &masker,
                     &plugins,
                     &files,
+                    endpoint,
                     block_unknown_formats,
                 )
             })
@@ -825,6 +838,7 @@ fn protect_anthropic_request_body(
     masker: &StdMutex<pentect_agent::ActiveToolOutputMasker>,
     plugins: &StdMutex<pentect_agent::PluginMiddleware>,
     files: &HashMap<String, crate::http_files::Coverage>,
+    endpoint: AnthropicEndpoint,
     block_unknown_formats: bool,
 ) -> Result<ProtectedJsonBody, String> {
     let mut value: Value = match serde_json::from_slice(body) {
@@ -868,7 +882,7 @@ fn protect_anthropic_request_body(
             })
             .map_err(|error| format!("could not encode plugin response: {error}"));
     }
-    let unknown_content_kind = anthropic_request_unknown_content_kind(&value);
+    let unknown_content_kind = anthropic_request_unknown_content_kind(&value, endpoint);
     let partial_schema = unknown_content_kind.is_some();
     if block_unknown_formats && (partial_schema || plugin_partial) {
         let detail = unknown_content_kind
@@ -878,15 +892,15 @@ fn protect_anthropic_request_body(
             "unknown format blocked: Anthropic request contains {detail}; set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to pass it through"
         ));
     }
-    warn_provider_mcp_credentials(&value);
+    warn_provider_mcp_credentials(&value, endpoint);
     // Image handling deliberately follows the existing image policy. With
     // the default image.unscanned="block", an uninspectable image is an
     // error; users can explicitly choose allow in configuration.
-    redact_anthropic_base64_images(&mut value, files)?;
+    redact_anthropic_base64_images(&mut value, files, endpoint)?;
     let mut masker = masker
         .lock()
         .map_err(|_| "Claude request masker lock was poisoned".to_string())?;
-    if let Err(error) = mask_anthropic_request(&mut value, &mut masker, files) {
+    if let Err(error) = mask_anthropic_request(&mut value, &mut masker, files, endpoint) {
         // Explicit media-policy decisions are not detector failures. Letting
         // them enter the general fail-open path would send the very PDF/image
         // that the configured policy rejected.
@@ -910,7 +924,7 @@ fn protect_anthropic_request_body(
             local_response: None,
         });
     }
-    inject_handle_contract(&mut value);
+    inject_handle_contract(&mut value, endpoint);
     match serde_json::to_vec(&value) {
         Ok(protected) => Ok(ProtectedJsonBody {
             body: Bytes::from(protected),
@@ -932,7 +946,30 @@ fn protect_anthropic_request_body(
     }
 }
 
-fn anthropic_request_unknown_content_kind(value: &Value) -> Option<&str> {
+fn anthropic_request_unknown_content_kind(
+    value: &Value,
+    endpoint: AnthropicEndpoint,
+) -> Option<&str> {
+    if endpoint == AnthropicEndpoint::MessageBatches {
+        let Some(requests) = value.get("requests").and_then(Value::as_array) else {
+            return Some("<invalid message batch>");
+        };
+        for request in requests {
+            let Some(params) = request.get("params").filter(|params| params.is_object()) else {
+                return Some("<invalid message batch request>");
+            };
+            if let Some(kind) =
+                anthropic_request_unknown_content_kind(params, AnthropicEndpoint::Messages)
+            {
+                return Some(kind);
+            }
+        }
+        return None;
+    }
+    if endpoint == AnthropicEndpoint::Complete {
+        return (!value.get("prompt").is_some_and(Value::is_string))
+            .then_some("<invalid completion prompt>");
+    }
     let mut roots = Vec::new();
     if let Some(system) = value.get("system") {
         roots.push(system);
@@ -989,8 +1026,33 @@ fn is_media_policy_rejection(error: &str) -> bool {
     error.starts_with("document blocked:") || error.starts_with("image blocked:")
 }
 
-fn warn_provider_mcp_credentials(value: &Value) {
-    if value
+fn warn_provider_mcp_credentials(value: &Value, endpoint: AnthropicEndpoint) {
+    let forwarded = if endpoint == AnthropicEndpoint::MessageBatches {
+        value
+            .get("requests")
+            .and_then(Value::as_array)
+            .is_some_and(|requests| {
+                requests.iter().any(|request| {
+                    request
+                        .get("params")
+                        .is_some_and(provider_mcp_credentials_present)
+                })
+            })
+    } else {
+        provider_mcp_credentials_present(value)
+    };
+    if forwarded && !WARNED_PROVIDER_MCP_CREDENTIALS.swap(true, Ordering::Relaxed) {
+        diagnostic(
+            "provider-mcp-credential-forwarded",
+            "credential-forwarding",
+            "messages",
+            false,
+        );
+    }
+}
+
+fn provider_mcp_credentials_present(value: &Value) -> bool {
+    value
         .get("mcp_servers")
         .and_then(Value::as_array)
         .is_some_and(|servers| {
@@ -1001,19 +1063,32 @@ fn warn_provider_mcp_credentials(value: &Value) {
                     .is_some_and(|token| !token.is_empty())
             })
         })
-        && !WARNED_PROVIDER_MCP_CREDENTIALS.swap(true, Ordering::Relaxed)
-    {
-        diagnostic(
-            "provider-mcp-credential-forwarded",
-            "credential-forwarding",
-            "messages",
-            false,
-        );
-    }
 }
 
-fn inject_handle_contract(value: &mut Value) {
+fn inject_handle_contract(value: &mut Value, endpoint: AnthropicEndpoint) {
+    if endpoint == AnthropicEndpoint::MessageBatches {
+        if let Some(requests) = value.get_mut("requests").and_then(Value::as_array_mut) {
+            for request in requests {
+                if let Some(params) = request.get_mut("params") {
+                    inject_handle_contract(params, AnthropicEndpoint::Messages);
+                }
+            }
+        }
+        return;
+    }
     if !request_contains_masked_handle(value) {
+        return;
+    }
+    if endpoint == AnthropicEndpoint::Complete {
+        if let Some(prompt) = value
+            .get_mut("prompt")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+        {
+            if !prompt.contains(HANDLE_CONTRACT) {
+                value["prompt"] = Value::String(format!("{prompt}\n\n{HANDLE_CONTRACT}"));
+            }
+        }
         return;
     }
     let contract = serde_json::json!({
@@ -1505,7 +1580,33 @@ fn mask_anthropic_request(
     value: &mut Value,
     masker: &mut pentect_agent::ActiveToolOutputMasker,
     files: &HashMap<String, crate::http_files::Coverage>,
+    endpoint: AnthropicEndpoint,
 ) -> Result<(), String> {
+    if endpoint == AnthropicEndpoint::MessageBatches {
+        let requests = value
+            .get_mut("requests")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| "message batch requires a requests array".to_string())?;
+        for request in requests {
+            let params = request
+                .get_mut("params")
+                .filter(|params| params.is_object())
+                .ok_or_else(|| "message batch request requires params".to_string())?;
+            mask_anthropic_request(params, masker, files, AnthropicEndpoint::Messages)?;
+        }
+        return Ok(());
+    }
+    if endpoint == AnthropicEndpoint::Complete {
+        let prompt = value
+            .get_mut("prompt")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "completion request requires a string prompt".to_string())?
+            .to_string();
+        let mut protected = prompt;
+        mask_string(&mut protected, false, masker)?;
+        value["prompt"] = Value::String(protected);
+        return Ok(());
+    }
     // Anthropic system content is client/provider-authored. It must be
     // protected, but prompt-only unmask markers are not trusted here.
     if let Some(system) = value.get_mut("system") {
@@ -1525,7 +1626,25 @@ fn mask_anthropic_request(
 fn redact_anthropic_base64_images(
     value: &mut Value,
     files: &HashMap<String, crate::http_files::Coverage>,
+    endpoint: AnthropicEndpoint,
 ) -> Result<(), String> {
+    if endpoint == AnthropicEndpoint::MessageBatches {
+        let requests = value
+            .get_mut("requests")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| "message batch requires a requests array".to_string())?;
+        for request in requests {
+            let params = request
+                .get_mut("params")
+                .filter(|params| params.is_object())
+                .ok_or_else(|| "message batch request requires params".to_string())?;
+            redact_anthropic_base64_images(params, files, AnthropicEndpoint::Messages)?;
+        }
+        return Ok(());
+    }
+    if endpoint == AnthropicEndpoint::Complete {
+        return Ok(());
+    }
     if let Some(system) = value.get_mut("system") {
         redact_content_images(system, files)?;
     }
@@ -2575,6 +2694,10 @@ fn classify_anthropic_endpoint(path_and_query: &str) -> AnthropicEndpoint {
         AnthropicEndpoint::Messages
     } else if path.ends_with("/v1/messages/count_tokens") {
         AnthropicEndpoint::CountTokens
+    } else if path.ends_with("/v1/messages/batches") || path.contains("/v1/messages/batches/") {
+        AnthropicEndpoint::MessageBatches
+    } else if path.ends_with("/v1/complete") {
+        AnthropicEndpoint::Complete
     } else if path.ends_with("/v1/files") || path.contains("/v1/files/") {
         AnthropicEndpoint::Files
     } else if path.ends_with("/v1/models") || path.contains("/v1/models/") {
@@ -3361,7 +3484,15 @@ mod tests {
         );
         assert_eq!(
             classify_anthropic_endpoint("/v1/messages/batches"),
-            AnthropicEndpoint::Unknown
+            AnthropicEndpoint::MessageBatches
+        );
+        assert_eq!(
+            classify_anthropic_endpoint("/v1/messages/batches/msgbatch_123/results"),
+            AnthropicEndpoint::MessageBatches
+        );
+        assert_eq!(
+            classify_anthropic_endpoint("/v1/complete"),
+            AnthropicEndpoint::Complete
         );
         assert!(enforce_known_anthropic_endpoint(AnthropicEndpoint::Unknown, true).is_err());
         assert!(enforce_known_anthropic_endpoint(AnthropicEndpoint::Unknown, false).is_ok());
@@ -3394,14 +3525,14 @@ mod tests {
             "system": "existing",
             "messages": [{"role": "user", "content": "use <<SECRET_0123456789abcdef>>"}]
         });
-        inject_handle_contract(&mut request);
+        inject_handle_contract(&mut request, AnthropicEndpoint::Messages);
         assert_eq!(request["system"][0]["text"], "existing");
         assert_eq!(request["system"][1]["text"], HANDLE_CONTRACT);
-        inject_handle_contract(&mut request);
+        inject_handle_contract(&mut request, AnthropicEndpoint::Messages);
         assert_eq!(request["system"].as_array().unwrap().len(), 2);
 
         let mut empty = serde_json::json!({"messages": []});
-        inject_handle_contract(&mut empty);
+        inject_handle_contract(&mut empty, AnthropicEndpoint::Messages);
         assert!(empty.get("system").is_none());
     }
 
@@ -3411,7 +3542,7 @@ mod tests {
             "system": "existing",
             "messages": [{"role": "user", "content": "hello"}]
         });
-        inject_handle_contract(&mut clean);
+        inject_handle_contract(&mut clean, AnthropicEndpoint::Messages);
         assert_eq!(clean["system"], "existing");
 
         let mut protected = serde_json::json!({
@@ -3421,7 +3552,7 @@ mod tests {
                 "content": "use <<SECRET_0123456789abcdef>>"
             }]
         });
-        inject_handle_contract(&mut protected);
+        inject_handle_contract(&mut protected, AnthropicEndpoint::Messages);
         assert_eq!(protected["system"][0]["text"], "existing");
         assert_eq!(protected["system"][1]["text"], HANDLE_CONTRACT);
     }
@@ -3435,15 +3566,29 @@ mod tests {
         let masker = StdMutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
         let plugins = StdMutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
         let files = HashMap::new();
-        let error = match protect_anthropic_request_body(&body, &masker, &plugins, &files, true) {
+        let error = match protect_anthropic_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Messages,
+            true,
+        ) {
             Ok(_) => panic!("unknown Anthropic block should be rejected"),
             Err(error) => error,
         };
         assert!(error.starts_with("unknown format blocked:"), "{error}");
         assert!(error.contains("future_block"), "{error}");
 
-        let allowed =
-            protect_anthropic_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        let allowed = protect_anthropic_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Messages,
+            false,
+        )
+        .unwrap();
         assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
         let allowed: Value = serde_json::from_slice(&allowed.body).unwrap();
         let original: Value = serde_json::from_slice(&body).unwrap();
@@ -3463,7 +3608,10 @@ mod tests {
                 ]
             }]
         });
-        assert_eq!(anthropic_request_unknown_content_kind(&value), None);
+        assert_eq!(
+            anthropic_request_unknown_content_kind(&value, AnthropicEndpoint::Messages),
+            None
+        );
     }
 
     #[test]
@@ -3473,11 +3621,108 @@ mod tests {
         let masker = StdMutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
         let plugins = StdMutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
         let files = HashMap::new();
-        assert!(protect_anthropic_request_body(&body, &masker, &plugins, &files, true).is_err());
-        let allowed =
-            protect_anthropic_request_body(&body, &masker, &plugins, &files, false).unwrap();
+        assert!(protect_anthropic_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Messages,
+            true,
+        )
+        .is_err());
+        let allowed = protect_anthropic_request_body(
+            &body,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Messages,
+            false,
+        )
+        .unwrap();
         assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
         assert_eq!(allowed.body, body);
+    }
+
+    #[test]
+    fn batch_and_legacy_completion_prompts_are_masked_at_their_real_boundaries() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        let secret = [
+            "rpa_",
+            "ZYXWVUTS",
+            "RQPONMLK",
+            "JIHGFEDC",
+            "BA098765",
+            "4321fedcba",
+        ]
+        .concat();
+        let masker = StdMutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = StdMutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
+        let files = HashMap::new();
+
+        let batch = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "requests": [{
+                    "custom_id": "request-1",
+                    "params": {
+                        "model": "test",
+                        "max_tokens": 8,
+                        "messages": [{
+                            "role": "user",
+                            "content": format!("RUNPOD_API_KEY={secret}")
+                        }]
+                    }
+                }]
+            }))
+            .unwrap(),
+        );
+        let protected = protect_anthropic_request_body(
+            &batch,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::MessageBatches,
+            true,
+        )
+        .unwrap();
+        let protected: Value = serde_json::from_slice(&protected.body).unwrap();
+        assert!(!protected.to_string().contains(&secret));
+        assert!(first_valid_handle(
+            protected["requests"][0]["params"]["messages"][0]["content"]
+                .as_str()
+                .unwrap()
+        )
+        .is_some());
+        assert!(protected.get("system").is_none());
+        assert_eq!(
+            protected["requests"][0]["params"]["system"][0]["text"],
+            HANDLE_CONTRACT
+        );
+
+        let completion = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "test",
+                "max_tokens_to_sample": 8,
+                "prompt": format!("RUNPOD_API_KEY={secret}")
+            }))
+            .unwrap(),
+        );
+        let protected = protect_anthropic_request_body(
+            &completion,
+            &masker,
+            &plugins,
+            &files,
+            AnthropicEndpoint::Complete,
+            true,
+        )
+        .unwrap();
+        let protected: Value = serde_json::from_slice(&protected.body).unwrap();
+        let prompt = protected["prompt"].as_str().unwrap();
+        assert!(!prompt.contains(&secret));
+        assert!(first_valid_handle(prompt).is_some());
+        assert!(prompt.contains(HANDLE_CONTRACT));
+        assert!(protected.get("system").is_none());
     }
 
     #[test]

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1082,7 +1082,7 @@ fn inject_handle_contract(value: &mut Value, endpoint: AnthropicEndpoint) {
     if endpoint == AnthropicEndpoint::Complete {
         if let Some(prompt) = value
             .get_mut("prompt")
-            .and_then(Value::as_str)
+            .and_then(|prompt| prompt.as_str())
             .map(str::to_owned)
         {
             if !prompt.contains(HANDLE_CONTRACT) {
@@ -1599,7 +1599,7 @@ fn mask_anthropic_request(
     if endpoint == AnthropicEndpoint::Complete {
         let prompt = value
             .get_mut("prompt")
-            .and_then(Value::as_str)
+            .and_then(|prompt| prompt.as_str())
             .ok_or_else(|| "completion request requires a string prompt".to_string())?
             .to_string();
         let mut protected = prompt;

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -295,7 +295,7 @@ async fn proxy_request_inner(
             Err(error) => return Err(format!("could not read Google Cloud Code request: {error}")),
         };
         let mut remote_budget = crate::remote_content::RemoteRequestBudget::default();
-        let body = resolve_cloud_code_remote_files(body, &mut remote_budget).await?;
+        let body = resolve_google_remote_files(body, &mut remote_budget).await?;
         let protected = protect_request_body(
             &body,
             endpoint,
@@ -405,7 +405,7 @@ async fn proxy_request_inner(
         .map_err(|error| format!("could not build Google Cloud Code response: {error}"))
 }
 
-async fn resolve_cloud_code_remote_files(
+pub(crate) async fn resolve_google_remote_files(
     body: Bytes,
     budget: &mut crate::remote_content::RemoteRequestBudget,
 ) -> Result<Bytes, String> {
@@ -413,13 +413,13 @@ async fn resolve_cloud_code_remote_files(
         Ok(value) => value,
         Err(_) => return Ok(body),
     };
-    resolve_cloud_code_remote_values(&mut value, budget).await?;
+    resolve_google_remote_values(&mut value, budget).await?;
     serde_json::to_vec(&value)
         .map(Bytes::from)
         .map_err(|_| "could not encode resolved Google Cloud Code attachment".to_string())
 }
 
-fn resolve_cloud_code_remote_values<'a>(
+fn resolve_google_remote_values<'a>(
     value: &'a mut Value,
     budget: &'a mut crate::remote_content::RemoteRequestBudget,
 ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + 'a>> {
@@ -427,7 +427,7 @@ fn resolve_cloud_code_remote_values<'a>(
         match value {
             Value::Array(values) => {
                 for value in values {
-                    resolve_cloud_code_remote_values(value, budget).await?;
+                    resolve_google_remote_values(value, budget).await?;
                 }
             }
             Value::Object(object) => {
@@ -455,7 +455,7 @@ fn resolve_cloud_code_remote_values<'a>(
                     }
                 }
                 for value in object.values_mut() {
-                    resolve_cloud_code_remote_values(value, budget).await?;
+                    resolve_google_remote_values(value, budget).await?;
                 }
             }
             _ => {}
@@ -761,9 +761,7 @@ fn mask_part(
         .transpose()?
         .flatten();
     if object.contains_key("fileData") && pentect_agent::unscanned_images_should_block()? {
-        return Err(
-            "document blocked: Google Cloud Code fileData could not be scanned".to_string(),
-        );
+        return Err("document blocked: Google fileData could not be scanned".to_string());
     }
     if let Some(code) = object.get_mut("executableCode") {
         mask_value_strings(code, false, masker)?;

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -304,6 +304,12 @@ async fn proxy_request_inner(
             state.block_unknown_formats,
         )?;
         if let Some(response) = protected.local_response {
+            if is_stream {
+                return Ok(text_response(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "Plugin local responses are unavailable for streaming Google Cloud Code requests",
+                ));
+            }
             return Ok(json_response(StatusCode::OK, response));
         }
         reqwest::Body::from(protected.body)

--- a/crates/pentect-cli/src/default_launch.rs
+++ b/crates/pentect-cli/src/default_launch.rs
@@ -12,15 +12,10 @@ enum Action {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ShellKind {
-    #[cfg(windows)]
     PowerShell,
-    #[cfg(windows)]
     Pwsh,
-    #[cfg(not(windows))]
     Bash,
-    #[cfg(not(windows))]
     Zsh,
-    #[cfg(not(windows))]
     Fish,
 }
 
@@ -304,16 +299,29 @@ fn backup_path(profile: &Path) -> PathBuf {
 
 fn definition(shell: ShellKind, tool: &str) -> String {
     match shell {
-        #[cfg(windows)]
         ShellKind::PowerShell | ShellKind::Pwsh => {
             format!("function global:{tool} {{ & pentect {tool} @args }}")
         }
-        #[cfg(not(windows))]
         ShellKind::Bash | ShellKind::Zsh => {
             format!(r#"{tool}() {{ command pentect {tool} "$@"; }}"#)
         }
-        #[cfg(not(windows))]
         ShellKind::Fish => format!("function {tool}\n    command pentect {tool} $argv\nend"),
+    }
+}
+
+fn shell_kind_from_name(name: &str) -> Option<ShellKind> {
+    let name = name
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(name)
+        .to_ascii_lowercase();
+    match name.as_str() {
+        "powershell" | "powershell.exe" => Some(ShellKind::PowerShell),
+        "pwsh" | "pwsh.exe" => Some(ShellKind::Pwsh),
+        "bash" | "bash.exe" => Some(ShellKind::Bash),
+        "zsh" | "zsh.exe" => Some(ShellKind::Zsh),
+        "fish" | "fish.exe" => Some(ShellKind::Fish),
+        _ => None,
     }
 }
 
@@ -326,39 +334,35 @@ fn detect_shell() -> Result<ShellKind, String> {
         let Some(process) = system.process(pid) else {
             break;
         };
-        let name = process.name().to_string_lossy().to_ascii_lowercase();
-        if matches!(name.as_str(), "pwsh" | "pwsh.exe") {
-            return Ok(ShellKind::Pwsh);
-        }
-        if matches!(name.as_str(), "powershell" | "powershell.exe") {
-            return Ok(ShellKind::PowerShell);
+        if let Some(shell) = shell_kind_from_name(&process.name().to_string_lossy()) {
+            return Ok(shell);
         }
         let Some(parent) = process.parent() else {
             break;
         };
         pid = parent;
     }
-    Err("could not detect PowerShell; run this command from PowerShell".into())
+    if let Some(shell) =
+        std::env::var_os("SHELL").and_then(|value| shell_kind_from_name(&value.to_string_lossy()))
+    {
+        return Ok(shell);
+    }
+    Err("could not detect the shell; use Bash, Zsh, Fish, or PowerShell".into())
 }
 
 #[cfg(not(windows))]
 fn detect_shell() -> Result<ShellKind, String> {
     let shell = std::env::var_os("SHELL")
-        .and_then(|value| PathBuf::from(value).file_name().map(|name| name.to_owned()))
-        .and_then(|name| name.to_str().map(str::to_ascii_lowercase))
+        .and_then(|value| shell_kind_from_name(&value.to_string_lossy()))
         .ok_or_else(|| "could not detect the shell from SHELL".to_string())?;
-    match shell.as_str() {
-        "bash" => Ok(ShellKind::Bash),
-        "zsh" => Ok(ShellKind::Zsh),
-        "fish" => Ok(ShellKind::Fish),
-        _ => Err(format!(
-            "unsupported shell '{shell}'; use Bash, Zsh, Fish, or PowerShell"
-        )),
-    }
+    Ok(shell)
 }
 
 #[cfg(windows)]
 fn profile_path(shell: ShellKind) -> Result<PathBuf, String> {
+    if matches!(shell, ShellKind::Bash | ShellKind::Zsh | ShellKind::Fish) {
+        return posix_profile_path(shell);
+    }
     let executable = powershell_executable(shell)?;
     let output = Command::new(&executable)
         .args([
@@ -431,6 +435,10 @@ fn powershell_executable(shell: ShellKind) -> Result<PathBuf, String> {
 
 #[cfg(not(windows))]
 fn profile_path(shell: ShellKind) -> Result<PathBuf, String> {
+    posix_profile_path(shell)
+}
+
+fn posix_profile_path(shell: ShellKind) -> Result<PathBuf, String> {
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
         .ok_or_else(|| "HOME is unavailable".to_string())?;
@@ -438,12 +446,26 @@ fn profile_path(shell: ShellKind) -> Result<PathBuf, String> {
         ShellKind::Bash => Ok(home.join(".bashrc")),
         ShellKind::Zsh => Ok(home.join(".zshrc")),
         ShellKind::Fish => Ok(home.join(".config").join("fish").join("config.fish")),
+        ShellKind::PowerShell | ShellKind::Pwsh => {
+            Err("PowerShell profiles require Windows".to_string())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recognizes_windows_and_posix_shell_process_names() {
+        assert_eq!(shell_kind_from_name("bash.exe"), Some(ShellKind::Bash));
+        assert_eq!(
+            shell_kind_from_name(r"C:\Program Files\PowerShell\7\pwsh.exe"),
+            Some(ShellKind::Pwsh)
+        );
+        assert_eq!(shell_kind_from_name("/usr/bin/zsh"), Some(ShellKind::Zsh));
+        assert_eq!(shell_kind_from_name("cmd.exe"), None);
+    }
 
     #[test]
     fn installs_updates_and_removes_one_owned_block() {

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -277,6 +277,10 @@ async fn proxy_request_inner(
             }
             Err(error) => return Err(format!("could not read Gemini request: {error}")),
         };
+        let mut remote_budget = crate::remote_content::RemoteRequestBudget::default();
+        let body =
+            crate::cloud_code_http_proxy::resolve_google_remote_files(body, &mut remote_budget)
+                .await?;
         let protected = protect_request_body(
             &body,
             endpoint,
@@ -1121,6 +1125,18 @@ mod tests {
             ),
             "unknown"
         );
+    }
+
+    #[tokio::test]
+    async fn remote_file_data_uses_the_bounded_google_resolver() {
+        let body = Bytes::from_static(
+            br#"{"contents":[{"role":"user","parts":[{"fileData":{"mimeType":"text/plain","fileUri":"https://127.0.0.1/private"}}]}]}"#,
+        );
+        let mut budget = crate::remote_content::RemoteRequestBudget::default();
+        let error = crate::cloud_code_http_proxy::resolve_google_remote_files(body, &mut budget)
+            .await
+            .unwrap_err();
+        assert!(error.contains("non-public address"), "{error}");
     }
 
     #[test]

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -285,6 +285,12 @@ async fn proxy_request_inner(
             state.block_unknown_formats,
         )?;
         if let Some(response) = protected.local_response {
+            if endpoint == GeminiEndpoint::StreamGenerateContent {
+                return Ok(text_response(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "Plugin local responses are unavailable for streaming Gemini requests",
+                ));
+            }
             return Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(hyper::header::CONTENT_TYPE, "application/json")

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -984,8 +984,11 @@ fn validate_mask_args(args: &[String]) -> Result<(), String> {
             flag if flag.starts_with("--") => {
                 return Err(format!("unknown option: {flag}"));
             }
-            value => {
-                return Err(format!("unexpected argument for mask: {value}"));
+            _ => {
+                return Err(
+                    "pentect mask reads standard input only; pipe input to it or use `pentect mask < FILE`. Positional values are refused because command-line arguments may be recorded"
+                        .to_string(),
+                );
             }
         }
     }
@@ -3050,6 +3053,21 @@ fn required_value(args: &[String], i: &mut usize, flag: &str) -> Result<String, 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mask_positional_error_guides_without_echoing_the_value() {
+        let secret = "should-never-appear-in-an-error";
+        let args = vec![
+            "pentect".to_string(),
+            "mask".to_string(),
+            secret.to_string(),
+        ];
+        let error = validate_mask_args(&args).unwrap_err();
+        assert!(!error.contains(secret), "{error}");
+        assert!(error.contains("standard input"), "{error}");
+        assert!(error.contains("pentect mask < FILE"), "{error}");
+        assert!(error.contains("may be recorded"), "{error}");
+    }
 
     #[test]
     fn metadata_and_client_commands_skip_memory_store_probe() {

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -493,6 +493,12 @@ async fn proxy_request_inner(
             .map_err(|_| "OpenAI request protection task failed".to_string())??;
             request_coverage = Some(protected.coverage);
             if let Some(response) = protected.local_response {
+                if request_streaming {
+                    return Ok(text_response(
+                        StatusCode::UNPROCESSABLE_ENTITY,
+                        "Plugin local responses are unavailable for streaming OpenAI requests",
+                    ));
+                }
                 return Ok(json_response(StatusCode::OK, response));
             }
             reqwest::Body::from(protected.body)

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -2492,21 +2492,12 @@ fn streaming_response_body(
                 }
                 Some(Ok(chunk)) => {
                     if state.pending.len().saturating_add(chunk.len()) > MAX_PENDING_SSE_BYTES {
-                        if state.transform == StreamTransform::ChatCompletions
-                            && !state.chat.calls.is_empty()
-                        {
-                            state.finished = true;
-                            state.ready.push_back(Err(Box::new(io::Error::new(
-                                io::ErrorKind::PermissionDenied,
-                                "OpenAI Chat Completions tool input exceeded limit",
-                            ))));
-                            continue;
-                        }
                         proxy_diagnostic("sse-event-limit");
-                        state.transform = StreamTransform::None;
-                        let mut pending = std::mem::take(&mut state.pending);
-                        pending.extend_from_slice(&chunk);
-                        state.ready.push_back(Ok(Frame::data(Bytes::from(pending))));
+                        state.finished = true;
+                        state.ready.push_back(Err(Box::new(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            "OpenAI SSE event exceeded inspection limit",
+                        ))));
                         continue;
                     }
                     state.pending.extend_from_slice(&chunk);
@@ -2599,6 +2590,7 @@ struct ChatStreamState {
     calls: HashMap<(u64, u64), ChatStreamCall>,
     buffered_bytes: usize,
     output_text: HashMap<(u64, &'static str), crate::claude_http_proxy::OutputTextRestorer>,
+    last_envelope: Option<Value>,
 }
 
 #[derive(Default)]
@@ -2630,13 +2622,22 @@ impl ChatStreamState {
             return Ok(vec![Bytes::copy_from_slice(block)]);
         };
         if data == "[DONE]" {
-            if !self.calls.is_empty() {
-                return Err(
-                    "OpenAI Chat Completions stream ended before its tool call completed"
-                        .to_string(),
-                );
-            }
             let mut output = self.finish_output_text(text)?;
+            if !self.calls.is_empty() {
+                let envelope = self.last_envelope.take().ok_or_else(|| {
+                    "OpenAI Chat Completions stream ended without a tool call envelope".to_string()
+                })?;
+                let mut choices = self
+                    .calls
+                    .keys()
+                    .map(|(choice, _)| *choice)
+                    .collect::<Vec<_>>();
+                choices.sort_unstable();
+                choices.dedup();
+                for choice in choices {
+                    output.push(self.completed_tool_block(text, &envelope, choice, plugins)?);
+                }
+            }
             output.push(Bytes::copy_from_slice(block));
             return Ok(output);
         }
@@ -2741,6 +2742,7 @@ impl ChatStreamState {
             }
         }
         let keep_original = !has_tool_delta || chat_chunk_has_visible_delta(&value);
+        self.last_envelope = Some(value.clone());
         if keep_original {
             output.push(encode_sse_value(text, &value)?);
         }
@@ -4201,6 +4203,38 @@ mod tests {
             completed.contains(r#"{\"command\":\"echo ok\"}"#),
             "{completed}"
         );
+        assert!(state.calls.is_empty());
+        assert_eq!(state.buffered_bytes, 0);
+    }
+
+    #[test]
+    fn chat_stream_done_flushes_tool_calls_without_finish_reason() {
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let mut state = ChatStreamState::default();
+        let chunk = format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "id": "chat_1", "model": "test", "choices": [{"index": 0, "delta": {
+                    "tool_calls": [{"index": 0, "id": "call_1", "type": "function",
+                    "function": {"name": "run_command", "arguments": "{\"cmd\":\"ls\"}"}}]
+                }, "finish_reason": null}]
+            })
+        );
+        let mut resolve: HandleResolver = Box::new(|text: &str| Ok(text.to_string()));
+        assert!(state
+            .rewrite_block(chunk.as_bytes(), &plugins, false, &mut resolve)
+            .unwrap()
+            .is_empty());
+
+        let finished = state
+            .rewrite_block(b"data: [DONE]\n\n", &plugins, false, &mut resolve)
+            .unwrap();
+        assert_eq!(finished.len(), 2);
+        let tool_call = String::from_utf8_lossy(&finished[0]);
+        assert!(tool_call.contains("call_1"), "{tool_call}");
+        assert!(tool_call.contains("run_command"), "{tool_call}");
+        assert!(tool_call.contains(r#"{\"cmd\":\"ls\"}"#), "{tool_call}");
+        assert_eq!(finished[1], Bytes::from_static(b"data: [DONE]\n\n"));
         assert!(state.calls.is_empty());
         assert_eq!(state.buffered_bytes, 0);
     }

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -350,6 +350,7 @@ async fn proxy_request_inner(
     }
     let responses_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::Responses;
     let chat_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::ChatCompletions;
+    let completions_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::Completions;
     let standalone_search_path =
         method == hyper::Method::POST && endpoint == OpenAiEndpoint::StandaloneSearch;
     let embeddings_path = method == hyper::Method::POST && endpoint == OpenAiEndpoint::Embeddings;
@@ -358,12 +359,14 @@ async fn proxy_request_inner(
         OpenAiEndpoint::Responses | OpenAiEndpoint::ResponsesResource
     );
     let chat_response = endpoint == OpenAiEndpoint::ChatCompletions;
+    let completions_response = endpoint == OpenAiEndpoint::Completions;
     let protected_request = method == hyper::Method::POST
         && matches!(
             endpoint,
             OpenAiEndpoint::Responses
                 | OpenAiEndpoint::InputTokens
                 | OpenAiEndpoint::ChatCompletions
+                | OpenAiEndpoint::Completions
                 | OpenAiEndpoint::StandaloneSearch
                 | OpenAiEndpoint::Embeddings
         );
@@ -479,6 +482,8 @@ async fn proxy_request_inner(
                     &files,
                     if chat_path {
                         OpenAiRequestDialect::ChatCompletions
+                    } else if completions_path {
+                        OpenAiRequestDialect::Completions
                     } else if standalone_search_path {
                         OpenAiRequestDialect::StandaloneSearch
                     } else if embeddings_path {
@@ -548,11 +553,13 @@ async fn proxy_request_inner(
     // explicit stream flag is authoritative in that case.
     let is_event_stream = response_media_type
         .is_some_and(|value| value.eq_ignore_ascii_case("text/event-stream"))
-        || ((responses_path || chat_path) && request_streaming && response_media_type.is_none());
+        || ((responses_path || chat_path || completions_path)
+            && request_streaming
+            && response_media_type.is_none());
     let is_json_response = response_media_type.is_some_and(|value| {
         value.eq_ignore_ascii_case("application/json")
             || value.to_ascii_lowercase().ends_with("+json")
-    }) || ((responses_response || chat_response)
+    }) || ((responses_response || chat_response || completions_response)
         && !request_streaming
         && response_media_type.is_none());
     let restore_output = pentect_agent::output_restore_enabled()?;
@@ -571,7 +578,9 @@ async fn proxy_request_inner(
             .unwrap_or(crate::http_files::Coverage::None)
             .as_header(),
     );
-    if is_event_stream || (!(responses_response || chat_response) && !files_upload) {
+    if is_event_stream
+        || (!(responses_response || chat_response || completions_response) && !files_upload)
+    {
         return builder
             .body(streaming_response_body(
                 upstream,
@@ -579,6 +588,8 @@ async fn proxy_request_inner(
                     StreamTransform::Responses
                 } else if status.is_success() && chat_path && is_event_stream {
                     StreamTransform::ChatCompletions
+                } else if status.is_success() && completions_path && is_event_stream {
+                    StreamTransform::Completions
                 } else {
                     StreamTransform::None
                 },
@@ -626,25 +637,29 @@ async fn proxy_request_inner(
             }
         }
     }
-    let response_body =
-        if (responses_response || chat_response) && status.is_success() && is_json_response {
-            let response_body = run_response_plugins(response_body, &state.plugins, "openai")?;
-            let rewritten = if chat_response {
-                rewrite_chat_completions_json_response(&response_body, restore_output)
-            } else {
-                rewrite_openai_json_response(&response_body, restore_output)
-            };
-            match rewritten {
-                Ok(rewritten) => Bytes::from(rewritten),
-                Err(error) => {
-                    let _ = error;
-                    proxy_diagnostic("response-restore-skipped");
-                    response_body
-                }
-            }
+    let response_body = if (responses_response || chat_response || completions_response)
+        && status.is_success()
+        && is_json_response
+    {
+        let response_body = run_response_plugins(response_body, &state.plugins, "openai")?;
+        let rewritten = if chat_response {
+            rewrite_chat_completions_json_response(&response_body, restore_output)
+        } else if completions_response {
+            rewrite_completions_json_response(&response_body, restore_output)
         } else {
-            response_body
+            rewrite_openai_json_response(&response_body, restore_output)
         };
+        match rewritten {
+            Ok(rewritten) => Bytes::from(rewritten),
+            Err(error) => {
+                let _ = error;
+                proxy_diagnostic("response-restore-skipped");
+                response_body
+            }
+        }
+    } else {
+        response_body
+    };
     builder
         .body(full_body(response_body))
         .map_err(|error| format!("could not build OpenAI response: {error}"))
@@ -809,6 +824,7 @@ fn decode_openai_request_body(
 enum OpenAiRequestDialect {
     Responses,
     ChatCompletions,
+    Completions,
     StandaloneSearch,
     Embeddings,
 }
@@ -900,7 +916,9 @@ fn protect_openai_request_body(
     }
     if matches!(
         dialect,
-        OpenAiRequestDialect::Responses | OpenAiRequestDialect::ChatCompletions
+        OpenAiRequestDialect::Responses
+            | OpenAiRequestDialect::ChatCompletions
+            | OpenAiRequestDialect::Completions
     ) {
         inject_handle_contract(&mut value);
     }
@@ -1348,8 +1366,29 @@ fn openai_request_unknown_content_kind(
             .get("messages")
             .map(visit_chat_messages)
             .unwrap_or(Some("missing messages")),
+        OpenAiRequestDialect::Completions => completions_unknown_shape(value),
         OpenAiRequestDialect::StandaloneSearch => standalone_search_unknown_shape(value, visit),
         OpenAiRequestDialect::Embeddings => embeddings_unknown_shape(value),
+    }
+}
+
+fn completions_unknown_shape(value: &Value) -> Option<&str> {
+    let Some(prompt) = value.as_object().and_then(|object| object.get("prompt")) else {
+        return Some("missing completion prompt");
+    };
+    match prompt {
+        Value::String(_) => None,
+        Value::Array(items) if items.iter().all(Value::is_string) => None,
+        Value::Array(items) if items.iter().all(Value::is_u64) => None,
+        Value::Array(items)
+            if items.iter().all(|item| {
+                item.as_array()
+                    .is_some_and(|tokens| tokens.iter().all(Value::is_u64))
+            }) =>
+        {
+            None
+        }
+        _ => Some("unsupported completion prompt"),
     }
 }
 
@@ -1477,6 +1516,10 @@ fn inject_handle_contract(value: &mut Value) {
         inject_chat_handle_contract(value);
         return;
     }
+    if let Some(prompt) = value.get_mut("prompt") {
+        inject_completion_handle_contract(prompt);
+        return;
+    }
     match value.get_mut("instructions") {
         Some(Value::String(instructions)) if !instructions.contains(HANDLE_CONTRACT) => {
             let existing = std::mem::take(instructions);
@@ -1484,6 +1527,21 @@ fn inject_handle_contract(value: &mut Value) {
         }
         Some(Value::Null) | None => {
             value["instructions"] = Value::String(HANDLE_CONTRACT.to_string());
+        }
+        _ => {}
+    }
+}
+
+fn inject_completion_handle_contract(prompt: &mut Value) {
+    match prompt {
+        Value::String(text) if !text.contains(HANDLE_CONTRACT) => {
+            text.push_str("\n\n");
+            text.push_str(HANDLE_CONTRACT);
+        }
+        Value::Array(items) if items.iter().all(Value::is_string) => {
+            for item in items {
+                inject_completion_handle_contract(item);
+            }
         }
         _ => {}
     }
@@ -1552,6 +1610,9 @@ fn mask_openai_request(
     if let Some(messages) = value.get_mut("messages") {
         mask_chat_messages(messages, masker, files)?;
     }
+    if let Some(prompt) = value.get_mut("prompt") {
+        mask_completion_prompt(prompt, masker)?;
+    }
     // Tool descriptions and JSON Schemas are sent to the model too. MCP and
     // editor integrations commonly generate them from local state, so they
     // must cross the same masking boundary as messages. Keys are structural;
@@ -1576,6 +1637,34 @@ fn mask_openai_request(
         }
     }
     Ok(())
+}
+
+fn mask_completion_prompt(
+    prompt: &mut Value,
+    masker: &mut pentect_agent::ActiveToolOutputMasker,
+) -> Result<(), String> {
+    match prompt {
+        Value::String(text) => mask_text(text, false, masker),
+        Value::Array(items) if items.iter().all(Value::is_string) => {
+            for item in items {
+                let Value::String(text) = item else {
+                    unreachable!("completion prompt shape checked before masking")
+                };
+                mask_text(text, false, masker)?;
+            }
+            Ok(())
+        }
+        Value::Array(items)
+            if items.iter().all(Value::is_u64)
+                || items.iter().all(|item| {
+                    item.as_array()
+                        .is_some_and(|tokens| tokens.iter().all(Value::is_u64))
+                }) =>
+        {
+            Ok(())
+        }
+        _ => Err("OpenAI completion prompt has an unsupported shape".to_string()),
+    }
 }
 
 fn mask_embeddings_request(
@@ -2000,6 +2089,32 @@ fn rewrite_chat_completions_json_response(
     }
     serde_json::to_vec(&value)
         .map_err(|error| format!("could not encode restored Chat Completions response: {error}"))
+}
+
+fn rewrite_completions_json_response(body: &[u8], restore_output: bool) -> Result<Vec<u8>, String> {
+    let mut value: Value = serde_json::from_slice(body)
+        .map_err(|error| format!("OpenAI Completions response was not valid JSON: {error}"))?;
+    if restore_output {
+        let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
+        restore_completion_output_text(&mut value, &mut resolve)?;
+    }
+    serde_json::to_vec(&value)
+        .map_err(|error| format!("could not encode restored Completions response: {error}"))
+}
+
+fn restore_completion_output_text<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
+    let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    for choice in choices {
+        if let Some(Value::String(text)) = choice.get_mut("text") {
+            *text = resolve(text)?;
+        }
+    }
+    Ok(())
 }
 
 fn restore_openai_output_text<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
@@ -2447,6 +2562,7 @@ struct StreamState {
     ready: VecDeque<Result<Frame<Bytes>, ProxyBodyError>>,
     transform: StreamTransform,
     chat: ChatStreamState,
+    completions: CompletionStreamState,
     finished: bool,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
     restore_output: bool,
@@ -2459,6 +2575,7 @@ enum StreamTransform {
     None,
     Responses,
     ChatCompletions,
+    Completions,
 }
 
 fn streaming_response_body(
@@ -2473,6 +2590,7 @@ fn streaming_response_body(
         ready: VecDeque::new(),
         transform,
         chat: ChatStreamState::default(),
+        completions: CompletionStreamState::default(),
         finished: false,
         plugins,
         restore_output,
@@ -2493,8 +2611,10 @@ fn streaming_response_body(
                 }
                 Some(Ok(chunk)) => {
                     if state.pending.len().saturating_add(chunk.len()) > MAX_PENDING_SSE_BYTES {
-                        if state.transform == StreamTransform::ChatCompletions
-                            && !state.chat.calls.is_empty()
+                        if (state.transform == StreamTransform::ChatCompletions
+                            && !state.chat.calls.is_empty())
+                            || (state.transform == StreamTransform::Completions
+                                && !state.completions.output_text.is_empty())
                         {
                             state.finished = true;
                             state.ready.push_back(Err(Box::new(io::Error::new(
@@ -2535,6 +2655,11 @@ fn streaming_response_body(
                             StreamTransform::ChatCompletions => state.chat.rewrite_block(
                                 &block,
                                 &state.plugins,
+                                state.restore_output,
+                                &mut state.output_resolve,
+                            ),
+                            StreamTransform::Completions => state.completions.rewrite_block(
+                                &block,
                                 state.restore_output,
                                 &mut state.output_resolve,
                             ),
@@ -2580,6 +2705,18 @@ fn streaming_response_body(
                                 error,
                             )))),
                         }
+                    } else if state.transform == StreamTransform::Completions {
+                        match state.completions.finish_output_text("data: {}\n\n") {
+                            Ok(blocks) => {
+                                for block in blocks {
+                                    state.ready.push_back(Ok(Frame::data(block)));
+                                }
+                            }
+                            Err(error) => state.ready.push_back(Err(Box::new(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                error,
+                            )))),
+                        }
                     }
                     if !state.pending.is_empty() {
                         state
@@ -2593,6 +2730,108 @@ fn streaming_response_body(
         }
     });
     StreamBody::new(stream).boxed_unsync()
+}
+
+#[derive(Default)]
+struct CompletionStreamState {
+    output_text: HashMap<u64, crate::claude_http_proxy::OutputTextRestorer>,
+}
+
+impl CompletionStreamState {
+    fn rewrite_block(
+        &mut self,
+        block: &[u8],
+        restore_output: bool,
+        resolve: &mut HandleResolver,
+    ) -> Result<Vec<Bytes>, String> {
+        let Ok(template) = std::str::from_utf8(block) else {
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        };
+        let Some(data) = sse_data(template) else {
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        };
+        if data == "[DONE]" {
+            let mut output = self.finish_output_text(template)?;
+            output.push(Bytes::copy_from_slice(block));
+            return Ok(output);
+        }
+        let Ok(mut value) = serde_json::from_str::<Value>(data.as_ref()) else {
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        };
+        if restore_output {
+            let mut finished = Vec::new();
+            if let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) {
+                for choice in choices {
+                    let Some(choice) = choice.as_object_mut() else {
+                        continue;
+                    };
+                    let index = choice.get("index").and_then(Value::as_u64).unwrap_or(0);
+                    if let Some(Value::String(text)) = choice.get_mut("text") {
+                        *text = self
+                            .output_text
+                            .entry(index)
+                            .or_default()
+                            .push(text, resolve)?;
+                    }
+                    if choice
+                        .get("finish_reason")
+                        .is_some_and(|reason| !reason.is_null())
+                    {
+                        finished.push(index);
+                    }
+                }
+            }
+            for index in finished {
+                if let Some(mut restorer) = self.output_text.remove(&index) {
+                    let pending = restorer.finish();
+                    if !pending.is_empty() {
+                        if let Some(choice) = value
+                            .get_mut("choices")
+                            .and_then(Value::as_array_mut)
+                            .and_then(|choices| {
+                                choices.iter_mut().find(|choice| {
+                                    choice.as_object().is_some_and(|choice| {
+                                        choice.get("index").and_then(Value::as_u64).unwrap_or(0)
+                                            == index
+                                    })
+                                })
+                            })
+                        {
+                            let text = choice
+                                .as_object_mut()
+                                .expect("choice object was selected above")
+                                .entry("text")
+                                .or_insert_with(|| Value::String(String::new()));
+                            if let Value::String(text) = text {
+                                text.push_str(&pending);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(vec![encode_sse_value(template, &value)?])
+    }
+
+    fn finish_output_text(&mut self, template: &str) -> Result<Vec<Bytes>, String> {
+        let mut pending = self.output_text.drain().collect::<Vec<_>>();
+        pending.sort_by_key(|(index, _)| *index);
+        pending
+            .into_iter()
+            .filter_map(|(index, mut restorer)| {
+                let text = restorer.finish();
+                (!text.is_empty()).then_some((index, text))
+            })
+            .map(|(index, text)| {
+                encode_sse_value(
+                    template,
+                    &serde_json::json!({
+                        "choices": [{"index": index, "text": text, "finish_reason": Value::Null}]
+                    }),
+                )
+            })
+            .collect()
+    }
 }
 
 #[derive(Default)]
@@ -3142,6 +3381,7 @@ enum OpenAiEndpoint {
     InputTokens,
     StandaloneSearch,
     ChatCompletions,
+    Completions,
     Embeddings,
     FilesCollection,
     Files,
@@ -3158,6 +3398,7 @@ impl OpenAiEndpoint {
             Self::InputTokens => "input-tokens",
             Self::StandaloneSearch => "standalone-search",
             Self::ChatCompletions => "chat-completions",
+            Self::Completions => "completions",
             Self::Embeddings => "embeddings",
             Self::FilesCollection => "files-collection",
             Self::Files => "files",
@@ -3187,6 +3428,11 @@ fn classify_openai_endpoint(path_and_query: &str) -> OpenAiEndpoint {
         OpenAiEndpoint::ResponsesResource
     } else if path.ends_with("/chat/completions") {
         OpenAiEndpoint::ChatCompletions
+    } else if matches!(
+        segments.as_slice(),
+        ["completions"] | ["v1", "completions"] | ["backend-api", "codex", "completions"]
+    ) {
+        OpenAiEndpoint::Completions
     } else if matches!(
         segments.as_slice(),
         ["v1", "embeddings"] | ["backend-api", "codex", "embeddings"]
@@ -3993,6 +4239,14 @@ mod tests {
             OpenAiEndpoint::ChatCompletions
         );
         assert_eq!(
+            classify_openai_endpoint("/v1/completions"),
+            OpenAiEndpoint::Completions
+        );
+        assert_eq!(
+            classify_openai_endpoint("/completions?stream=true"),
+            OpenAiEndpoint::Completions
+        );
+        assert_eq!(
             classify_openai_endpoint("/v1/embeddings"),
             OpenAiEndpoint::Embeddings
         );
@@ -4039,6 +4293,71 @@ mod tests {
         );
         assert!(enforce_known_openai_endpoint(OpenAiEndpoint::Unknown, true).is_err());
         assert!(enforce_known_openai_endpoint(OpenAiEndpoint::Unknown, false).is_ok());
+    }
+
+    #[test]
+    fn legacy_completion_prompts_and_output_are_protected_at_their_schema_boundaries() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = ProviderBoundaryTestEnv::install(&store);
+        let secret = ["rpa_", "LEGACYOPENAI", "ZYXWVUTS", "RQPONMLK", "1234567890"].concat();
+        let mut prompt = serde_json::json!([
+            format!("RUNPOD_API_KEY={secret}"),
+            format!("repeat RUNPOD_API_KEY={secret}")
+        ]);
+        let mut masker = pentect_agent::ActiveToolOutputMasker::new().unwrap();
+
+        mask_completion_prompt(&mut prompt, &mut masker).unwrap();
+        assert!(!prompt.to_string().contains(&secret));
+        assert!(prompt
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| pentect_agent::contains_pentect_masked_handle(item.as_str().unwrap())));
+        inject_completion_handle_contract(&mut prompt);
+        assert!(prompt
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| item.as_str().unwrap().contains(HANDLE_CONTRACT)));
+
+        let mut response = serde_json::json!({
+            "choices": [{"index": 0, "text": "before <<KEYED_SECRET_test>> after"}]
+        });
+        restore_completion_output_text(&mut response, &mut |text| {
+            Ok(text.replace("<<KEYED_SECRET_test>>", "restored"))
+        })
+        .unwrap();
+        assert_eq!(response["choices"][0]["text"], "before restored after");
+    }
+
+    #[test]
+    fn legacy_completion_stream_restores_handles_split_across_deltas() {
+        let mut state = CompletionStreamState::default();
+        let mut resolve: HandleResolver =
+            Box::new(|text| Ok(text.replace("<<KEYED_SECRET_split>>", "restored")));
+        let first = state
+            .rewrite_block(
+                b"data: {\"choices\":[{\"index\":0,\"text\":\"before <<KEYED_\",\"finish_reason\":null}]}\n\n",
+                true,
+                &mut resolve,
+            )
+            .unwrap();
+        let second = state
+            .rewrite_block(
+                b"data: {\"choices\":[{\"index\":0,\"text\":\"SECRET_split>> after\",\"finish_reason\":\"stop\"}]}\n\n",
+                true,
+                &mut resolve,
+            )
+            .unwrap();
+        let output = first
+            .into_iter()
+            .chain(second)
+            .map(|bytes| String::from_utf8(bytes.to_vec()).unwrap())
+            .collect::<String>();
+        assert!(output.contains("before "), "{output}");
+        assert!(output.contains("restored after"), "{output}");
+        assert!(!output.contains("KEYED_SECRET_split"), "{output}");
     }
 
     #[test]

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -887,6 +887,14 @@ impl NewPluginForm {
     }
 }
 
+fn new_plugin_next_steps(form: NewPluginForm) -> &'static str {
+    match form {
+        NewPluginForm::Manifest => "pentect plugins test .\npentect plugins add .",
+        NewPluginForm::Wasm => "pentect plugins dev .\npentect plugins test .",
+        NewPluginForm::Command => "pentect plugins setup .\npentect plugins test .",
+    }
+}
+
 fn choose_new_plugin_form() -> Result<NewPluginForm, String> {
     if !std::io::stdin().is_terminal() {
         return Err("choose a form: pentect plugins new NAME manifest|wasm|command".to_string());
@@ -932,16 +940,17 @@ fn new_plugin(name: &str, form: Option<NewPluginForm>, json_output: bool) -> Res
         NewPluginForm::Wasm => write_wasm_plugin_template(&root, name, &crate_name)?,
         NewPluginForm::Command => write_command_plugin_template(&root, name)?,
     }
+    let next_steps = new_plugin_next_steps(form);
     std::fs::write(
         root.join("README.md"),
-        format!("# {name}\n\nCreated with `pentect plugins new {name}`.\n\n```sh\npentect plugins setup .\npentect plugins test .\n```\n\nRead the plugin guide at https://pentect.dev/plugins/build/.\n"),
+        format!("# {name}\n\nCreated with `pentect plugins new {name}`.\n\n```sh\n{next_steps}\n```\n\nRead the plugin guide at https://pentect.dev/plugins/build/.\n"),
     )
     .map_err(|error| format!("could not write plugin README: {error}"))?;
     println!("created: {}", display_path(&root));
-    println!(
-        "next: cd {} && pentect plugins setup .",
-        display_path(&root)
-    );
+    println!("next: cd {}", display_path(&root));
+    for command in next_steps.lines() {
+        println!("      {command}");
+    }
     Ok(())
 }
 
@@ -3975,6 +3984,42 @@ mod tests {
             ));
         }
         assert!(NewPluginForm::parse("native").is_err());
+    }
+
+    #[test]
+    fn generated_plugin_steps_match_each_runtime() {
+        assert_eq!(
+            new_plugin_next_steps(NewPluginForm::Manifest),
+            "pentect plugins test .\npentect plugins add ."
+        );
+        assert_eq!(
+            new_plugin_next_steps(NewPluginForm::Wasm),
+            "pentect plugins dev .\npentect plugins test ."
+        );
+        assert_eq!(
+            new_plugin_next_steps(NewPluginForm::Command),
+            "pentect plugins setup .\npentect plugins test ."
+        );
+    }
+
+    #[test]
+    fn wasm_template_bridges_cargo_and_release_artifact_names() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("pentect-wasm-template-{nonce}"));
+        std::fs::create_dir_all(&root).unwrap();
+        write_wasm_plugin_template(&root, "my-test-plugin", "my_test_plugin").unwrap();
+
+        let manifest = std::fs::read_to_string(root.join("plugin.toml")).unwrap();
+        let workflow = std::fs::read_to_string(root.join(".github/workflows/release.yml")).unwrap();
+        assert!(manifest.contains("wasm = \"my-test-plugin.wasm\""));
+        assert!(workflow.contains(
+            "cp target/wasm32-unknown-unknown/release/my_test_plugin.wasm my-test-plugin.wasm"
+        ));
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -3036,6 +3036,13 @@ fn print_permissions(permissions: &PermissionsConfig) {
     }
     if !permissions.env.is_empty() {
         println!("permission-env: {}", permissions.env.join(", "));
+        let sensitive = sensitive_env_permissions(&permissions.env);
+        if !sensitive.is_empty() {
+            println!(
+                "WARNING: credential-like environment access: {}",
+                sensitive.join(", ")
+            );
+        }
     }
     for argv in &permissions.run {
         println!("permission-run: {}", display_command(argv));
@@ -3043,6 +3050,36 @@ fn print_permissions(permissions: &PermissionsConfig) {
     if permissions.storage {
         println!("permission-storage: enabled");
     }
+}
+
+fn sensitive_env_permissions(names: &[String]) -> Vec<&str> {
+    names
+        .iter()
+        .filter(|name| {
+            let upper = name.to_ascii_uppercase();
+            upper == "PASSWORD"
+                || upper == "PASSWD"
+                || upper == "API_KEY"
+                || upper == "SECRET"
+                || upper == "TOKEN"
+                || upper == "CREDENTIAL"
+                || upper == "CREDENTIALS"
+                || upper == "PRIVATE_KEY"
+                || upper == "ACCESS_KEY"
+                || upper.ends_with("_PASSWORD")
+                || upper.ends_with("_PASSWD")
+                || upper.contains("_API_KEY")
+                || upper.ends_with("_SECRET")
+                || upper.contains("_SECRET_")
+                || upper.ends_with("_TOKEN")
+                || upper.contains("_TOKEN_")
+                || upper.ends_with("_CREDENTIAL")
+                || upper.ends_with("_CREDENTIALS")
+                || upper.ends_with("_PRIVATE_KEY")
+                || upper.ends_with("_ACCESS_KEY")
+        })
+        .map(String::as_str)
+        .collect()
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -4790,5 +4827,26 @@ pattern = "token-[0-9]+"
 
         let _ = std::fs::remove_dir_all(data_dir);
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn credential_like_environment_permissions_are_highlighted() {
+        let names = vec![
+            "PATH".to_string(),
+            "OPENAI_API_KEY".to_string(),
+            "GITHUB_TOKEN".to_string(),
+            "AWS_SECRET_ACCESS_KEY".to_string(),
+            "DATABASE_PASSWORD".to_string(),
+            "PUBLIC_ENDPOINT".to_string(),
+        ];
+        assert_eq!(
+            sensitive_env_permissions(&names),
+            [
+                "OPENAI_API_KEY",
+                "GITHUB_TOKEN",
+                "AWS_SECRET_ACCESS_KEY",
+                "DATABASE_PASSWORD"
+            ]
+        );
     }
 }

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -2483,6 +2483,36 @@ fn storage_path(root: &Path, key: &str) -> PathBuf {
     ))
 }
 
+struct BoundedCommandStream {
+    bytes: Vec<u8>,
+    exceeded: bool,
+}
+
+fn read_command_stream<R>(
+    mut reader: R,
+    overflow: mpsc::Sender<()>,
+) -> std::io::Result<BoundedCommandStream>
+where
+    R: Read,
+{
+    let mut bytes = Vec::with_capacity(HOST_MAX_COMMAND_STREAM_BYTES);
+    let mut exceeded = false;
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        let remaining = HOST_MAX_COMMAND_STREAM_BYTES.saturating_sub(bytes.len());
+        bytes.extend_from_slice(&buffer[..read.min(remaining)]);
+        if read > remaining && !exceeded {
+            exceeded = true;
+            let _ = overflow.send(());
+        }
+    }
+    Ok(BoundedCommandStream { bytes, exceeded })
+}
+
 fn run_brokered_command(
     cwd: &Path,
     argv: &[String],
@@ -2514,20 +2544,10 @@ fn run_brokered_command(
         .stderr
         .take()
         .ok_or_else(|| "stderr unavailable".to_string())?;
-    let stdout_reader = std::thread::spawn(move || {
-        let mut value = Vec::new();
-        stdout
-            .take((HOST_MAX_COMMAND_STREAM_BYTES + 1) as u64)
-            .read_to_end(&mut value)
-            .map(|_| value)
-    });
-    let stderr_reader = std::thread::spawn(move || {
-        let mut value = Vec::new();
-        stderr
-            .take((HOST_MAX_COMMAND_STREAM_BYTES + 1) as u64)
-            .read_to_end(&mut value)
-            .map(|_| value)
-    });
+    let (overflow_sender, overflow_receiver) = mpsc::channel();
+    let stdout_overflow = overflow_sender.clone();
+    let stdout_reader = std::thread::spawn(move || read_command_stream(stdout, stdout_overflow));
+    let stderr_reader = std::thread::spawn(move || read_command_stream(stderr, overflow_sender));
     if let Some(mut input) = child.stdin.take() {
         let bytes = stdin.as_bytes().to_vec();
         let (sender, receiver) = mpsc::channel();
@@ -2535,24 +2555,43 @@ fn run_brokered_command(
             let result = input.write_all(&bytes);
             let _ = sender.send(result);
         });
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        match receiver.recv_timeout(remaining) {
-            Ok(Ok(())) => {}
-            Ok(Err(_)) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+        loop {
+            if overflow_receiver.try_recv().is_ok() {
                 tree.terminate();
                 let _ = child.kill();
                 let _ = child.wait();
-                return Err("approved command input failed".to_string());
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
+                return Err("approved command output exceeds its limit".to_string());
             }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
                 tree.terminate();
                 let _ = child.kill();
                 let _ = child.wait();
                 return Err("approved command timed out".to_string());
             }
+            match receiver.recv_timeout(remaining.min(Duration::from_millis(2))) {
+                Ok(Ok(())) => break,
+                Ok(Err(_)) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    tree.terminate();
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err("approved command input failed".to_string());
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+            }
         }
     }
     let status = loop {
+        if overflow_receiver.try_recv().is_ok() {
+            tree.terminate();
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            return Err("approved command output exceeds its limit".to_string());
+        }
         if let Some(status) = child
             .try_wait()
             .map_err(|_| "approved command wait failed".to_string())?
@@ -2578,15 +2617,14 @@ fn run_brokered_command(
         .join()
         .map_err(|_| "approved command error output failed".to_string())?
         .map_err(|_| "approved command error output failed".to_string())?;
-    if stdout.len() > HOST_MAX_COMMAND_STREAM_BYTES || stderr.len() > HOST_MAX_COMMAND_STREAM_BYTES
-    {
+    if stdout.exceeded || stderr.exceeded {
         return Err("approved command output exceeds its limit".to_string());
     }
     Ok(json!({
         "status": status.code(),
         "success": status.success(),
-        "stdout": String::from_utf8_lossy(&stdout),
-        "stderr": String::from_utf8_lossy(&stderr),
+        "stdout": String::from_utf8_lossy(&stdout.bytes),
+        "stderr": String::from_utf8_lossy(&stderr.bytes),
     }))
 }
 
@@ -3606,6 +3644,11 @@ fn plugin_id(value: &str) -> String {
 mod tests {
     use super::*;
 
+    fn oversized_output_command() -> Option<Vec<String>> {
+        let bytes = HOST_MAX_COMMAND_STREAM_BYTES + 64 * 1024;
+        python_protocol_fixture(&format!("import sys; sys.stdout.buffer.write(b'x' * {bytes})"))
+    }
+
     fn command_fixture(response: &str) -> Vec<String> {
         #[cfg(windows)]
         {
@@ -3951,6 +3994,23 @@ mod tests {
             )
             .unwrap_err();
         assert!(error.contains("mismatched protocol response"), "{error}");
+    }
+
+    #[test]
+    fn brokered_command_fails_promptly_when_output_exceeds_limit() {
+        let Some(command) = oversized_output_command() else {
+            return;
+        };
+        let started = Instant::now();
+        let error = run_brokered_command(
+            &std::env::current_dir().unwrap(),
+            &command,
+            "",
+            Instant::now() + Duration::from_secs(5),
+        )
+        .unwrap_err();
+        assert!(error.contains("output exceeds its limit"), "{error}");
+        assert!(started.elapsed() < Duration::from_secs(3));
     }
 
     fn invalid_command_plugin(required: bool) -> PluginBinary {

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -3665,7 +3665,9 @@ mod tests {
 
     fn oversized_output_command() -> Option<Vec<String>> {
         let bytes = HOST_MAX_COMMAND_STREAM_BYTES + 64 * 1024;
-        python_protocol_fixture(&format!("import sys; sys.stdout.buffer.write(b'x' * {bytes})"))
+        python_protocol_fixture(&format!(
+            "import sys; sys.stdout.buffer.write(b'x' * {bytes})"
+        ))
     }
 
     #[test]

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -3817,9 +3817,9 @@ mod tests {
     }
 
     #[test]
-    fn command_program_cold_start_consumes_the_chain_deadline() {
+    fn command_program_warm_request_uses_request_timeout_after_cold_start() {
         let Some(command) = python_protocol_fixture(
-            "import json,sys,time; time.sleep(0.15);\nfor line in sys.stdin:\n r=json.loads(line); time.sleep(0.10); print(json.dumps({'id':r['id']}), flush=True)",
+            "import json,sys,time\nfor index,line in enumerate(sys.stdin):\n r=json.loads(line)\n if index: time.sleep(2)\n print(json.dumps({'id':r['id']}), flush=True)",
         ) else {
             return;
         };

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -2310,11 +2310,25 @@ fn perform_host_request(
                 Err(_) => HostResponse::failed(),
             }
         }
-        HostRequest::FileWrite { path, data } => {
+        HostRequest::FileWrite {
+            path: requested_path,
+            data,
+        } => {
             if data.len() > HOST_MAX_VALUE_BYTES {
                 return HostResponse::failed();
             }
-            let Some(path) = approved_file_path(policy, &path, true) else {
+            let Some(path) = approved_file_path(policy, &requested_path, true) else {
+                return HostResponse::denied();
+            };
+            let Some(parent) = path.parent() else {
+                return HostResponse::denied();
+            };
+            if std::fs::create_dir_all(parent).is_err() {
+                return HostResponse::failed();
+            }
+            // Re-resolve after creating the path so a symlink introduced in an
+            // absent component cannot redirect the write outside its scope.
+            let Some(path) = approved_file_path(policy, &requested_path, true) else {
                 return HostResponse::denied();
             };
             let temporary = path.with_extension(format!(
@@ -2409,20 +2423,26 @@ fn approved_file_path(policy: &PermissionPolicy, value: &str, write: bool) -> Op
         return None;
     }
     let allowed = if write { &policy.write } else { &policy.read };
+    let candidate = root.join(&relative);
     if !allowed.iter().any(|permission| {
         permission.scope == scope
             && if permission.recursive {
                 relative.starts_with(&permission.relative)
+                    || canonical_permission_contains(root, &candidate, permission)
             } else {
                 relative == permission.relative
+                    || canonical_paths_match(root, &candidate, permission)
             }
     }) {
         return None;
     }
-    let candidate = root.join(&relative);
     if write {
-        let parent = candidate.parent()?.canonicalize().ok()?;
-        if !parent.starts_with(root) {
+        let mut existing = candidate.parent()?;
+        while !existing.exists() {
+            existing = existing.parent()?;
+        }
+        let existing = existing.canonicalize().ok()?;
+        if !existing.starts_with(root) {
             return None;
         }
         if candidate.exists() {
@@ -2435,6 +2455,36 @@ fn approved_file_path(policy: &PermissionPolicy, value: &str, write: bool) -> Op
         let canonical = candidate.canonicalize().ok()?;
         (canonical.starts_with(root) && canonical.is_file()).then_some(canonical)
     }
+}
+
+fn canonical_paths_match(root: &Path, candidate: &Path, permission: &PathPermission) -> bool {
+    let Ok(candidate) = candidate.canonicalize() else {
+        return false;
+    };
+    let Ok(allowed) = root.join(&permission.relative).canonicalize() else {
+        return false;
+    };
+    candidate == allowed
+}
+
+fn canonical_permission_contains(
+    root: &Path,
+    candidate: &Path,
+    permission: &PathPermission,
+) -> bool {
+    let Ok(allowed) = root.join(&permission.relative).canonicalize() else {
+        return false;
+    };
+    let mut existing = candidate;
+    while !existing.exists() {
+        let Some(parent) = existing.parent() else {
+            return false;
+        };
+        existing = parent;
+    }
+    existing
+        .canonicalize()
+        .is_ok_and(|candidate| candidate.starts_with(allowed))
 }
 
 fn valid_storage_key(key: &str) -> bool {
@@ -4375,24 +4425,44 @@ disk = "CPU: about 5 GB"
         std::fs::create_dir_all(&storage).unwrap();
         std::fs::write(project.join("allowed.txt"), "visible").unwrap();
         std::fs::write(project.join("denied.txt"), "hidden").unwrap();
+        #[cfg(windows)]
+        {
+            std::fs::create_dir(project.join("Config")).unwrap();
+            std::fs::write(project.join("Config/settings.json"), "case-safe").unwrap();
+        }
         let requested_command = vec!["rustc".to_string(), "--version".to_string()];
         let mut resolved_command = requested_command.clone();
         resolved_command[0] = resolve_command_executable("rustc")
             .unwrap()
             .to_string_lossy()
             .into_owned();
-        let policy = PermissionPolicy {
-            name: "fixture".to_string(),
-            read: vec![PathPermission {
+        let read_permissions = vec![
+            PathPermission {
                 scope: PathScope::Project,
                 relative: PathBuf::from("allowed.txt"),
                 recursive: false,
-            }],
-            write: vec![PathPermission {
+            },
+            PathPermission {
                 scope: PathScope::Project,
-                relative: PathBuf::from("written.txt"),
+                relative: PathBuf::from("config/settings.json"),
                 recursive: false,
-            }],
+            },
+        ];
+        let policy = PermissionPolicy {
+            name: "fixture".to_string(),
+            read: read_permissions,
+            write: vec![
+                PathPermission {
+                    scope: PathScope::Project,
+                    relative: PathBuf::from("written.txt"),
+                    recursive: false,
+                },
+                PathPermission {
+                    scope: PathScope::Project,
+                    relative: PathBuf::from("output"),
+                    recursive: true,
+                },
+            ],
             env: BTreeSet::from(["PATH".to_string()]),
             run: BTreeMap::from([(requested_command.clone(), resolved_command)]),
             storage: true,
@@ -4410,6 +4480,20 @@ disk = "CPU: about 5 GB"
         );
         assert!(allowed.ok);
         assert_eq!(allowed.value, Some(Value::String("visible".to_string())));
+        #[cfg(windows)]
+        {
+            let case_variant = perform_host_request(
+                &policy,
+                HostRequest::FileRead {
+                    path: "project:Config/settings.json".to_string(),
+                },
+                Instant::now() + Duration::from_secs(1),
+            );
+            assert_eq!(
+                case_variant.value,
+                Some(Value::String("case-safe".to_string()))
+            );
+        }
         let denied = perform_host_request(
             &policy,
             HostRequest::FileRead {
@@ -4448,6 +4532,19 @@ disk = "CPU: about 5 GB"
         assert_eq!(
             std::fs::read_to_string(project.join("written.txt")).unwrap(),
             "generated"
+        );
+        let nested = perform_host_request(
+            &policy,
+            HostRequest::FileWrite {
+                path: "project:output/session/result.json".to_string(),
+                data: "nested".to_string(),
+            },
+            Instant::now() + Duration::from_secs(1),
+        );
+        assert!(nested.ok);
+        assert_eq!(
+            std::fs::read_to_string(project.join("output/session/result.json")).unwrap(),
+            "nested"
         );
 
         let stored = perform_host_request(


### PR DESCRIPTION
## Why this batch exists

The repository requires every PR branch to be current with `main`. Merging these already-reviewed fixes one at a time would invalidate the remaining successful checks and rerun the full matrix after every merge. This integration branch merges the original PR heads, preserving every commit and review lineage, and runs the combined state through one authoritative GitHub Actions matrix.

## Included pull requests

- #1084: bound brokered command output promptly; also removes a macOS timing-test race found while triaging CI.
- #1090: reject non-streaming plugin local responses on streaming provider requests.
- #1091: resolve and inspect Gemini remote `fileData` consistently.
- #1092: fail closed on incomplete OpenAI streams and SSE inspection limits.
- #1094: make nested plugin file creation and path matching portable.
- #1095: flag sensitive-looking environment access during plugin approval.
- #1096: support Git Bash/MSYS2 shell detection on Windows.
- #1099: protect Anthropic batches/Complete and OpenAI legacy Completions, including JSON/SSE output restoration.
- #1104: give safe stdin guidance without echoing rejected positional secrets.
- #1108: generate runtime-correct plugin development instructions.

## Conflict resolution

The only provider conflict was at OpenAI SSE overflow handling. The stricter #1092 behavior wins: every transformed SSE stream fails closed when an event exceeds the inspection limit, including legacy Completions.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo check -p pentect-cli --locked`
- The changed-path and platform test matrix runs in GitHub Actions.

Closes #960
Closes #973
Closes #1013
Closes #1022
Closes #1023
Closes #1031
Closes #1033
Closes #1034
Closes #1035
Closes #1040
Closes #1070
Closes #1072
Closes #1105