### PR TITLE
release: v0.0.67

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.66"
+version = "0.0.67"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.66"
+version = "0.0.67"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
Prepare v0.0.67.

Includes the merged prompt precision fix (#1193), full CredSweeper v1.18.1 compatibility gate and PKCS#12 fix (#1194), and Windows Codex App lifecycle fix (#1195).

Release assets, package publication, and installation-to-agent E2E remain gated by the tag workflow after this version bump merges.
