### PR TITLE
fix(masking): protect quoted Kubernetes Secret manifests

### DIFF
--- a/crates/pentect-core/src/lib.rs
+++ b/crates/pentect-core/src/lib.rs
@@ -156,8 +156,26 @@ fn has_yaml_key_value(raw: &str, expected_key: &str, expected_value: Option<&str
             return false;
         };
         key.trim() == expected_key
-            && expected_value.is_none_or(|expected| value.trim().eq_ignore_ascii_case(expected))
+            && expected_value.is_none_or(|expected| {
+                yaml_scalar_without_quotes(value).eq_ignore_ascii_case(expected)
+            })
     })
+}
+
+pub(crate) fn yaml_scalar_without_quotes(value: &str) -> &str {
+    let value = value.trim();
+    if value.len() < 2 {
+        return value;
+    }
+    let bytes = value.as_bytes();
+    if matches!(
+        (bytes[0], bytes[value.len() - 1]),
+        (b'"', b'"') | (b'\'', b'\'')
+    ) {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    }
 }
 
 fn looks_like_aws_config(raw: &str) -> bool {
@@ -414,13 +432,17 @@ mod tests {
             infer_kind_with_content(Path::new("stdin"), r#"{"token":"x"}"#),
             Kind::Json
         );
-        assert_eq!(
-            infer_kind_with_content(
-                Path::new("stdin"),
-                "apiVersion: v1\nkind: Secret\nmetadata:\n  name: app\nstringData:\n  password: x\n"
-            ),
-            Kind::Other("structured".into())
-        );
+        for kind in ["Secret", "\"Secret\"", "'Secret'"] {
+            assert_eq!(
+                infer_kind_with_content(
+                    Path::new("stdin"),
+                    &format!(
+                        "apiVersion: v1\nkind: {kind}\nmetadata:\n  name: app\nstringData:\n  password: x\n"
+                    )
+                ),
+                Kind::Other("structured".into())
+            );
+        }
         assert_eq!(
             infer_kind_with_content(
                 Path::new("stdin"),

--- a/crates/pentect-core/src/parse/mod.rs
+++ b/crates/pentect-core/src/parse/mod.rs
@@ -334,8 +334,9 @@ impl Parser for StructuredParser {
     fn parse(&self, raw: &str) -> Option<Vec<Region>> {
         let kubernetes_secret = raw.lines().any(|line| {
             let line = line.trim();
-            line.strip_prefix("kind:")
-                .is_some_and(|value| value.trim().eq_ignore_ascii_case("secret"))
+            line.strip_prefix("kind:").is_some_and(|value| {
+                crate::yaml_scalar_without_quotes(value).eq_ignore_ascii_case("secret")
+            })
         });
         let mut regions = Vec::new();
         let mut yaml_stack: Vec<(usize, String)> = Vec::new();

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -2519,34 +2519,32 @@ mod tests {
 
     #[test]
     fn kubernetes_secret_schema_masks_low_entropy_values_by_key() {
-        let raw = concat!(
-            "apiVersion: v1\n",
-            "kind: Secret\n",
-            "metadata:\n  name: app\n",
-            "stringData:\n  DB_PASSWORD: plain\n",
-            "data:\n  API_TOKEN: YWJj\n",
-        );
-        let result = Engine::with_profile(Profile::Strict).mask(
-            Input {
-                kind: Kind::Other("structured".into()),
-                data: raw.into(),
-            },
-            &Config::insecure_testing(),
-        );
-        assert!(result.masked.contains("name: app"), "{}", result.masked);
-        assert!(
-            result.masked.contains("DB_PASSWORD: <<DB_PASSWORD_"),
-            "{}",
-            result.masked
-        );
-        assert!(
-            result.masked.contains("API_TOKEN: <<API_TOKEN_"),
-            "{}",
-            result.masked
-        );
-        assert!(!result.masked.contains(": plain"), "{}", result.masked);
-        assert!(!result.masked.contains(": YWJj"), "{}", result.masked);
-        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+        for kind in ["Secret", "\"Secret\"", "'Secret'"] {
+            let raw = format!(
+                "apiVersion: v1\nkind: {kind}\nmetadata:\n  name: app\nstringData:\n  DB_PASSWORD: plain\ndata:\n  API_TOKEN: YWJj\n"
+            );
+            let result = Engine::with_profile(Profile::Strict).mask(
+                Input {
+                    kind: Kind::Other("structured".into()),
+                    data: raw.clone(),
+                },
+                &Config::insecure_testing(),
+            );
+            assert!(result.masked.contains("name: app"), "{}", result.masked);
+            assert!(
+                result.masked.contains("DB_PASSWORD: <<DB_PASSWORD_"),
+                "{}",
+                result.masked
+            );
+            assert!(
+                result.masked.contains("API_TOKEN: <<API_TOKEN_"),
+                "{}",
+                result.masked
+            );
+            assert!(!result.masked.contains(": plain"), "{}", result.masked);
+            assert!(!result.masked.contains(": YWJj"), "{}", result.masked);
+            assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- normalize matching single- and double-quoted YAML scalar values in one shared helper
- use the same normalization for content sniffing and structured Kubernetes Secret parsing
- protect low-entropy values under both `data` and `stringData` for `Secret`, `"Secret"`, and `Secret`
- preserve exact restoration of the original manifest

## Root cause
Both content inference and `StructuredParser` compared the raw scalar after `kind:` directly with `Secret`. Valid YAML quotes therefore prevented Secret-schema hints from reaching values under `data` and `stringData`.

## Focused tests
- `kubernetes_secret_schema_masks_low_entropy_values_by_key`
- `content_sniffing_recognizes_structured_stdin_formats`

Closes #419