### PR TITLE
fix: retry npm asset body download failures

### DIFF
--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -54,7 +54,7 @@ export function retryableStatus(status) {
   return status === 408 || status === 429 || status >= 500;
 }
 
-export async function fetchWithRetry(url, options = {}) {
+export async function downloadWithRetry(url, options = {}) {
   const request = options.request || globalThis.fetch;
   const wait = options.wait || ((milliseconds) => new Promise(
     (resolveDelay) => setTimeout(resolveDelay, milliseconds),
@@ -68,9 +68,24 @@ export async function fetchWithRetry(url, options = {}) {
         headers: { 'user-agent': 'pentect-npm-installer' },
         signal: timeout(),
       });
-      if (!retryableStatus(response.status) || attempt === 3) return response;
-      await response.body?.cancel();
-      lastError = new Error(`Download failed (${response.status} ${response.statusText})`);
+      if (!response.ok) {
+        await response.body?.cancel();
+        if (!retryableStatus(response.status) || attempt === 3) {
+          return {
+            ok: false,
+            status: response.status,
+            statusText: response.statusText,
+          };
+        }
+        lastError = new Error(`Download failed (${response.status} ${response.statusText})`);
+      } else {
+        return {
+          ok: true,
+          status: response.status,
+          statusText: response.statusText,
+          bytes: Buffer.from(await response.arrayBuffer()),
+        };
+      }
     } catch (error) {
       lastError = error;
       if (attempt === 3) throw error;
@@ -81,14 +96,14 @@ export async function fetchWithRetry(url, options = {}) {
 }
 
 async function download(url) {
-  const response = await fetchWithRetry(url);
+  const response = await downloadWithRetry(url);
   if (!response.ok) throw new Error(`Download failed (${response.status} ${response.statusText})`);
-  return Buffer.from(await response.arrayBuffer());
+  return response.bytes;
 }
 
 async function downloadBinary(base, asset) {
-  const compressed = await fetchWithRetry(`${base}/${asset}.gz`);
-  if (compressed.ok) return gunzipSync(Buffer.from(await compressed.arrayBuffer()));
+  const compressed = await downloadWithRetry(`${base}/${asset}.gz`);
+  if (compressed.ok) return gunzipSync(compressed.bytes);
   if (compressed.status !== 404) {
     throw new Error(`Download failed (${compressed.status} ${compressed.statusText})`);
   }

--- a/packaging/npm/install.test.js
+++ b/packaging/npm/install.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   expectedChecksum,
-  fetchWithRetry,
+  downloadWithRetry,
   installationPath,
   releaseAsset,
   retryableStatus,
@@ -35,16 +35,54 @@ test('retries only transient download failures', () => {
   assert.equal(retryableStatus(401), false);
 });
 
-test('retries transient responses before returning success', async () => {
+test('retries transient responses before returning a complete body', async () => {
   const statuses = [503, 429, 200];
   const waits = [];
-  const response = await fetchWithRetry('https://example.invalid/pentect', {
-    request: async () => new Response(null, { status: statuses.shift() }),
+  const cancelled = [];
+  const response = await downloadWithRetry('https://example.invalid/pentect', {
+    request: async () => {
+      const status = statuses.shift();
+      if (status === 200) return new Response('pentect', { status });
+      return {
+        ok: false,
+        status,
+        statusText: 'transient',
+        body: { cancel: async () => cancelled.push(status) },
+      };
+    },
     timeout: () => undefined,
     wait: async (milliseconds) => waits.push(milliseconds),
   });
   assert.equal(response.status, 200);
+  assert.equal(response.bytes.toString('utf8'), 'pentect');
   assert.deepEqual(waits, [250, 500]);
+  assert.deepEqual(cancelled, [503, 429]);
+});
+
+test('retries when a successful response fails during body download', async () => {
+  let requests = 0;
+  const waits = [];
+  const response = await downloadWithRetry('https://example.invalid/pentect', {
+    request: async () => {
+      requests += 1;
+      if (requests === 1) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          arrayBuffer: async () => {
+            throw new Error('body download timed out');
+          },
+        };
+      }
+      return new Response('complete', { status: 200 });
+    },
+    timeout: () => undefined,
+    wait: async (milliseconds) => waits.push(milliseconds),
+  });
+  assert.equal(requests, 2);
+  assert.deepEqual(waits, [250]);
+  assert.equal(response.bytes.toString('utf8'), 'complete');
 });
 
 test('uses a user-writable versioned cache for the installed binary', () => {


### PR DESCRIPTION
Fixes #1222.

## Root cause

The npm retry boundary ended when `fetch()` returned response headers. Body consumption happened later via `arrayBuffer()`, so a timeout during a slow release-asset body download bypassed all configured retries.

## Changes

- consume the complete response body inside each retry attempt
- restart from a fresh response after transient header or body failures
- cancel bodies for rejected HTTP responses
- preserve 404 compressed-asset fallback and mandatory SHA-256 verification
- add a deterministic regression test for a successful response whose body fails before a later attempt succeeds

## Verification

- `npm test` (9 passed)
- fresh `PENTECT_NPM_CACHE` launcher smoke downloaded, verified, and ran published v0.0.68: `pentect 0.0.68`
- `git diff --check`