### PR TITLE
Release v0.0.64 without main-tip race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
           if ($env:GITHUB_REF_NAME -ne "v$version") {
             throw "tag $env:GITHUB_REF_NAME must match pentect-cli version v$version"
           }
-          $main = git rev-parse origin/main
-          if ($env:GITHUB_SHA -ne $main) {
-            throw "release tag must point at origin/main ($main)"
+          git merge-base --is-ancestor $env:GITHUB_SHA origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw "release tag must point at a commit in origin/main history"
           }
       - name: Validate POSIX installer
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ package metadata through an auto-merge pull request, creates the matching
 `nix-vX.Y.Z` tag, and tests the Homebrew formula on Intel and Apple Silicon before
 publishing it.
 
+The tagged commit must remain in `main` history, but a later merge may advance
+the branch while release verification is starting. The workflow accepts that
+race; it rejects tags from commits that are not ancestors of `origin/main`.
+
 Do not create or publish the GitHub Release manually. Push only the matching tag;
 the release workflow creates a prerelease and promotes it after every installer
 and launcher check passes. A guard changes incomplete manually published releases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.63"
+version = "0.0.64"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Release

Bump Pentect to v0.0.64 and fix the release verifier race exposed by failed v0.0.63 run 33180277193.

## Root cause
The v0.0.63 tag correctly pointed at `main` when pushed. PR #1140 advanced `main` before the verify job fetched it, so exact SHA equality rejected an otherwise valid tagged main commit before any artifact was built.

## Fix
Require the tagged commit to be an ancestor of `origin/main`, rejecting tags from unmerged histories while allowing normal merges to advance main during release startup. Tags remain immutable and must still match package version metadata.

## Verification
- `cargo metadata --no-deps --format-version 1`
- `npm pack --dry-run --ignore-scripts`
- actionlint (with the repository custom `macos-15-intel` runner label ignored)
- `git merge-base --is-ancestor 667c3b6 origin/main`