### PR TITLE
Release v0.0.63

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.62"
+version = "0.0.63"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Release

Bump the CLI and npm package metadata to v0.0.63.

The tag will be created only after this PR and the post-merge main CI pass the required `CI Gate`.

## Verification
- `cargo metadata --no-deps --format-version 1`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`