### PR TITLE
Run file plugins for inline Base64 attachments

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -2039,6 +2039,23 @@ fn protect_chat_request(
             local_response: Some(body),
         });
     }
+    let inline_file_partial = {
+        let plugins = plugins
+            .lock()
+            .map_err(|_| "Claude App plugin lock was poisoned".to_string())?;
+        crate::http_files::run_anthropic_inline_file_stages(
+            &value,
+            &plugins,
+            "claude",
+            "desktop_http_json",
+        )
+    }?;
+    if block_unknown_formats && inline_file_partial {
+        return Err(
+            "unknown format blocked: a Claude App file plugin reported partial inline-file coverage"
+                .to_string(),
+        );
+    }
     let mut masker = masker
         .lock()
         .map_err(|_| "Claude App Chat masker lock was poisoned".to_string())?;

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -884,7 +884,7 @@ fn protect_anthropic_request_body(
             value,
             Some(serde_json::json!({"provider": "anthropic", "transport": "http"})),
         )?;
-    let plugin_partial = run.coverage == pentect_agent::MiddlewareCoverage::Partial;
+    let mut plugin_partial = run.coverage == pentect_agent::MiddlewareCoverage::Partial;
     value = run.payload;
     if let Some(outcome) = run.stopped {
         if outcome == pentect_agent::StopOutcome::Block {
@@ -901,6 +901,17 @@ fn protect_anthropic_request_body(
             })
             .map_err(|error| format!("could not encode plugin response: {error}"));
     }
+    plugin_partial |= {
+        let plugins = plugins
+            .lock()
+            .map_err(|_| "Claude plugin lock was poisoned".to_string())?;
+        crate::http_files::run_anthropic_inline_file_stages(
+            &value,
+            &plugins,
+            "anthropic",
+            "http_json",
+        )
+    }?;
     let unknown_content_kind = anthropic_request_unknown_content_kind(&value, endpoint);
     let partial_schema = unknown_content_kind.is_some();
     if block_unknown_formats && (partial_schema || plugin_partial) {

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -618,6 +618,23 @@ fn protect_request_body(
                 .to_string(),
         );
     }
+    let inline_file_partial = {
+        let plugins = plugins
+            .lock()
+            .map_err(|_| "Google Cloud Code plugin lock was poisoned".to_string())?;
+        crate::http_files::run_google_inline_file_stages(
+            &value,
+            &plugins,
+            "google-cloud-code",
+            "http_json",
+        )
+    }?;
+    if block_unknown_formats && inline_file_partial {
+        return Err(
+            "unknown format blocked: a file plugin reported partial Google Cloud Code inline-file coverage"
+                .to_string(),
+        );
+    }
     let mut masker = masker
         .lock()
         .map_err(|_| "Google Cloud Code request masker lock was poisoned".to_string())?;

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -504,6 +504,18 @@ fn protect_request_body(
         );
     }
     value = run.payload;
+    let inline_file_partial = {
+        let plugins = plugins
+            .lock()
+            .map_err(|_| "Gemini plugin lock was poisoned".to_string())?;
+        crate::http_files::run_google_inline_file_stages(&value, &plugins, "gemini", "http_json")
+    }?;
+    if block_unknown_formats && inline_file_partial {
+        return Err(
+            "unknown format blocked: a file plugin reported partial Gemini inline-file coverage"
+                .to_string(),
+        );
+    }
     let mut masker = masker
         .lock()
         .map_err(|_| "Gemini masker lock was poisoned".to_string())?;

--- a/crates/pentect-cli/src/http_files.rs
+++ b/crates/pentect-cli/src/http_files.rs
@@ -442,6 +442,221 @@ fn run_file_stage(
     Ok(run.payload)
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct InlineFileMetadata {
+    filename: Option<String>,
+    media_type: String,
+    size: usize,
+}
+
+pub(crate) fn run_anthropic_inline_file_stages(
+    value: &serde_json::Value,
+    plugins: &pentect_agent::PluginMiddleware,
+    provider: &str,
+    transport: &str,
+) -> Result<bool, String> {
+    let mut files = Vec::new();
+    collect_anthropic_inline_files(value, &mut files);
+    run_inline_file_stages(files, plugins, provider, transport)
+}
+
+pub(crate) fn run_google_inline_file_stages(
+    value: &serde_json::Value,
+    plugins: &pentect_agent::PluginMiddleware,
+    provider: &str,
+    transport: &str,
+) -> Result<bool, String> {
+    let mut files = Vec::new();
+    collect_google_inline_files(value, &mut files);
+    run_inline_file_stages(files, plugins, provider, transport)
+}
+
+fn run_inline_file_stages(
+    files: Vec<InlineFileMetadata>,
+    plugins: &pentect_agent::PluginMiddleware,
+    provider: &str,
+    transport: &str,
+) -> Result<bool, String> {
+    let mut partial = false;
+    for file in files {
+        let run = plugins.run(
+            pentect_agent::MiddlewareStage::File,
+            serde_json::json!({
+                "filename": file.filename,
+                "media_type": file.media_type,
+                "size": file.size,
+            }),
+            Some(serde_json::json!({
+                "provider": provider,
+                "transport": transport,
+                "inline": true,
+                "encoding": "base64",
+            })),
+        )?;
+        partial |= run.coverage == pentect_agent::MiddlewareCoverage::Partial;
+        if run.stopped.is_some() {
+            return Err(format!(
+                "file upload blocked: {}",
+                run.message
+                    .unwrap_or_else(|| "blocked by plugin".to_string())
+            ));
+        }
+    }
+    Ok(partial)
+}
+
+fn collect_anthropic_inline_files(value: &serde_json::Value, output: &mut Vec<InlineFileMetadata>) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_anthropic_inline_files(value, output);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            let kind = object
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            if matches!(kind, "document" | "image") {
+                if let Some(source) = object.get("source").and_then(serde_json::Value::as_object) {
+                    if source.get("type").and_then(serde_json::Value::as_str) == Some("base64") {
+                        push_inline_file(
+                            output,
+                            object_filename(object),
+                            source
+                                .get("media_type")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or("application/octet-stream"),
+                            source.get("data").and_then(serde_json::Value::as_str),
+                        );
+                    }
+                } else if let Some((field, data)) = ["file_data", "image_url", "url", "data"]
+                    .into_iter()
+                    .find_map(|key| {
+                        object
+                            .get(key)
+                            .and_then(serde_json::Value::as_str)
+                            .map(|data| (key, data))
+                    })
+                {
+                    if data.starts_with("data:") {
+                        push_data_uri_file(output, object_filename(object), data);
+                    } else if matches!(field, "file_data" | "data") {
+                        push_inline_file(
+                            output,
+                            object_filename(object),
+                            object_media_type(object),
+                            Some(data),
+                        );
+                    }
+                }
+                return;
+            }
+            if matches!(kind, "tool_use" | "mcp_tool_use" | "server_tool_use") {
+                return;
+            }
+            for child in object.values() {
+                collect_anthropic_inline_files(child, output);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_google_inline_files(value: &serde_json::Value, output: &mut Vec<InlineFileMetadata>) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_google_inline_files(value, output);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            if let Some(inline) = object
+                .get("inlineData")
+                .and_then(serde_json::Value::as_object)
+            {
+                push_inline_file(
+                    output,
+                    None,
+                    inline
+                        .get("mimeType")
+                        .or_else(|| inline.get("mime_type"))
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("application/octet-stream"),
+                    inline.get("data").and_then(serde_json::Value::as_str),
+                );
+            }
+            for (key, child) in object {
+                if !matches!(
+                    key.as_str(),
+                    "inlineData" | "functionCall" | "functionResponse"
+                ) {
+                    collect_google_inline_files(child, output);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn object_filename(object: &serde_json::Map<String, serde_json::Value>) -> Option<String> {
+    ["filename", "file_name", "name"]
+        .into_iter()
+        .find_map(|key| object.get(key).and_then(serde_json::Value::as_str))
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn object_media_type(object: &serde_json::Map<String, serde_json::Value>) -> &str {
+    ["media_type", "mime_type", "mimeType"]
+        .into_iter()
+        .find_map(|key| object.get(key).and_then(serde_json::Value::as_str))
+        .filter(|value| !value.is_empty())
+        .unwrap_or("application/octet-stream")
+}
+
+fn push_data_uri_file(output: &mut Vec<InlineFileMetadata>, filename: Option<String>, data: &str) {
+    let Some((metadata, encoded)) = data.split_once(',') else {
+        return;
+    };
+    let Some(media_type) = metadata
+        .strip_prefix("data:")
+        .and_then(|metadata| metadata.strip_suffix(";base64"))
+    else {
+        return;
+    };
+    push_inline_file(output, filename, media_type, Some(encoded));
+}
+
+fn push_inline_file(
+    output: &mut Vec<InlineFileMetadata>,
+    filename: Option<String>,
+    media_type: &str,
+    encoded: Option<&str>,
+) {
+    let Some(encoded) = encoded else {
+        return;
+    };
+    let Ok(max_size) = data_encoding::BASE64.decode_len(encoded.len()) else {
+        return;
+    };
+    let padding = encoded
+        .as_bytes()
+        .iter()
+        .rev()
+        .take_while(|byte| **byte == b'=')
+        .count()
+        .min(2);
+    let Some(size) = max_size.checked_sub(padding) else {
+        return;
+    };
+    output.push(InlineFileMetadata {
+        filename,
+        media_type: media_type.to_string(),
+        size,
+    });
+}
+
 fn extend_protected_output(output: &mut Vec<u8>, bytes: &[u8]) -> Result<(), String> {
     if bytes.len() > MAX_MULTIPART_OUTPUT_BYTES.saturating_sub(output.len()) {
         output.zeroize();
@@ -1399,6 +1614,79 @@ mod tests {
         assert_eq!(
             multipart_boundary("multipart/form-data; boundary=\"hello-world\""),
             Some("hello-world".to_string())
+        );
+    }
+
+    #[test]
+    fn collects_only_known_anthropic_inline_media_blocks() {
+        let value = serde_json::json!({
+            "messages": [{"content": [
+                {"type": "document", "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": "aGVsbG8="
+                }},
+                {"type": "image", "name": "screen.png", "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "YWJjZA=="
+                }},
+                {"type": "document", "file_name": "notes.txt",
+                    "media_type": "text/plain", "file_data": "YWJj"
+                },
+                {"type": "image", "image_url": "https://example.com/not-inline.png"},
+                {"type": "tool_use", "input": {"type": "document", "source": {
+                    "type": "base64", "data": "aGlkZGVu"
+                }}}
+            ]}]
+        });
+        let mut files = Vec::new();
+        collect_anthropic_inline_files(&value, &mut files);
+        assert_eq!(
+            files,
+            [
+                InlineFileMetadata {
+                    filename: None,
+                    media_type: "application/pdf".to_string(),
+                    size: 5,
+                },
+                InlineFileMetadata {
+                    filename: Some("screen.png".to_string()),
+                    media_type: "image/png".to_string(),
+                    size: 4,
+                },
+                InlineFileMetadata {
+                    filename: Some("notes.txt".to_string()),
+                    media_type: "text/plain".to_string(),
+                    size: 3,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn collects_google_inline_data_but_not_function_arguments() {
+        let value = serde_json::json!({
+            "contents": [{"parts": [
+                {"inlineData": {
+                    "mimeType": "text/plain",
+                    "data": "aGVsbG8="
+                }},
+                {"functionCall": {"args": {"inlineData": {
+                    "mimeType": "text/plain",
+                    "data": "aGlkZGVu"
+                }}}}
+            ]}]
+        });
+        let mut files = Vec::new();
+        collect_google_inline_files(&value, &mut files);
+        assert_eq!(
+            files,
+            [InlineFileMetadata {
+                filename: None,
+                media_type: "text/plain".to_string(),
+                size: 5,
+            }]
         );
     }
 

--- a/website/src/content/docs/plugins/overview.md
+++ b/website/src/content/docs/plugins/overview.md
@@ -103,7 +103,9 @@ client input
   → completed tool_call
 ```
 
-The `file` hook runs when Pentect handles supported file information. Built-in
+The `file` hook runs for multipart uploads and known inline Base64 media in
+Anthropic, Claude App, Gemini, and Google Cloud Code requests. Inline media has
+`filename: null`; `media_type` and `size` describe the decoded payload. Built-in
 checks still run. A regex plugin cannot turn them off.
 
 ## What a plugin can see


### PR DESCRIPTION
## What changed

- run File-stage plugins for known Anthropic and Claude App inline Base64 document/image blocks
- run the same stage for Gemini and Google Cloud Code `inlineData`
- pass nullable filename, declared media type, decoded byte size, provider, transport, and inline/Base64 context
- preserve strict-mode handling of partial plugin coverage and local plugin block responses
- avoid treating tool/function arguments or ordinary remote image URLs as uploaded files
- document inline File-stage behavior

## Why

File-stage plugins previously ran only for multipart uploads, so common inline PDF and image attachments bypassed file policy entirely.

## Focused verification

- Anthropic known shapes, direct raw Base64, decoded sizes, remote URL boundary, and nested tool input boundary
- Google `inlineData`, decoded size, and nested function argument boundary
- existing Cloud Code inline-data strict-mode regression test
- `git diff --check`

## Stack

This PR is stacked on #1178 while the strict up-to-date merge queue drains. Enable auto-merge only after its parent PRs have landed and this branch has been updated from `main`.

Closes #1101
