### PR TITLE
fix(test): remove process-host startup race

### DIFF
--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -3749,7 +3749,12 @@ mod tests {
             std::env::set_var("PENTECT_HOME", &home);
             std::env::set_var("HOME", &home);
             std::env::set_var("LOCALAPPDATA", &home);
-            let process_host_candidate = Some(
+            let mut environment = Self {
+                saved,
+                home,
+                process_host_candidate: None,
+            };
+            environment.process_host_candidate = Some(
                 pentect_agent::register_process_host_candidate(
                     &pentect_agent::process_host_root().unwrap(),
                     store.addr(),
@@ -3760,11 +3765,7 @@ mod tests {
                 )
                 .unwrap(),
             );
-            Self {
-                saved,
-                home,
-                process_host_candidate,
-            }
+            environment
         }
 
         fn set(&mut self, name: &'static str, value: &str) {

--- a/crates/pentect-runtime/src/delegated_process_host.rs
+++ b/crates/pentect-runtime/src/delegated_process_host.rs
@@ -464,6 +464,26 @@ mod tests {
     }
 
     #[test]
+    fn newly_started_in_process_store_registers_without_a_scheduling_race() {
+        for iteration in 0..8 {
+            let root = test_root(&format!("in-process-ready-{iteration}"));
+            let store = crate::memory_store::start_in_process_memory_store().unwrap();
+            let candidate = register_candidate(
+                &root,
+                store.addr(),
+                store.token(),
+                store.process_host_read_token(),
+                store.process_host_write_token(),
+                10_000 + iteration,
+            )
+            .unwrap();
+            assert_eq!(ensure_host_at(&root).unwrap().addr, store.addr());
+            unregister_candidate(&candidate);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
     fn process_host_files_contain_no_activity_events() {
         let root = test_root("metadata");
         let addr = spawn_test_memory_store_with_activity(

--- a/crates/pentect-runtime/src/memory_store.rs
+++ b/crates/pentect-runtime/src/memory_store.rs
@@ -740,14 +740,21 @@ pub fn start_in_process_memory_store() -> Result<InProcessMemoryStore> {
             });
         }
     });
-    Ok(InProcessMemoryStore {
+    let store = InProcessMemoryStore {
         addr,
         token,
         process_host_read_token,
         process_host_write_token,
         shutdown: Some(shutdown_tx),
         server_thread: Some(server_thread),
-    })
+    };
+    MemoryStoreClient::for_activity(
+        store.addr.clone(),
+        store.process_host_read_token.to_string(),
+    )
+    .poll_activity_once(u64::MAX, REQUEST_TIMEOUT)
+    .context("in-process memory store did not become ready")?;
+    Ok(store)
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
## Summary
- require an authenticated activity round trip before an in-process memory store is returned as ready
- exercise immediate process-host registration repeatedly
- construct the OpenAI provider test environment guard before registration so failed setup still restores HOME and control variables

## Why

The macOS proxy shard could probe a newly bound store before its server thread had served any request. Registration then failed with `no running Delegated Process Host`; the panic happened before the environment guard existed and poisoned the shared test lock.

## Tests
- `cargo test -p pentect-runtime newly_started_in_process_store_registers_without_a_scheduling_race --locked`
- `cargo test -p pentect-cli --no-default-features chat_history_masks_legacy_function_and_custom_tool_payloads --locked`
- `git diff --check`

Closes #1171