### PR TITLE
fix: preserve canonical labels in privacy metrics

### DIFF
--- a/crates/pentect-core/src/model.rs
+++ b/crates/pentect-core/src/model.rs
@@ -8,48 +8,67 @@ pub type Label = String;
 /// placeholders; keeping the shared ones here stops the same string being
 /// retyped (and drifting) across detectors.
 pub mod labels {
-    /// High-entropy run with no anchoring context (entropy detector).
-    pub const LIKELY_SECRET: &str = "LIKELY_SECRET";
-    /// Decodes to binary-looking bytes ("looks encrypted") with no inner secret.
-    pub const OPAQUE_BLOB: &str = "OPAQUE_BLOB";
-    /// Value masked because its key name looks sensitive.
-    pub const SECRET: &str = "SECRET";
-    /// Ambiguous personally identifying information.
-    pub const PII: &str = "PII";
-    /// Ambiguous identifier.
-    pub const IDENTIFIER: &str = "IDENTIFIER";
-    /// Ambiguous endpoint.
-    pub const ENDPOINT: &str = "ENDPOINT";
-    /// Sensitive value whose category could not be narrowed further.
-    pub const SENSITIVE: &str = "SENSITIVE";
-    /// Value masked because a plaintext key/value structure carries a sensitive key.
-    pub const KEYED_SECRET: &str = "KEYED_SECRET";
-    /// One-time password or verification code.
-    pub const OTP: &str = "OTP";
-    /// BIP-39 wallet recovery phrase.
-    pub const BIP39_MNEMONIC: &str = "BIP39_MNEMONIC";
-    /// Body of a PEM private-key block.
-    pub const PRIVATE_KEY: &str = "PRIVATE_KEY";
-    /// Host/authority of an internal service URL.
-    pub const INTERNAL_ENDPOINT: &str = "INTERNAL_ENDPOINT";
-    /// Resource identifier inside an internal URL path.
-    pub const RESOURCE_ID: &str = "RESOURCE_ID";
-    /// User-info credential portion of a URL authority.
-    pub const URL_CREDENTIAL: &str = "URL_CREDENTIAL";
-    /// Password-like value passed through a shell or PowerShell command option.
-    pub const CMD_PASSWORD: &str = "CMD_PASSWORD";
-    /// UUID/GUID value in an identifier-bearing slot.
-    pub const UUID: &str = "UUID";
-    /// Bucket name in an Amazon S3 hostname.
-    pub const AWS_S3_BUCKET: &str = "AWS_S3_BUCKET";
-    /// Firebase project/database prefix in a Realtime Database hostname.
-    pub const FIREBASE_PROJECT_ID: &str = "FIREBASE_PROJECT_ID";
-    /// Query parameter value in an internal URL.
-    pub const URL_QUERY_VALUE: &str = "URL_QUERY_VALUE";
-    /// Fragment value in an internal URL.
-    pub const URL_FRAGMENT: &str = "URL_FRAGMENT";
-    /// Location metadata embedded in image EXIF GPS tags.
-    pub const IMAGE_GPS_METADATA: &str = "IMAGE_GPS_METADATA";
+    macro_rules! define_canonical_labels {
+        ($( $(#[$meta:meta])* $name:ident = $value:literal; )+) => {
+            $(
+                $(#[$meta])*
+                pub const $name: &str = $value;
+            )+
+
+            /// Every synthetic label emitted by the core detectors.
+            pub const ALL: &[&str] = &[$($name),+];
+
+            /// Whether `value` is a fixed, core-defined label rather than input text.
+            pub fn is_canonical(value: &str) -> bool {
+                ALL.contains(&value)
+            }
+        };
+    }
+
+    define_canonical_labels! {
+        /// High-entropy run with no anchoring context (entropy detector).
+        LIKELY_SECRET = "LIKELY_SECRET";
+        /// Decodes to binary-looking bytes ("looks encrypted") with no inner secret.
+        OPAQUE_BLOB = "OPAQUE_BLOB";
+        /// Value masked because its key name looks sensitive.
+        SECRET = "SECRET";
+        /// Ambiguous personally identifying information.
+        PII = "PII";
+        /// Ambiguous identifier.
+        IDENTIFIER = "IDENTIFIER";
+        /// Ambiguous endpoint.
+        ENDPOINT = "ENDPOINT";
+        /// Sensitive value whose category could not be narrowed further.
+        SENSITIVE = "SENSITIVE";
+        /// Value masked because a plaintext key/value structure carries a sensitive key.
+        KEYED_SECRET = "KEYED_SECRET";
+        /// One-time password or verification code.
+        OTP = "OTP";
+        /// BIP-39 wallet recovery phrase.
+        BIP39_MNEMONIC = "BIP39_MNEMONIC";
+        /// Body of a PEM private-key block.
+        PRIVATE_KEY = "PRIVATE_KEY";
+        /// Host/authority of an internal service URL.
+        INTERNAL_ENDPOINT = "INTERNAL_ENDPOINT";
+        /// Resource identifier inside an internal URL path.
+        RESOURCE_ID = "RESOURCE_ID";
+        /// User-info credential portion of a URL authority.
+        URL_CREDENTIAL = "URL_CREDENTIAL";
+        /// Password-like value passed through a shell or PowerShell command option.
+        CMD_PASSWORD = "CMD_PASSWORD";
+        /// UUID/GUID value in an identifier-bearing slot.
+        UUID = "UUID";
+        /// Bucket name in an Amazon S3 hostname.
+        AWS_S3_BUCKET = "AWS_S3_BUCKET";
+        /// Firebase project/database prefix in a Realtime Database hostname.
+        FIREBASE_PROJECT_ID = "FIREBASE_PROJECT_ID";
+        /// Query parameter value in an internal URL.
+        URL_QUERY_VALUE = "URL_QUERY_VALUE";
+        /// Fragment value in an internal URL.
+        URL_FRAGMENT = "URL_FRAGMENT";
+        /// Location metadata embedded in image EXIF GPS tags.
+        IMAGE_GPS_METADATA = "IMAGE_GPS_METADATA";
+    }
 }
 
 /// Half-open byte range into the raw input, aligned to UTF-8 char boundaries.

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -1,6 +1,6 @@
 use crate::delegated_process_host::{self, ProcessHostEndpoint};
 use crate::memory_store::MemoryStoreClient;
-use pentect_core::MaskResult;
+use pentect_core::{model::labels, MaskResult};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
@@ -546,16 +546,16 @@ fn safe_metric_surface(value: &str) -> &str {
 }
 
 fn safe_metric_secret_type(value: &str) -> &str {
+    if labels::is_canonical(value) {
+        return value;
+    }
     match value {
         "ACCESS_TOKEN" | "ANTHROPIC_API_KEY" | "API_KEY" | "AWS_AKID" | "AWS_MULTI"
-        | "AWS_S3_BUCKET" | "BASE64_PRIVATE_KEY" | "BASIC_AUTH" | "BEARER_TOKEN" | "CREDENTIAL"
-        | "CREDENTIALS" | "CREDIT_CARD" | "EMAIL_ADDRESS" | "GITHUB_PAT" | "GITHUB_TOKEN"
-        | "GOOGLE_API_KEY" | "HUGGINGFACE_TOKEN" | "IBAN_CODE" | "KEYED_SECRET"
-        | "LIKELY_SECRET" | "OPENAI_API_KEY" | "PASSWORD" | "PEM_PRIVATE_KEY" | "PHONE_NUMBER"
-        | "PRIVATE_KEY" | "SECRET" | "SESSION_TOKEN" | "SLACK_TOKEN" | "SLACK_WEBHOOK"
-        | "STRIPE_SECRET_KEY" | "TELEGRAM_BOT_TOKEN" | "TOKEN" | "UK_NINO" | "URL_CREDENTIAL" => {
-            value
-        }
+        | "BASE64_PRIVATE_KEY" | "BASIC_AUTH" | "BEARER_TOKEN" | "CREDENTIAL" | "CREDENTIALS"
+        | "CREDIT_CARD" | "EMAIL_ADDRESS" | "GITHUB_PAT" | "GITHUB_TOKEN" | "GOOGLE_API_KEY"
+        | "HUGGINGFACE_TOKEN" | "IBAN_CODE" | "OPENAI_API_KEY" | "PASSWORD" | "PEM_PRIVATE_KEY"
+        | "PHONE_NUMBER" | "SESSION_TOKEN" | "SLACK_TOKEN" | "SLACK_WEBHOOK"
+        | "STRIPE_SECRET_KEY" | "TELEGRAM_BOT_TOKEN" | "TOKEN" | "UK_NINO" => value,
         _ => "OTHER",
     }
 }
@@ -1533,6 +1533,9 @@ mod tests {
     #[test]
     fn privacy_metric_dimensions_collapse_untrusted_values() {
         assert_eq!(safe_metric_secret_type("AWS_AKID"), "AWS_AKID");
+        for label in labels::ALL {
+            assert_eq!(safe_metric_secret_type(label), *label);
+        }
         assert_eq!(safe_metric_secret_type("accountIdentifier456"), "OTHER");
         assert_eq!(safe_metric_secret_type("secret\u{1b}[31m"), "OTHER");
         assert_eq!(safe_metric_surface("prompt"), "prompt");


### PR DESCRIPTION
Closes #1144.

## Root cause

The privacy-metrics allowlist duplicated only six of the 21 fixed labels declared by `pentect-core`. The remaining canonical labels were treated like untrusted free-form input and collapsed into `OTHER`.

## Fix

- declare canonical core labels through one macro that emits both the constants and `labels::ALL`
- expose `labels::is_canonical` from that same declaration source
- let metrics accept every canonical label before applying the separate fixed vendor-label allowlist
- test every current canonical label, while retaining rejection tests for arbitrary and control-character input

The metrics output still cannot contain arbitrary detector/user text.

## Focused verification

- `cargo test -p pentect-runtime --no-default-features privacy_metric_dimensions_collapse_untrusted_values --locked`
- `cargo test -p pentect-core --lib --locked` (423 passed)
- `cargo fmt --all --check`
- `git diff --check`
