### PR TITLE
Keep project configuration active in nested directories

### DIFF
--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -181,10 +181,12 @@ fn same_path(left: &Path, right: &Path) -> bool {
 }
 
 fn check_configs() -> Vec<Check> {
-    let project = PathBuf::from(".pentect").join("config.toml");
+    let project = pentect_agent::project_root()
+        .map(|root| check_config("config-project", root.join(".pentect").join("config.toml")))
+        .unwrap_or_else(|error| Check::fail("config-project", error));
     let global = home_dir().map(|home| home.join(".pentect").join("config.toml"));
     vec![
-        check_config("config-project", project),
+        project,
         global.map_or_else(
             || Check::warn("config-user", "home directory unavailable"),
             |path| check_config("config-user", path),
@@ -754,6 +756,23 @@ impl Check {
 mod tests {
     use super::*;
 
+    struct CurrentDirGuard(PathBuf);
+
+    impl CurrentDirGuard {
+        fn enter(path: &Path) -> Self {
+            std::fs::create_dir_all(path).unwrap();
+            let previous = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self(previous)
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
     #[test]
     fn doctor_rejects_positionals() {
         let args = vec!["pentect".into(), "doctor".into(), "codex".into()];
@@ -833,6 +852,35 @@ mod tests {
         let check = check_config("test-config", path);
         assert_eq!(check.status, Status::Ok);
         assert_eq!(check.detail, "ready");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn doctor_checks_the_project_config_from_a_nested_working_directory() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let root = std::env::temp_dir().join(format!(
+            "pentect-doctor-project-root-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let config_dir = root.join(".pentect");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config = config_dir.join("config.toml");
+        std::fs::write(&config, "[output]\nrestore = 3\n").unwrap();
+        let nested = root.join("src").join("nested");
+        {
+            let _cwd = CurrentDirGuard::enter(&nested);
+            let check = check_configs()
+                .into_iter()
+                .find(|check| check.name == "config-project")
+                .unwrap();
+            assert_eq!(check.status, Status::Fail);
+            assert!(check.detail.contains(&config.display().to_string()));
+            assert!(check.detail.contains("output.restore must be a boolean"));
+        }
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/pentect-runtime/src/config.rs
+++ b/crates/pentect-runtime/src/config.rs
@@ -28,7 +28,7 @@ pub(crate) enum HandleScope {
 
 #[cfg_attr(test, allow(dead_code))]
 pub(crate) fn handle_identity_key() -> Result<[u8; 32], String> {
-    let project = read_handle_scope(project_config_path())?;
+    let project = read_handle_scope(project_config_path()?)?;
     let global = read_handle_scope(global_config_path()?)?;
     match project.or(global).unwrap_or_default() {
         HandleScope::Device => machine_identity_key(),
@@ -407,20 +407,20 @@ struct DecodeConfigPartial {
 }
 
 pub(crate) fn require_pentect_agent_by_config() -> Result<bool, String> {
-    let project = read_agent_require_pentect(project_config_path())?;
+    let project = read_agent_require_pentect(project_config_path()?)?;
     let global = read_agent_require_pentect(global_config_path()?)?;
     Ok(require_pentect_agent_effective(project, global))
 }
 
 pub(crate) fn image_ocr_config() -> Result<ImageOcrConfig, String> {
-    let project = read_image_ocr_config(project_config_path())?;
+    let project = read_image_ocr_config(project_config_path()?)?;
     let global = read_image_ocr_config(global_config_path()?)?;
     merge_image_ocr_config(project, global)
 }
 
 #[cfg(not(test))]
 pub(crate) fn environment_variable_prefix() -> Result<String, String> {
-    reject_removed_environment_config(project_config_path())?;
+    reject_removed_environment_config(project_config_path()?)?;
     reject_removed_environment_config(global_config_path()?)?;
     Ok(DEFAULT_ENVIRONMENT_PREFIX.to_string())
 }
@@ -432,7 +432,7 @@ pub(crate) fn environment_variable_prefix() -> Result<String, String> {
 
 #[cfg(not(test))]
 pub(crate) fn decode_config(profile: Profile) -> Result<DecodeConfig, String> {
-    let project = read_decode_config(project_config_path())?;
+    let project = read_decode_config(project_config_path()?)?;
     let global = read_decode_config(global_config_path()?)?;
     merge_decode_config(profile, project, global)?.validate()
 }
@@ -448,19 +448,19 @@ pub(crate) fn decode_config(profile: Profile) -> Result<DecodeConfig, String> {
 }
 
 pub(crate) fn remember_files_enabled() -> Result<bool, String> {
-    let project = read_files_remember(project_config_path())?;
+    let project = read_files_remember(project_config_path()?)?;
     let global = read_files_remember(global_config_path()?)?;
     Ok(project.or(global).unwrap_or(true))
 }
 
 pub(crate) fn activity_share_enabled() -> Result<bool, String> {
-    let project = read_activity_share(project_config_path())?;
+    let project = read_activity_share(project_config_path()?)?;
     let global = read_activity_share(global_config_path()?)?;
     Ok(local_privacy_setting_enabled(project, global))
 }
 
 pub(crate) fn metrics_enabled() -> Result<bool, String> {
-    let project = read_metrics_enabled(project_config_path())?;
+    let project = read_metrics_enabled(project_config_path()?)?;
     let global = read_metrics_enabled(global_config_path()?)?;
     Ok(local_privacy_setting_enabled(project, global))
 }
@@ -472,13 +472,13 @@ fn local_privacy_setting_enabled(project: Option<bool>, global: Option<bool>) ->
 }
 
 pub(crate) fn update_check_enabled() -> Result<bool, String> {
-    let project = read_update_check(project_config_path())?;
+    let project = read_update_check(project_config_path()?)?;
     let global = read_update_check(global_config_path()?)?;
     Ok(project.or(global).unwrap_or(true))
 }
 
 pub(crate) fn output_restore_enabled() -> Result<bool, String> {
-    let project = read_output_restore(project_config_path())?;
+    let project = read_output_restore(project_config_path()?)?;
     let global = read_output_restore(global_config_path()?)?;
     Ok(output_restore_effective(project, global))
 }
@@ -491,7 +491,7 @@ fn output_restore_effective(project: Option<bool>, global: Option<bool>) -> bool
 }
 
 pub(crate) fn unknown_formats_should_block() -> Result<bool, String> {
-    let project = read_unknown_format_policy(project_config_path())?;
+    let project = read_unknown_format_policy(project_config_path()?)?;
     let global = read_unknown_format_policy(global_config_path()?)?;
     unknown_formats_should_block_effective(project, global)
 }
@@ -1135,8 +1135,8 @@ fn agent_config_bool(value: &toml::Value, field: &str) -> Result<bool, String> {
     Err(format!("agent config {field} must be a boolean"))
 }
 
-fn project_config_path() -> PathBuf {
-    PathBuf::from(PENTECT_DIR).join(CONFIG_FILE)
+fn project_config_path() -> Result<PathBuf, String> {
+    Ok(project_root()?.join(PENTECT_DIR).join(CONFIG_FILE))
 }
 
 fn global_config_path() -> Result<PathBuf, String> {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -538,6 +538,25 @@ fn default_session_root_lives_under_project_pentect_dir() {
 }
 
 #[test]
+fn project_config_remains_effective_from_a_nested_working_directory() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("nested-project-config");
+    write_project_config(&root, "[output]\nrestore = false\n");
+    let _home = write_user_config(&root, "");
+    let nested = root.join("src").join("nested");
+    {
+        let _cwd = enter_temp_cwd(&nested);
+        assert!(!output_restore_enabled().unwrap());
+    }
+    write_project_config(&nested, "[output]\nrestore = true\n");
+    {
+        let _cwd = enter_temp_cwd(&nested.join("deeper"));
+        assert!(output_restore_enabled().unwrap());
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn open_at_stays_process_local() {
     let root = temp_root("open-at-in-memory");
     let persisted = Session::open_capability_at(&root, "t").unwrap();


### PR DESCRIPTION
## Corrected root cause

The issue originally described a doctor-only mismatch, but the runtime project config path was also still relative to the current directory. Other project-scoped features already used the shared ancestor resolver, so both runtime and doctor silently lost root configuration in nested directories. Fixing doctor alone would have made diagnostics disagree with execution.

## Fix

- resolve every runtime project-config read through the shared project root
- make doctor inspect the same resolved config path
- propagate project-root resolution errors instead of silently falling back
- preserve nearest nested `.pentect` as an intentional separate scope

## Verification

- root `[output] restore = false` remains effective from a nested working directory
- a nearer nested `.pentect` still starts a separate scope
- doctor rejects an invalid root config from a nested working directory and reports its actual path
- all 30 runtime config unit tests pass
- focused doctor config and repair tests pass
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1211