### PR TITLE
Accept assignment-form values across Pentect command parsers

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -872,6 +872,27 @@ impl ClaudeAppOptions {
             2
         };
         while index < args.len() {
+            let argument = args[index].as_str();
+            if let Some(value) = crate::assigned_option_value(argument, "--app")? {
+                app = Some(PathBuf::from(value));
+                index += 1;
+                continue;
+            }
+            if let Some(value) = crate::assigned_option_value(argument, "--upstream")? {
+                upstream = Some(value);
+                index += 1;
+                continue;
+            }
+            if let Some(value) = crate::assigned_option_value(argument, "--upstream-header-env")? {
+                upstream_header_env.push(value);
+                index += 1;
+                continue;
+            }
+            if let Some(value) = crate::assigned_option_value(argument, "--plugins")? {
+                crate::plugins::parse_plugin_value(&value).map_err(|error| error.to_string())?;
+                index += 1;
+                continue;
+            }
             match args[index].as_str() {
                 "--app" => {
                     let value = args
@@ -3465,6 +3486,33 @@ mod tests {
         let options = ClaudeAppOptions::parse(&args).unwrap();
         assert_eq!(options.app, Some(PathBuf::from("Claude.exe")));
         assert!(options.check);
+        assert!(options.assume_yes);
+    }
+
+    #[test]
+    fn options_accept_assignment_form_for_all_valued_options() {
+        let args = [
+            "pentect",
+            "claude",
+            "app",
+            "--plugins=company-policy",
+            "--app=Claude.exe",
+            "--upstream=https://example.test/anthropic",
+            "--upstream-header-env=x-api-key=ANTHROPIC_API_KEY",
+            "--upstream-header-env=x-gateway-key=GATEWAY_KEY",
+            "--yes",
+        ]
+        .map(str::to_string);
+        let options = ClaudeAppOptions::parse(&args).unwrap();
+        assert_eq!(options.app, Some(PathBuf::from("Claude.exe")));
+        assert_eq!(
+            options.upstream.as_deref(),
+            Some("https://example.test/anthropic")
+        );
+        assert_eq!(
+            options.upstream_header_env,
+            ["x-api-key=ANTHROPIC_API_KEY", "x-gateway-key=GATEWAY_KEY"]
+        );
         assert!(options.assume_yes);
     }
 

--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -903,6 +903,27 @@ impl CodexAppOptions {
             2
         };
         while index < args.len() {
+            let argument = args[index].as_str();
+            if let Some(value) = crate::assigned_option_value(argument, "--app")? {
+                app = Some(PathBuf::from(value));
+                index += 1;
+                continue;
+            }
+            if let Some(value) = crate::assigned_option_value(argument, "--upstream")? {
+                upstream = Some(value);
+                index += 1;
+                continue;
+            }
+            if let Some(value) = crate::assigned_option_value(argument, "--upstream-header-env")? {
+                upstream_header_env.push(value);
+                index += 1;
+                continue;
+            }
+            if let Some(value) = crate::assigned_option_value(argument, "--plugins")? {
+                crate::plugins::parse_plugin_value(&value).map_err(|error| error.to_string())?;
+                index += 1;
+                continue;
+            }
             match args[index].as_str() {
                 "--app" => {
                     let value = args
@@ -1340,6 +1361,34 @@ mod tests {
                 app: None,
                 upstream: None,
                 upstream_header_env: Vec::new(),
+                check: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_assignment_form_for_all_valued_options() {
+        let args = [
+            "pentect",
+            "codex",
+            "app",
+            "--plugins=company-policy",
+            "--app=Codex.exe",
+            "--upstream=https://example.test/v1",
+            "--upstream-header-env=authorization=GATEWAY_AUTH",
+            "--upstream-header-env=x-request-id=REQUEST_ID",
+            "--dry-run",
+        ]
+        .map(str::to_string);
+        assert_eq!(
+            CodexAppOptions::parse(&args).unwrap(),
+            CodexAppOptions {
+                app: Some(PathBuf::from("Codex.exe")),
+                upstream: Some("https://example.test/v1".to_string()),
+                upstream_header_env: vec![
+                    "authorization=GATEWAY_AUTH".to_string(),
+                    "x-request-id=REQUEST_ID".to_string(),
+                ],
                 check: true,
             }
         );

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -966,7 +966,34 @@ fn cmd_mask(args: &[String]) {
 
 fn validate_mask_args(args: &[String]) -> Result<(), String> {
     let mut i = 2usize;
-    while i < args.len() {
+    'arguments: while i < args.len() {
+        let argument = args[i].as_str();
+        for option in [
+            "--kind",
+            "--profile",
+            "--input",
+            "--pack",
+            "--pack-dir",
+            "--plugins",
+        ] {
+            let Some(value) = assigned_option_value(argument, option)? else {
+                continue;
+            };
+            match option {
+                "--kind" => {
+                    parse_kind(&value)?;
+                }
+                "--profile" => {
+                    value.parse::<Profile>()?;
+                }
+                "--plugins" => {
+                    plugins::parse_plugin_value(&value).map_err(|e| e.to_string())?;
+                }
+                _ => {}
+            }
+            i += 1;
+            continue 'arguments;
+        }
         match args[i].as_str() {
             "--kind" | "--profile" | "--input" | "--pack" | "--pack-dir" | "--plugins" => {
                 let Some(value) = args.get(i + 1) else {
@@ -1220,6 +1247,7 @@ enum ReadInputFormat {
     Image,
 }
 
+#[derive(Debug)]
 struct ReadOpts {
     input_format: ReadInputFormat,
     kind: Option<Kind>,
@@ -1239,6 +1267,31 @@ impl ReadOpts {
         let mut path = None;
         let mut i = 2;
         while i < args.len() {
+            let argument = args[i].as_str();
+            if let Some(value) = assigned_option_value(argument, "--input")? {
+                input_format = parse_read_input_format(&value)?;
+                i += 1;
+                continue;
+            }
+            if let Some(value) = assigned_option_value(argument, "--kind")? {
+                kind = Some(parse_kind(&value)?);
+                i += 1;
+                continue;
+            }
+            if let Some(value) = assigned_option_value(argument, "--profile")? {
+                profile = value.parse()?;
+                i += 1;
+                continue;
+            }
+            if let Some(value) = assigned_option_value(argument, "--plugins")? {
+                for spec in plugins::parse_plugin_value(&value).map_err(|e| e.to_string())? {
+                    if !plugins.iter().any(|existing| existing == &spec) {
+                        plugins.push(spec);
+                    }
+                }
+                i += 1;
+                continue;
+            }
             match args[i].as_str() {
                 "--input" => {
                     input_format =
@@ -1337,6 +1390,15 @@ impl AgentToolOpts {
             }
             if let Some(value) = assigned_option_value(argument, "--upstream-header-env")? {
                 upstream_header_env.push(value);
+                i += 1;
+                continue;
+            }
+            if let Some(value) = assigned_option_value(argument, "--plugins")? {
+                for name in plugins::parse_plugin_value(&value).map_err(|e| e.to_string())? {
+                    if !plugins.iter().any(|existing| existing == &name) {
+                        plugins.push(name);
+                    }
+                }
                 i += 1;
                 continue;
             }
@@ -1439,7 +1501,10 @@ impl AgentToolOpts {
     }
 }
 
-fn assigned_option_value(argument: &str, option: &str) -> Result<Option<String>, String> {
+pub(crate) fn assigned_option_value(
+    argument: &str,
+    option: &str,
+) -> Result<Option<String>, String> {
     let Some(value) = argument
         .strip_prefix(option)
         .and_then(|suffix| suffix.strip_prefix('='))
@@ -3122,18 +3187,27 @@ fn has_flag(args: &[String], flag: &str) -> bool {
 
 /// All values following each occurrence of `flag` (so `--pack` can repeat).
 fn arg_values(args: &[String], flag: &str) -> Vec<String> {
-    args.iter()
-        .enumerate()
-        .filter(|(_, a)| a.as_str() == flag)
-        .filter_map(|(i, _)| args.get(i + 1).cloned())
-        .collect()
+    let assigned_prefix = format!("{flag}=");
+    let mut values = Vec::new();
+    let mut index = 0;
+    while index < args.len() {
+        if args[index] == flag {
+            if let Some(value) = args.get(index + 1) {
+                values.push(value.clone());
+            }
+            index += 2;
+        } else {
+            if let Some(value) = args[index].strip_prefix(&assigned_prefix) {
+                values.push(value.to_string());
+            }
+            index += 1;
+        }
+    }
+    values
 }
 
 fn arg_value(args: &[String], flag: &str) -> Option<String> {
-    args.iter()
-        .position(|a| a == flag)
-        .and_then(|i| args.get(i + 1))
-        .cloned()
+    arg_values(args, flag).into_iter().next()
 }
 
 fn required_value(args: &[String], i: &mut usize, flag: &str) -> Result<String, String> {
@@ -3161,6 +3235,83 @@ mod tests {
         assert!(error.contains("standard input"), "{error}");
         assert!(error.contains("pentect mask < FILE"), "{error}");
         assert!(error.contains("may be recorded"), "{error}");
+    }
+
+    #[test]
+    fn mask_and_read_accept_assignment_form_for_all_valued_options() {
+        let mask = [
+            "pentect",
+            "mask",
+            "--kind=json",
+            "--profile=strict",
+            "--input=text",
+            "--pack=rules.toml",
+            "--pack-dir=rules",
+            "--plugins=company-policy,company-policy",
+        ]
+        .map(str::to_string);
+        validate_mask_args(&mask).unwrap();
+        assert_eq!(arg_value(&mask, "--kind").as_deref(), Some("json"));
+        assert_eq!(arg_value(&mask, "--profile").as_deref(), Some("strict"));
+        assert_eq!(arg_value(&mask, "--input").as_deref(), Some("text"));
+        assert_eq!(arg_values(&mask, "--pack"), ["rules.toml"]);
+        assert_eq!(arg_values(&mask, "--pack-dir"), ["rules"]);
+
+        let read = [
+            "pentect",
+            "read",
+            "--input=text",
+            "--kind=json",
+            "--profile=strict",
+            "--plugins=company-policy,company-policy",
+            "fixture.json",
+        ]
+        .map(str::to_string);
+        let options = ReadOpts::parse(&read).unwrap();
+        assert_eq!(options.input_format, ReadInputFormat::Text);
+        assert_eq!(options.kind, Some(Kind::Json));
+        assert_eq!(options.profile, Profile::Strict);
+        assert_eq!(options.plugins, ["company-policy"]);
+        assert_eq!(options.path, PathBuf::from("fixture.json"));
+
+        for option in ["--kind", "--profile", "--input", "--plugins"] {
+            let args = [
+                "pentect".to_string(),
+                "read".to_string(),
+                format!("{option}="),
+            ];
+            assert!(
+                ReadOpts::parse(&args)
+                    .unwrap_err()
+                    .contains(&format!("{option} requires a value")),
+                "{option}"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_assignment_plugin_is_activated_instead_of_forwarded() {
+        let args = [
+            "pentect",
+            "codex",
+            "--plugins=company-policy,company-policy",
+            "--",
+            "exec",
+            "hello",
+        ]
+        .map(str::to_string);
+        let options = AgentToolOpts::parse(&client_descriptor::CODEX, &args).unwrap();
+        assert_eq!(options.plugins, ["company-policy"]);
+        assert_eq!(options.tool_args, ["exec", "hello"]);
+
+        let empty = [
+            "pentect".to_string(),
+            "codex".to_string(),
+            "--plugins=".to_string(),
+        ];
+        assert!(AgentToolOpts::parse(&client_descriptor::CODEX, &empty)
+            .unwrap_err()
+            .contains("--plugins requires a value"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1215.

## Root cause

Plugin pre-extraction supported `--plugins=VALUE`, but the real command parsers independently recognized only `--plugins VALUE`. Agent launchers silently forwarded the unrecognized option to the AI client; mask/read/app parsers rejected it. The same parsers also rejected assignment form for adjacent valued options.

## Fix

- expose and reuse one non-empty assignment-value helper
- consume `--plugins=VALUE` in descriptor-based agent launchers
- support all valued assignment forms in mask, read, Codex App, and Claude App parsers
- make mask's actual value readers understand assignment form, including repeatable pack options
- preserve repeated upstream header bindings and plugin de-duplication

## Verification

Focused parser tests prove:

- mask validates and reads kind/profile/input/pack/pack-dir/plugin assignments
- read applies every assigned value and rejects empty assignments
- agent plugin assignments activate once and are not forwarded after `--`
- both desktop app parsers apply path/upstream/repeated-header/plugin assignments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `--option=value` syntax across CLI options.
  * Plugin values are now validated, parsed, and deduplicated consistently.
* **Bug Fixes**
  * Empty option assignments now return clear validation errors.
  * Improved handling of application, upstream, model, API, masking, and agent options.
* **Tests**
  * Added coverage for assignment-form options, plugin activation, and missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->