### PR TITLE
fix: resolve project plugin state from project root

### DIFF
--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -397,7 +397,7 @@ pub(crate) fn config_specs_scoped() -> Result<Vec<(PluginScope, String)>> {
     let mut specs = Vec::new();
     for (scope, path) in [
         (PluginScope::User, user_plugin_config_path()?),
-        (PluginScope::Project, project_plugin_config_path()),
+        (PluginScope::Project, project_plugin_config_path()?),
     ] {
         for spec in config_specs_at(&path)? {
             if let Some(existing) = specs.iter_mut().find(|(_, value)| value == &spec) {
@@ -426,8 +426,11 @@ fn config_specs_at(path: &Path) -> Result<Vec<String>> {
         .with_context(|| format!("invalid plugin config '{}'", path.display()))
 }
 
-pub(crate) fn project_plugin_config_path() -> PathBuf {
-    PathBuf::from(PENTECT_DIR).join(PENTECT_CONFIG_FILE)
+pub(crate) fn project_plugin_config_path() -> Result<PathBuf> {
+    Ok(pentect_agent::project_root()
+        .map_err(anyhow::Error::msg)?
+        .join(PENTECT_DIR)
+        .join(PENTECT_CONFIG_FILE))
 }
 
 pub(crate) fn user_plugin_config_path() -> Result<PathBuf> {
@@ -548,7 +551,7 @@ fn plugin_paths_for_named_scoped(
     scope: PluginScope,
 ) -> Result<PluginPaths> {
     validate_plugin_name(name)?;
-    let project_dir = plugins_root().join(name);
+    let project_dir = plugins_root()?.join(name);
     let official_dir = official_plugins_root().join(name);
 
     if scope == PluginScope::Project {
@@ -728,8 +731,11 @@ fn canonical_file(path: &Path) -> Result<PathBuf> {
         .with_context(|| format!("could not resolve '{}'", path.display()))
 }
 
-fn plugins_root() -> PathBuf {
-    PathBuf::from(PENTECT_DIR).join(PLUGINS_DIR)
+pub(crate) fn plugins_root() -> Result<PathBuf> {
+    Ok(pentect_agent::project_root()
+        .map_err(anyhow::Error::msg)?
+        .join(PENTECT_DIR)
+        .join(PLUGINS_DIR))
 }
 
 fn official_plugins_root() -> PathBuf {
@@ -956,7 +962,7 @@ fn plugin_source_with_refresh(
     validate_plugin_name(spec)?;
     if scope == PluginScope::Project {
         for (root, repository) in [
-            (plugins_root().join(spec), None),
+            (plugins_root()?.join(spec), None),
             (
                 official_plugins_root().join(spec),
                 Some(DEFAULT_PLUGIN_REPOSITORY.to_string()),
@@ -1119,8 +1125,10 @@ fn fetch_remote_plugin_file(url: &str) -> Result<Option<PathBuf>> {
     fetch_remote_plugin_file_with_refresh(url, false)
 }
 
-pub(crate) fn project_plugin_lock_path() -> PathBuf {
-    PathBuf::from(PROJECT_PLUGIN_LOCK_FILE)
+pub(crate) fn project_plugin_lock_path() -> Result<PathBuf> {
+    Ok(pentect_agent::project_root()
+        .map_err(anyhow::Error::msg)?
+        .join(PROJECT_PLUGIN_LOCK_FILE))
 }
 
 pub(crate) fn user_plugin_lock_path() -> Result<PathBuf> {
@@ -1132,7 +1140,7 @@ pub(crate) fn user_plugin_lock_path() -> Result<PathBuf> {
 pub(crate) fn plugin_lock_path(scope: PluginScope) -> Result<PathBuf> {
     match scope {
         PluginScope::User => user_plugin_lock_path(),
-        PluginScope::Project => Ok(project_plugin_lock_path()),
+        PluginScope::Project => project_plugin_lock_path(),
     }
 }
 

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -630,7 +630,9 @@ fn plugin_config_path(scope: plugins::PluginScope) -> Result<PathBuf, String> {
         plugins::PluginScope::User => {
             plugins::user_plugin_config_path().map_err(|error| error.to_string())
         }
-        plugins::PluginScope::Project => Ok(plugins::project_plugin_config_path()),
+        plugins::PluginScope::Project => {
+            plugins::project_plugin_config_path().map_err(|error| error.to_string())
+        }
     }
 }
 
@@ -3820,7 +3822,7 @@ fn plugin_row(
 fn plugin_rows() -> Result<Vec<PluginRow>, String> {
     let mut rows = Vec::new();
     rows.extend(plugin_rows_in(
-        Path::new(".pentect").join("plugins"),
+        plugins::plugins_root().map_err(|error| error.to_string())?,
         "project",
     )?);
     rows.extend(plugin_rows_in(

--- a/crates/pentect-cli/tests/plugin_scope.rs
+++ b/crates/pentect-cli/tests/plugin_scope.rs
@@ -121,5 +121,79 @@ fn plugins_are_user_global_by_default_and_project_scope_is_explicit() {
         "{inside_project}"
     );
 
+    let nested = first_project.join("src/nested");
+    std::fs::create_dir_all(&nested).unwrap();
+    let inside_nested = mask(&home, &nested, "GLOBAL-123456 PROJECT-123456");
+    assert!(inside_nested.contains("<<GLOBAL_TEST_"), "{inside_nested}");
+    assert!(inside_nested.contains("<<PROJECT_TEST_"), "{inside_nested}");
+    assert!(!nested.join(".pentect/config.toml").exists());
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn project_plugin_directory_is_visible_from_nested_working_directory() {
+    let root = temp_dir("plugin-nested-list");
+    let home = root.join("home");
+    let project = root.join("project");
+    let nested = project.join("src/nested");
+    std::fs::create_dir_all(project.join(".git")).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&nested).unwrap();
+    write_manifest(
+        &project.join(".pentect/plugins/nested-list"),
+        "nested-list",
+        "NESTED_LIST",
+        r"NESTED-[0-9]{6}",
+    );
+
+    let output = command(&home, &nested)
+        .args(["plugins", "list"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("nested-list: project ok configs=1 binary=no"),
+        "{stdout}"
+    );
+    assert!(!nested.join(".pentect/plugins").exists());
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn nearest_nested_pentect_directory_defines_a_separate_project_root() {
+    let root = temp_dir("plugin-explicit-nested-root");
+    let home = root.join("home");
+    let project = root.join("project");
+    let nested = project.join("packages/child");
+    std::fs::create_dir_all(project.join(".git")).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(
+        &project.join(".pentect/plugins/outer"),
+        "outer",
+        "OUTER",
+        r"OUTER-[0-9]{6}",
+    );
+    write_manifest(
+        &nested.join(".pentect/plugins/inner"),
+        "inner",
+        "INNER",
+        r"INNER-[0-9]{6}",
+    );
+
+    let output = command(&home, &nested)
+        .args(["plugins", "list"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("inner: project ok configs=1 binary=no"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("outer:"), "{stdout}");
+
     std::fs::remove_dir_all(root).unwrap();
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -152,6 +152,10 @@ pub fn validate_config_file(path: &Path) -> Result<(), String> {
     config::validate_config_file(path)
 }
 
+pub fn project_root() -> Result<PathBuf, String> {
+    config::project_root()
+}
+
 pub fn load_environment_variable_prefix() -> Result<String, String> {
     config::environment_variable_prefix()
 }

--- a/crates/pentect-runtime/src/session.rs
+++ b/crates/pentect-runtime/src/session.rs
@@ -139,7 +139,10 @@ impl Drop for Session {
 
 pub(crate) fn session_root(name: &str) -> Result<PathBuf> {
     let name = checked_session_name(name)?;
-    let base = PathBuf::from(PENTECT_DIR).join(AGENT_DIR);
+    let base = crate::config::project_root()
+        .map_err(anyhow::Error::msg)?
+        .join(PENTECT_DIR)
+        .join(AGENT_DIR);
     Ok(base.join(name))
 }
 

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -522,12 +522,19 @@ fn session_does_not_create_key_or_recovery_dir() {
 }
 
 #[test]
-fn default_session_root_lives_under_pentect_dir() {
+fn default_session_root_lives_under_project_pentect_dir() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     std::env::set_var("PENTECT_HOME", "attacker-selected-directory");
     let root = session_root("demo").unwrap();
     std::env::remove_var("PENTECT_HOME");
-    assert_eq!(root, PathBuf::from(".pentect").join("agent").join("demo"));
+    assert_eq!(
+        root,
+        config::project_root()
+            .unwrap()
+            .join(".pentect")
+            .join("agent")
+            .join("demo")
+    );
 }
 
 #[test]

--- a/website/src/content/docs/plugins/overview.md
+++ b/website/src/content/docs/plugins/overview.md
@@ -75,6 +75,10 @@ added and pinned by a lockfile.
 
 For a repository-owned plugin set, add `--project`. This writes
 `.pentect/config.toml` and `pentect.plugins.lock`; commit both project files.
+Pentect finds the project root by walking upward to the nearest `.pentect` or
+`.git` directory, so project plugins remain active from nested working
+directories. A nested `.pentect` directory intentionally starts a separate
+project scope.
 
 ```sh
 pentect plugins add github:@owner/repository/path@v1.2.3 --project


### PR DESCRIPTION
Fixes #1220.

## Root cause

Identity and file-pointer state used the existing ancestor-based project root, while project plugin config, directories, lockfiles, listing, and the legacy purge target remained relative to the launch directory.

The original issue also described active session persistence under `.pentect/agent`; investigation corrected that claim. Current sessions are process-local or memory-store-backed, and this path is currently only a purge target.

## Changes

- expose the existing runtime project-root resolver to CLI consumers
- resolve project plugin config, directory, lockfile, and list rows from that root
- resolve the legacy purge target from the same root
- preserve nearest nested `.pentect` as an explicit separate project
- document nested-working-directory and nested-project behavior

## Verification

- reproduced current-main failure: root `plugins list` showed `example-regex`, nested invocation showed `none`
- `cargo test -p pentect-cli --test plugin_scope -- --nocapture` (3 passed)
- `cargo test -p pentect-runtime default_session_root_lives_under_project_pentect_dir -- --nocapture`
- integration coverage verifies nested masking, nested listing, no accidental nested `.pentect`, and explicit nested-project isolation
- `git diff --check`