### PR TITLE
ci: bound APT repository history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
               - 'tools/install-apt.sh'
               - 'tools/package_deb.sh'
               - 'tools/build_apt_repository.sh'
+              - 'tools/download_recent_stable_debs.sh'
+              - 'tools/test_download_recent_stable_debs.sh'
               - 'tools/propose_automation_pr.sh'
               - 'tools/test_propose_automation_pr.sh'
               - 'tools/test_release_package_metadata.py'
@@ -415,7 +417,8 @@ jobs:
           python tools/test_client_smoke_coverage.py
           python tools/test_release_package_metadata.py
           python -m py_compile tools/client_smoke.py tools/install_portable_client_smoke.py tools/test_client_smoke_coverage.py tools/test_release_package_metadata.py tools/verify_client_smoke_log.py
-          sh -n tools/install.sh tools/install-apt.sh tools/package_deb.sh tools/build_apt_repository.sh tools/propose_automation_pr.sh tools/install_client_smoke.sh tools/test_install.sh tools/testdata/install-curl.sh
+          sh -n tools/install.sh tools/install-apt.sh tools/package_deb.sh tools/build_apt_repository.sh tools/download_recent_stable_debs.sh tools/propose_automation_pr.sh tools/install_client_smoke.sh tools/test_install.sh tools/testdata/install-curl.sh
+          sh tools/test_download_recent_stable_debs.sh
           sh tools/test_install.sh
           bash -n .github/scripts/publish-aur.sh
           cc -std=c11 -Wall -Wextra -Werror tools/codex-app-smoke-fixture.c -o "$RUNNER_TEMP/codex-app-smoke-fixture"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -69,18 +69,12 @@ jobs:
           EOF
           test -n "$(find debs -name 'pentect_*.deb' -print -quit)"
           gh release upload "$TAG" debs/* --clobber --repo "$GITHUB_REPOSITORY"
-      - name: Download all stable Debian packages
+      - name: Download recent stable Debian packages
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           rm -rf debs
-          mkdir -p debs
-          gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' |
-          while IFS= read -r tag; do
-            gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
-              --pattern 'pentect_*.deb' --dir debs --skip-existing || true
-          done
+          sh tools/download_recent_stable_debs.sh debs 3
       - name: Sign repository
         id: signing
         env:
@@ -92,6 +86,10 @@ jobs:
           test "$fingerprint" = "$(cat packaging/apt/KEY_FINGERPRINT)"
           bash tools/build_apt_repository.sh debs site \
             packaging/apt/pentect-archive-keyring.asc "$fingerprint"
+          bytes=$(du -sb site | awk '{print $1}')
+          packages=$(find site -type f -name '*.deb' | wc -l)
+          echo "APT repository: $packages package files, $bytes bytes"
+          test "$bytes" -le 800000000
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22

--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false
       - name: Resolve and verify release
         shell: bash
         env:

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with: {persist-credentials: false}
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with: {node-version: "24", package-manager-cache: false}
+        with: {node-version: "24"}
       - working-directory: sdk/javascript
         run: |
           npm test
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with: {persist-credentials: false}
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with: {node-version: "24", registry-url: https://registry.npmjs.org, package-manager-cache: false}
+        with: {node-version: "24", registry-url: https://registry.npmjs.org}
       - working-directory: sdk/javascript
         run: npm publish --access public
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,8 @@ jobs:
           }
       - name: Validate POSIX installer
         run: |
-          sh -n tools/install.sh tools/install-apt.sh tools/package_deb.sh tools/build_apt_repository.sh tools/propose_automation_pr.sh tools/install_client_smoke.sh tools/test_install.sh tools/testdata/install-curl.sh
+          sh -n tools/install.sh tools/install-apt.sh tools/package_deb.sh tools/build_apt_repository.sh tools/download_recent_stable_debs.sh tools/propose_automation_pr.sh tools/install_client_smoke.sh tools/test_install.sh tools/testdata/install-curl.sh
+          sh tools/test_download_recent_stable_debs.sh
           sh tools/test_install.sh
           bash -n .github/scripts/publish-aur.sh
           python tools/test_client_smoke_coverage.py
@@ -335,17 +336,7 @@ jobs:
       - name: Add historical stable packages
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' |
-          while IFS= read -r tag; do
-            if gh release view "$tag" --repo "$GITHUB_REPOSITORY" \
-              --json assets --jq '.assets[].name' | grep -Eq '^pentect_.*\.deb$'; then
-              gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
-                --pattern 'pentect_*.deb' --dir debs --skip-existing
-            fi
-          done
+        run: sh tools/download_recent_stable_debs.sh debs 2
           test -n "$(find debs -name 'pentect_*.deb' -print -quit)"
       - name: Import archive signing key
         id: signing
@@ -361,7 +352,12 @@ jobs:
       - name: Build signed repository
         env:
           KEY_FINGERPRINT: ${{ steps.signing.outputs.fingerprint }}
-        run: bash tools/build_apt_repository.sh debs site packaging/apt/pentect-archive-keyring.asc "$KEY_FINGERPRINT"
+        run: |
+          bash tools/build_apt_repository.sh debs site packaging/apt/pentect-archive-keyring.asc "$KEY_FINGERPRINT"
+          bytes=$(du -sb site | awk '{print $1}')
+          packages=$(find site -type f -name '*.deb' | wc -l)
+          echo "APT repository: $packages package files, $bytes bytes"
+          test "$bytes" -le 800000000
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: apt-site
@@ -779,7 +775,6 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false
       - name: Verify release version
         shell: bash
         run: |

--- a/tools/download_recent_stable_debs.sh
+++ b/tools/download_recent_stable_debs.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: download_recent_stable_debs.sh OUTPUT_DIR RELEASE_COUNT" >&2
+  exit 2
+fi
+
+output_dir=$1
+release_count=$2
+case "$release_count" in
+  ''|*[!0-9]*|0) echo "RELEASE_COUNT must be a positive integer" >&2; exit 2 ;;
+esac
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+command -v gh >/dev/null 2>&1 || { echo "gh is required" >&2; exit 2; }
+
+mkdir -p "$output_dir"
+tags_file=$(mktemp)
+trap 'rm -f "$tags_file"' EXIT HUP INT TERM
+gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+  --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' > "$tags_file"
+
+retained=0
+while IFS= read -r tag; do
+  if gh release view "$tag" --repo "$GITHUB_REPOSITORY" \
+    --json assets --jq '.assets[].name' | grep -Eq '^pentect_.*\.deb$'; then
+    gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+      --pattern 'pentect_*.deb' --dir "$output_dir" --skip-existing
+    retained=$((retained + 1))
+    [ "$retained" -ge "$release_count" ] && break
+  fi
+done < "$tags_file"
+
+echo "Retained Debian packages from $retained stable release(s)."

--- a/tools/test_download_recent_stable_debs.sh
+++ b/tools/test_download_recent_stable_debs.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+temporary=$(mktemp -d)
+trap 'rm -rf "$temporary"' EXIT HUP INT TERM
+mkdir -p "$temporary/bin" "$temporary/debs"
+
+cat > "$temporary/bin/gh" <<'EOF'
+#!/bin/sh
+set -eu
+case "$1 $2" in
+  'api --paginate')
+    printf '%s\n' v5 v4 v3 v2 v1
+    ;;
+  'release view')
+    [ "$3" = v4 ] && exit 0
+    printf '%s\n' pentect_1.0.0_amd64.deb pentect_1.0.0_arm64.deb
+    ;;
+  'release download')
+    tag=$3
+    shift 3
+    destination=
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = --dir ]; then
+        destination=$2
+        break
+      fi
+      shift
+    done
+    : "${destination:?missing download directory}"
+    : > "$destination/pentect_${tag#v}_amd64.deb"
+    : > "$destination/pentect_${tag#v}_arm64.deb"
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$temporary/bin/gh"
+
+PATH="$temporary/bin:$PATH" GITHUB_REPOSITORY=owner/repo \
+  sh "$root/tools/download_recent_stable_debs.sh" "$temporary/debs" 3
+
+actual=$(find "$temporary/debs" -type f -name '*.deb' -printf '%f\n' | sort)
+expected=$(printf '%s\n' \
+  pentect_2_amd64.deb pentect_2_arm64.deb \
+  pentect_3_amd64.deb pentect_3_arm64.deb \
+  pentect_5_amd64.deb pentect_5_arm64.deb | sort)
+[ "$actual" = "$expected" ]


### PR DESCRIPTION
Closes #1148.

## Root cause

Both Pages publication paths downloaded every historical stable Debian package. The repository therefore grew without a bound and reached 2.13 GB in v0.0.64 despite the job concluding successfully.

## Changes

- retain three stable package generations (the release workflow adds two prior generations to its newly built current package)
- skip releases that do not contain Debian assets without consuming a retained-generation slot
- log package count and apparent bytes, and fail before upload above 800 MB
- exercise retention behavior with a fake `gh` endpoint in the packaging CI path
- remove the unsupported `package-manager-cache` input from every setup-node invocation

## Focused local verification

- `sh -n tools/download_recent_stable_debs.sh tools/test_download_recent_stable_debs.sh`
- `sh tools/test_download_recent_stable_debs.sh`
- `python tools/test_release_package_metadata.py`
- confirmed no `package-manager-cache` remains under `.github/workflows`
- `git diff --check`
