### PR TITLE
Honor explicit provider Authorization overrides

### DIFF
--- a/crates/pentect-cli/src/ide_clients.rs
+++ b/crates/pentect-cli/src/ide_clients.rs
@@ -45,11 +45,12 @@ pub(crate) fn run(
     let active_plugins = crate::agent_tool_plugins(opts)?;
     let memory_store = crate::start_memory_store(pentect)?;
     let _parent_env = crate::agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
-    let standard_key_names = if has_authorization_override(&opts.upstream_header_env) {
-        &[][..]
-    } else {
-        &["OPENAI_API_KEY"][..]
-    };
+    let standard_key_names =
+        if crate::upstream::has_authorization_override(&opts.upstream_header_env) {
+            &[][..]
+        } else {
+            &["OPENAI_API_KEY"][..]
+        };
     let _authorization = crate::upstream_bearer_guard(standard_key_names);
     let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env(
         upstream,
@@ -455,13 +456,6 @@ fn nonempty_env(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
         .filter(|value| !value.trim().is_empty())
-}
-
-fn has_authorization_override(specs: &[String]) -> bool {
-    specs.iter().any(|spec| {
-        spec.split_once('=')
-            .is_some_and(|(name, _)| name.trim().eq_ignore_ascii_case("authorization"))
-    })
 }
 
 #[derive(Debug)]

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1157,7 +1157,7 @@ fn cmd_provider(args: &[String]) -> i32 {
     // credential. Rust converts the standard OpenAI key into an upstream-only
     // Authorization override, so a local caller's dummy header cannot replace
     // it and the key never appears in readiness output or arguments.
-    let _authorization = upstream_bearer_guard(&["OPENAI_API_KEY"]);
+    let _authorization = upstream_bearer_guard(provider_upstream_key_env_names(&header_env));
     let proxy =
         openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env(upstream, &header_env)
             .unwrap_or_else(|error| die_with_issue(error));
@@ -1187,6 +1187,14 @@ fn cmd_provider(args: &[String]) -> i32 {
     discard.zeroize();
     drop(proxy);
     0
+}
+
+fn provider_upstream_key_env_names(header_env: &[String]) -> &'static [&'static str] {
+    if upstream::has_authorization_override(header_env) {
+        &[]
+    } else {
+        &["OPENAI_API_KEY"]
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -3356,6 +3364,18 @@ mod tests {
             Some("https://cloud-code.example/base")
         );
         assert_eq!(antigravity.tool_args, ["--agent", "reviewer"]);
+    }
+
+    #[test]
+    fn provider_authorization_override_disables_implicit_openai_bearer() {
+        assert_eq!(
+            provider_upstream_key_env_names(&["authorization=MY_GATEWAY_AUTH".to_string()]),
+            &[] as &[&str]
+        );
+        assert_eq!(
+            provider_upstream_key_env_names(&["x-api-key=MY_GATEWAY_KEY".to_string()]),
+            &["OPENAI_API_KEY"]
+        );
     }
 
     #[test]

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -71,11 +71,12 @@ pub(crate) fn run(
         }
         _ => &["OPENAI_API_KEY"],
     };
-    let standard_key_names = if has_authorization_override(&opts.upstream_header_env) {
-        &[][..]
-    } else {
-        standard_key_names
-    };
+    let standard_key_names =
+        if crate::upstream::has_authorization_override(&opts.upstream_header_env) {
+            &[][..]
+        } else {
+            standard_key_names
+        };
     let _authorization = crate::upstream_bearer_guard(standard_key_names);
     let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env(
         upstream,
@@ -313,23 +314,23 @@ fn start_opencode_proxy(
     let mut header_env = base_header_env.to_vec();
     let bearer_env = route.bearer_env.filter(|name| {
         std::env::var_os(name).is_some_and(|value| !value.is_empty())
-            && !has_authorization_override(&header_env)
+            && !crate::upstream::has_authorization_override(&header_env)
     });
     let mut child_key_env = bearer_env.or_else(|| {
         route
             .bearer_env
-            .filter(|_| has_authorization_override(&header_env))
+            .filter(|_| crate::upstream::has_authorization_override(&header_env))
     });
     if route.protocol == OpenCodeProtocol::Anthropic {
         if let Some(name) = configured_key_env(&["ANTHROPIC_API_KEY"]) {
             child_key_env = Some(name);
             if !has_header_override(&header_env, "x-api-key")
-                && !has_authorization_override(&header_env)
+                && !crate::upstream::has_authorization_override(&header_env)
             {
                 header_env.push(format!("x-api-key={name}"));
             }
         } else if has_header_override(&header_env, "x-api-key")
-            || has_authorization_override(&header_env)
+            || crate::upstream::has_authorization_override(&header_env)
         {
             child_key_env = Some("ANTHROPIC_API_KEY");
         }
@@ -341,12 +342,12 @@ fn start_opencode_proxy(
         ]) {
             child_key_env = Some(name);
             if !has_header_override(&header_env, "x-goog-api-key")
-                && !has_authorization_override(&header_env)
+                && !crate::upstream::has_authorization_override(&header_env)
             {
                 header_env.push(format!("x-goog-api-key={name}"));
             }
         } else if has_header_override(&header_env, "x-goog-api-key")
-            || has_authorization_override(&header_env)
+            || crate::upstream::has_authorization_override(&header_env)
         {
             child_key_env = Some("GOOGLE_API_KEY");
         }
@@ -485,10 +486,6 @@ fn configured_key_env(names: &[&'static str]) -> Option<&'static str> {
         .iter()
         .copied()
         .find(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
-}
-
-fn has_authorization_override(specs: &[String]) -> bool {
-    has_header_override(specs, "authorization")
 }
 
 fn has_header_override(specs: &[String], header: &str) -> bool {
@@ -1017,13 +1014,13 @@ mod tests {
 
     #[test]
     fn explicit_authorization_header_disables_implicit_key_selection() {
-        assert!(has_authorization_override(&[
+        assert!(crate::upstream::has_authorization_override(&[
             "authorization=MY_HEADER".to_string()
         ]));
-        assert!(has_authorization_override(&[
+        assert!(crate::upstream::has_authorization_override(&[
             " Authorization =MY_HEADER".to_string()
         ]));
-        assert!(!has_authorization_override(&[
+        assert!(!crate::upstream::has_authorization_override(&[
             "X-Api-Key=MY_HEADER".to_string()
         ]));
     }

--- a/crates/pentect-cli/src/upstream.rs
+++ b/crates/pentect-cli/src/upstream.rs
@@ -149,6 +149,15 @@ pub(crate) fn header_overrides(specs: &[String]) -> Result<HeaderOverrides, Stri
     Ok(overrides)
 }
 
+pub(crate) fn has_authorization_override(specs: &[String]) -> bool {
+    specs.iter().any(|spec| {
+        spec.split_once('=').is_some_and(|(name, _)| {
+            name.trim()
+                .eq_ignore_ascii_case(reqwest::header::AUTHORIZATION.as_str())
+        })
+    })
+}
+
 pub(crate) fn header_overrides_with_bearer_env(
     specs: &[String],
     bearer_env: Option<&str>,
@@ -417,6 +426,20 @@ mod tests {
                 .as_str(),
             "http://localhost:8080/anthropic/v1/messages"
         );
+    }
+
+    #[test]
+    fn authorization_override_detection_is_case_and_whitespace_insensitive() {
+        assert!(has_authorization_override(&[
+            "authorization=GATEWAY_AUTH".to_string()
+        ]));
+        assert!(has_authorization_override(&[
+            " Authorization = GATEWAY_AUTH ".to_string()
+        ]));
+        assert!(!has_authorization_override(&[
+            "x-api-key=GATEWAY_KEY".to_string()
+        ]));
+        assert!(!has_authorization_override(&["authorization".to_string()]));
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

Authorization override precedence was implemented independently in OpenAI client launchers and IDE launchers, but the internal `provider` control process always generated `PENTECT_UPSTREAM_AUTHORIZATION` from `OPENAI_API_KEY`. Supplying `--upstream-header-env authorization=...` therefore created two Authorization overrides and startup failed as a duplicate.

## Changes

- Centralize case-insensitive Authorization override detection in `upstream.rs`.
- Reuse that rule in OpenAI clients, IDE clients, OpenCode routing, and the provider control process.
- Skip implicit `OPENAI_API_KEY` Bearer generation when the user explicitly provides an Authorization header source.
- Add regressions for whitespace/case handling and the provider-specific precedence decision.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p pentect-cli --locked`
- Focused regressions run in GitHub Actions.

This PR is stacked on #1111 so it tests only this change. It will be retargeted to `main` after #1111 merges.

Closes #1106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit upstream authorization settings now take precedence over automatically generated API key credentials.
  * Authorization detection is more consistent across supported provider integrations.
  * Non-authorization headers continue to use the standard credential behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->