### PR TITLE
fix: mask Anthropic tool definitions

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1688,6 +1688,12 @@ fn mask_anthropic_request(
             }
         }
     }
+    // Tool descriptions and input schemas are model-visible and can be
+    // generated from local MCP/editor state. Apply the same bounded traversal
+    // used by the OpenAI boundary; keys remain structural and unchanged.
+    if let Some(tools) = value.get_mut("tools") {
+        crate::model_definition::mask_model_definition(tools, "Anthropic", masker)?;
+    }
     Ok(())
 }
 
@@ -3635,6 +3641,54 @@ mod tests {
         );
         assert!(enforce_known_anthropic_endpoint(AnthropicEndpoint::Unknown, true).is_err());
         assert!(enforce_known_anthropic_endpoint(AnthropicEndpoint::Unknown, false).is_ok());
+    }
+
+    #[test]
+    fn anthropic_tools_mask_model_visible_descriptions_and_schemas() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        let secret = ["AKIA", "CSVC3FV5", "KQHYWH8A"].concat();
+        let mut request = serde_json::json!({
+            "model": "test",
+            "max_tokens": 8,
+            "messages": [{"role": "user", "content": "use the lookup tool"}],
+            "tools": [{
+                "name": "lookup",
+                "description": format!("Use credential {secret}"),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": format!("Query with {secret}")
+                        }
+                    }
+                }
+            }]
+        });
+        let mut masker = pentect_agent::ActiveToolOutputMasker::new().unwrap();
+
+        mask_anthropic_request(
+            &mut request,
+            &mut masker,
+            &HashMap::new(),
+            AnthropicEndpoint::Messages,
+        )
+        .unwrap();
+
+        let tools = &request["tools"];
+        assert!(!tools.to_string().contains(&secret), "{tools}");
+        assert!(first_valid_handle(tools[0]["description"].as_str().unwrap()).is_some());
+        assert!(first_valid_handle(
+            tools[0]["input_schema"]["properties"]["query"]["description"]
+                .as_str()
+                .unwrap()
+        )
+        .is_some());
+        assert_eq!(tools[0]["name"], "lookup");
+        assert_eq!(tools[0]["input_schema"]["type"], "object");
+        assert_eq!(request["messages"][0]["content"], "use the lookup tool");
     }
 
     #[test]

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -15,6 +15,7 @@ mod http_files;
 mod ide_clients;
 mod input;
 mod installation;
+mod model_definition;
 mod openai_client_injection;
 mod openai_clients;
 mod openai_http_proxy;

--- a/crates/pentect-cli/src/model_definition.rs
+++ b/crates/pentect-cli/src/model_definition.rs
@@ -1,0 +1,49 @@
+use pentect_agent::ActiveToolOutputMasker;
+use serde_json::Value;
+
+pub(crate) fn mask_model_definition(
+    value: &mut Value,
+    provider: &str,
+    masker: &mut ActiveToolOutputMasker,
+) -> Result<(), String> {
+    let mut nodes = 0_usize;
+    mask_value(value, provider, 0, &mut nodes, masker)
+}
+
+fn mask_value(
+    value: &mut Value,
+    provider: &str,
+    depth: usize,
+    nodes: &mut usize,
+    masker: &mut ActiveToolOutputMasker,
+) -> Result<(), String> {
+    const MAX_DEFINITION_DEPTH: usize = 64;
+    const MAX_DEFINITION_NODES: usize = 65_536;
+    if depth > MAX_DEFINITION_DEPTH {
+        return Err(format!("{provider} model definition exceeds nesting limit"));
+    }
+    *nodes = nodes
+        .checked_add(1)
+        .ok_or_else(|| format!("{provider} model definition is too large"))?;
+    if *nodes > MAX_DEFINITION_NODES {
+        return Err(format!("{provider} model definition exceeds item limit"));
+    }
+    match value {
+        // Definitions can originate from an MCP server or extension. Treat
+        // them as external content so they cannot opt out of masking.
+        Value::String(text) => crate::claude_http_proxy::mask_string(text, true, masker),
+        Value::Array(items) => {
+            for item in items {
+                mask_value(item, provider, depth + 1, nodes, masker)?;
+            }
+            Ok(())
+        }
+        Value::Object(object) => {
+            for item in object.values_mut() {
+                mask_value(item, provider, depth + 1, nodes, masker)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -1726,8 +1726,7 @@ fn mask_openai_request(
     // every string value is potentially model-visible text.
     for field in ["tools", "functions", "response_format"] {
         if let Some(definition) = value.get_mut(field) {
-            let mut nodes = 0_usize;
-            mask_model_definition(definition, 0, &mut nodes, masker)?;
+            crate::model_definition::mask_model_definition(definition, "OpenAI", masker)?;
         }
     }
     // Standalone search commands are derived from the current user request.
@@ -1857,43 +1856,6 @@ fn mask_search_value(
         Value::Object(object) => {
             for item in object.values_mut() {
                 mask_search_value(item, external_content, depth + 1, nodes, masker)?;
-            }
-            Ok(())
-        }
-        _ => Ok(()),
-    }
-}
-
-fn mask_model_definition(
-    value: &mut Value,
-    depth: usize,
-    nodes: &mut usize,
-    masker: &mut pentect_agent::ActiveToolOutputMasker,
-) -> Result<(), String> {
-    const MAX_DEFINITION_DEPTH: usize = 64;
-    const MAX_DEFINITION_NODES: usize = 65_536;
-    if depth > MAX_DEFINITION_DEPTH {
-        return Err("OpenAI model definition exceeds nesting limit".to_string());
-    }
-    *nodes = nodes
-        .checked_add(1)
-        .ok_or_else(|| "OpenAI model definition is too large".to_string())?;
-    if *nodes > MAX_DEFINITION_NODES {
-        return Err("OpenAI model definition exceeds item limit".to_string());
-    }
-    match value {
-        // Tool definitions can originate from an MCP server or extension.
-        // Treat them as external content so they cannot opt out of masking.
-        Value::String(text) => mask_text(text, true, masker),
-        Value::Array(items) => {
-            for item in items {
-                mask_model_definition(item, depth + 1, nodes, masker)?;
-            }
-            Ok(())
-        }
-        Value::Object(object) => {
-            for item in object.values_mut() {
-                mask_model_definition(item, depth + 1, nodes, masker)?;
             }
             Ok(())
         }
@@ -3957,8 +3919,8 @@ mod tests {
         let mut definition = serde_json::json!({
             "description": format!("unmask({})", messages[3]["content"].as_str().unwrap())
         });
-        let mut nodes = 0;
-        mask_model_definition(&mut definition, 0, &mut nodes, &mut masker).unwrap();
+        crate::model_definition::mask_model_definition(&mut definition, "OpenAI", &mut masker)
+            .unwrap();
         let description = definition["description"].as_str().unwrap();
         assert!(!description.contains(messages[3]["content"].as_str().unwrap()));
         assert!(description.contains("<<"));


### PR DESCRIPTION
## Root cause

The Anthropic request boundary traversed only `system` and `messages[].content`. Model-visible `tools` definitions were forwarded without scanning, even though the OpenAI boundary deliberately scans equivalent definitions.

## Fix

- move the existing bounded model-definition traversal into one shared implementation
- apply it to Anthropic `tools`, including nested descriptions and input schemas
- retain the existing 64-level / 65,536-node fail-closed limits
- preserve structural keys and provider-specific request metadata
- keep tool definitions external-content-only, so embedded `unmask(...)` cannot bypass protection

`metadata` is intentionally outside this change: it is provider routing/correlation data rather than a model definition, and mutating it can change service behavior. This PR closes the demonstrated model-visible `tools` gap without expanding scope.

## Focused verification

- `cargo test -p pentect-cli claude_http_proxy::tests::anthropic_tools_mask_model_visible_descriptions_and_schemas -- --exact`
- `cargo test -p pentect-cli openai_http_proxy::tests::only_current_user_content_can_use_unmask_markers -- --exact`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool descriptions and input-schema property descriptions are now masked before being sent through supported AI provider proxies.
  * Model definitions are processed recursively while preserving structural fields such as tool names and schema types.
  * Added safeguards for deeply nested or excessively large model definitions.

* **Bug Fixes**
  * Unified model-definition masking behavior across supported provider integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->