### PR TITLE
release: v0.0.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.67"
+version = "0.0.68"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.67"
+version = "0.0.68"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
Prepare v0.0.68.

Includes the merged model-definition masking fix (#395), Antigravity schema verification (#1097), release automation repair (#1200), Claude Voice WebSocket support (#1071), Windows child-process and certificate lifecycle fixes (#1042, #1039), local privacy-setting precedence fix (#1032), short trusted-secret recovery fix (#1024), and complete SSE EOF processing across Gemini, OpenAI, and Anthropic (#1020).

Release assets, package publication, and installation-to-agent E2E remain gated by the tag workflow after this version bump merges.