### PR TITLE
Prevent ambient provider credentials from accompanying explicit upstream auth

### DIFF
--- a/crates/pentect-cli/src/http_files.rs
+++ b/crates/pentect-cli/src/http_files.rs
@@ -827,12 +827,7 @@ impl FileAttestationStore {
     pub(crate) fn account_scope_for_app_headers(&self, headers: &hyper::HeaderMap) -> String {
         let mut fields = headers
             .iter()
-            .filter(|(name, _)| {
-                matches!(
-                    name.as_str().to_ascii_lowercase().as_str(),
-                    "authorization" | "cookie" | "x-api-key" | "api-key" | "x-goog-api-key"
-                )
-            })
+            .filter(|(name, _)| crate::upstream::is_origin_auth_header(name.as_str()))
             .map(|(name, value)| {
                 (
                     name.as_str().to_ascii_lowercase().into_bytes(),

--- a/crates/pentect-cli/src/ide_clients.rs
+++ b/crates/pentect-cli/src/ide_clients.rs
@@ -45,12 +45,12 @@ pub(crate) fn run(
     let active_plugins = crate::agent_tool_plugins(opts)?;
     let memory_store = crate::start_memory_store(pentect)?;
     let _parent_env = crate::agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
-    let standard_key_names =
-        if crate::upstream::has_authorization_override(&opts.upstream_header_env) {
-            &[][..]
-        } else {
-            &["OPENAI_API_KEY"][..]
-        };
+    let standard_key_names = if crate::upstream::has_origin_auth_override(&opts.upstream_header_env)
+    {
+        &[][..]
+    } else {
+        &["OPENAI_API_KEY"][..]
+    };
     let _authorization = crate::upstream_bearer_guard(standard_key_names);
     let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env(
         upstream,

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1207,7 +1207,7 @@ fn cmd_provider(args: &[String]) -> i32 {
 }
 
 fn provider_upstream_key_env_names(header_env: &[String]) -> &'static [&'static str] {
-    if upstream::has_authorization_override(header_env) {
+    if upstream::has_origin_auth_override(header_env) {
         &[]
     } else {
         &["OPENAI_API_KEY"]
@@ -1612,7 +1612,7 @@ fn run_endpoint_env(
                 .iter()
                 .find_map(|name| nonempty_env(name));
             let shield_child_key = google_api_key.is_some()
-                || upstream::has_google_api_key_override(&opts.upstream_header_env);
+                || upstream::has_origin_auth_override(&opts.upstream_header_env);
             let proxy = gemini_http_proxy::GeminiHttpProxyGuard::start_with_header_env_and_api_key(
                 upstream,
                 &opts.upstream_header_env,
@@ -3530,13 +3530,15 @@ mod tests {
     }
 
     #[test]
-    fn provider_authorization_override_disables_implicit_openai_bearer() {
+    fn provider_origin_auth_override_disables_implicit_openai_bearer() {
+        for header in ["authorization", "x-api-key", "api-key", "x-goog-api-key"] {
+            assert_eq!(
+                provider_upstream_key_env_names(&[format!("{header}=MY_GATEWAY_AUTH")]),
+                &[] as &[&str]
+            );
+        }
         assert_eq!(
-            provider_upstream_key_env_names(&["authorization=MY_GATEWAY_AUTH".to_string()]),
-            &[] as &[&str]
-        );
-        assert_eq!(
-            provider_upstream_key_env_names(&["x-api-key=MY_GATEWAY_KEY".to_string()]),
+            provider_upstream_key_env_names(&["x-request-id=REQUEST_ID".to_string()]),
             &["OPENAI_API_KEY"]
         );
     }

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -63,12 +63,12 @@ pub(crate) fn run(
     let memory_store = crate::start_memory_store(pentect)?;
     let _parent_env = crate::agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
     let standard_key_names = provider_key_env_names(injection);
-    let standard_key_names =
-        if crate::upstream::has_authorization_override(&opts.upstream_header_env) {
-            &[][..]
-        } else {
-            standard_key_names
-        };
+    let standard_key_names = if crate::upstream::has_origin_auth_override(&opts.upstream_header_env)
+    {
+        &[][..]
+    } else {
+        standard_key_names
+    };
     let _authorization = crate::upstream_bearer_guard(standard_key_names);
     let proxy = crate::openai_http_proxy::OpenAiHttpProxyGuard::start_with_header_env(
         upstream,
@@ -354,23 +354,23 @@ fn opencode_proxy_auth(
     let mut header_env = base_header_env.to_vec();
     let bearer_env = route.bearer_env.filter(|name| {
         std::env::var_os(name).is_some_and(|value| !value.is_empty())
-            && !crate::upstream::has_authorization_override(&header_env)
+            && !crate::upstream::has_origin_auth_override(&header_env)
     });
     let mut child_key_env = bearer_env.or_else(|| {
         route
             .bearer_env
-            .filter(|_| crate::upstream::has_authorization_override(&header_env))
+            .filter(|_| crate::upstream::has_origin_auth_override(&header_env))
     });
     if route.protocol == OpenCodeProtocol::Anthropic {
         if let Some(name) = configured_key_env(&["ANTHROPIC_API_KEY"]) {
             child_key_env = Some(name);
             if !has_header_override(&header_env, "x-api-key")
-                && !crate::upstream::has_authorization_override(&header_env)
+                && !crate::upstream::has_origin_auth_override(&header_env)
             {
                 header_env.push(format!("x-api-key={name}"));
             }
         } else if has_header_override(&header_env, "x-api-key")
-            || crate::upstream::has_authorization_override(&header_env)
+            || crate::upstream::has_origin_auth_override(&header_env)
         {
             child_key_env = Some("ANTHROPIC_API_KEY");
         }
@@ -382,12 +382,12 @@ fn opencode_proxy_auth(
         ]) {
             child_key_env = Some(name);
             if !has_header_override(&header_env, "x-goog-api-key")
-                && !crate::upstream::has_authorization_override(&header_env)
+                && !crate::upstream::has_origin_auth_override(&header_env)
             {
                 header_env.push(format!("x-goog-api-key={name}"));
             }
         } else if has_header_override(&header_env, "x-goog-api-key")
-            || crate::upstream::has_authorization_override(&header_env)
+            || crate::upstream::has_origin_auth_override(&header_env)
         {
             child_key_env = Some("GOOGLE_API_KEY");
         }
@@ -1062,16 +1062,16 @@ mod tests {
     }
 
     #[test]
-    fn explicit_authorization_header_disables_implicit_key_selection() {
+    fn explicit_origin_auth_header_disables_implicit_key_selection() {
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let _authorization = ScopedEnv::remove("PENTECT_UPSTREAM_AUTHORIZATION");
-        assert!(crate::upstream::has_authorization_override(&[
+        assert!(crate::upstream::has_origin_auth_override(&[
             "authorization=MY_HEADER".to_string()
         ]));
-        assert!(crate::upstream::has_authorization_override(&[
+        assert!(crate::upstream::has_origin_auth_override(&[
             " Authorization =MY_HEADER".to_string()
         ]));
-        assert!(!crate::upstream::has_authorization_override(&[
+        assert!(crate::upstream::has_origin_auth_override(&[
             "X-Api-Key=MY_HEADER".to_string()
         ]));
     }

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -3853,6 +3853,11 @@ mod tests {
             self.saved.push((name, std::env::var_os(name)));
             std::env::set_var(name, value);
         }
+
+        fn remove(&mut self, name: &'static str) {
+            self.saved.push((name, std::env::var_os(name)));
+            std::env::remove_var(name);
+        }
     }
 
     impl Drop for ProviderBoundaryTestEnv {
@@ -4182,6 +4187,58 @@ mod tests {
         assert!(!command.contains(&secret), "{command}");
         assert!(!command.contains(&handle), "{command}");
         assert!(command.contains("script-b64"), "{command}");
+    }
+
+    #[test]
+    fn explicit_native_auth_header_does_not_forward_ambient_openai_key() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let mut env = ProviderBoundaryTestEnv::install(&store);
+        env.remove("PENTECT_UPSTREAM_AUTHORIZATION");
+        env.set("OPENAI_API_KEY", "ambient-openai-key-must-not-leave");
+        env.set("PENTECT_TEST_NATIVE_KEY", "explicit-native-key");
+        let specs = ["x-api-key=PENTECT_TEST_NATIVE_KEY".to_string()];
+        let _authorization =
+            crate::upstream_bearer_guard(crate::provider_upstream_key_env_names(&specs));
+        let secret = ["rpa_", "AUTHBOUNDARY", "ZYXWVUTS", "1234567890"].concat();
+        let (upstream, captured, thread) = mock_chat_upstream();
+        let proxy = OpenAiHttpProxyGuard::start_with_header_env(upstream, &specs).unwrap();
+
+        reqwest::blocking::Client::new()
+            .post(format!("{}/v1/chat/completions", proxy.base_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(
+                serde_json::to_vec(&serde_json::json!({
+                    "model": "test",
+                    "messages": [{
+                        "role": "user",
+                        "content": format!("Use RUNPOD_API_KEY={secret}")
+                    }]
+                }))
+                .unwrap(),
+            )
+            .send()
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+
+        let (headers, _) = captured
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .unwrap();
+        thread.join().unwrap();
+        assert!(
+            headers
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case("x-api-key: explicit-native-key")),
+            "{headers}"
+        );
+        assert!(
+            !headers
+                .lines()
+                .any(|line| line.to_ascii_lowercase().starts_with("authorization:")),
+            "ambient OpenAI authorization reached the upstream:\n{headers}"
+        );
+        assert!(!headers.contains("ambient-openai-key-must-not-leave"));
     }
 
     #[test]

--- a/crates/pentect-cli/src/upstream.rs
+++ b/crates/pentect-cli/src/upstream.rs
@@ -149,25 +149,11 @@ pub(crate) fn header_overrides(specs: &[String]) -> Result<HeaderOverrides, Stri
     Ok(overrides)
 }
 
-pub(crate) fn has_authorization_override(specs: &[String]) -> bool {
+pub(crate) fn has_origin_auth_override(specs: &[String]) -> bool {
     std::env::var_os(AUTHORIZATION_ENV).is_some()
         || specs.iter().any(|spec| {
-            spec.split_once('=').is_some_and(|(name, _)| {
-                name.trim()
-                    .eq_ignore_ascii_case(reqwest::header::AUTHORIZATION.as_str())
-            })
-        })
-}
-
-pub(crate) fn has_google_api_key_override(specs: &[String]) -> bool {
-    std::env::var_os(AUTHORIZATION_ENV).is_some()
-        || specs.iter().any(|spec| {
-            spec.split_once('=').is_some_and(|(name, _)| {
-                matches!(
-                    name.trim().to_ascii_lowercase().as_str(),
-                    "authorization" | "x-goog-api-key"
-                )
-            })
+            spec.split_once('=')
+                .is_some_and(|(name, _)| is_replaceable_origin_auth_header(name.trim()))
         })
 }
 
@@ -263,7 +249,7 @@ pub(crate) fn header_source_env_name(spec: &str) -> Option<&str> {
     (!env_name.is_empty()).then_some(env_name)
 }
 
-fn is_origin_auth_header(name: &str) -> bool {
+pub(crate) fn is_origin_auth_header(name: &str) -> bool {
     name.eq_ignore_ascii_case("authorization")
         || name.eq_ignore_ascii_case("x-api-key")
         || name.eq_ignore_ascii_case("api-key")
@@ -490,27 +476,35 @@ mod tests {
     }
 
     #[test]
-    fn authorization_override_detection_is_case_and_whitespace_insensitive() {
+    fn origin_auth_override_detection_is_case_and_whitespace_insensitive() {
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let _unset = EnvRestore::remove(AUTHORIZATION_ENV);
-        assert!(has_authorization_override(&[
+        assert!(has_origin_auth_override(&[
             "authorization=GATEWAY_AUTH".to_string()
         ]));
-        assert!(has_authorization_override(&[
+        assert!(has_origin_auth_override(&[
             " Authorization = GATEWAY_AUTH ".to_string()
         ]));
-        assert!(!has_authorization_override(&[
-            "x-api-key=GATEWAY_KEY".to_string()
+        for header in ["x-api-key", "api-key", "x-goog-api-key"] {
+            assert!(has_origin_auth_override(&[format!(
+                " {header} = GATEWAY_KEY "
+            )]));
+        }
+        assert!(!has_origin_auth_override(&["authorization".to_string()]));
+        assert!(!has_origin_auth_override(&[
+            "cookie=GATEWAY_COOKIE".to_string()
         ]));
-        assert!(!has_authorization_override(&["authorization".to_string()]));
+        assert!(!has_origin_auth_override(&[
+            "x-request-id=REQUEST_ID".to_string()
+        ]));
         {
             let _authorization = EnvRestore::set(AUTHORIZATION_ENV, "Bearer gateway-token");
-            assert!(has_authorization_override(&[]));
+            assert!(has_origin_auth_override(&[]));
         }
         {
             let _authorization = EnvRestore::set(AUTHORIZATION_ENV, "");
             assert!(
-                has_authorization_override(&[]),
+                has_origin_auth_override(&[]),
                 "an empty control value explicitly removes origin authorization"
             );
         }
@@ -707,7 +701,7 @@ mod tests {
         let _authorization = EnvRestore::remove(AUTHORIZATION_ENV);
         let _explicit = EnvRestore::set("PENTECT_TEST_GOOGLE_OVERRIDE", "explicit-test-key");
         let specs = ["x-goog-api-key=PENTECT_TEST_GOOGLE_OVERRIDE".to_string()];
-        assert!(has_google_api_key_override(&specs));
+        assert!(has_origin_auth_override(&specs));
         let overrides =
             header_overrides_with_google_api_key(&specs, Some("ignored-provider-key".to_string()))
                 .unwrap();
@@ -743,5 +737,29 @@ mod tests {
             .headers()
             .get(reqwest::header::AUTHORIZATION)
             .is_none());
+    }
+
+    #[test]
+    fn explicitly_configured_multiple_origin_auth_headers_are_preserved() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let _bearer = EnvRestore::set("PENTECT_TEST_EXPLICIT_BEARER", "Bearer gateway-key");
+        let _native = EnvRestore::set("PENTECT_TEST_EXPLICIT_NATIVE", "native-provider-key");
+        let overrides = header_overrides(&[
+            "authorization=PENTECT_TEST_EXPLICIT_BEARER".to_string(),
+            "x-api-key=PENTECT_TEST_EXPLICIT_NATIVE".to_string(),
+        ])
+        .unwrap();
+        let request = overrides
+            .apply(reqwest::Client::new().get("https://example.test"))
+            .build()
+            .unwrap();
+        assert_eq!(
+            request.headers().get("authorization").unwrap(),
+            "Bearer gateway-key"
+        );
+        assert_eq!(
+            request.headers().get("x-api-key").unwrap(),
+            "native-provider-key"
+        );
     }
 }


### PR DESCRIPTION
Closes #1217.

## Root cause

Pentect had four hand-written interpretations of origin authentication headers. Request forwarding recognized `authorization`, `x-api-key`, `api-key`, and `x-goog-api-key`, but launcher-side implicit bearer selection recognized only `authorization`. Consequently an explicit native provider key could be accompanied by an unrelated ambient `OPENAI_API_KEY`.

## Fix

- replace the protocol-specific override checks with one shared origin-auth override predicate
- reuse the canonical origin credential predicate for file attestation account scopes
- treat native API-key headers as explicit authentication, while retaining `cookie` only as account-scoping credential material
- preserve explicitly configured combinations such as both `authorization` and `x-api-key`

## Verification

- focused override-selection tests for all four replaceable origin auth headers
- explicit dual-auth preservation test
- actual localhost proxy POST proving `x-api-key` reaches the recorder while an ambient `OPENAI_API_KEY` and synthesized `Authorization` do not
- existing OpenCode authorization-control regression test
