### PR TITLE
Anchor masked read copies to the discovered project root

### DIFF
--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -3209,29 +3209,38 @@ fn masked_read_copy(session: &Session, path_text: &str) -> Result<Option<PathBuf
 }
 
 fn masked_read_copy_path(original: &Path) -> PathBuf {
-    let display_path = masked_read_display_path(original);
-    PathBuf::from(".pentect").join("read").join(display_path)
+    let root = config::project_root().unwrap_or_else(|_| {
+        std::env::current_dir()
+            .ok()
+            .and_then(|cwd| cwd.canonicalize().ok().or(Some(cwd)))
+            .unwrap_or_else(|| PathBuf::from("."))
+    });
+    let display_path = masked_read_display_path(original, &root);
+    root.join(".pentect").join("read").join(display_path)
 }
 
-fn masked_read_display_path(original: &Path) -> PathBuf {
-    if original.is_absolute() {
-        if let Ok(cwd) = std::env::current_dir() {
-            if let Ok(relative) = original.strip_prefix(cwd) {
-                return safe_masked_read_path(relative);
-            }
-        }
-        return PathBuf::from("_external")
-            .join(masked_read_path_hash(original))
-            .join(
-                original
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .map(safe_masked_read_component)
-                    .filter(|name| !name.is_empty())
-                    .unwrap_or_else(|| "file.txt".to_string()),
-            );
+fn masked_read_display_path(original: &Path, project_root: &Path) -> PathBuf {
+    let absolute = if original.is_absolute() {
+        original.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| project_root.to_path_buf())
+            .join(original)
+    };
+    let normalized = absolute.canonicalize().unwrap_or(absolute);
+    if let Ok(relative) = normalized.strip_prefix(project_root) {
+        return safe_masked_read_path(relative);
     }
-    safe_masked_read_path(original)
+    PathBuf::from("_external")
+        .join(masked_read_path_hash(&normalized))
+        .join(
+            normalized
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(safe_masked_read_component)
+                .filter(|name| !name.is_empty())
+                .unwrap_or_else(|| "file.txt".to_string()),
+        )
 }
 
 fn masked_read_path_hash(path: &Path) -> String {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -3527,7 +3527,12 @@ fn pretool_rewrites_direct_read_tool_to_masked_copy() {
         .unwrap();
     let masked_path_buf = PathBuf::from(masked_path);
     assert!(
-        masked_path_buf.starts_with(Path::new(".pentect").join("read")),
+        masked_path_buf.starts_with(
+            config::project_root()
+                .unwrap()
+                .join(".pentect")
+                .join("read")
+        ),
         "{masked_path}"
     );
     assert!(
@@ -3579,7 +3584,7 @@ fn pretool_rewrites_secret_read_many_paths_to_masked_copies() {
         let masked_path = paths[1].as_str().unwrap();
         let masked_path_buf = PathBuf::from(masked_path);
         assert!(
-            masked_path_buf.starts_with(Path::new(".pentect").join("read")),
+            masked_path_buf.starts_with(project.join(".pentect").join("read")),
             "{masked_path}"
         );
         assert!(masked_path_buf.ends_with(&env), "{masked_path}");
@@ -3594,14 +3599,44 @@ fn pretool_rewrites_secret_read_many_paths_to_masked_copies() {
 
 #[test]
 fn masked_read_copy_path_mirrors_relative_paths() {
-    let path = masked_read_copy_path(Path::new("nested/.env"));
-    assert_eq!(
-        path,
-        Path::new(".pentect")
-            .join("read")
-            .join("nested")
-            .join(".env")
-    );
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("masked-read-project-root");
+    let project = root.join("project");
+    let nested = project.join("src").join("nested");
+    std::fs::create_dir_all(project.join(".git")).unwrap();
+    std::fs::create_dir_all(&nested).unwrap();
+    let source = project.join("config.env");
+    std::fs::write(
+        &source,
+        "RUNPOD_API_KEY=rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\n",
+    )
+    .unwrap();
+
+    let (relative_copy, absolute_copy) = {
+        let _cwd = enter_temp_cwd(&nested);
+        let session = Session::open_at(&project, "t").unwrap();
+        let relative = masked_read_copy(&session, Path::new("../../config.env").to_str().unwrap())
+            .unwrap()
+            .unwrap();
+        let absolute = masked_read_copy(&session, source.to_str().unwrap())
+            .unwrap()
+            .unwrap();
+        (relative, absolute)
+    };
+
+    let expected = project
+        .canonicalize()
+        .unwrap()
+        .join(".pentect")
+        .join("read")
+        .join("config.env");
+    assert_eq!(relative_copy, expected);
+    assert_eq!(absolute_copy, expected);
+    assert!(!nested.join(".pentect").exists());
+    assert!(std::fs::read_to_string(&expected)
+        .unwrap()
+        .contains("<<RUNPOD_API_KEY_"));
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3638,10 +3673,11 @@ fn masked_read_copy_paths_do_not_collide_for_external_same_basename() {
     };
 
     assert_ne!(first_masked, second_masked);
-    assert!(first_masked.starts_with(Path::new(".pentect").join("read").join("_external")));
-    assert!(second_masked.starts_with(Path::new(".pentect").join("read").join("_external")));
-    let first_text = std::fs::read_to_string(project.join(&first_masked)).unwrap();
-    let second_text = std::fs::read_to_string(project.join(&second_masked)).unwrap();
+    let external_root = project.join(".pentect").join("read").join("_external");
+    assert!(first_masked.starts_with(&external_root));
+    assert!(second_masked.starts_with(&external_root));
+    let first_text = std::fs::read_to_string(&first_masked).unwrap();
+    let second_text = std::fs::read_to_string(&second_masked).unwrap();
     assert!(first_text.contains("<<RUNPOD_API_KEY_"), "{first_text}");
     assert!(second_text.contains("<<OPENAI_API_KEY_"), "{second_text}");
     let _ = std::fs::remove_dir_all(root);


### PR DESCRIPTION
Closes #1214.

## Root cause

Masked read copies were rooted at the current directory, and only absolute inputs were compared against that same current directory. A nested invocation therefore created a nested `.pentect/read`, while project files above the launch directory could be classified as external.

## Fix

- anchor copies at the existing ancestor-discovered canonical project root
- resolve relative inputs against the current directory and normalize the existing file
- classify normalized project files by stable project-relative path
- retain hashed `_external` paths for files outside the project
- return the absolute masked-copy path so rewritten tool input stays valid from nested directories

## Verification

- relative and absolute references to one project file from a nested directory converge on exactly one copy
- no nested `.pentect` directory is created
- the copy contains masked data
- two external files with the same basename still receive distinct hashed paths
- existing direct-read and multi-read hook rewrites pass with project-root paths
