### PR TITLE
Parse database IPv6 host ports safely

### DIFF
--- a/crates/pentect-core/src/detect/validate.rs
+++ b/crates/pentect-core/src/detect/validate.rs
@@ -1255,10 +1255,20 @@ fn db_host_without_port(host: &str) -> &str {
     let host = host
         .trim()
         .trim_matches(|ch| matches!(ch, '"' | '\'' | '`'));
+    if host.starts_with('[') {
+        let Some((without_closing_bracket, port)) = host.rsplit_once("]:") else {
+            return host;
+        };
+        return if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) {
+            &host[..without_closing_bracket.len() + 1]
+        } else {
+            host
+        };
+    }
     let Some((without_port, port)) = host.rsplit_once(':') else {
         return host;
     };
-    if port.bytes().all(|b| b.is_ascii_digit()) && !without_port.contains(']') {
+    if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) && !without_port.contains(':') {
         without_port
     } else {
         host
@@ -1402,9 +1412,26 @@ mod tests {
             "postgresql://testuser:testpwd@localhost" => false,
             "postgres://my-user:my-password@example.com:5432" => false,
             "postgres://user:password@host" => false,
+            "postgres://user:password@[::1]:5432/app" => false,
+            "postgres://admin:s3cr3t@[::1]:5432/app" => true,
             "postgresql://[user[:password]@][host][:port][" => false,
             "mongodb://username:<password>@cluster0.example.com:27017" => false,
             "redis://***:***@localhost:6379" => false);
+    }
+
+    #[test]
+    fn db_host_port_parsing_handles_bracketed_and_unbracketed_ipv6() {
+        vectors!(db_host_without_port,
+            "[::1]:5432" => "[::1]",
+            "[::1]" => "[::1]",
+            "[2001:db8::1]:5432" => "[2001:db8::1]",
+            "[::1]:not-a-port" => "[::1]:not-a-port",
+            "[::1]:" => "[::1]:",
+            "::1" => "::1",
+            "2001:db8::1" => "2001:db8::1",
+            "localhost:5432" => "localhost",
+            "localhost:" => "localhost:",
+            "127.0.0.1:5432" => "127.0.0.1");
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

The custom `db_connection_string` validator inferred ports with `rsplit_once(":")` and a closing-bracket condition. That condition both retained ports on bracketed IPv6 hosts and stripped the final numeric component from unbracketed IPv6.

The originally reported default-engine over-mask does not occur: `UrlDetector` owns that path and already rejects placeholder credentials. The issue has been corrected and downgraded to describe the custom-validator scope.

## Fix

Parse bracketed IPv6 and unbracketed hosts separately. Strip only non-empty numeric ports after `]`, preserve unbracketed IPv6, and retain hostname/IPv4 port behavior.

## Verification

- Host parser vectors for bracketed/unbracketed IPv6, IPv4, hostnames, invalid and empty ports
- Database validator tests for placeholder and concrete credentials on IPv6 loopback
- pentect-core clippy with warnings denied

Closes #1239