### PR TITLE
Use one Google credential set across Gemini launchers

### DIFF
--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -1335,6 +1335,14 @@ mod tests {
         use std::io::{Read, Write};
 
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let _google_keys = crate::EnvVarGuard::set_optional([
+            ("GOOGLE_API_KEY", None),
+            (
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+                Some(std::ffi::OsString::from("generative-only-key")),
+            ),
+            ("GEMINI_API_KEY", None),
+        ]);
         let store = pentect_agent::start_in_process_memory_store().unwrap();
         let _env = TestEnv::install(&store);
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -1372,7 +1380,7 @@ mod tests {
         let proxy = GeminiHttpProxyGuard::start_with_header_env_and_api_key(
             format!("http://{address}"),
             &[],
-            Some("upstream-test-key".to_string()),
+            crate::configured_google_api_key(),
         )
         .unwrap();
         reqwest::blocking::Client::new()
@@ -1395,7 +1403,7 @@ mod tests {
         assert!(
             headers
                 .lines()
-                .any(|line| line.eq_ignore_ascii_case("x-goog-api-key: upstream-test-key")),
+                .any(|line| line.eq_ignore_ascii_case("x-goog-api-key: generative-only-key")),
             "upstream did not receive the gateway-owned key"
         );
         assert!(!headers.contains("pentect-local"));

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1673,9 +1673,7 @@ fn run_endpoint_env(
             run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
         }
         client_descriptor::Protocol::Gemini => {
-            let google_api_key = ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
-                .iter()
-                .find_map(|name| nonempty_env(name));
+            let google_api_key = configured_google_api_key();
             let shield_child_key = google_api_key.is_some()
                 || upstream::has_origin_auth_override(&opts.upstream_header_env);
             let proxy = gemini_http_proxy::GeminiHttpProxyGuard::start_with_header_env_and_api_key(
@@ -1693,9 +1691,22 @@ fn run_endpoint_env(
 
 fn shield_google_api_key_env(command: &mut Command, enabled: bool) {
     if enabled {
-        command.env("GEMINI_API_KEY", "pentect-local");
-        command.env("GOOGLE_API_KEY", "pentect-local");
+        for name in GOOGLE_API_KEY_ENV_NAMES {
+            command.env(name, "pentect-local");
+        }
     }
+}
+
+pub(crate) const GOOGLE_API_KEY_ENV_NAMES: &[&str] = &[
+    "GOOGLE_API_KEY",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    "GEMINI_API_KEY",
+];
+
+fn configured_google_api_key() -> Option<String> {
+    GOOGLE_API_KEY_ENV_NAMES
+        .iter()
+        .find_map(|name| nonempty_env(name))
 }
 
 const CLAUDE_CLOUD_PROVIDER_FLAGS: &[&str] = &[
@@ -3953,23 +3964,37 @@ mod tests {
 
     #[test]
     fn gemini_child_receives_only_local_placeholder_keys_when_gateway_owns_auth() {
+        let _lock = TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let _google_keys = EnvVarGuard::set_optional([
+            ("GOOGLE_API_KEY", None),
+            (
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+                Some(OsString::from("generative-only-key")),
+            ),
+            ("GEMINI_API_KEY", None),
+        ]);
+        assert_eq!(
+            configured_google_api_key().as_deref(),
+            Some("generative-only-key")
+        );
+
         let mut command = Command::new("gemini-child");
-        command.env("GEMINI_API_KEY", "inherited-value");
-        command.env("GOOGLE_API_KEY", "inherited-value");
+        for name in GOOGLE_API_KEY_ENV_NAMES {
+            command.env(name, "inherited-value");
+        }
 
         shield_google_api_key_env(&mut command, true);
 
         let environment = command
             .get_envs()
             .collect::<std::collections::BTreeMap<_, _>>();
-        assert_eq!(
-            environment.get(OsStr::new("GEMINI_API_KEY")),
-            Some(&Some(OsStr::new("pentect-local")))
-        );
-        assert_eq!(
-            environment.get(OsStr::new("GOOGLE_API_KEY")),
-            Some(&Some(OsStr::new("pentect-local")))
-        );
+        for name in GOOGLE_API_KEY_ENV_NAMES {
+            assert_eq!(
+                environment.get(OsStr::new(name)),
+                Some(&Some(OsStr::new("pentect-local"))),
+                "{name}"
+            );
+        }
     }
 
     #[test]

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -375,11 +375,7 @@ fn opencode_proxy_auth(
             child_key_env = Some("ANTHROPIC_API_KEY");
         }
     } else if route.protocol == OpenCodeProtocol::Gemini {
-        if let Some(name) = configured_key_env(&[
-            "GOOGLE_API_KEY",
-            "GOOGLE_GENERATIVE_AI_API_KEY",
-            "GEMINI_API_KEY",
-        ]) {
+        if let Some(name) = configured_key_env(crate::GOOGLE_API_KEY_ENV_NAMES) {
             child_key_env = Some(name);
             if !has_header_override(&header_env, "x-goog-api-key")
                 && !crate::upstream::has_origin_auth_override(&header_env)
@@ -410,10 +406,10 @@ fn opencode_command(
         "OPENCODE_API_KEY",
         "OPENROUTER_API_KEY",
         "ANTHROPIC_API_KEY",
-        "GOOGLE_API_KEY",
-        "GOOGLE_GENERATIVE_AI_API_KEY",
-        "GEMINI_API_KEY",
     ] {
+        command.env_remove(name);
+    }
+    for name in crate::GOOGLE_API_KEY_ENV_NAMES {
         command.env_remove(name);
     }
     crate::apply_plugin_env(&mut command, active_plugins)?;
@@ -1084,7 +1080,12 @@ mod tests {
             "Bearer custom-upstream-token",
         );
         let _anthropic_key = ScopedEnv::set("ANTHROPIC_API_KEY", "anthropic-origin-key");
-        let _gemini_key = ScopedEnv::set("GOOGLE_API_KEY", "google-origin-key");
+        let _google_key = ScopedEnv::remove("GOOGLE_API_KEY");
+        let _generative_key = ScopedEnv::set(
+            "GOOGLE_GENERATIVE_AI_API_KEY",
+            "google-generative-origin-key",
+        );
+        let _gemini_key = ScopedEnv::remove("GEMINI_API_KEY");
 
         for (protocol, forbidden_header, expected_child_key) in [
             (
@@ -1092,7 +1093,11 @@ mod tests {
                 "x-api-key",
                 "ANTHROPIC_API_KEY",
             ),
-            (OpenCodeProtocol::Gemini, "x-goog-api-key", "GOOGLE_API_KEY"),
+            (
+                OpenCodeProtocol::Gemini,
+                "x-goog-api-key",
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+            ),
         ] {
             let route = OpenCodeRoute {
                 provider: "test".to_string(),


### PR DESCRIPTION
## Root cause

Google credential environment names were duplicated across launch paths. The endpoint Gemini launcher omitted `GOOGLE_GENERATIVE_AI_API_KEY`, while OpenCode recognized it, so the same configured key could be ignored by the gateway and remain visible in the child process.

## Fix

- define one ordered Google credential environment-name list
- reuse it for Gemini key selection, child placeholder shielding, OpenCode provider selection, and OpenCode child cleanup
- exercise the previously omitted key through the real localhost Gemini proxy path

## Verification

- `cargo test -p pentect-cli gateway_replaces_the_child_google_key_before_upstream -- --nocapture`
- `cargo test -p pentect-cli gemini_child_receives_only_local_placeholder_keys_when_gateway_owns_auth -- --nocapture`
- `cargo test -p pentect-cli authorization_control_env_prevents_native_provider_key_injection -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1213