### PR TITLE
fix: keep image handles out of metric labels

### DIFF
--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -560,6 +560,18 @@ fn safe_metric_secret_type(value: &str) -> &str {
     }
 }
 
+fn safe_metric_labels(values: &BTreeMap<String, u64>) -> BTreeMap<String, u64> {
+    let mut labels = BTreeMap::new();
+    for (label, count) in values {
+        increment_metric(
+            &mut labels,
+            safe_metric_secret_type(label).to_string(),
+            *count,
+        );
+    }
+    labels
+}
+
 pub(crate) fn record_mask_result(surface: &str, result: &MaskResult, target: Option<&Path>) {
     if result.summary.masked_count == 0 {
         return;
@@ -606,23 +618,11 @@ pub(crate) fn record_summary(
     ));
 }
 
-pub(crate) fn record_image(secret_images: usize, notes: &[String]) {
+pub(crate) fn record_image(secret_images: usize, detected_labels: &BTreeMap<String, u64>) {
     if secret_images == 0 {
         return;
     }
-    let mut labels = BTreeMap::new();
-    for note in notes {
-        let Some((_, list)) = note.split_once(']') else {
-            continue;
-        };
-        for label in list
-            .split(',')
-            .map(str::trim)
-            .filter(|label| !label.is_empty())
-        {
-            *labels.entry(label.to_string()).or_insert(0) += 1;
-        }
-    }
+    let labels = safe_metric_labels(detected_labels);
     record(ActivityEvent::new(
         "redact",
         "image",
@@ -1536,6 +1536,13 @@ mod tests {
         for label in labels::ALL {
             assert_eq!(safe_metric_secret_type(label), *label);
         }
+        let image_labels = safe_metric_labels(&BTreeMap::from([
+            (labels::KEYED_SECRET.to_string(), 2),
+            ("<<KEYED_SECRET_deadbeefdeadbeef>>".to_string(), 1),
+        ]));
+        assert_eq!(image_labels.get(labels::KEYED_SECRET), Some(&2));
+        assert_eq!(image_labels.get("OTHER"), Some(&1));
+        assert!(image_labels.keys().all(|label| !label.contains("<<")));
         assert_eq!(safe_metric_secret_type("accountIdentifier456"), "OTHER");
         assert_eq!(safe_metric_secret_type("secret\u{1b}[31m"), "OTHER");
         assert_eq!(safe_metric_surface("prompt"), "prompt");

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -10,7 +10,7 @@ use pentect_core::placeholder::{identity_hash, render_placeholder};
 use pentect_core::ByteRange;
 use pentect_core::Recovery;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 #[cfg(feature = "ocr")]
 use std::net::{IpAddr, SocketAddr};
 
@@ -52,7 +52,7 @@ pub(crate) struct ImageRedaction {
     pub(crate) unscanned_images: usize,
     pub(crate) ocr_failures: usize,
     pub(crate) secret_images: usize,
-    pub(crate) notes: Vec<String>,
+    pub(crate) labels: BTreeMap<String, u64>,
     pub(crate) recovery: Recovery,
     pub(crate) visual_notes: Vec<String>,
     pub(crate) metadata_notes: Vec<String>,
@@ -66,7 +66,7 @@ struct ImageRedactionState {
     attempted_images: usize,
     total_image_bytes: u64,
     started_at: std::time::Instant,
-    notes: Vec<String>,
+    labels: BTreeMap<String, u64>,
     recovery: HashMap<String, String>,
     visual_notes: Vec<String>,
     metadata_notes: Vec<String>,
@@ -264,7 +264,7 @@ pub(crate) fn redact_tool_images_for_secrets(
         attempted_images: 0,
         total_image_bytes: 0,
         started_at: std::time::Instant::now(),
-        notes: Vec::new(),
+        labels: BTreeMap::new(),
         recovery: HashMap::new(),
         visual_notes: Vec::new(),
         metadata_notes: Vec::new(),
@@ -282,7 +282,7 @@ pub(crate) fn redact_tool_images_for_secrets(
         unscanned_images: state.unscanned_images,
         ocr_failures: state.ocr_failures,
         secret_images: state.secret_images,
-        notes: state.notes,
+        labels: state.labels,
         recovery: Recovery::seal(state.recovery, key),
         visual_notes: state.visual_notes,
         metadata_notes: state.metadata_notes,
@@ -674,14 +674,15 @@ fn redact_image_bytes(
     }
     state.secret_images += 1;
     let index = state.secret_images;
+    for label in visual_labels.iter().chain(&metadata_labels) {
+        *state.labels.entry(label.clone()).or_default() += 1;
+    }
     if let Some(summary) = image_note_summary(&visual_labels, &visual_handles) {
         let note = format!("[{index}] {summary}");
-        state.notes.push(note.clone());
         state.visual_notes.push(note);
     }
     if let Some(summary) = image_note_summary(&metadata_labels, &metadata_handles) {
         let note = format!("[{index}] {summary}");
-        state.notes.push(note.clone());
         state.metadata_notes.push(note);
     }
     let payload = redacted_image_payload(bytes, index, cfg, &findings)?;
@@ -3466,6 +3467,9 @@ mod tests {
         assert!(!visual.contains("<<KEYED_SECRET_"), "{visual}");
         assert!(metadata.contains("<<KEYED_SECRET_"), "{metadata}");
         assert!(!metadata.contains("<<AWS_CLIENT_ID_"), "{metadata}");
+        assert_eq!(redaction.labels.get("AWS_CLIENT_ID"), Some(&1));
+        assert_eq!(redaction.labels.get(labels::KEYED_SECRET), Some(&1));
+        assert!(redaction.labels.keys().all(|label| !label.contains("<<")));
         assert!(
             redaction.recovery.resolve(&visual).contains(visual_secret),
             "{visual}"

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -299,7 +299,7 @@ pub fn redact_tool_images_into_active_memory_store(value: &Value) -> Result<Opti
     session
         .sync_recovery(&redaction.recovery)
         .map_err(|error| error.to_string())?;
-    activity_log::record_image(redaction.secret_images, &redaction.notes);
+    activity_log::record_image(redaction.secret_images, &redaction.labels);
     if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Block) {
         if redaction.unscanned_images > 0 {
             return Err("image blocked: image could not be fetched or scanned.".to_string());
@@ -4205,7 +4205,7 @@ fn claude_image_tool_output(
     session
         .sync_recovery(&redaction.recovery)
         .map_err(|error| error.to_string())?;
-    activity_log::record_image(redaction.secret_images, &redaction.notes);
+    activity_log::record_image(redaction.secret_images, &redaction.labels);
     if matches!(cfg.unscanned_images, config::UnscannedImagePolicy::Block) {
         if redaction.unscanned_images > 0 {
             return Ok(Some(ToolTextOutput::Block(

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -1325,6 +1325,10 @@ fn is_env_name(name: &str) -> bool {
 }
 
 fn redact_env_derivative_lines(text: &str) -> String {
+    // This is a syntactically valid handle so every masking pass preserves it,
+    // but `is_reusable_placeholder` explicitly excludes its label because no
+    // recovery value exists for derived previews.
+    const REDACTED_DERIVED_HANDLE: &str = "<<REDACTED_DERIVED_0000000000000000>>";
     let mut out = String::with_capacity(text.len());
     let mut changed = false;
     for segment in text.split_inclusive('\n') {
@@ -1335,7 +1339,8 @@ fn redact_env_derivative_lines(text: &str) -> String {
             let indent_len = body.len() - body.trim_start().len();
             out.push_str(&body[..indent_len]);
             out.push_str(key);
-            out.push_str("=<<REDACTED_DERIVED>>");
+            out.push('=');
+            out.push_str(REDACTED_DERIVED_HANDLE);
             out.push_str(ending);
             changed = true;
         } else {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2990,7 +2990,7 @@ fn view_length_comes_from_recovery_not_label() {
 fn derived_redactions_do_not_claim_to_be_reusable_handles() {
     let (root, session) = empty_session("exec-derived-no-hint");
     let masked = mask_tool_output(&session, "PREFIX_32=rpa_FAKE\n").unwrap();
-    assert_eq!(masked, "PREFIX_32=<<REDACTED_DERIVED>>\n");
+    assert_eq!(masked, "PREFIX_32=<<REDACTED_DERIVED_0000000000000000>>\n");
     assert!(
         first_reusable_env_name(&masked, "PENTECT_").is_none(),
         "{masked}"
@@ -3076,28 +3076,40 @@ fn derived_env_summary_output_does_not_leak_prefix_suffix_or_length() {
         assert!(!masked.contains(leaked), "{masked}");
     }
     assert!(
-        masked.contains("RUNPOD_API_KEY=<<REDACTED_DERIVED>>"),
+        masked.contains("RUNPOD_API_KEY=<<REDACTED_DERIVED_0000000000000000>>"),
         "{masked}"
     );
     assert!(
-        masked.contains("TEST_SECRET=<<REDACTED_DERIVED>>"),
-        "{masked}"
-    );
-    assert!(masked.contains("NOTE=<<REDACTED_DERIVED>>"), "{masked}");
-    assert!(masked.contains("KEY=<<REDACTED_DERIVED>>"), "{masked}");
-    assert!(masked.contains("key=<<REDACTED_DERIVED>>"), "{masked}");
-    assert!(
-        masked.contains("PREFIX_32=<<REDACTED_DERIVED>>"),
+        masked.contains("TEST_SECRET=<<REDACTED_DERIVED_0000000000000000>>"),
         "{masked}"
     );
     assert!(
-        masked.contains("SUFFIX_32=<<REDACTED_DERIVED>>"),
+        masked.contains("NOTE=<<REDACTED_DERIVED_0000000000000000>>"),
         "{masked}"
     );
-    assert!(masked.contains("BASE64=<<REDACTED_DERIVED>>"), "{masked}");
+    assert!(
+        masked.contains("KEY=<<REDACTED_DERIVED_0000000000000000>>"),
+        "{masked}"
+    );
+    assert!(
+        masked.contains("key=<<REDACTED_DERIVED_0000000000000000>>"),
+        "{masked}"
+    );
+    assert!(
+        masked.contains("PREFIX_32=<<REDACTED_DERIVED_0000000000000000>>"),
+        "{masked}"
+    );
+    assert!(
+        masked.contains("SUFFIX_32=<<REDACTED_DERIVED_0000000000000000>>"),
+        "{masked}"
+    );
+    assert!(
+        masked.contains("BASE64=<<REDACTED_DERIVED_0000000000000000>>"),
+        "{masked}"
+    );
     assert_eq!(
         masked
-            .matches("RUNPOD_API_KEY=<<REDACTED_DERIVED>>")
+            .matches("RUNPOD_API_KEY=<<REDACTED_DERIVED_0000000000000000>>")
             .count(),
         2,
         "{masked}"
@@ -3228,10 +3240,13 @@ fn encoded_env_derivatives_do_not_leak() {
     assert!(!masked.contains("68656c6c6f20776f726c64"), "{masked}");
     assert!(masked.contains("<<SECRET_"), "{masked}");
     assert!(
-        masked.contains("RUNPOD_API_KEY=<<REDACTED_DERIVED>>"),
+        masked.contains("RUNPOD_API_KEY=<<REDACTED_DERIVED_0000000000000000>>"),
         "{masked}"
     );
-    assert!(masked.contains("NOTE=<<REDACTED_DERIVED>>"), "{masked}");
+    assert!(
+        masked.contains("NOTE=<<REDACTED_DERIVED_0000000000000000>>"),
+        "{masked}"
+    );
     let _ = std::fs::remove_dir_all(root);
 }
 


### PR DESCRIPTION
Closes #1150.

## Root cause

Image redaction generated human-facing notes with recoverable handles, then `record_image` reparsed those notes as if they contained detector labels. This mixed a presentation channel with metrics data: handles reached persistent activity records and later collapsed to `OTHER`.

## Fix

- collect detector-label counts directly while processing each image
- pass that typed label map to the activity logger instead of parsing display notes
- sanitize the map before persistence so an unexpected label becomes `OTHER`, never a handle
- remove the now-unused combined handle-note copy; visual and metadata notes used by the UI are unchanged
- verify a real QR + PNG metadata redaction reports `AWS_CLIENT_ID` and `KEYED_SECRET` labels without any handle text

## Focused verification

- `cargo test -p pentect-runtime --no-default-features privacy_metric_dimensions_collapse_untrusted_values --locked`
- `cargo test -p pentect-runtime one_image_separates_visual_and_metadata_handles --locked`
- `cargo fmt --all --check`
- `git diff --check`
