### PR TITLE
Warm release builds with a shared sccache

### DIFF
--- a/.github/workflows/release-cache.yml
+++ b/.github/workflows/release-cache.yml
@@ -1,0 +1,110 @@
+name: Warm release compiler cache
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "tools/alcatraz-helper/**"
+      - ".github/actions/rust-toolchain/**"
+      - ".github/workflows/release-cache.yml"
+      - ".github/workflows/release.yml"
+  schedule:
+    - cron: "17 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-release-compiler-cache-main
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.repository == 'EdamAme-x/pentect'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            asset: pentect-windows-x86_64.exe
+          - os: ubuntu-22.04
+            asset: pentect-linux-x86_64
+          - os: ubuntu-22.04-arm
+            asset: pentect-linux-aarch64
+          - os: macos-15-intel
+            asset: pentect-macos-x86_64
+          - os: macos-15
+            asset: pentect-macos-aarch64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: ./.github/actions/rust-toolchain
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/alcatraz-helper/go.mod
+          cache-dependency-path: tools/alcatraz-helper/go.sum
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: release-${{ matrix.asset }}
+      - name: Set up shared compiler cache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        with:
+          version: "v0.17.0"
+      - name: Build release profile
+        id: release-build
+        shell: pwsh
+        env:
+          PENTECT_REQUIRE_ALCATRAZ: "1"
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_VERSION: pentect-release-v1-${{ matrix.asset }}
+        run: |
+          & $env:SCCACHE_PATH --zero-stats
+          if ($LASTEXITCODE -ne 0) { throw 'could not reset sccache statistics' }
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          cargo build --release --locked --timings -p pentect-cli
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          "Release cache warm-up elapsed: $($timer.Elapsed)"
+          "elapsed_seconds=$([Math]::Round($timer.Elapsed.TotalSeconds, 3))" >> $env:GITHUB_OUTPUT
+          if ($exitCode -ne 0) { exit $exitCode }
+      - name: Record compiler cache statistics
+        if: always()
+        shell: pwsh
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_VERSION: pentect-release-v1-${{ matrix.asset }}
+        run: |
+          $stats = (& $env:SCCACHE_PATH --show-stats 2>&1 | Out-String).Trim()
+          $exitCode = $LASTEXITCODE
+          $stats
+          $stats | Set-Content -Encoding utf8 sccache-stats.txt
+          @"
+          ### ${{ matrix.asset }} compiler cache
+
+          - Release build: `${{ steps.release-build.outputs.elapsed_seconds }}` seconds
+
+          ``````text
+          $stats
+          ``````
+          "@ >> $env:GITHUB_STEP_SUMMARY
+          if ($exitCode -ne 0) { exit $exitCode }
+      - name: Upload cache warm-up diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-cache-diagnostics-${{ matrix.asset }}
+          path: |
+            target/cargo-timings/*.html
+            sccache-stats.txt
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,10 @@ jobs:
         id: rust-cache
         with:
           shared-key: release-${{ matrix.asset }}
+      - name: Set up shared compiler cache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        with:
+          version: "v0.17.0"
       - name: Report release build environment
         shell: pwsh
         run: |
@@ -158,15 +162,41 @@ jobs:
           cargo --version --verbose
           go version
       - name: Build release binary
+        id: release-build
         shell: pwsh
         env:
           PENTECT_REQUIRE_ALCATRAZ: "1"
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_VERSION: pentect-release-v1-${{ matrix.asset }}
         run: |
+          & $env:SCCACHE_PATH --zero-stats
+          if ($LASTEXITCODE -ne 0) { throw 'could not reset sccache statistics' }
           $timer = [Diagnostics.Stopwatch]::StartNew()
           cargo build --release --locked --timings -p pentect-cli
           $exitCode = $LASTEXITCODE
           $timer.Stop()
           "Release build elapsed: $($timer.Elapsed)"
+          "elapsed_seconds=$([Math]::Round($timer.Elapsed.TotalSeconds, 3))" >> $env:GITHUB_OUTPUT
+          if ($exitCode -ne 0) { exit $exitCode }
+      - name: Record compiler cache statistics
+        if: always()
+        shell: pwsh
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_VERSION: pentect-release-v1-${{ matrix.asset }}
+        run: |
+          $stats = (& $env:SCCACHE_PATH --show-stats 2>&1 | Out-String).Trim()
+          $exitCode = $LASTEXITCODE
+          $stats
+          $stats | Set-Content -Encoding utf8 sccache-stats.txt
+          @"
+          #### sccache
+
+          ``````text
+          $stats
+          ``````
+          "@ >> $env:GITHUB_STEP_SUMMARY
           if ($exitCode -ne 0) { exit $exitCode }
       - name: Summarize release build diagnostics
         if: always()
@@ -182,6 +212,7 @@ jobs:
           - Runner: `$env:RUNNER_OS/$env:RUNNER_ARCH`
           - Logical processors: $([Environment]::ProcessorCount)
           - Rust cache hit: `${{ steps.rust-cache.outputs.cache-hit }}`
+          - Release build: `${{ steps.release-build.outputs.elapsed_seconds }}` seconds
           - Target directory: ${targetMiB} MiB
           "@ >> $env:GITHUB_STEP_SUMMARY
       - name: Upload Cargo timing report
@@ -190,6 +221,14 @@ jobs:
         with:
           name: build-diagnostics-${{ matrix.asset }}
           path: target/cargo-timings/*.html
+          if-no-files-found: warn
+          retention-days: 14
+      - name: Upload compiler cache statistics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sccache-statistics-${{ matrix.asset }}
+          path: sccache-stats.txt
           if-no-files-found: warn
           retention-days: 14
       - name: Verify bundled Alcatraz without an external Go runtime


### PR DESCRIPTION
## Root cause

Release jobs restore Cargo target directories, but they do not share compiler outputs through `sccache`. Adding sccache only to tag builds would not solve this: GitHub cache scope isolates different tags, while tag runs may restore caches created on the default branch.

## Fix

- pin `mozilla-actions/sccache-action` and sccache v0.17.0 on all five release targets
- add a main-branch release-profile cache warmer for the same five targets
- trigger warm-up after relevant main changes, weekly, and manually
- cancel superseded warm-up runs during merge bursts
- namespace caches by release schema and platform; sccache itself keys compiler, target, profile, arguments, dependencies, and source inputs
- preserve Cargo target caching, Cargo timing reports, packaging, checksums, attestations, and installer E2E
- record build elapsed seconds and complete sccache statistics in job summaries and artifacts

The first main warm-up and following release will provide measured hit rates and wall-time comparison. This PR does not claim an unmeasured speedup.

## Validation

- actionlint v1.7.12: passed for both workflows
- YAML parsing: passed
- `git diff --check`

Refs #739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved release build efficiency through compiler caching across supported platforms.
  * Added cache warm-up builds on a weekly schedule and when relevant build files change.

* **Diagnostics**
  * Added build timing and compiler-cache statistics to release summaries.
  * Release and cache-warming diagnostics are preserved as downloadable artifacts for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->