### PR TITLE
release: v0.0.65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.64"
+version = "0.0.65"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.64"
+version = "0.0.65"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
Prepare v0.0.65 after the validated post-v0.0.64 fixes:

- bounded APT package history and repaired automation aggregate gates
- canonical and image-specific privacy metric labels
- non-recoverable derived-output sentinel stability
- project-root-stable file-pointer persistence

Focused version verification:

- Cargo metadata reports `pentect-cli 0.0.65`
- npm manifest/pack reports `pentect 0.0.65`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and command-line package version to 0.0.65.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->