### PR TITLE
Validate automation PRs with every required gate

### DIFF
--- a/tools/propose_automation_pr.sh
+++ b/tools/propose_automation_pr.sh
@@ -57,8 +57,10 @@ latest_run() {
 
 previous_ci=$(latest_run ci.yml)
 previous_nix=$(latest_run nix.yml)
+previous_clients=$(latest_run current-clients.yml)
 gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
 gh workflow run nix.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
+gh workflow run current-clients.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
 aur_state=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/aur.yml" --jq .state)
 if [ "$aur_state" = active ]; then
   gh workflow run aur.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" >&2
@@ -83,14 +85,17 @@ new_run() {
 
 ci_run=$(new_run ci.yml "$previous_ci")
 nix_run=$(new_run nix.yml "$previous_nix")
+clients_run=$(new_run current-clients.yml "$previous_clients")
 gh run watch "$ci_run" --repo "$GITHUB_REPOSITORY" --exit-status >&2
 gh run watch "$nix_run" --repo "$GITHUB_REPOSITORY" --exit-status >&2
+gh run watch "$clients_run" --repo "$GITHUB_REPOSITORY" --exit-status >&2
 
 ci_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$ci_run"
 for context in \
   test \
   'Native OCR (windows-latest)' \
-  'Native OCR (macos-latest)'
+  'Native OCR (macos-latest)' \
+  'CI Gate'
 do
   gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head" \
     -f state=success \
@@ -98,6 +103,13 @@ do
     -f description='Validated by the automation PR CI workflow' \
     -f target_url="$ci_url" >/dev/null
 done
+
+clients_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$clients_run"
+gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head" \
+  -f state=success \
+  -f context='Current Client Gate' \
+  -f description='Validated by the current-client compatibility workflow' \
+  -f target_url="$clients_url" >/dev/null
 
 gh pr merge "$pull" --repo "$GITHUB_REPOSITORY" --auto --merge --delete-branch \
   --match-head-commit "$head" >&2

--- a/tools/test_propose_automation_pr.sh
+++ b/tools/test_propose_automation_pr.sh
@@ -21,6 +21,7 @@ case "$1 $2" in
     case "$*" in
       *ci.yml*) touch "$MOCK_STATE/ci" ;;
       *nix.yml*) touch "$MOCK_STATE/nix" ;;
+      *current-clients.yml*) touch "$MOCK_STATE/clients" ;;
       *aur.yml*) touch "$MOCK_STATE/aur" ;;
     esac
     ;;
@@ -28,6 +29,7 @@ case "$1 $2" in
     case "$*" in
       *ci.yml*) test ! -e "$MOCK_STATE/ci" || printf '%s\n' 101 ;;
       *nix.yml*) test ! -e "$MOCK_STATE/nix" || printf '%s\n' 102 ;;
+      *current-clients.yml*) test ! -e "$MOCK_STATE/clients" || printf '%s\n' 103 ;;
     esac
     ;;
   "run watch") printf '%s\n' "$*" >> "$MOCK_STATE/watch" ;;
@@ -51,13 +53,17 @@ output=$(
 )
 test "$output" = https://github.com/example/project/pull/1
 test ! -e "$tmp/state/aur"
-test "$(wc -l < "$tmp/state/watch")" -eq 2
+test "$(wc -l < "$tmp/state/watch")" -eq 3
 grep -Fx 'run watch 101 --repo example/project --exit-status' "$tmp/state/watch"
 grep -Fx 'run watch 102 --repo example/project --exit-status' "$tmp/state/watch"
-test "$(wc -l < "$tmp/state/api")" -eq 3
+grep -Fx 'run watch 103 --repo example/project --exit-status' "$tmp/state/watch"
+test "$(wc -l < "$tmp/state/api")" -eq 5
 status_endpoint='api --method POST repos/example/project/statuses/0123456789abcdef'
-test "$(grep -Fc "$status_endpoint" "$tmp/state/api")" -eq 3
+test "$(grep -Fc "$status_endpoint" "$tmp/state/api")" -eq 5
 grep -F 'context=test' "$tmp/state/api"
 grep -F 'context=Native OCR (windows-latest)' "$tmp/state/api"
 grep -F 'context=Native OCR (macos-latest)' "$tmp/state/api"
-test "$(grep -Fc 'target_url=https://github.com/example/project/actions/runs/101' "$tmp/state/api")" -eq 3
+grep -F 'context=CI Gate' "$tmp/state/api"
+grep -F 'context=Current Client Gate' "$tmp/state/api"
+test "$(grep -Fc 'target_url=https://github.com/example/project/actions/runs/101' "$tmp/state/api")" -eq 4
+test "$(grep -Fc 'target_url=https://github.com/example/project/actions/runs/103' "$tmp/state/api")" -eq 1


### PR DESCRIPTION
Prevent the package-metadata release job from stalling after `Current Client Gate` became required.

- dispatch and wait for `current-clients.yml` on the exact automation commit
- publish `CI Gate` only after dispatched CI succeeds
- publish `Current Client Gate` only after the compatibility workflow succeeds
- extend the shell mock regression test from two workflows/three statuses to three workflows/five statuses

This was discovered on package metadata PR #1146 during v0.0.64.

Local: `sh -n tools/propose_automation_pr.sh tools/test_propose_automation_pr.sh`; `sh tools/test_propose_automation_pr.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation proposals now validate the current-client workflow in addition to existing CI checks.
  * Added a dedicated “Current Client Gate” status after successful validation.
  * CI gate status reporting now provides clearer workflow coverage.

* **Tests**
  * Updated automation tests to verify current-client workflow execution, monitoring, and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->