### PR TITLE
test(masking): pin AWS STS access key coverage

### DIFF
--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -1532,6 +1532,7 @@ mod tests {
     // inputs whose validity does not depend on invented vendor test tokens.
     const CORE_FLOOR: &[(&str, &str)] = &[
         ("AKIACSVC3FV5KQHYWH8A", "aws_access_key"),
+        ("ASIACSVC3FV5KQHYWH8A", "aws_sts_access_key"),
         (
             "api_key=Zk7Qx9Lm2Pw8Rt4Vy6Nb1Cs3Df5Gh",
             "keyed_secret",


### PR DESCRIPTION
## Summary
- add a non-example `ASIA...` AWS STS access key ID to the canonical masking recall floor
- prevent future detector-stack changes from silently dropping temporary AWS credentials

## Investigation result
The reported leak no longer reproduces on current `main`. The standard pipeline now uses the native CredSweeper-compatible detector, whose AWS Client ID rule includes `ASIA`. The issue reproduction uses AWS documentation value `ASIAIOSFODNN7EXAMPLE`, which CredSweeper intentionally filters as a known example. A non-example value is masked as `AWS_CLIENT_ID`.

## Focused test
- `pipeline::tests::recall_corpus_core_floor_holds`

Closes #422