### PR TITLE
fix(release): preserve APT history command boundaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,7 +336,8 @@ jobs:
       - name: Add historical stable packages
         env:
           GH_TOKEN: ${{ github.token }}
-        run: sh tools/download_recent_stable_debs.sh debs 2
+        run: |
+          sh tools/download_recent_stable_debs.sh debs 2
           test -n "$(find debs -name 'pentect_*.deb' -print -quit)"
       - name: Import archive signing key
         id: signing

--- a/tools/test_release_package_metadata.py
+++ b/tools/test_release_package_metadata.py
@@ -79,6 +79,12 @@ def main() -> None:
         assert path in release_workflow
     assert 'git diff --quiet -- "${metadata_paths[@]}"' in release_workflow
     assert 'git add "${metadata_paths[@]}"' in release_workflow
+    assert (
+        "run: |\n"
+        "          sh tools/download_recent_stable_debs.sh debs 2\n"
+        "          test -n \"$(find debs -name 'pentect_*.deb' -print -quit)\""
+        in release_workflow
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1148.

The v0.0.65 release exposed that the multi-line APT history step lacked a YAML block scalar. GitHub folded both commands into one invocation, so the downloader received four arguments and exited with usage code 2.

This restores `run: |` and adds a workflow-source regression assertion so the two commands cannot silently collapse again.

Focused tests:
- `python tools/test_release_package_metadata.py`
- `sh tools/test_download_recent_stable_debs.sh`