### PR TITLE
ci: enforce full CredSweeper compatibility gates

### DIFF
--- a/.github/workflows/update-credsweeper.yml
+++ b/.github/workflows/update-credsweeper.yml
@@ -6,6 +6,7 @@ on:
     - cron: "17 3 * * 1"
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -27,21 +28,22 @@ jobs:
       - name: Sync latest CredSweeper release
         run: python tools/update_credsweeper.py latest
 
-      - name: Open update pull request
+      - name: Validate candidate against the full official oracle
+        id: candidate
         env:
           GH_TOKEN: ${{ github.token }}
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           if git diff --quiet --ignore-submodules=dirty && [ -z "$(git status --porcelain)" ]; then
             echo "CredSweeper is already current"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          branch="automation/credsweeper-latest"
+          validation_branch="automation/credsweeper-validation-$GITHUB_RUN_ID"
           version="$(python -c 'import json; print(json.load(open("crates/pentect-core/vendors/credsweeper-assets/SOURCE.json"))["version"])')"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$branch"
+          git checkout -B "$validation_branch"
           git add -- \
             crates/pentect-core/vendors/CredSweeper \
             crates/pentect-core/vendors/credsweeper-assets \
@@ -49,6 +51,30 @@ jobs:
             tools/credsweeper-sidecar/patches/lazy-imports.patch \
             THIRD_PARTY_LICENSES.txt
           git commit -m "chore: update CredSweeper to $version"
+          git push origin "HEAD:$validation_branch"
+
+          run_url="$(gh workflow run credsweeper-regression.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$validation_branch" \
+            -f full=true)"
+          run_id="${run_url##*/}"
+          echo "Full CredData parity: $run_url" >> "$GITHUB_STEP_SUMMARY"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "validation_branch=$validation_branch" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+
+      - name: Open validated update pull request
+        if: steps.candidate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          VALIDATION_BRANCH: ${{ steps.candidate.outputs.validation_branch }}
+          VERSION: ${{ steps.candidate.outputs.version }}
+          PARITY_RUN_URL: ${{ steps.candidate.outputs.run_url }}
+        run: |
+          branch="automation/credsweeper-latest"
           git push --force-with-lease origin "HEAD:$branch"
 
           if [ "$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$branch" --json number --jq 'length')" -eq 0 ]; then
@@ -56,6 +82,13 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --base "$BASE_BRANCH" \
               --head "$branch" \
-              --title "chore: update CredSweeper to $version" \
-              --body "Automated CredSweeper release sync. The CredSweeper regression workflow must pass before this update is merged."
+              --title "chore: update CredSweeper to $VERSION" \
+              --body "Automated CredSweeper release sync. The full 333-repository native/oracle compatibility gate passed before this PR was opened: $PARITY_RUN_URL"
           fi
+
+      - name: Remove temporary validation branch
+        if: always() && steps.candidate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VALIDATION_BRANCH: ${{ steps.candidate.outputs.validation_branch }}
+        run: git push origin --delete "$VALIDATION_BRANCH"

--- a/.github/workflows/update-credsweeper.yml
+++ b/.github/workflows/update-credsweeper.yml
@@ -52,16 +52,35 @@ jobs:
             THIRD_PARTY_LICENSES.txt
           git commit -m "chore: update CredSweeper to $version"
           git push origin "HEAD:$validation_branch"
-
-          run_url="$(gh workflow run credsweeper-regression.yml \
-            --repo "$GITHUB_REPOSITORY" \
-            --ref "$validation_branch" \
-            -f full=true)"
-          run_id="${run_url##*/}"
-          echo "Full CredData parity: $run_url" >> "$GITHUB_STEP_SUMMARY"
           echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "validation_branch=$validation_branch" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          candidate_sha="$(git rev-parse HEAD)"
+          gh workflow run credsweeper-regression.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$validation_branch" \
+            -f full=true
+          run_id=""
+          for _ in $(seq 1 30); do
+            run_id="$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow credsweeper-regression.yml \
+              --event workflow_dispatch \
+              --branch "$validation_branch" \
+              --commit "$candidate_sha" \
+              --limit 10 \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')"
+            [ -n "$run_id" ] && break
+            sleep 2
+          done
+          if [ -z "$run_id" ]; then
+            echo "Could not locate the dispatched CredSweeper parity run" >&2
+            exit 1
+          fi
+          run_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/$run_id"
+          echo "Full CredData parity: $run_url" >> "$GITHUB_STEP_SUMMARY"
           echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
           gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
 

--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -3837,7 +3837,11 @@ fn load_der_private_key(data: &[u8]) -> Option<CredSweeperPrivateKey> {
     if let Some(key) = load_pkcs8_private_key(data) {
         return Some(key);
     }
-    let store = KeyStore::from_pkcs12(data, "", Pkcs12ImportPolicy::Raw).ok()?;
+    // Raw import stores an unlinked private key and its certificate under the
+    // same friendly name. The certificate is inserted last and can overwrite
+    // the key entry. Relaxed import links matching local-key IDs while still
+    // retaining unmatched private keys, matching CredSweeper's load_pk probe.
+    let store = KeyStore::from_pkcs12(data, "", Pkcs12ImportPolicy::Relaxed).ok()?;
     let (_, chain) = store.private_key_chain()?;
     load_pkcs8_private_key(chain.key().as_der())
 }
@@ -6874,7 +6878,7 @@ fn normalize_label(rule: &str) -> String {
 mod tests {
     use super::*;
     use crate::detect::region;
-    use p12_keystore::{KeyStoreEntry, PrivateKey, PrivateKeyChain};
+    use p12_keystore::{Certificate, KeyStoreEntry, PrivateKey, PrivateKeyChain};
 
     fn rsa_pkcs8_fixture() -> Vec<u8> {
         BASE64
@@ -6922,6 +6926,27 @@ mod tests {
         store.add_entry("test", KeyStoreEntry::PrivateKeyChain(chain));
         let p12 = store.writer("").write().expect("PKCS#12 fixture");
         let key = load_der_private_key(&p12).expect("load PKCS#12");
+        assert!(private_key_is_valid(&key));
+    }
+
+    #[test]
+    fn private_key_loader_keeps_pkcs12_keys_that_share_a_certificate_alias() {
+        let ed25519 = data_encoding::HEXLOWER
+            .decode(b"302e020100300506032b65700422042017ed9c73e9db649ec189a612831c5fc570238207c1aa9dfbd2c53e3ff5e5ea85")
+            .expect("Ed25519 PKCS#8 fixture");
+        let certificate = BASE64
+            .decode(b"MIIBWDCCAQqgAwIBAgIUJHqHxlYUeJLW/OvjdnQXBwy/eWswBQYDK2VwMBYxFDASBgNVBAMMC2V4YW1wbGUuY29tMB4XDTI2MDYxOTA2MjA1OFoXDTI4MDUxOTA2MjA1OFowFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wKjAFBgMrZXADIQBZeSuQJmHBhe6U7x4GDBUMK4INE8VxqP311K/ejllcnaNqMGgwCQYDVR0TBAIwADAaBgNVHREEEzARgglsb2NhbGhvc3SHBH8AAAEwCwYDVR0PBAQDAgOIMBMGA1UdJQQMMAoGCCsGAQUFBwMBMB0GA1UdDgQWBBSw1lXZ6Gnm3DuRtrFmcWOZEYxdqjAFBgMrZXADQQCicT1reAXWy/i58EABJ2n2zNYdeKP1jyvjlUwzm81sZbNfeaqYNjJoYAK1EBiCW0PGfFIuS++1od7w56YgV+EO")
+            .expect("X.509 fixture");
+        let chain = PrivateKeyChain::new(
+            [1_u8, 2, 3, 4].as_slice(),
+            PrivateKey::from_der(&ed25519).expect("private key"),
+            [Certificate::from_der(&certificate).expect("certificate")],
+        );
+        let mut store = KeyStore::new();
+        store.add_entry("shared alias", KeyStoreEntry::PrivateKeyChain(chain));
+        let p12 = store.writer("").write().expect("PKCS#12 fixture");
+
+        let key = load_der_private_key(&p12).expect("load PKCS#12 key with certificate");
         assert!(private_key_is_valid(&key));
     }
 

--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -6937,14 +6937,22 @@ mod tests {
         let certificate = BASE64
             .decode(b"MIIBWDCCAQqgAwIBAgIUJHqHxlYUeJLW/OvjdnQXBwy/eWswBQYDK2VwMBYxFDASBgNVBAMMC2V4YW1wbGUuY29tMB4XDTI2MDYxOTA2MjA1OFoXDTI4MDUxOTA2MjA1OFowFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wKjAFBgMrZXADIQBZeSuQJmHBhe6U7x4GDBUMK4INE8VxqP311K/ejllcnaNqMGgwCQYDVR0TBAIwADAaBgNVHREEEzARgglsb2NhbGhvc3SHBH8AAAEwCwYDVR0PBAQDAgOIMBMGA1UdJQQMMAoGCCsGAQUFBwMBMB0GA1UdDgQWBBSw1lXZ6Gnm3DuRtrFmcWOZEYxdqjAFBgMrZXADQQCicT1reAXWy/i58EABJ2n2zNYdeKP1jyvjlUwzm81sZbNfeaqYNjJoYAK1EBiCW0PGfFIuS++1od7w56YgV+EO")
             .expect("X.509 fixture");
+        let certificate = Certificate::from_der(&certificate).expect("certificate");
+        let alias = certificate.subject().to_owned();
         let chain = PrivateKeyChain::new(
             [1_u8, 2, 3, 4].as_slice(),
             PrivateKey::from_der(&ed25519).expect("private key"),
-            [Certificate::from_der(&certificate).expect("certificate")],
+            [certificate],
         );
         let mut store = KeyStore::new();
-        store.add_entry("shared alias", KeyStoreEntry::PrivateKeyChain(chain));
+        store.add_entry(&alias, KeyStoreEntry::PrivateKeyChain(chain));
         let p12 = store.writer("").write().expect("PKCS#12 fixture");
+        let raw =
+            KeyStore::from_pkcs12(&p12, "", Pkcs12ImportPolicy::Raw).expect("raw PKCS#12 import");
+        assert!(
+            raw.private_key_chain().is_none(),
+            "fixture must reproduce the same-alias overwrite"
+        );
 
         let key = load_der_private_key(&p12).expect("load PKCS#12 key with certificate");
         assert!(private_key_is_valid(&key));

--- a/tools/creddata_shards.py
+++ b/tools/creddata_shards.py
@@ -121,6 +121,8 @@ def summarize(root: Path, artifacts: Path, count: int, output: Path) -> None:
 
         report_path = manifest_path.with_name("report.json")
         report = load_json(report_path)
+        if report.get("schema") != 2:
+            raise SystemExit(f"unsupported parity report schema: {report_path}")
         for key in totals:
             totals[key] += int(report[key])
         for rule, counts in report["by_rule"].items():

--- a/tools/creddata_shards.py
+++ b/tools/creddata_shards.py
@@ -102,6 +102,7 @@ def summarize(root: Path, artifacts: Path, count: int, output: Path) -> None:
     seen_indices: set[int] = set()
     seen_repositories: set[str] = set()
     totals = {key: 0 for key in ("rust", "oracle", "common", "missing", "extra")}
+    by_rule: dict[str, dict[str, int]] = {}
     versions: set[str] = set()
     metadata_files = 0
     for manifest_path in manifests:
@@ -122,6 +123,10 @@ def summarize(root: Path, artifacts: Path, count: int, output: Path) -> None:
         report = load_json(report_path)
         for key in totals:
             totals[key] += int(report[key])
+        for rule, counts in report["by_rule"].items():
+            aggregate = by_rule.setdefault(rule, {key: 0 for key in totals})
+            for key in totals:
+                aggregate[key] += int(counts[key])
         if int(report["missing"]) or int(report["extra"]):
             raise SystemExit(f"CredSweeper mismatch in shard {index}: {report_path}")
         if not bool(report["ml_probability_within_tolerance"]):
@@ -140,11 +145,12 @@ def summarize(root: Path, artifacts: Path, count: int, output: Path) -> None:
         raise SystemExit(f"shards used different CredSweeper versions: {sorted(versions)}")
 
     summary = {
-        "schema": 1,
+        "schema": 2,
         "shards": count,
         "repositories": len(seen_repositories),
         "metadata_files": metadata_files,
         "credsweeper_version": versions.pop(),
+        "by_rule": dict(sorted(by_rule.items())),
         **totals,
     }
     write_json(output, summary)

--- a/tools/pentect-bench/src/main.rs
+++ b/tools/pentect-bench/src/main.rs
@@ -1399,8 +1399,18 @@ impl fmt::Display for CredSweeperParityExample {
     }
 }
 
+#[derive(Clone, Debug, Default, Serialize)]
+struct CredSweeperParityRuleCounts {
+    rust: usize,
+    oracle: usize,
+    common: usize,
+    missing: usize,
+    extra: usize,
+}
+
 #[derive(Clone, Debug, Serialize)]
 struct CredSweeperParityReport {
+    schema: u32,
     dataset: &'static str,
     #[serde(rename = "rust")]
     rust_count: usize,
@@ -1415,6 +1425,7 @@ struct CredSweeperParityReport {
     ml_probability_max_delta: f64,
     ml_probability_tolerance: f64,
     ml_probability_within_tolerance: bool,
+    by_rule: BTreeMap<String, CredSweeperParityRuleCounts>,
     missing_examples: Vec<CredSweeperParityExample>,
     extra_examples: Vec<CredSweeperParityExample>,
 }
@@ -1433,13 +1444,30 @@ impl CredSweeperParityReport {
         let mut extra = 0usize;
         let mut missing_examples = Vec::new();
         let mut extra_examples = Vec::new();
+        let mut by_rule = BTreeMap::<String, CredSweeperParityRuleCounts>::new();
+
+        for (key, seen) in &rust {
+            by_rule.entry(key.rule.clone()).or_default().rust += *seen;
+        }
+        for (key, seen) in &oracle {
+            by_rule.entry(key.rule.clone()).or_default().oracle += *seen;
+        }
 
         for (key, oracle_seen) in &oracle {
             let rust_seen = rust.get(key).copied().unwrap_or(0);
-            common += (*oracle_seen).min(rust_seen);
+            let shared = (*oracle_seen).min(rust_seen);
+            common += shared;
+            by_rule
+                .get_mut(&key.rule)
+                .expect("oracle rule was inventoried")
+                .common += shared;
             if *oracle_seen > rust_seen {
                 let count = *oracle_seen - rust_seen;
                 missing += count;
+                by_rule
+                    .get_mut(&key.rule)
+                    .expect("oracle rule was inventoried")
+                    .missing += count;
                 if missing_examples.len() < example_limit {
                     missing_examples.push(key.to_example(count));
                 }
@@ -1451,6 +1479,10 @@ impl CredSweeperParityReport {
             if *rust_seen > oracle_seen {
                 let count = *rust_seen - oracle_seen;
                 extra += count;
+                by_rule
+                    .get_mut(&key.rule)
+                    .expect("Rust rule was inventoried")
+                    .extra += count;
                 if extra_examples.len() < example_limit {
                     extra_examples.push(key.to_example(count));
                 }
@@ -1465,6 +1497,7 @@ impl CredSweeperParityReport {
             2.0 * precision * recall / (precision + recall)
         };
         Self {
+            schema: 2,
             dataset: "credsweeper-parity",
             rust_count,
             oracle_count,
@@ -1478,6 +1511,7 @@ impl CredSweeperParityReport {
             ml_probability_tolerance: CREDSWEEPER_ML_PROBABILITY_TOLERANCE,
             ml_probability_within_tolerance: ml_probability_max_delta
                 <= CREDSWEEPER_ML_PROBABILITY_TOLERANCE,
+            by_rule,
             missing_examples,
             extra_examples,
         }
@@ -1863,6 +1897,7 @@ mod tests {
         let oracle = credsweeper_parity_multiset(&credentials);
         let report = CredSweeperParityReport::build(rust, oracle, 10, 0.0);
 
+        assert_eq!(report.schema, 2);
         assert_eq!(report.rust_count, 1);
         assert_eq!(report.oracle_count, 1);
         assert_eq!(report.common, 1);
@@ -1870,6 +1905,12 @@ mod tests {
         assert_eq!(report.extra, 0);
         assert_eq!(report.precision, 1.0);
         assert_eq!(report.recall, 1.0);
+        let rule = &report.by_rule["api-key"];
+        assert_eq!(rule.rust, 1);
+        assert_eq!(rule.oracle, 1);
+        assert_eq!(rule.common, 1);
+        assert_eq!(rule.missing, 0);
+        assert_eq!(rule.extra, 0);
     }
 
     #[test]
@@ -1961,6 +2002,12 @@ mod tests {
         assert!(missing.contains("len=17"), "{missing}");
         assert!(extra.contains("len=15"), "{extra}");
         assert!(missing.contains("sha256="), "{missing}");
+        let rule = &report.by_rule["api-key"];
+        assert_eq!(rule.rust, 1);
+        assert_eq!(rule.oracle, 1);
+        assert_eq!(rule.common, 0);
+        assert_eq!(rule.missing, 1);
+        assert_eq!(rule.extra, 1);
     }
 
     #[test]

--- a/tools/test_creddata_shards.py
+++ b/tools/test_creddata_shards.py
@@ -48,6 +48,15 @@ class CredDataShardsTest(unittest.TestCase):
                         "missing": 0,
                         "extra": 0,
                         "ml_probability_within_tolerance": True,
+                        "by_rule": {
+                            "Test Rule": {
+                                "rust": repository_count,
+                                "oracle": repository_count,
+                                "common": repository_count,
+                                "missing": 0,
+                                "extra": 0,
+                            }
+                        },
                     },
                 )
 
@@ -59,6 +68,9 @@ class CredDataShardsTest(unittest.TestCase):
             self.assertEqual(summary["credsweeper_version"], "v1.2.3")
             self.assertEqual(summary["missing"], 0)
             self.assertEqual(summary["extra"], 0)
+            self.assertEqual(
+                summary["by_rule"]["Test Rule"]["common"], len(snapshot)
+            )
 
     def test_partition_balances_metadata_weight(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/test_creddata_shards.py
+++ b/tools/test_creddata_shards.py
@@ -42,6 +42,7 @@ class CredDataShardsTest(unittest.TestCase):
                 self.write_json(
                     shard_artifact / "report.json",
                     {
+                        "schema": 2,
                         "rust": repository_count,
                         "oracle": repository_count,
                         "common": repository_count,
@@ -68,9 +69,13 @@ class CredDataShardsTest(unittest.TestCase):
             self.assertEqual(summary["credsweeper_version"], "v1.2.3")
             self.assertEqual(summary["missing"], 0)
             self.assertEqual(summary["extra"], 0)
-            self.assertEqual(
-                summary["by_rule"]["Test Rule"]["common"], len(snapshot)
-            )
+            self.assertEqual(summary["schema"], 2)
+            rule = summary["by_rule"]["Test Rule"]
+            self.assertEqual(rule["rust"], len(snapshot))
+            self.assertEqual(rule["oracle"], len(snapshot))
+            self.assertEqual(rule["common"], len(snapshot))
+            self.assertEqual(rule["missing"], 0)
+            self.assertEqual(rule["extra"], 0)
 
     def test_partition_balances_metadata_weight(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Root cause

The weekly full-corpus workflow had not yet been executed, and automated update PRs created with `GITHUB_TOKEN` did not prove full native/oracle parity before opening. The first manual 333-repository run exposed one real native false negative: a PKCS#12 private key was lost because `Raw` import inserted a certificate with the same friendly name after the private key and overwrote the key entry.

## Changes

- validate every automated CredSweeper update against all 333 CredData repositories before opening its PR
- retain unmatched PKCS#12 keys while linking matching certificate local-key IDs
- add a same-alias PKCS#12 regression test
- publish value-free per-rule Rust/oracle/common/missing/extra counts in shard and weekly summaries
- clean up temporary validation branches on success or failure

## Focused verification

- PKCS#12 private-key loader tests: 5 passed
- reproduced the v1.18.1 shard-4 mismatch (`BASE64 Private Key`, missing=1)
- reran the affected CredData repository after the fix: rust=72, oracle=72, common=72, missing=0, extra=0
- parity-report tests: 6 passed
- shard aggregation tests: 2 passed
- actionlint: passed

Progresses #399.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PKCS#12 private-key handling when certificates and keys share the same alias.
* **New Features**
  * Added per-rule breakdowns to CredSweeper parity reports, including schema versioning and detailed comparison counts.
  * Enhanced shard summaries with aggregated rule-level results.
* **Chores**
  * CredSweeper updates are now validated against the full official regression suite before update pull requests are opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->