### PR TITLE
Make every platform CI failure block merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,8 @@ jobs:
       - name: Format
         if: needs.changes.outputs.rust == 'true'
         run: cargo fmt --all --check
+      - name: Validate required CI gate
+        run: python -m unittest tools/test_ci_results.py
       - name: Verify third-party licenses
         if: needs.changes.outputs.manifests == 'true'
         run: python tools/generate_licenses.py --check
@@ -474,3 +476,25 @@ jobs:
       - name: Full test on main
         if: github.event_name == 'push'
         run: cargo test --all-features --locked
+
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs:
+      - changes
+      - npm-package
+      - native-ocr
+      - plugin-platform
+      - app-platform
+      - windows-powershell-installer
+      - test
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Require every applicable CI job
+        env:
+          PENTECT_CI_NEEDS: ${{ toJSON(needs) }}
+        run: python tools/check_ci_results.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,8 @@ back to prereleases so they cannot replace the last healthy `latest` release.
 
 Never reuse a release tag. A workflow retry may fill in a missing prerelease
 asset only when every already-published asset has the same SHA-256 digest.
+
+The `main` ruleset must require the stable `CI Gate` status. Requiring only the
+Linux `test` job is unsafe: the gate converts every applicable Windows, macOS,
+packaging, plugin, OCR, and npm job into one required result. Keep the gate name
+stable when matrix job display names change.

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -3727,6 +3727,7 @@ mod tests {
                 "PENTECT_MEMORY_STORE_TOKEN",
                 "PENTECT_AGENT_LAUNCHED",
                 "PENTECT_HOME",
+                "HOME",
                 "LOCALAPPDATA",
             ];
             let saved = names
@@ -3746,6 +3747,7 @@ mod tests {
             std::env::set_var("PENTECT_MEMORY_STORE_TOKEN", store.token());
             std::env::set_var("PENTECT_AGENT_LAUNCHED", store.token());
             std::env::set_var("PENTECT_HOME", &home);
+            std::env::set_var("HOME", &home);
             std::env::set_var("LOCALAPPDATA", &home);
             let process_host_candidate = Some(
                 pentect_agent::register_process_host_candidate(

--- a/tools/check_ci_results.py
+++ b/tools/check_ci_results.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fail unless every applicable CI dependency succeeded."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+EXPECTED_JOBS = {
+    "changes",
+    "npm-package",
+    "native-ocr",
+    "plugin-platform",
+    "app-platform",
+    "windows-powershell-installer",
+    "test",
+}
+
+
+def failed_jobs(needs: object) -> list[str]:
+    if not isinstance(needs, dict):
+        return ["CI dependency payload is not an object"]
+    missing = sorted(EXPECTED_JOBS - needs.keys())
+    failures = [f"{name}: missing" for name in missing]
+    for name in sorted(EXPECTED_JOBS & needs.keys()):
+        dependency = needs[name]
+        result = dependency.get("result") if isinstance(dependency, dict) else None
+        allowed = {"success"} if name == "changes" else {"success", "skipped"}
+        if result not in allowed:
+            failures.append(f"{name}: {result or 'missing result'}")
+    return failures
+
+
+def main() -> int:
+    try:
+        needs = json.loads(os.environ["PENTECT_CI_NEEDS"])
+    except KeyError:
+        print("PENTECT_CI_NEEDS is missing", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as error:
+        print(f"PENTECT_CI_NEEDS is invalid JSON: {error}", file=sys.stderr)
+        return 2
+    failures = failed_jobs(needs)
+    if failures:
+        print("CI Gate blocked:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("CI Gate passed: every applicable job succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_ci_results.py
+++ b/tools/test_ci_results.py
@@ -1,0 +1,37 @@
+import unittest
+
+from tools.check_ci_results import EXPECTED_JOBS, failed_jobs
+
+
+def payload(result: str = "success") -> dict[str, dict[str, str]]:
+    return {name: {"result": result} for name in EXPECTED_JOBS}
+
+
+class CiGateTests(unittest.TestCase):
+    def test_all_success_passes(self) -> None:
+        self.assertEqual(failed_jobs(payload()), [])
+
+    def test_optional_skips_pass(self) -> None:
+        needs = payload()
+        for name in EXPECTED_JOBS - {"changes", "test"}:
+            needs[name]["result"] = "skipped"
+        self.assertEqual(failed_jobs(needs), [])
+
+    def test_platform_failure_blocks(self) -> None:
+        needs = payload()
+        needs["app-platform"]["result"] = "failure"
+        self.assertEqual(failed_jobs(needs), ["app-platform: failure"])
+
+    def test_missing_job_blocks(self) -> None:
+        needs = payload()
+        del needs["native-ocr"]
+        self.assertEqual(failed_jobs(needs), ["native-ocr: missing"])
+
+    def test_change_detection_may_not_skip(self) -> None:
+        needs = payload()
+        needs["changes"]["result"] = "skipped"
+        self.assertEqual(failed_jobs(needs), ["changes: skipped"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #373.

## What changed
- add a stable `CI Gate` job that fails when any applicable package, plugin, OCR, app, installer, or Rust test job fails or is cancelled
- test the gate against failed and missing dependency results
- isolate `HOME` in the OpenAI proxy boundary test environment so macOS delegated-process-host registration cannot collide across tests
- document that the main ruleset must require `CI Gate`

## Incident addressed
PR #1135 merged while its macOS desktop-app boundary job was failing. The first failure was an OpenAI proxy test reusing the real macOS cache root; later failures were mutex-poison fallout. This change fixes that test isolation and makes the platform aggregate merge-blocking.

## Local verification
- `python -m unittest tools/test_ci_results.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml`
- `cargo fmt --all -- --check`
- `git diff --check`
- focused Rust regression test is running; GitHub Actions remains authoritative for macOS