### PR TITLE
Use CredSweeper's official Discord token fixture

### DIFF
--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -7088,13 +7088,18 @@ mod tests {
     }
 
     #[test]
-    fn value_discord_bot_requires_numeric_id_and_signature_entropy() {
-        assert!(!value_discord_bot_filtered(
-            "MTIzNDU2Nzg5MA.abcdefghijklmnopqrstuvwxyz012345"
-        ));
+    fn value_discord_bot_matches_upstream_fixture_and_entropy_filter() {
+        assert!(!value_discord_bot_filtered(concat!(
+            "MTIzNDU2Nzg5MDEyMzQ1Njc4OQ.E2-E4_.",
+            "Zig9V5mpMk-JybgCFvqSfgY9EoqWjkA5O_qDje"
+        )));
         assert!(value_discord_bot_filtered(
             "OTk5.abcdefghijklmnopqrstuvwxyz012345"
         ));
+        assert!(value_discord_bot_filtered(concat!(
+            "MTA1NDMyMTA5ODc2NTQzMjEwMA.GAxYzA.",
+            "dGVzdHNpZ25hdHVyZXRlc3RzaWduYXR1cmUxMjM"
+        )));
         assert!(value_discord_bot_filtered("MTIzNDU2Nzg5MA.aaaaaaaaaaaa"));
         assert!(value_discord_bot_filtered("not-a-token"));
     }


### PR DESCRIPTION
## Summary

- replace Pentect's contrived Discord filter unit fixture with CredSweeper's official fixture
- retain the issue's repeated-ASCII signature as an explicitly filtered low-entropy case
- document in the issue that Pentect's implementation and threshold match pinned CredSweeper v1.17.4

This intentionally does not lower the CredSweeper entropy threshold. The reported fixture is rejected by both implementations and is not evidence of a real cryptographic Discord signature.

## Verification

- `cargo test -p pentect-core detect::credsweeper::tests::value_discord_bot_matches_upstream_fixture_and_entropy_filter -- --exact --nocapture`
- `cargo clippy -p pentect-core --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
