### PR TITLE
Keep Gemini provider API keys in the local gateway

### DIFF
--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -62,8 +62,16 @@ impl GeminiHttpProxyGuard {
         upstream: String,
         header_env: &[String],
     ) -> Result<Self, String> {
+        Self::start_with_header_env_and_api_key(upstream, header_env, None)
+    }
+
+    pub(crate) fn start_with_header_env_and_api_key(
+        upstream: String,
+        header_env: &[String],
+        api_key: Option<String>,
+    ) -> Result<Self, String> {
         let upstream = crate::upstream::parse_base(&upstream, "Gemini")?;
-        let headers = crate::upstream::header_overrides(header_env)?;
+        let headers = crate::upstream::header_overrides_with_google_api_key(header_env, api_key)?;
         let auth = random_auth_token()?;
         let (ready_tx, ready_rx) = mpsc::channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -1204,6 +1212,77 @@ mod tests {
             value["candidates"][0]["content"]["parts"][1]["functionCall"]["args"]["key"],
             "sk_test_synthetic"
         );
+    }
+
+    #[test]
+    fn gateway_replaces_the_child_google_key_before_upstream() {
+        use std::io::{Read, Write};
+
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (headers_tx, headers_rx) = std::sync::mpsc::channel();
+        let upstream = std::thread::spawn(move || {
+            let (mut socket, _) = listener.accept().unwrap();
+            socket
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 4096];
+            let header_end = loop {
+                let read = socket.read(&mut buffer).unwrap();
+                assert!(read > 0);
+                request.extend_from_slice(&buffer[..read]);
+                if let Some(at) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                    break at + 4;
+                }
+            };
+            headers_tx
+                .send(String::from_utf8(request[..header_end].to_vec()).unwrap())
+                .unwrap();
+            let response = r#"{"candidates":[]}"#;
+            write!(
+                socket,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response.len(),
+                response
+            )
+            .unwrap();
+            socket.flush().unwrap();
+        });
+
+        let proxy = GeminiHttpProxyGuard::start_with_header_env_and_api_key(
+            format!("http://{address}"),
+            &[],
+            Some("upstream-test-key".to_string()),
+        )
+        .unwrap();
+        reqwest::blocking::Client::new()
+            .post(format!(
+                "{}/v1beta/models/gemini-test:generateContent",
+                proxy.base_url()
+            ))
+            .header("x-goog-api-key", "pentect-local")
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(r#"{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}"#)
+            .send()
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+
+        let headers = headers_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .unwrap();
+        upstream.join().unwrap();
+        assert!(
+            headers
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case("x-goog-api-key: upstream-test-key")),
+            "upstream did not receive the gateway-owned key"
+        );
+        assert!(!headers.contains("pentect-local"));
     }
 
     #[test]

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1545,14 +1545,28 @@ fn run_endpoint_env(
             run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
         }
         client_descriptor::Protocol::Gemini => {
-            let proxy = gemini_http_proxy::GeminiHttpProxyGuard::start_with_header_env(
+            let google_api_key = ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+                .iter()
+                .find_map(|name| nonempty_env(name));
+            let shield_child_key = google_api_key.is_some()
+                || upstream::has_google_api_key_override(&opts.upstream_header_env);
+            let proxy = gemini_http_proxy::GeminiHttpProxyGuard::start_with_header_env_and_api_key(
                 upstream,
                 &opts.upstream_header_env,
+                google_api_key,
             )?;
+            shield_google_api_key_env(&mut command, shield_child_key);
             command.env(tool.upstream_env[0], proxy.base_url());
             run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
         }
         _ => Err("internal endpoint-environment protocol mismatch".to_string()),
+    }
+}
+
+fn shield_google_api_key_env(command: &mut Command, enabled: bool) {
+    if enabled {
+        command.env("GEMINI_API_KEY", "pentect-local");
+        command.env("GOOGLE_API_KEY", "pentect-local");
     }
 }
 
@@ -3595,6 +3609,27 @@ mod tests {
         assert_eq!(
             environment.get(OsStr::new(plugins::GLOBAL_BINARY_IDS_ENV)),
             Some(&None)
+        );
+    }
+
+    #[test]
+    fn gemini_child_receives_only_local_placeholder_keys_when_gateway_owns_auth() {
+        let mut command = Command::new("gemini-child");
+        command.env("GEMINI_API_KEY", "inherited-value");
+        command.env("GOOGLE_API_KEY", "inherited-value");
+
+        shield_google_api_key_env(&mut command, true);
+
+        let environment = command
+            .get_envs()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_eq!(
+            environment.get(OsStr::new("GEMINI_API_KEY")),
+            Some(&Some(OsStr::new("pentect-local")))
+        );
+        assert_eq!(
+            environment.get(OsStr::new("GOOGLE_API_KEY")),
+            Some(&Some(OsStr::new("pentect-local")))
         );
     }
 

--- a/crates/pentect-cli/src/upstream.rs
+++ b/crates/pentect-cli/src/upstream.rs
@@ -159,6 +159,57 @@ pub(crate) fn has_authorization_override(specs: &[String]) -> bool {
         })
 }
 
+pub(crate) fn has_google_api_key_override(specs: &[String]) -> bool {
+    std::env::var_os(AUTHORIZATION_ENV).is_some()
+        || specs.iter().any(|spec| {
+            spec.split_once('=').is_some_and(|(name, _)| {
+                matches!(
+                    name.trim().to_ascii_lowercase().as_str(),
+                    "authorization" | "x-goog-api-key"
+                )
+            })
+        })
+}
+
+pub(crate) fn header_overrides_with_google_api_key(
+    specs: &[String],
+    mut api_key: Option<String>,
+) -> Result<HeaderOverrides, String> {
+    let mut overrides = match header_overrides(specs) {
+        Ok(overrides) => overrides,
+        Err(error) => {
+            if let Some(value) = api_key.as_mut() {
+                value.zeroize();
+            }
+            return Err(error);
+        }
+    };
+    if overrides.suppress_origin_auth {
+        if let Some(value) = api_key.as_mut() {
+            value.zeroize();
+        }
+        return Ok(overrides);
+    }
+    let Some(mut value) = api_key else {
+        return Ok(overrides);
+    };
+    if value.is_empty() {
+        return Err("provider Google API key is empty".to_string());
+    }
+    if value.len() > 16 * 1024 {
+        value.zeroize();
+        return Err("provider Google API key is too large".to_string());
+    }
+    let header = sensitive_header_value(&value, "provider Google API key");
+    value.zeroize();
+    overrides.suppress_origin_auth = true;
+    overrides.values.push(HeaderOverride {
+        name: reqwest::header::HeaderName::from_static("x-goog-api-key"),
+        value: Some(header?),
+    });
+    Ok(overrides)
+}
+
 pub(crate) fn header_overrides_with_bearer_env(
     specs: &[String],
     bearer_env: Option<&str>,
@@ -582,6 +633,52 @@ mod tests {
             "Bearer provider-test-key"
         );
         assert!(!overrides.forward_incoming_header("authorization"));
+    }
+
+    #[test]
+    fn provider_google_key_becomes_an_upstream_only_header() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let _authorization = EnvRestore::remove(AUTHORIZATION_ENV);
+        let overrides = header_overrides_with_google_api_key(
+            &[],
+            Some("synthetic-google-provider-key".to_string()),
+        )
+        .unwrap();
+        let request = overrides
+            .apply(reqwest::Client::new().get("https://example.test"))
+            .build()
+            .unwrap();
+        assert_eq!(
+            request.headers().get("x-goog-api-key").unwrap(),
+            "synthetic-google-provider-key"
+        );
+        assert!(!overrides.forward_incoming_header("x-goog-api-key"));
+        assert!(!overrides.forward_incoming_header("authorization"));
+        assert!(request
+            .headers()
+            .get("x-goog-api-key")
+            .unwrap()
+            .is_sensitive());
+    }
+
+    #[test]
+    fn explicit_google_auth_override_prevents_provider_key_injection() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let _authorization = EnvRestore::remove(AUTHORIZATION_ENV);
+        let _explicit = EnvRestore::set("PENTECT_TEST_GOOGLE_OVERRIDE", "explicit-test-key");
+        let specs = ["x-goog-api-key=PENTECT_TEST_GOOGLE_OVERRIDE".to_string()];
+        assert!(has_google_api_key_override(&specs));
+        let overrides =
+            header_overrides_with_google_api_key(&specs, Some("ignored-provider-key".to_string()))
+                .unwrap();
+        let request = overrides
+            .apply(reqwest::Client::new().get("https://example.test"))
+            .build()
+            .unwrap();
+        assert_eq!(
+            request.headers().get("x-goog-api-key").unwrap(),
+            "explicit-test-key"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- capture inherited `GEMINI_API_KEY` / `GOOGLE_API_KEY` before launching Gemini
- move the selected key into a sensitive gateway-owned `x-goog-api-key` override and zeroize the source string
- give the child only `pentect-local`, preventing the agent and its tools from inheriting the provider key
- preserve explicit Authorization and `x-goog-api-key` overrides

Cloud Code is intentionally unchanged: Antigravity uses OAuth, so these API-key variables are not its provider credentials. Removing unrelated Google keys from that child would change general environment inheritance without providing replacement authentication.

## Root cause
The endpoint-environment launcher redirected Gemini traffic but still relied on the child to attach the real key. Unlike the OpenAI launchers, the gateway did not own the provider credential.

## Verification
- local proxy E2E: a request carrying the child placeholder reached a localhost recorder with only the gateway-owned key
- focused tests cover generated header injection, explicit override precedence, child environment replacement, and plaintext absence upstream
- `git diff --check`

This PR is stacked after #1168, #1170, and #1174 so their already-running CI can merge in dependency order without repeated full runs.

Closes #1110