### PR TITLE
Remove stale Pentect session controls from agent children

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -3755,6 +3755,52 @@ mod tests {
     }
 
     #[test]
+    fn child_environment_keeps_pi_user_options_but_removes_internal_client_state() {
+        let mut command = Command::new("pentect-child");
+        for name in [
+            "PENTECT_PI_REASONING",
+            "PENTECT_PI_CONTEXT_WINDOW",
+            "PENTECT_PI_MAX_TOKENS",
+            "PENTECT_PI_INPUTS",
+        ] {
+            command.env(name, "user-selected-value");
+        }
+        for name in [
+            "PENTECT_ANTHROPIC_UPSTREAM",
+            "PENTECT_JUNIE_API_KEY",
+            "PENTECT_PROXY_URL",
+            "PENTECT_PROVIDER_MODEL",
+            "PENTECT_PROVIDER_API",
+            "PENTECT_GATEWAY_API_KEY",
+            "PENTECT_API_KEY",
+            "PENTECT_LOG_DIR",
+        ] {
+            command.env(name, "stale-inherited-value");
+        }
+
+        clear_pentect_control_env(&mut command);
+
+        let environment = command
+            .get_envs()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        for name in [
+            "PENTECT_PI_REASONING",
+            "PENTECT_PI_CONTEXT_WINDOW",
+            "PENTECT_PI_MAX_TOKENS",
+            "PENTECT_PI_INPUTS",
+        ] {
+            assert_eq!(
+                environment.get(OsStr::new(name)).and_then(|value| *value),
+                Some(OsStr::new("user-selected-value")),
+                "{name}"
+            );
+        }
+        for name in pentect_agent::pentect_control_env_names() {
+            assert_eq!(environment.get(OsStr::new(name)), Some(&None), "{name}");
+        }
+    }
+
+    #[test]
     fn gemini_child_receives_only_local_placeholder_keys_when_gateway_owns_auth() {
         let mut command = Command::new("gemini-child");
         command.env("GEMINI_API_KEY", "inherited-value");

--- a/crates/pentect-runtime/src/memory_store.rs
+++ b/crates/pentect-runtime/src/memory_store.rs
@@ -140,6 +140,7 @@ pub(crate) fn is_reserved_child_env_name(name: &str) -> bool {
 /// prefix, so the boundary is an explicit case-insensitive list rather than a
 /// blanket prefix ban.
 const PENTECT_CONTROL_ENV_NAMES: &[&str] = &[
+    // Process and session control.
     "PENTECT_BIN",
     "PENTECT_AGENT_LAUNCHED",
     "PENTECT_MEMORY_STORE_ADDR",
@@ -159,8 +160,18 @@ const PENTECT_CONTROL_ENV_NAMES: &[&str] = &[
     "PENTECT_HOME",
     "PENTECT_SESSION",
     "PENTECT_FILE_POINTER_MANAGER_DIR",
+    "PENTECT_LOG_DIR",
+    // Client routing and generated child configuration. Launchers that need
+    // these values set a fresh value after inherited controls are removed.
     "PENTECT_CODEX",
     "PENTECT_CLAUDE",
+    "PENTECT_ANTHROPIC_UPSTREAM",
+    "PENTECT_JUNIE_API_KEY",
+    "PENTECT_PROXY_URL",
+    "PENTECT_PROVIDER_MODEL",
+    "PENTECT_PROVIDER_API",
+    "PENTECT_GATEWAY_API_KEY",
+    "PENTECT_API_KEY",
     "PENTECT_UPSTREAM_AUTHORIZATION",
     "PENTECT_UPSTREAM_CA_CERT",
     "PENTECT_UPSTREAM_IDENTITY",

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1608,6 +1608,27 @@ fn session_environment_name_is_reserved_for_internal_use() {
         "PENTECT_GLOBAL_PLUGIN_BINARIES"
     ));
     assert!(is_pentect_control_env_name("pentect_global_plugin_ids"));
+    for name in [
+        "PENTECT_ANTHROPIC_UPSTREAM",
+        "PENTECT_JUNIE_API_KEY",
+        "PENTECT_PROXY_URL",
+        "PENTECT_PROVIDER_MODEL",
+        "PENTECT_PROVIDER_API",
+        "PENTECT_GATEWAY_API_KEY",
+        "PENTECT_API_KEY",
+        "PENTECT_LOG_DIR",
+    ] {
+        assert!(is_pentect_control_env_name(name), "{name}");
+        assert!(is_pentect_control_env_name(&name.to_ascii_lowercase()));
+    }
+    for name in [
+        "PENTECT_PI_REASONING",
+        "PENTECT_PI_CONTEXT_WINDOW",
+        "PENTECT_PI_MAX_TOKENS",
+        "PENTECT_PI_INPUTS",
+    ] {
+        assert!(!is_pentect_control_env_name(name), "{name}");
+    }
     let mut names = pentect_control_env_names().to_vec();
     names.sort_unstable();
     names.dedup();


### PR DESCRIPTION
Closes #1216.

## Root cause

Pentect uses an explicit allowlist for its internal child-session environment because secret aliases may legitimately use the `PENTECT_` prefix. Eight clear-then-reapply/session-control variables were absent from that list, allowing stale routing, loopback credentials, provider configuration, or log routing to remain in an agent child.

## Fix

- reserve and clear the eight proven session-control variables
- retain Pi's four child-read user settings
- retain npm installation identity and update preferences because nested installation management may need them
- document the clear-before-reapply category in the canonical list

## Verification

- all control names are rejected case-insensitively and remain duplicate-free
- child environment construction removes every canonical control name
- a concrete child `Command` keeps all four Pi settings while removing stale routing, generated client state, and log routing
