### PR TITLE
fix: allow recursive Wasm root permissions

### DIFF
--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -1690,14 +1690,16 @@ fn validate_permissions(permissions: Option<&PermissionsConfig>) -> Result<(), S
         for path in paths {
             let valid_root = path.starts_with("project:") || path.starts_with("plugin:");
             let relative = path.split_once(':').map(|(_, value)| value).unwrap_or("");
+            let recursive_root = matches!(relative, "**" | "/**");
             if !valid_root
-                || relative.is_empty()
-                || relative.starts_with(['/', '\\'])
-                || relative
-                    .split(['/', '\\'])
-                    .any(|part| part.is_empty() || part == "." || part == "..")
-                || (!relative.ends_with("/**") && relative.contains('*'))
-                || relative.contains('?')
+                || (!recursive_root
+                    && (relative.is_empty()
+                        || relative.starts_with(['/', '\\'])
+                        || relative
+                            .split(['/', '\\'])
+                            .any(|part| part.is_empty() || part == "." || part == "..")
+                        || (!relative.ends_with("/**") && relative.contains('*'))
+                        || relative.contains('?')))
             {
                 return Err(format!(
                     "Wasm permission {kind} path must be project:PATH or plugin:PATH and may only end in /**"
@@ -4426,6 +4428,12 @@ mod tests {
         let broad_glob: PermissionsConfig =
             toml::from_str(r#"read = ["project:**/*.env"]"#).unwrap();
         assert!(validate_permissions(Some(&broad_glob)).is_err());
+
+        for path in ["project:**", "project:/**", "plugin:**", "plugin:/**"] {
+            let recursive_root: PermissionsConfig =
+                toml::from_str(&format!(r#"read = ["{path}"]"#)).unwrap();
+            validate_permissions(Some(&recursive_root)).unwrap();
+        }
     }
 
     #[test]

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -3331,10 +3331,15 @@ fn parse_path_permission(name: &str, value: &str) -> Result<PathPermission, Stri
             ))
         }
     };
-    let recursive = relative.ends_with("/**");
-    let relative = relative.strip_suffix("/**").unwrap_or(relative);
+    let recursive_root = matches!(relative, "**" | "/**");
+    let recursive = recursive_root || relative.ends_with("/**");
+    let relative = if recursive_root {
+        ""
+    } else {
+        relative.strip_suffix("/**").unwrap_or(relative)
+    };
     let relative = PathBuf::from(relative);
-    if relative.as_os_str().is_empty()
+    if (!recursive_root && relative.as_os_str().is_empty())
         || relative
             .components()
             .any(|component| !matches!(component, std::path::Component::Normal(_)))
@@ -4805,6 +4810,64 @@ disk = "CPU: about 5 GB"
             Instant::now() + Duration::from_secs(5),
         );
         assert!(!denied_command.ok);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recursive_root_permissions_reach_nested_files_without_escaping_the_root() {
+        for value in ["project:**", "project:/**"] {
+            let permission = parse_path_permission("fixture", value).unwrap();
+            assert_eq!(permission.scope, PathScope::Project);
+            assert!(permission.relative.as_os_str().is_empty());
+            assert!(permission.recursive);
+        }
+        for value in ["plugin:**", "plugin:/**"] {
+            let permission = parse_path_permission("fixture", value).unwrap();
+            assert_eq!(permission.scope, PathScope::Plugin);
+            assert!(permission.relative.as_os_str().is_empty());
+            assert!(permission.recursive);
+        }
+
+        let root = std::env::temp_dir().join(format!(
+            "pentect-plugin-recursive-root-{}",
+            std::process::id()
+        ));
+        let project = root.join("project");
+        let plugin = root.join("plugin");
+        let storage = root.join("storage");
+        std::fs::create_dir_all(project.join("nested")).unwrap();
+        std::fs::create_dir_all(&plugin).unwrap();
+        std::fs::create_dir_all(&storage).unwrap();
+        std::fs::write(project.join("nested/visible.txt"), "visible").unwrap();
+        std::fs::write(root.join("outside.txt"), "hidden").unwrap();
+
+        let policy = PermissionPolicy {
+            name: "fixture".to_string(),
+            read: vec![parse_path_permission("fixture", "project:**").unwrap()],
+            write: Vec::new(),
+            env: BTreeSet::new(),
+            run: BTreeMap::new(),
+            storage: false,
+            project_root: project.canonicalize().unwrap(),
+            plugin_root: plugin.canonicalize().unwrap(),
+            storage_root: storage.canonicalize().unwrap(),
+        };
+        let nested = perform_host_request(
+            &policy,
+            HostRequest::FileRead {
+                path: "project:nested/visible.txt".to_string(),
+            },
+            Instant::now() + Duration::from_secs(1),
+        );
+        assert_eq!(nested.value, Some(Value::String("visible".to_string())));
+        let escaped = perform_host_request(
+            &policy,
+            HostRequest::FileRead {
+                path: "project:../outside.txt".to_string(),
+            },
+            Instant::now() + Duration::from_secs(1),
+        );
+        assert!(!escaped.ok);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/website/src/content/docs/plugins/manifest.md
+++ b/website/src/content/docs/plugins/manifest.md
@@ -178,8 +178,10 @@ storage = true
 ```
 
 `project:` means the current project. `plugin:` means the plugin directory.
-Paths are exact unless they end in `/**`. Parent traversal and general glob
-patterns are rejected. Commands are argv arrays and must match exactly; no
+Paths are exact unless they end in `/**`. Use `project:**` or `project:/**` for
+the whole project recursively, and the equivalent `plugin:` forms for the whole
+plugin directory. Parent traversal and general glob patterns are rejected.
+Commands are argv arrays and must match exactly; no
 shell parses them. Pentect resolves the approved executable to one absolute
 path before the Wasm plugin can request it. `storage = true` enables private
 persistent JSON storage.


### PR DESCRIPTION
Fixes #1017.

## Root cause

Both the CLI manifest validator and runtime permission parser assumed that a recursive permission always contained at least one subdirectory before `/**`. That made the project or plugin root impossible to represent.

## Changes

- accept `project:**` and `project:/**` as equivalent recursive project-root permissions
- accept the corresponding `plugin:` forms
- preserve rejection of traversal, absolute paths, and partial globs
- document the root-recursive forms
- test CLI validation, runtime parsing, nested file access, and root confinement

## Focused verification

- `cargo test -p pentect-cli wasm_permissions_use_compact_explicit_scopes -- --nocapture`
- `cargo test -p pentect-runtime recursive_root_permissions_reach_nested_files_without_escaping_the_root -- --nocapture`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recursive-root Wasm permissions using `project:**`, `project:/**`, `plugin:**`, or `plugin:/**`.
  * These permissions grant access to all files within the corresponding project or plugin directory.

* **Bug Fixes**
  * Recursive permissions now correctly allow nested file access while preventing path traversal outside the permitted directory.

* **Documentation**
  * Updated plugin manifest documentation to describe recursive permissions, exact paths, and supported path restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->