### PR TITLE
Fix sccache action pin and warm-up triggers

### DIFF
--- a/.github/workflows/release-cache.yml
+++ b/.github/workflows/release-cache.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "Cargo.lock"
       - "Cargo.toml"
+      - "rust-toolchain.toml"
       - "crates/**"
       - "tools/alcatraz-helper/**"
       - ".github/actions/rust-toolchain/**"
@@ -56,7 +57,7 @@ jobs:
         with:
           shared-key: release-${{ matrix.asset }}
       - name: Set up shared compiler cache
-        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.17.0"
       - name: Build release profile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
         with:
           shared-key: release-${{ matrix.asset }}
       - name: Set up shared compiler cache
-        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.17.0"
       - name: Report release build environment


### PR DESCRIPTION
## Root cause

The initial workflow pinned the annotated `v0.0.11` tag object SHA rather than the action commit obtained by dereferencing that tag. GitHub successfully dereferenced it in the first live warm-up, so this was not an observed setup failure. However, a direct immutable action commit is the precise and auditable pin used elsewhere in the repository.

The warm-up path filter also omitted `rust-toolchain.toml`, so a compiler-channel change would not seed a matching cache.

## Fix

- replace the annotated tag object with the verified dereferenced commit SHA in both workflows
- trigger warm-up when `rust-toolchain.toml` changes

## Validation

- verified both tag SHAs with `git ls-remote` and used `refs/tags/v0.0.11^{}`
- confirmed the original tag-object pin did complete action setup in the live warm-up
- actionlint v1.7.12: passed
- `git diff --check`

Follow-up to #1130.