### PR TITLE
test: document Antigravity user settings schema

### DIFF
--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -1655,6 +1655,28 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_user_settings_remain_control_only() {
+        let endpoint = classify_endpoint("/v1internal:setUserSettings");
+        assert_eq!(endpoint, CloudCodeEndpoint::Control);
+        assert!(!endpoint.is_protected());
+
+        // Extracted protobuf schema:
+        // google.internal.cloud.code.v1internal.SetUserSettingsRequest.
+        // UserSettings contains only these three boolean controls; it has no
+        // prompt, custom-instruction, identifier, or other free-form field.
+        let payload = serde_json::json!({
+            "userSettings": {
+                "telemetryEnabled": true,
+                "userDataCollectionForceDisabled": false,
+                "marketingEmailsEnabled": false
+            }
+        });
+        let settings = payload["userSettings"].as_object().unwrap();
+        assert_eq!(settings.len(), 3);
+        assert!(settings.values().all(Value::is_boolean));
+    }
+
+    #[test]
     fn custom_cloud_code_base_path_and_query_are_preserved() {
         let upstream = crate::upstream::parse_base(
             "http://127.0.0.1:8080/team/cloud-code?tenant=demo",


### PR DESCRIPTION
## Finding

`/v1internal:setUserSettings` is a control-plane settings endpoint, not a prompt-bearing endpoint.

The extracted protobuf descriptor for `google.internal.cloud.code.v1internal.SetUserSettingsRequest` points to `UserSettings`, which contains exactly three fields:

- `telemetry_enabled: bool`
- `user_data_collection_force_disabled: bool`
- `marketing_emails_enabled: bool`

Schema evidence: https://github.com/jkfujinami/antigravity-client/blob/9bf1d415f8ba2390a87f2c58309ff6d74388ebd6/src/gen/exa/google/internal/cloud/code/v1internal/jetski_service_pb.ts#L248-L352

There is no prompt, conversation history, custom-instruction, identifier, or free-form field to mask. Running generic string masking on this endpoint would therefore add compatibility risk without protecting content.

## Change

Add a focused regression test that records the verified payload shape and requires this endpoint to remain an unprotected `Control` endpoint.

Real-account traffic verification remains unavailable and is not claimed. The decision is based on the generated protobuf descriptor extracted from the Antigravity client binary.

## Focused verification

- `cargo test -p pentect-cli cloud_code_http_proxy::tests::antigravity_user_settings_remain_control_only -- --exact`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1097
