### PR TITLE
fix(doctor): validate runtime config values

### DIFF
--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -214,7 +214,10 @@ fn check_config(name: &'static str, path: PathBuf) -> Check {
             format!("{} uses removed settings", path.display()),
             Repair::MigrateConfig { path },
         ),
-        Ok(None) => Check::ok(name, "ready"),
+        Ok(None) => match pentect_agent::validate_config_file(&path) {
+            Ok(()) => Check::ok(name, "ready"),
+            Err(error) => Check::fail(name, format!("{}: {error}", path.display())),
+        },
         Err(error) => Check::fail(name, format!("{}: {error}", path.display())),
     }
 }
@@ -227,6 +230,15 @@ fn migrate_removed_config_keys(source: &str) -> Result<Option<String>, String> {
         .parse::<toml_edit::DocumentMut>()
         .map_err(|error| format!("invalid TOML: {error}"))?;
     let mut changed = false;
+
+    if table_has(&document, "environment", "prefix") {
+        let environment = ensure_table(&mut document, "environment")?;
+        environment.remove("prefix");
+        if environment.is_empty() {
+            document.remove("environment");
+        }
+        changed = true;
+    }
 
     if table_has(&document, "handles", "hash_scope") {
         let scope = table_string(&document, "handles", "hash_scope")
@@ -790,6 +802,42 @@ mod tests {
         assert!(migrate_removed_config_keys("[handles]\nhash_scope = \"team\"\n").is_err());
         assert!(migrate_removed_config_keys("[handles]\nhash_scope = 1\n").is_err());
         assert!(migrate_removed_config_keys("not = = toml").is_err());
+    }
+
+    #[test]
+    fn removed_environment_prefix_is_discarded() {
+        let migrated = migrate_removed_config_keys(
+            "[environment]\nprefix = \"PRIVATE_\"\n\n[output]\nrestore = true\n",
+        )
+        .unwrap()
+        .unwrap();
+        assert!(!migrated.contains("environment"), "{migrated}");
+        assert!(migrated.contains("[output]"), "{migrated}");
+        assert!(migrated.contains("restore = true"), "{migrated}");
+    }
+
+    #[test]
+    fn config_check_uses_runtime_value_validation() {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-doctor-validation-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("config.toml");
+        std::fs::write(&path, "[output]\nrestore = 3\n").unwrap();
+        let check = check_config("test-config", path.clone());
+        assert_eq!(check.status, Status::Fail);
+        assert!(check.detail.contains("output.restore must be a boolean"));
+
+        std::fs::write(&path, "[output]\nrestore = false\n").unwrap();
+        let check = check_config("test-config", path);
+        assert_eq!(check.status, Status::Ok);
+        assert_eq!(check.detail, "ready");
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -59,6 +59,29 @@ fn parse_config_file(path: &Path) -> Result<Option<toml::Value>, String> {
         .map_err(|error| format!("could not parse '{}': {error}", path.display()))
 }
 
+pub(crate) fn validate_config_file(path: &Path) -> Result<(), String> {
+    let Some(value) = parse_config_file(path)? else {
+        return Ok(());
+    };
+    validate_config_value(&value)
+}
+
+fn validate_config_value(value: &toml::Value) -> Result<(), String> {
+    handle_scope_value(value)?;
+    agent_require_pentect_value(value)?;
+    image_ocr_config_value(value)?;
+    let decode = decode_config_value(value)?;
+    merge_decode_config_unchecked(Profile::Strict, decode, DecodeConfigPartial::default())
+        .validate()?;
+    files_remember_value(value)?;
+    activity_share_value(value)?;
+    metrics_enabled_value(value)?;
+    update_check_value(value)?;
+    output_restore_value(value)?;
+    unknown_format_policy_value(value)?;
+    reject_removed_environment_value(value)
+}
+
 fn handle_scope_value(value: &toml::Value) -> Result<Option<HandleScope>, String> {
     let Some(handles) = value.get("handles") else {
         return Ok(None);
@@ -668,6 +691,10 @@ fn reject_removed_environment_config(path: PathBuf) -> Result<(), String> {
     let Some(value) = parse_config_file(&path)? else {
         return Ok(());
     };
+    reject_removed_environment_value(&value)
+}
+
+fn reject_removed_environment_value(value: &toml::Value) -> Result<(), String> {
     if value.get("environment").is_some() {
         return Err(
             "environment.prefix was removed; handle variables always start with PENTECT_"

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -148,6 +148,10 @@ pub fn update_check_enabled() -> Result<bool, String> {
     config::update_check_enabled()
 }
 
+pub fn validate_config_file(path: &Path) -> Result<(), String> {
+    config::validate_config_file(path)
+}
+
 pub fn load_environment_variable_prefix() -> Result<String, String> {
     config::environment_variable_prefix()
 }


### PR DESCRIPTION
## Summary
- validate each config with the same value parsers used by the runtime before reporting `ready`
- include cross-field decode validation
- migrate the removed `environment.prefix` setting by discarding it and removing an empty legacy table
- retain unrelated settings and report invalid values as failed doctor checks

## Tests
- `cargo test -p pentect-cli --no-default-features config_check_uses_runtime_value_validation --locked`
- `cargo test -p pentect-cli --no-default-features removed_environment_prefix_is_discarded --locked`
- `git diff --check`

Closes #1124