### PR TITLE
Fail closed on oversized Claude SSE events

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -2373,7 +2373,7 @@ struct ChatStreamState {
     upstream: ChatFrameStream,
     pending: Vec<u8>,
     ready: VecDeque<Result<Frame<Bytes>, ProxyBodyError>>,
-    passthrough: bool,
+    max_pending_bytes: usize,
     finished: bool,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
     resolve: Option<ChatResolver>,
@@ -2457,11 +2457,22 @@ fn chat_sse_body<S>(stream: S, plugins: Arc<Mutex<pentect_agent::PluginMiddlewar
 where
     S: futures_util::Stream<Item = Result<Frame<Bytes>, ProxyBodyError>> + Send + 'static,
 {
+    chat_sse_body_with_limit(stream, plugins, MAX_CHAT_BODY_BYTES)
+}
+
+fn chat_sse_body_with_limit<S>(
+    stream: S,
+    plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
+    max_pending_bytes: usize,
+) -> ProxyBody
+where
+    S: futures_util::Stream<Item = Result<Frame<Bytes>, ProxyBodyError>> + Send + 'static,
+{
     let state = ChatStreamState {
         upstream: Box::pin(stream),
         pending: Vec::new(),
         ready: VecDeque::new(),
-        passthrough: false,
+        max_pending_bytes,
         finished: false,
         plugins,
         resolve: Some(Box::new(crate::claude_http_proxy::request_scoped_resolver())),
@@ -2475,21 +2486,18 @@ where
                 return None;
             }
             match state.upstream.next().await {
-                Some(Ok(frame)) if state.passthrough => {
-                    return Some((Ok(frame), state));
-                }
                 Some(Ok(frame)) => {
                     let Ok(chunk) = frame.into_data() else {
                         continue;
                     };
-                    if state.pending.len().saturating_add(chunk.len()) > MAX_CHAT_BODY_BYTES {
-                        eprintln!(
-                            "[pentect] Claude App Chat restoration disabled: event exceeded limit"
-                        );
-                        let mut bytes = std::mem::take(&mut state.pending);
-                        bytes.extend_from_slice(&chunk);
-                        state.ready.push_back(Ok(Frame::data(Bytes::from(bytes))));
-                        state.passthrough = true;
+                    if state.pending.len().saturating_add(chunk.len()) > state.max_pending_bytes {
+                        eprintln!("[pentect] Claude App Chat response blocked: SSE event exceeded inspection limit");
+                        state.pending.clear();
+                        state.finished = true;
+                        state.ready.push_back(Err(Box::new(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            "Claude App Chat SSE event exceeded inspection limit",
+                        ))));
                         continue;
                     }
                     state.pending.extend_from_slice(&chunk);
@@ -3105,6 +3113,29 @@ fn success_status() -> std::process::ExitStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn oversized_chat_sse_event_fails_closed_without_emitting_it() {
+        let stream = futures_util::stream::iter(vec![Ok::<_, ProxyBodyError>(Frame::data(
+            Bytes::from_static(b"12345"),
+        ))]);
+        let body = chat_sse_body_with_limit(
+            stream,
+            Arc::new(Mutex::new(pentect_agent::PluginMiddleware::default())),
+            4,
+        );
+
+        let error = match body.collect().await {
+            Ok(_) => panic!("oversized uninspected event must not be emitted"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("SSE event exceeded inspection limit"),
+            "{error}"
+        );
+    }
 
     #[test]
     fn early_exit_diagnostic_does_not_recommend_an_update_or_unsafe_bypass() {

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1239,6 +1239,7 @@ struct SseStreamTransformer<R> {
     pending: Vec<u8>,
     tool_buffer: Option<ToolStreamBuffer>,
     passthrough: bool,
+    max_pending_bytes: usize,
     plugins: Option<Arc<StdMutex<pentect_agent::PluginMiddleware>>>,
     restore_output: bool,
     output_text: HashMap<(u64, &'static str), OutputTextRestorer>,
@@ -1269,6 +1270,7 @@ where
             pending: Vec::new(),
             tool_buffer: None,
             passthrough: false,
+            max_pending_bytes: MAX_PENDING_SSE_BYTES,
             plugins,
             restore_output,
             output_text: HashMap::new(),
@@ -1279,9 +1281,9 @@ where
         if self.passthrough {
             return Ok(vec![Bytes::copy_from_slice(chunk)]);
         }
-        if self.pending.len().saturating_add(chunk.len()) > MAX_PENDING_SSE_BYTES {
+        if self.pending.len().saturating_add(chunk.len()) > self.max_pending_bytes {
             diagnostic("sse-event-limit", "limit", "messages", false);
-            return Ok(self.fail_open_with(chunk));
+            return Err("Anthropic SSE event exceeded inspection limit".to_string());
         }
         self.pending.extend_from_slice(chunk);
         let mut output = Vec::new();
@@ -1352,14 +1354,10 @@ where
                 .bytes
                 .len()
                 .saturating_add(block.len())
-                > MAX_PENDING_SSE_BYTES
+                > self.max_pending_bytes
             {
                 diagnostic("sse-tool-limit", "limit", "messages", false);
-                let tools = self.tool_buffer.take().expect("tool buffer exists");
-                output.push(Bytes::from(tools.bytes));
-                output.push(Bytes::from(block));
-                self.passthrough = true;
-                return Ok(());
+                return Err("Anthropic SSE tool input exceeded inspection limit".to_string());
             }
             let boundary = sse_tool_boundary(&block);
             let tools = self.tool_buffer.as_mut().expect("tool buffer exists");
@@ -1410,19 +1408,6 @@ where
             _ => output.push(Bytes::from(block)),
         }
         Ok(())
-    }
-
-    fn fail_open_with(&mut self, chunk: &[u8]) -> Vec<Bytes> {
-        let mut output = self.finish_output_text();
-        let mut bytes = self
-            .tool_buffer
-            .take()
-            .map_or_else(Vec::new, |tools| tools.bytes);
-        bytes.append(&mut self.pending);
-        bytes.extend_from_slice(chunk);
-        self.passthrough = true;
-        output.push(Bytes::from(bytes));
-        output
     }
 }
 
@@ -3817,6 +3802,35 @@ mod tests {
             .is_empty());
         let output = transformer.push(&event.as_bytes()[split..]).unwrap();
         assert_eq!(output, vec![Bytes::from(event)]);
+    }
+
+    #[test]
+    fn oversized_streaming_event_fails_closed_without_emitting_pending_bytes() {
+        let mut transformer =
+            SseStreamTransformer::new(|text: &str| Ok(text.to_string()), None, false);
+        transformer.max_pending_bytes = 4;
+
+        let error = transformer.push(b"12345").unwrap_err();
+        assert_eq!(error, "Anthropic SSE event exceeded inspection limit");
+    }
+
+    #[test]
+    fn oversized_streaming_tool_input_fails_closed() {
+        let start = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"input\":{}}}\n\n"
+        );
+        let delta = concat!(
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}\n\n"
+        );
+        let mut transformer =
+            SseStreamTransformer::new(|text: &str| Ok(text.to_string()), None, false);
+        transformer.max_pending_bytes = start.len().max(delta.len());
+
+        assert!(transformer.push(start.as_bytes()).unwrap().is_empty());
+        let error = transformer.push(delta.as_bytes()).unwrap_err();
+        assert_eq!(error, "Anthropic SSE tool input exceeded inspection limit");
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

The OpenAI streaming path stopped the response when an SSE inspection budget was exceeded, but both Claude paths switched to a permanent passthrough mode. The Anthropic API path did this for both an oversized event and an oversized buffered tool call. Claude App did it for an oversized event. The remaining response was then forwarded without tool-call inspection or handle restoration.

## Fix

- abort Anthropic API streams when an event exceeds the inspection budget
- abort Anthropic API streams when buffered tool input exceeds the budget
- abort Claude App Chat streams instead of forwarding the oversized event and all later frames
- never emit the pending uninspected bytes on these failures
- inject small test-only limits so regressions do not allocate 32 MiB fixtures

## Validation

- focused oversized-stream tests: 5 passed, including the 3 new Claude regressions
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1115