### PR TITLE
fix: unify Windows command discovery

### DIFF
--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -680,15 +680,11 @@ fn update_process_path(directory: &Path) -> Result<(), String> {
 
 #[cfg(windows)]
 fn command_names(name: &str) -> Vec<String> {
-    let has_ext = Path::new(name).extension().is_some();
-    if has_ext {
-        return vec![name.to_string()];
-    }
-    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
-    pathext
-        .split(';')
-        .filter(|ext| !ext.is_empty())
-        .map(|ext| format!("{name}{ext}"))
+    let pathext = std::env::var_os("PATHEXT")
+        .unwrap_or_else(|| std::ffi::OsString::from(".COM;.EXE;.BAT;.CMD"));
+    crate::windows_executable_candidates(Path::new(name), &pathext)
+        .into_iter()
+        .map(|candidate| candidate.to_string_lossy().into_owned())
         .collect()
 }
 

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -690,47 +690,7 @@ fn resolve_agent_command(program: &Path) -> Result<PathBuf, String> {
 
 #[cfg(any(windows, test))]
 fn resolve_windows_command_from(program: &Path, path: &OsStr, pathext: &OsStr) -> Option<PathBuf> {
-    let names = if program.extension().is_none() {
-        let mut extensions = pathext
-            .to_string_lossy()
-            .split(';')
-            .map(str::trim)
-            .filter(|extension| !extension.is_empty())
-            // Command::new can launch PE binaries and cmd/bat shims. A
-            // PowerShell .ps1 entry may appear in PATHEXT but cannot be
-            // executed directly through CreateProcess.
-            .filter(|extension| {
-                matches!(
-                    extension.to_ascii_uppercase().as_str(),
-                    ".COM" | ".EXE" | ".BAT" | ".CMD"
-                )
-            })
-            .map(str::to_string)
-            .collect::<Vec<_>>();
-        for fallback in [".COM", ".EXE", ".BAT", ".CMD"] {
-            if !extensions
-                .iter()
-                .any(|extension| extension.eq_ignore_ascii_case(fallback))
-            {
-                extensions.push(fallback.to_string());
-            }
-        }
-        let mut names = extensions
-            .into_iter()
-            .map(|extension| {
-                let mut name = program.as_os_str().to_os_string();
-                name.push(extension);
-                PathBuf::from(name)
-            })
-            .collect::<Vec<_>>();
-        // npm installs a POSIX shim without an extension beside the Windows
-        // .cmd/.ps1 shims. It is a file, but Windows cannot execute it. Keep
-        // the raw name only as a final fallback after PATHEXT candidates.
-        names.push(program.to_path_buf());
-        names
-    } else {
-        vec![program.to_path_buf()]
-    };
+    let names = windows_executable_candidates(program, pathext);
 
     let explicit_path = program.is_absolute() || program.components().count() > 1;
     if explicit_path {
@@ -745,6 +705,53 @@ fn resolve_windows_command_from(program: &Path, path: &OsStr, pathext: &OsStr) -
         }
     }
     None
+}
+
+#[cfg(any(windows, test))]
+fn windows_executable_candidates(program: &Path, pathext: &OsStr) -> Vec<PathBuf> {
+    if program.extension().is_some() {
+        return vec![program.to_path_buf()];
+    }
+    let mut extensions = pathext
+        .to_string_lossy()
+        .split(';')
+        .map(str::trim)
+        .filter(|extension| windows_command_extension_supported(extension))
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    for fallback in [".COM", ".EXE", ".BAT", ".CMD"] {
+        if !extensions
+            .iter()
+            .any(|extension| extension.eq_ignore_ascii_case(fallback))
+        {
+            extensions.push(fallback.to_string());
+        }
+    }
+    let mut names = extensions
+        .into_iter()
+        .map(|extension| {
+            let mut name = program.as_os_str().to_os_string();
+            name.push(extension);
+            PathBuf::from(name)
+        })
+        .collect::<Vec<_>>();
+    // An extensionless PE executable is valid. Keep the raw name only after
+    // known launchable PATHEXT candidates so npm's POSIX shim cannot shadow
+    // its adjacent cmd shim.
+    names.push(program.to_path_buf());
+    names
+}
+
+#[cfg(any(windows, test))]
+pub(crate) fn windows_command_extension_supported(extension: &str) -> bool {
+    matches!(
+        extension
+            .strip_prefix('.')
+            .unwrap_or(extension)
+            .to_ascii_lowercase()
+            .as_str(),
+        "exe" | "com" | "cmd" | "bat"
+    )
 }
 
 fn cmd_claude_app(args: &[String]) -> i32 {
@@ -3196,6 +3203,26 @@ mod tests {
             .to_string_lossy()
             .eq_ignore_ascii_case("codex.cmd"));
         std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn windows_command_candidates_exclude_script_host_extensions() {
+        let candidates =
+            windows_executable_candidates(Path::new("codex"), OsStr::new(".PS1;.VBS;.JS;.CMD"));
+        let names = candidates
+            .iter()
+            .map(|path| path.to_string_lossy().to_ascii_lowercase())
+            .collect::<Vec<_>>();
+        assert!(names.iter().any(|name| name == "codex.cmd"), "{names:?}");
+        assert!(
+            !names.iter().any(|name| name.ends_with(".ps1")),
+            "{names:?}"
+        );
+        assert!(
+            !names.iter().any(|name| name.ends_with(".vbs")),
+            "{names:?}"
+        );
+        assert!(!names.iter().any(|name| name.ends_with(".js")), "{names:?}");
     }
 
     #[cfg(windows)]

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -2775,36 +2775,16 @@ fn resolve_command_executable(value: &str) -> Result<PathBuf, String> {
     }
     let paths = std::env::var_os("PATH").unwrap_or_default();
     #[cfg(windows)]
-    let extensions = std::env::var_os("PATHEXT")
-        .map(|value| {
-            value
-                .to_string_lossy()
-                .split(';')
-                .filter(|extension| windows_command_extension_supported(extension))
-                .map(str::to_owned)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_else(|| {
-            vec![
-                ".EXE".to_string(),
-                ".COM".to_string(),
-                ".CMD".to_string(),
-                ".BAT".to_string(),
-            ]
-        });
+    let names = crate::windows_executable_candidates(
+        candidate,
+        &std::env::var_os("PATHEXT")
+            .unwrap_or_else(|| std::ffi::OsString::from(".COM;.EXE;.BAT;.CMD")),
+    );
     #[cfg(not(windows))]
-    let extensions = vec![String::new()];
+    let names = vec![candidate.to_path_buf()];
     for directory in std::env::split_paths(&paths) {
-        for extension in &extensions {
-            let path = if extension.is_empty()
-                || value
-                    .to_ascii_lowercase()
-                    .ends_with(&extension.to_ascii_lowercase())
-            {
-                directory.join(value)
-            } else {
-                directory.join(format!("{value}{extension}"))
-            };
+        for name in &names {
+            let path = directory.join(name);
             if let Ok(path) = path.canonicalize() {
                 if supported_command_executable(&path) {
                     return Ok(path);
@@ -2828,19 +2808,7 @@ fn supported_command_executable(path: &Path) -> bool {
         && path
             .extension()
             .and_then(|extension| extension.to_str())
-            .is_some_and(windows_command_extension_supported)
-}
-
-#[cfg(any(windows, test))]
-fn windows_command_extension_supported(extension: &str) -> bool {
-    matches!(
-        extension
-            .strip_prefix('.')
-            .unwrap_or(extension)
-            .to_ascii_lowercase()
-            .as_str(),
-        "exe" | "com" | "cmd" | "bat"
-    )
+            .is_some_and(crate::windows_command_extension_supported)
 }
 
 fn stage_remote_command_files(
@@ -3928,14 +3896,11 @@ fn find_command(path: &Path) -> Option<PathBuf> {
 
 #[cfg(windows)]
 fn command_names(name: &str) -> Vec<String> {
-    if Path::new(name).extension().is_some() {
-        return vec![name.to_string()];
-    }
-    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
-    pathext
-        .split(';')
-        .filter(|ext| !ext.is_empty())
-        .map(|ext| format!("{name}{ext}"))
+    let pathext = std::env::var_os("PATHEXT")
+        .unwrap_or_else(|| std::ffi::OsString::from(".COM;.EXE;.BAT;.CMD"));
+    crate::windows_executable_candidates(Path::new(name), &pathext)
+        .into_iter()
+        .map(|candidate| candidate.to_string_lossy().into_owned())
         .collect()
 }
 
@@ -3963,10 +3928,10 @@ mod tests {
     #[test]
     fn windows_command_plugins_accept_batch_shims_only() {
         for extension in [".EXE", "com", ".CMD", "bat"] {
-            assert!(windows_command_extension_supported(extension));
+            assert!(crate::windows_command_extension_supported(extension));
         }
         for extension in ["ps1", ".js", "sh", ""] {
-            assert!(!windows_command_extension_supported(extension));
+            assert!(!crate::windows_command_extension_supported(extension));
         }
     }
 


### PR DESCRIPTION
Fixes #1219.

## Root cause

The real launchers filtered Windows PATHEXT to CreateProcess-compatible executables and batch shims, while doctor and plugin diagnostics expanded every PATHEXT script type and accepted any matching file.

## Changes

- extract one Windows executable candidate generator
- share `.com/.exe/.bat/.cmd` filtering, fallback order, and raw-name fallback
- use it in agent launch, plugin command launch, doctor, and plugin diagnostics
- remove the duplicate plugin extension predicate and two unfiltered PATHEXT implementations

## Verification

- `windows_command_candidates_exclude_script_host_extensions`
- `windows_command_resolution_skips_powershell_only_pathext_entries`
- `windows_command_plugins_accept_batch_shims_only`
- all three focused tests passed locally
- `git diff --check`

Windows GitHub Actions provide the platform-native compile and behavior gate.