### PR TITLE
fix: inspect SSE response tails at EOF

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -2757,12 +2757,20 @@ where
                 None => {
                     state.finished = true;
                     if let Some(mut transformer) = state.transformer.take() {
-                        state.ready.extend(
-                            transformer
-                                .finish()
-                                .into_iter()
-                                .map(|chunk| Ok(Frame::data(chunk))),
-                        );
+                        match transformer.finish() {
+                            Ok(chunks) => state
+                                .ready
+                                .extend(chunks.into_iter().map(|chunk| Ok(Frame::data(chunk)))),
+                            Err(error) => {
+                                eprintln!(
+                                    "[pentect] Claude App Chat response blocked at EOF: {error}"
+                                );
+                                state.ready.push_back(Err(Box::new(io::Error::new(
+                                    io::ErrorKind::PermissionDenied,
+                                    error,
+                                ))));
+                            }
+                        }
                     }
                 }
             }

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1239,13 +1239,15 @@ fn streaming_response_body(
                 }
                 None => {
                     state.finished = true;
-                    state.ready.extend(
-                        state
-                            .transformer
-                            .finish()
-                            .into_iter()
-                            .map(|chunk| Ok(Frame::data(chunk))),
-                    );
+                    match state.transformer.finish() {
+                        Ok(chunks) => state
+                            .ready
+                            .extend(chunks.into_iter().map(|chunk| Ok(Frame::data(chunk)))),
+                        Err(error) => state.ready.push_back(Err(Box::new(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            error,
+                        )))),
+                    }
                 }
             }
         }
@@ -1363,20 +1365,20 @@ where
         Ok(output)
     }
 
-    pub(crate) fn finish(&mut self) -> Vec<Bytes> {
+    pub(crate) fn finish(&mut self) -> Result<Vec<Bytes>, String> {
         if self.terminated {
-            return Vec::new();
+            return Ok(Vec::new());
         }
-        let mut output = self.finish_output_text();
-        if let Some(mut tools) = self.tool_buffer.take() {
-            tools.bytes.append(&mut self.pending);
-            if !tools.bytes.is_empty() {
-                output.push(Bytes::from(tools.bytes));
-            }
-        } else if !self.pending.is_empty() {
-            output.push(Bytes::from(std::mem::take(&mut self.pending)));
+        let mut output = Vec::new();
+        if !self.pending.is_empty() {
+            let pending = std::mem::take(&mut self.pending);
+            self.process_block(pending, &mut output)?;
         }
-        output
+        if self.tool_buffer.take().is_some() {
+            return Err("Anthropic SSE tool input ended before content_block_stop".to_string());
+        }
+        output.extend(self.finish_output_text());
+        Ok(output)
     }
 
     fn finish_output_text(&mut self) -> Vec<Bytes> {
@@ -4244,7 +4246,7 @@ mod tests {
     }
 
     #[test]
-    fn interrupted_tool_stream_keeps_handles_unresolved() {
+    fn interrupted_tool_stream_fails_closed_without_emitting_handles() {
         let incomplete = concat!(
             "event: content_block_start\n",
             "data: {\"type\":\"content_block_start\",\"index\":3,\"content_block\":{\"type\":\"tool_use\",\"input\":{}}}\n\n",
@@ -4257,9 +4259,28 @@ mod tests {
             false,
         );
         assert!(transformer.push(incomplete.as_bytes()).unwrap().is_empty());
-        let output = join_bytes(transformer.finish());
-        assert!(output.contains("<<SECRET_deadbeef>>"));
-        assert!(!output.contains("must-not-appear"));
+        let error = transformer.finish().unwrap_err();
+        assert!(error.contains("ended before content_block_stop"), "{error}");
+    }
+
+    #[test]
+    fn unterminated_final_sse_event_is_processed_at_eof() {
+        let event = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"<<SECRET_deadbeef>>\"}}"
+        );
+        let mut transformer = SseStreamTransformer::new(
+            |text: &str| Ok(text.replace("<<SECRET_deadbeef>>", "local-value")),
+            None,
+            true,
+        );
+        let output = transformer.push(event.as_bytes()).unwrap();
+        assert!(join_bytes(output).contains("content_block_start"));
+        let output = join_bytes(transformer.finish().unwrap());
+        assert!(output.contains("local-value"), "{output}");
+        assert!(!output.contains("<<SECRET_deadbeef>>"), "{output}");
     }
 
     #[test]
@@ -4321,7 +4342,7 @@ mod tests {
             error
         );
         assert!(transformer.push(after_error.as_bytes()).unwrap().is_empty());
-        assert!(transformer.finish().is_empty());
+        assert!(transformer.finish().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -902,18 +902,35 @@ fn streaming_response_body(
                 }
                 None => {
                     state.finished = true;
-                    if !state.pending.is_empty() {
-                        state
-                            .ready
-                            .push_back(Ok(Frame::data(Bytes::from(std::mem::take(
-                                &mut state.pending,
-                            )))));
+                    match rewrite_pending_sse(
+                        &mut state.pending,
+                        &state.plugins,
+                        state.block_unknown_formats,
+                    ) {
+                        Ok(Some(block)) => state.ready.push_back(Ok(Frame::data(block))),
+                        Ok(None) => {}
+                        Err(error) => state.ready.push_back(Err(Box::new(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            error,
+                        )))),
                     }
                 }
             }
         }
     });
     StreamBody::new(stream).boxed_unsync()
+}
+
+fn rewrite_pending_sse(
+    pending: &mut Vec<u8>,
+    plugins: &Mutex<pentect_agent::PluginMiddleware>,
+    block_unknown_formats: bool,
+) -> Result<Option<Bytes>, String> {
+    if pending.is_empty() {
+        return Ok(None);
+    }
+    let pending = std::mem::take(pending);
+    rewrite_sse_block(&pending, plugins, block_unknown_formats).map(Some)
 }
 
 fn rewrite_sse_block(
@@ -1638,5 +1655,21 @@ mod tests {
             "{rewritten:?}"
         );
         assert!(rewritten.ends_with("\r\n\r\n"), "{rewritten:?}");
+    }
+
+    #[test]
+    fn unterminated_final_sse_event_is_processed_at_eof() {
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let mut pending = br#"data: {"candidates":[]}"#.to_vec();
+        let rewritten = rewrite_pending_sse(&mut pending, &plugins, true)
+            .unwrap()
+            .unwrap();
+        assert!(pending.is_empty());
+        assert!(rewritten.ends_with(b"\n\n"));
+
+        let mut malformed = b"data: {broken".to_vec();
+        let error = rewrite_pending_sse(&mut malformed, &plugins, true).unwrap_err();
+        assert!(malformed.is_empty());
+        assert!(error.starts_with("unknown format blocked:"), "{error}");
     }
 }

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -2681,6 +2681,45 @@ enum StreamTransform {
     Completions,
 }
 
+fn process_stream_block(state: &mut StreamState, block: Vec<u8>) -> Result<(), String> {
+    let block = run_sse_response_plugins(&block, &state.plugins)?;
+    let rewritten = match state.transform {
+        StreamTransform::Responses => rewrite_openai_sse_block(
+            &block,
+            &state.plugins,
+            state.restore_output,
+            &mut state.output_text,
+            &mut state.output_resolve,
+        ),
+        StreamTransform::ChatCompletions => state.chat.rewrite_block(
+            &block,
+            &state.plugins,
+            state.restore_output,
+            &mut state.output_resolve,
+        ),
+        StreamTransform::Completions => {
+            state
+                .completions
+                .rewrite_block(&block, state.restore_output, &mut state.output_resolve)
+        }
+        StreamTransform::None => Ok(vec![Bytes::from(block)]),
+    }?;
+    for block in rewritten {
+        if !block.is_empty() {
+            state.ready.push_back(Ok(Frame::data(block)));
+        }
+    }
+    Ok(())
+}
+
+fn process_pending_stream_block(state: &mut StreamState) -> Result<(), String> {
+    if state.pending.is_empty() {
+        return Ok(());
+    }
+    let pending = std::mem::take(&mut state.pending);
+    process_stream_block(state, pending)
+}
+
 fn streaming_response_body(
     response: reqwest::Response,
     transform: StreamTransform,
@@ -2725,54 +2764,13 @@ fn streaming_response_body(
                     state.pending.extend_from_slice(&chunk);
                     while let Some(end) = first_sse_block_end(&state.pending) {
                         let block = state.pending.drain(..end).collect::<Vec<_>>();
-                        let block = match run_sse_response_plugins(&block, &state.plugins) {
-                            Ok(block) => block,
-                            Err(error) => {
-                                state.finished = true;
-                                state.ready.push_back(Err(Box::new(io::Error::new(
-                                    io::ErrorKind::PermissionDenied,
-                                    error,
-                                ))));
-                                break;
-                            }
-                        };
-                        let rewritten = match state.transform {
-                            StreamTransform::Responses => rewrite_openai_sse_block(
-                                &block,
-                                &state.plugins,
-                                state.restore_output,
-                                &mut state.output_text,
-                                &mut state.output_resolve,
-                            ),
-                            StreamTransform::ChatCompletions => state.chat.rewrite_block(
-                                &block,
-                                &state.plugins,
-                                state.restore_output,
-                                &mut state.output_resolve,
-                            ),
-                            StreamTransform::Completions => state.completions.rewrite_block(
-                                &block,
-                                state.restore_output,
-                                &mut state.output_resolve,
-                            ),
-                            StreamTransform::None => Ok(vec![Bytes::from(block)]),
-                        };
-                        match rewritten {
-                            Ok(blocks) => {
-                                for block in blocks {
-                                    if !block.is_empty() {
-                                        state.ready.push_back(Ok(Frame::data(block)));
-                                    }
-                                }
-                            }
-                            Err(error) => {
-                                state.finished = true;
-                                state.ready.push_back(Err(Box::new(io::Error::new(
-                                    io::ErrorKind::PermissionDenied,
-                                    error,
-                                ))));
-                                break;
-                            }
+                        if let Err(error) = process_stream_block(&mut state, block) {
+                            state.finished = true;
+                            state.ready.push_back(Err(Box::new(io::Error::new(
+                                io::ErrorKind::PermissionDenied,
+                                error,
+                            ))));
+                            break;
                         }
                     }
                 }
@@ -2785,6 +2783,13 @@ fn streaming_response_body(
                 }
                 None => {
                     state.finished = true;
+                    if let Err(error) = process_pending_stream_block(&mut state) {
+                        state.ready.push_back(Err(Box::new(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            error,
+                        ))));
+                        continue;
+                    }
                     if state.transform == StreamTransform::ChatCompletions {
                         match state.chat.finish_output_text("data: {}\n\n") {
                             Ok(blocks) => {
@@ -2809,13 +2814,6 @@ fn streaming_response_body(
                                 error,
                             )))),
                         }
-                    }
-                    if !state.pending.is_empty() {
-                        state
-                            .ready
-                            .push_back(Ok(Frame::data(Bytes::from(std::mem::take(
-                                &mut state.pending,
-                            )))));
                     }
                 }
             }
@@ -4893,6 +4891,65 @@ mod tests {
         assert_eq!(finished[1], Bytes::from_static(b"data: [DONE]\n\n"));
         assert!(state.calls.is_empty());
         assert_eq!(state.buffered_bytes, 0);
+    }
+
+    #[test]
+    fn unterminated_final_chat_event_is_processed_at_eof() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = ProviderBoundaryTestEnv::install(&store);
+        let mut masker = pentect_agent::ActiveToolOutputMasker::new().unwrap();
+        let masked = masker
+            .mask_prompt_text("pentect(local-value)")
+            .unwrap()
+            .unwrap();
+        let handle = first_handle(&masked).unwrap();
+        let event = format!(
+            "data: {}",
+            serde_json::json!({
+                "id": "chat_eof",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"tool_calls": [{
+                        "index": 0,
+                        "id": "call_eof",
+                        "type": "function",
+                        "function": {
+                            "name": "shell",
+                            "arguments": format!("{{\"token\":\"{handle}\"}}")
+                        }
+                    }]},
+                    "finish_reason": "tool_calls"
+                }]
+            })
+        );
+        let upstream: UpstreamByteStream =
+            Box::pin(stream::empty::<Result<Bytes, reqwest::Error>>());
+        let mut state = StreamState {
+            upstream,
+            pending: event.into_bytes(),
+            ready: VecDeque::new(),
+            transform: StreamTransform::ChatCompletions,
+            chat: ChatStreamState::default(),
+            completions: CompletionStreamState::default(),
+            finished: false,
+            plugins: Arc::new(Mutex::new(pentect_agent::PluginMiddleware::default())),
+            restore_output: false,
+            output_text: HashMap::new(),
+            output_resolve: Box::new(|text| Ok(text.to_string())),
+        };
+
+        process_pending_stream_block(&mut state).unwrap();
+        assert!(state.pending.is_empty());
+        let mut output = Vec::new();
+        while let Some(frame) = state.ready.pop_front() {
+            if let Ok(data) = frame.unwrap().into_data() {
+                output.extend_from_slice(&data);
+            }
+        }
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("local-value"), "{output}");
+        assert!(!output.contains(&handle), "{output}");
     }
 
     #[test]


### PR DESCRIPTION
## Why

Gemini, OpenAI, and Anthropic transformed complete SSE blocks during normal streaming but emitted the final unterminated buffer through separate raw-byte EOF paths. This bypassed response plugins, provider transforms, handle restoration, and strict Gemini format handling. Anthropic also emitted an entire partial tool-use buffer if the stream ended before content_block_stop.

This is primarily a local execution and correctness boundary bug, not a new request-side plaintext leak to the model.

## What changed

- Gemini rewrites a pending final event through the normal SSE response transformer
- strict malformed Gemini tails fail instead of passing through
- OpenAI uses one shared block processor for normal and EOF events
- OpenAI EOF tails run response plugins and the selected Responses, Chat Completions, or Completions transformer before text restorers are flushed
- Anthropic processes a valid final event before flushing output text
- interrupted Anthropic tool-use streams fail closed instead of emitting partial unresolved calls
- Claude Desktop handles the new EOF error explicitly and logs the reason

## Verification

- all three unterminated-final-event regressions pass
- OpenAI test uses a real in-process memory store and restores a known handle in an unterminated Chat Completions tool call
- Anthropic interrupted tool stream fails closed
- Anthropic streaming tests: 4 passed
- OpenAI chat streaming tests: 4 passed
- cargo fmt --all -- --check
- git diff --check

Closes #1020