### PR TITLE
fix: preserve global privacy opt-outs

### DIFF
--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -456,13 +456,19 @@ pub(crate) fn remember_files_enabled() -> Result<bool, String> {
 pub(crate) fn activity_share_enabled() -> Result<bool, String> {
     let project = read_activity_share(project_config_path())?;
     let global = read_activity_share(global_config_path()?)?;
-    Ok(project.or(global).unwrap_or(true))
+    Ok(local_privacy_setting_enabled(project, global))
 }
 
 pub(crate) fn metrics_enabled() -> Result<bool, String> {
     let project = read_metrics_enabled(project_config_path())?;
     let global = read_metrics_enabled(global_config_path()?)?;
-    Ok(project.or(global).unwrap_or(true))
+    Ok(local_privacy_setting_enabled(project, global))
+}
+
+fn local_privacy_setting_enabled(project: Option<bool>, global: Option<bool>) -> bool {
+    // A repository may narrow local event sharing and metrics visibility, but
+    // it must not re-enable either after the user disabled it globally.
+    global.unwrap_or(true) && project.unwrap_or(true)
 }
 
 pub(crate) fn update_check_enabled() -> Result<bool, String> {
@@ -1729,6 +1735,19 @@ unknown_min_bytes = 32
 
         let invalid = "[metrics]\nenabled = 3".parse::<toml::Value>().unwrap();
         assert!(metrics_enabled_value(&invalid).is_err());
+    }
+
+    #[test]
+    fn local_privacy_settings_default_on_and_either_scope_can_disable_them() {
+        assert!(local_privacy_setting_enabled(None, None));
+        assert!(local_privacy_setting_enabled(Some(true), None));
+        assert!(local_privacy_setting_enabled(None, Some(true)));
+        assert!(local_privacy_setting_enabled(Some(true), Some(true)));
+        assert!(!local_privacy_setting_enabled(Some(false), None));
+        assert!(!local_privacy_setting_enabled(None, Some(false)));
+        assert!(!local_privacy_setting_enabled(Some(false), Some(true)));
+        assert!(!local_privacy_setting_enabled(Some(true), Some(false)));
+        assert!(!local_privacy_setting_enabled(Some(false), Some(false)));
     }
 
     #[test]

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -172,8 +172,14 @@ enabled = true
 never sent externally. Setting it to `false` disables the summary; diagnostic
 logging and rotation continue independently so crashes remain diagnosable.
 
+For `activity.share` and `metrics.enabled`, `false` in either the user config or
+the project config disables the feature. A project cannot re-enable a feature
+that the user disabled globally.
+
 Project values normally override user values. `agent.required` is stricter: if
-either file sets it to `true`, the effective value is true.
+either file sets it to `true`, the effective value is true. The local privacy
+settings above and `output.restore` are opt-out settings, so `false` in either
+scope wins.
 
 ## Assistant output restoration
 


### PR DESCRIPTION
## Why

A repository-level .pentect/config.toml could set activity.share or metrics.enabled to true and override false in the user config. These features are local-only, but an untrusted project should not be able to reverse an explicit user preference.

## What changed

- require both user and project scopes to permit local activity sharing
- apply the same precedence to local metrics visibility
- preserve the existing enabled-by-default behavior
- test every project/global boolean combination
- document that these controls are local-only and that false in either scope wins

## Verification

- cargo test -p pentect-runtime config::tests::local_privacy_settings_default_on_and_either_scope_can_disable_them --locked -- --exact
- cargo fmt --all -- --check
- git diff --check

Closes #1032