### PR TITLE
fix(prompt): preserve label-like prose on proxy paths

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -3686,6 +3686,10 @@ fn safe_noop_edit_anchor(content: &str, key: &[u8; 32]) -> Option<String> {
         .split_inclusive('\n')
         .find(|candidate| safe_noop_edit_anchor_candidate(candidate, key))
         .map(str::to_string)
+        // A file made entirely of secret-bearing lines has no publishable
+        // text anchor. Replacing one existing line feed with itself is still
+        // a valid edit no-op and reveals none of the file content.
+        .or_else(|| content.contains('\n').then(|| "\n".to_string()))
 }
 
 fn safe_noop_edit_anchor_candidate(candidate: &str, key: &[u8; 32]) -> bool {

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -132,21 +132,25 @@ impl OutputMasker {
             remasked,
             &Kind::Text,
         )?;
-        // Prompt scalars are structurally text, but dotenv assignments can be
-        // embedded in prose. Run the Env parser first so assignment labels are
-        // preserved, then feed the result through the same cached text engine.
-        let env_result = self.prompt_engine.mask(
-            Input {
-                kind: Kind::Env,
-                data: remasked,
-            },
-            &Config {
-                disclose_length: false,
-                ..Config::new(self.store.session.key)
-                    .with_identity_key(self.store.session.identity_key)
-            },
-        );
-        self.track_mask_result("prompt", &env_result);
+        // Prompt scalars are text. Only opt into dotenv parsing when the
+        // payload actually contains assignment syntax; treating every
+        // `Label: prose` sentence as Env turns ordinary messages into secrets.
+        let env_result = prompt_contains_env_assignments(&remasked).then(|| {
+            self.prompt_engine.mask(
+                Input {
+                    kind: Kind::Env,
+                    data: remasked.clone(),
+                },
+                &Config {
+                    disclose_length: false,
+                    ..Config::new(self.store.session.key)
+                        .with_identity_key(self.store.session.identity_key)
+                },
+            )
+        });
+        if let Some(env_result) = &env_result {
+            self.track_mask_result("prompt", env_result);
+        }
         let mut result = mask_read_input_with_engine_plugins_and_identity(
             self.store.session.key,
             self.store.session.identity_key,
@@ -154,10 +158,18 @@ impl OutputMasker {
             &self.plugin_middleware,
             Input {
                 kind: Kind::Text,
-                data: env_result.masked,
+                data: env_result
+                    .as_ref()
+                    .map_or(remasked, |result| result.masked.clone()),
             },
         )?;
-        result.recovery.extend_same_key(env_result.recovery);
+        if let Some(env_result) = env_result {
+            result.recovery.extend_same_key(env_result.recovery);
+            result.summary.masked_count = result
+                .summary
+                .masked_count
+                .saturating_add(env_result.summary.masked_count);
+        }
         let initially_masked = std::mem::take(&mut result.masked);
         let masked = self.run_text_plugins(
             crate::plugin_middleware::MiddlewareStage::Finalize,
@@ -176,10 +188,7 @@ impl OutputMasker {
             },
         );
         merge_final_mask_result(&mut result, final_result);
-        let masked_count = result
-            .summary
-            .masked_count
-            .saturating_add(env_result.summary.masked_count);
+        let masked_count = result.summary.masked_count;
         self.track_mask_result("prompt", &result);
         self.add_masked_count(masked_count);
         let masked = restore_prompt_unmask_markers(
@@ -1144,6 +1153,14 @@ fn looks_like_sensitive_env_output(text: &str) -> bool {
         }
     }
     false
+}
+
+fn prompt_contains_env_assignments(text: &str) -> bool {
+    looks_like_sensitive_env_output(text)
+        || looks_like_env_output(text)
+        || text
+            .lines()
+            .any(|line| embedded_sensitive_env_assignment_start(line).is_some())
 }
 
 #[cfg(test)]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -764,6 +764,27 @@ fn active_prompt_masks_keyed_and_vendor_secrets_in_prose() {
 }
 
 #[test]
+fn active_prompt_preserves_label_like_plain_prose() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-prompt-prose-precision");
+    let mut masker = ActiveToolOutputMasker::new().unwrap();
+
+    for prompt in [
+        "NOTE: please read the documentation before continuing.",
+        "Error: connection refused while contacting the service.",
+        "Summary: the build passed and all tests are green.",
+        "Question: why does the build fail on Windows only?",
+        "Traceback: File main.py line 12 in handler raise ValueError",
+        "Result: 42",
+        "Error connection refused while contacting the service",
+        "IMPORTANT: this context may or may not be relevant to your tasks.",
+    ] {
+        let masked = masker.mask_prompt_text(prompt).unwrap().unwrap();
+        assert_eq!(masked, prompt, "plain prompt was changed: {prompt}");
+    }
+}
+
+#[test]
 fn active_prompt_explicit_marker_masks_low_entropy_value_and_removes_wrapper() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-prompt-explicit-marker");

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -2026,7 +2026,10 @@ fn write_tool_applies_edit_with_masked_old_string_before_tool() {
         }
     });
     let output = handle_hook(HookProvider::Claude, "t", &session, input).unwrap();
-    assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
+    assert_eq!(
+        output["hookSpecificOutput"]["permissionDecision"], "allow",
+        "{output}"
+    );
     let updated = &output["hookSpecificOutput"]["updatedInput"];
     let old_string = updated["old_string"].as_str().unwrap();
     let new_string = updated["new_string"].as_str().unwrap();


### PR DESCRIPTION
## Summary
- run the Env parser on prompts only when dotenv assignment syntax is actually present
- preserve ordinary `Label: prose` and `Label prose` messages byte-for-byte
- retain strict masking for standalone and prose-embedded sensitive environment assignments
- exercise the real active-memory-store prompt path with every reported example

## Root cause
Although the CLI and proxy now share detectors, `mask_prompt_text` still forced every prompt through `Kind::Env` first. The Env parser interpreted ordinary label-like sentences as key/value records and masked their entire values before the normal text pass.

## Focused tests
- `active_prompt_preserves_label_like_plain_prose`
- `prompt_masking_uses_strict_input_detection_for_env_lines_in_prose`
- `prompt_masked_env_is_available_to_direct_execution`

Closes #407