### PR TITLE
Warn when pentect read handles are transient

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1057,7 +1057,16 @@ fn cmd_read(args: &[String]) {
         Err(e) => die(&e),
     };
     pentect_agent::record_read_activity(&result, &opts.path);
+    if let Some(warning) = transient_read_warning(result.summary.masked_count) {
+        eprintln!("{warning}");
+    }
     print_read_result(result, opts.emit_meta);
+}
+
+fn transient_read_warning(masked_count: usize) -> Option<&'static str> {
+    (masked_count > 0).then_some(
+        "[pentect] warning: no active memory store; handles in this output cannot be resolved later",
+    )
 }
 
 fn print_read_result(result: pentect_core::MaskResult, emit_meta: bool) {
@@ -3376,6 +3385,14 @@ mod tests {
             provider_upstream_key_env_names(&["x-api-key=MY_GATEWAY_KEY".to_string()]),
             &["OPENAI_API_KEY"]
         );
+    }
+
+    #[test]
+    fn transient_read_warns_only_when_it_emits_handles() {
+        assert!(transient_read_warning(0).is_none());
+        let warning = transient_read_warning(1).unwrap();
+        assert!(warning.contains("no active memory store"));
+        assert!(warning.contains("cannot be resolved later"));
     }
 
     #[test]

--- a/website/src/content/docs/start/commands.md
+++ b/website/src/content/docs/start/commands.md
@@ -15,7 +15,10 @@ this guide before reaching for the advanced `resolve` command.
 | Inspect a handle | `pentect view HANDLE` | Nowhere; only safe metadata is printed |
 
 `read` uses the filename to recognize formats and can retain safe recovery
-metadata in the active local store. `mask` is a one-run stdin filter.
+metadata in the active local store. Without an active store, `read` still masks
+the file but any emitted handles are intentionally one-run values and cannot be
+resolved later; Pentect prints a warning to stderr in that case. `mask` is
+always a one-run stdin filter.
 
 ::: code-group
 


### PR DESCRIPTION
## Root cause

`pentect read` uses the active memory store when one exists, but silently falls back to a fresh one-run key otherwise. Both paths emit the same handle syntax even though only the first path can be resolved later.

## Changes

- Warn on stderr when the fallback path actually emits one or more handles.
- Keep stdout byte-compatible for pipes and redirected masked output.
- Avoid warning when no value was masked.
- Document the active-store and one-run behavior in the command guide.
- Add a focused regression for the warning condition and message.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p pentect-cli --locked`
- Focused regression and docs checks run in GitHub Actions.

This PR is stacked on #1112 and will be retargeted as the stack merges.

Closes #1102