### PR TITLE
fix(runtime): bound delegated host probes

### DIFF
--- a/crates/pentect-runtime/src/delegated_process_host.rs
+++ b/crates/pentect-runtime/src/delegated_process_host.rs
@@ -13,6 +13,7 @@ const CANDIDATE_PREFIX: &str = "process-host-candidate-";
 const CANDIDATE_SUFFIX: &str = ".json";
 const ELECTION_ATTEMPTS: usize = 8;
 const ELECTION_RETRY: Duration = Duration::from_millis(10);
+const HOST_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct ProcessHostEndpoint {
@@ -347,7 +348,7 @@ fn endpoint_is_alive(endpoint: &ProcessHostEndpoint) -> bool {
         return false;
     }
     MemoryStoreClient::for_activity(endpoint.addr.clone(), endpoint.read_token.clone())
-        .poll_activity(u64::MAX)
+        .poll_activity_once(u64::MAX, HOST_PROBE_TIMEOUT)
         .is_ok()
 }
 
@@ -403,6 +404,33 @@ fn restrict_file(_: &File) {}
 mod tests {
     use super::*;
     use crate::memory_store::spawn_test_memory_store_with_activity;
+    use std::net::TcpListener;
+    use std::time::Instant;
+
+    #[test]
+    fn host_probe_times_out_once_without_general_request_retries() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (_stream, _) = listener.accept().unwrap();
+            std::thread::sleep(Duration::from_secs(2));
+        });
+        let endpoint = ProcessHostEndpoint {
+            addr: addr.to_string(),
+            store_token_hash: String::new(),
+            read_token: "read-token".to_string(),
+            write_token: "write-token".to_string(),
+            pid: 1,
+        };
+
+        let started = Instant::now();
+        assert!(!endpoint_is_alive(&endpoint));
+        assert!(
+            started.elapsed() < Duration::from_millis(1500),
+            "host probe exceeded its single short timeout: {:?}",
+            started.elapsed()
+        );
+    }
 
     #[test]
     fn remaining_candidate_takes_over_when_host_unregisters() {

--- a/crates/pentect-runtime/src/memory_store.rs
+++ b/crates/pentect-runtime/src/memory_store.rs
@@ -447,7 +447,20 @@ impl MemoryStoreClient {
 
     pub(crate) fn poll_activity(&self, after: u64) -> Result<Vec<(u64, String)>> {
         let line = self.request("LOGS", &after.to_string())?;
-        let fields = response_fields(&line)?;
+        Self::decode_activity_response(&line)
+    }
+
+    pub(crate) fn poll_activity_once(
+        &self,
+        after: u64,
+        timeout: Duration,
+    ) -> Result<Vec<(u64, String)>> {
+        let line = self.request_once_with_timeout("LOGS", &after.to_string(), timeout)?;
+        Self::decode_activity_response(&line)
+    }
+
+    fn decode_activity_response(line: &str) -> Result<Vec<(u64, String)>> {
+        let fields = response_fields(line)?;
         if fields.len() != 2 || fields[0] != "OK" {
             bail!("memory store activity response is malformed");
         }


### PR DESCRIPTION
Closes #1156.

- probe delegated process hosts once with a dedicated 500 ms loopback timeout
- keep ordinary memory-store requests on their existing retry and timeout policy
- share activity response decoding between ordinary reads and probes
- reproduce an accepting-but-unresponsive endpoint and assert the probe returns in under 1.5 seconds

Focused tests:
- `cargo test -p pentect-runtime host_probe_times_out_once_without_general_request_retries --locked`
- `cargo test -p pentect-runtime shared_activity_is_replicated_to_handoff_candidates --locked`