### PR TITLE
fix: anchor file-pointer state to the project root

### DIFF
--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -33,7 +33,7 @@ pub(crate) fn handle_identity_key() -> Result<[u8; 32], String> {
     match project.or(global).unwrap_or_default() {
         HandleScope::Device => machine_identity_key(),
         HandleScope::Project => {
-            let root = project_identity_root()?;
+            let root = project_root()?;
             Ok(derive_project_identity_key(&machine_identity_key()?, &root))
         }
         HandleScope::Session => random_identity_key(),
@@ -303,7 +303,7 @@ fn restrict_identity_file(_: &Path) -> Result<(), String> {
 }
 
 #[cfg_attr(test, allow(dead_code))]
-fn project_identity_root() -> Result<PathBuf, String> {
+pub(crate) fn project_root() -> Result<PathBuf, String> {
     let cwd =
         std::env::current_dir().map_err(|e| format!("could not read current directory: {e}"))?;
     let root = cwd

--- a/crates/pentect-runtime/src/file_pointer_manager.rs
+++ b/crates/pentect-runtime/src/file_pointer_manager.rs
@@ -410,7 +410,10 @@ fn replace_file(tmp: &Path, path: &Path) -> Result<(), String> {
 }
 
 fn manager_dir() -> PathBuf {
-    PathBuf::from(".pentect").join(MANAGER_DIR)
+    crate::config::project_root()
+        .unwrap_or_else(|_| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+        .join(".pentect")
+        .join(MANAGER_DIR)
 }
 
 fn empty_index() -> FilePointerIndex {
@@ -425,14 +428,18 @@ fn envelope_overhead() -> usize {
 }
 
 fn stored_path(path: &Path) -> String {
-    if path.is_absolute() {
-        if let Ok(cwd) = std::env::current_dir() {
-            if let Ok(relative) = path.strip_prefix(cwd) {
-                return relative.to_string_lossy().into_owned();
+    path.canonicalize()
+        .unwrap_or_else(|_| {
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                std::env::current_dir()
+                    .map(|cwd| cwd.join(path))
+                    .unwrap_or_else(|_| path.to_path_buf())
             }
-        }
-    }
-    path.to_string_lossy().into_owned()
+        })
+        .to_string_lossy()
+        .into_owned()
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -3626,6 +3626,44 @@ fn file_pointer_manager_recovers_read_handle_after_restart() {
 }
 
 #[test]
+fn file_pointer_manager_uses_project_root_across_nested_working_directories() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("file-pointer-project-root");
+    let _cwd = enter_temp_cwd(&root);
+    write_project_config(&root, "[files]\nremember = true\n");
+    let env = root.join(".env");
+    std::fs::write(&env, "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\n").unwrap();
+
+    let session = Session::open_at(&root, "t").unwrap();
+    let masked_path = masked_read_copy(&session, env.to_str().unwrap())
+        .unwrap()
+        .unwrap();
+    let masked = std::fs::read_to_string(masked_path).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+    let root_manager = root.join(".pentect").join("file-pointer-manager");
+    assert!(root_manager.join("index.bin").exists());
+    assert!(root_manager.join("key.bin").exists());
+
+    let nested = root.join("src").join("nested");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::env::set_current_dir(&nested).unwrap();
+    let restarted = Session::open_at(&root.join("restart"), "t").unwrap();
+    let store = MemoryStore::for_session(&restarted);
+    assert_eq!(file_pointer_manager::handle_length(&handle), Some(27));
+    assert_eq!(
+        store.resolve_all(&handle).unwrap(),
+        "sk-ABCDEFGHIJKLMNOPQRSTUVWX"
+    );
+    assert!(!nested
+        .join(".pentect")
+        .join("file-pointer-manager")
+        .exists());
+
+    drop(_cwd);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn file_pointer_manager_refuses_changed_source_file() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("file-pointer-changed");


### PR DESCRIPTION
Closes #1152.

## Root cause

Configuration and project identity resolved the nearest ancestor containing `.git` or `.pentect`, but file-pointer index/key paths were hard-coded relative to the current working directory. Stored source paths were also CWD-relative. Fixing only the index location would therefore still leave recovery broken after changing directories.

## Fix

- expose and reuse the runtime's existing project-root resolver
- place the manager index and key under that root's `.pentect/file-pointer-manager`
- persist canonical absolute source paths inside the already-encrypted index, removing recovery's CWD dependency
- verify registration at the project root and recovery from a nested working directory
- verify no nested `.pentect/file-pointer-manager` is created

`PENTECT_FILE_POINTER_MANAGER_DIR` remains reserved but intentionally is not made into a new undocumented override surface in this fix.

## Focused verification

`cargo test -p pentect-runtime --no-default-features file_pointer_manager_ --locked -- --test-threads=1` — 6 passed.
