### PR TITLE
Parse Unicode environment keys

### DIFF
--- a/crates/pentect-core/src/parse/mod.rs
+++ b/crates/pentect-core/src/parse/mod.rs
@@ -667,7 +667,7 @@ fn inline_env_comment_start(value: &str) -> Option<usize> {
 }
 
 fn is_key_char(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-'
+    c.is_alphanumeric() || c == '_' || c == '.' || c == '-'
 }
 
 fn closing_double_quote(value: &str) -> Option<usize> {
@@ -708,6 +708,20 @@ mod tests {
             [
                 (Some("API_KEY".into()), "AKIAIOSFODNN7EXAMPLE".into()),
                 (Some("DB_PASSWORD".into()), "hunter2".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn extracts_values_for_unicode_keys_without_losing_byte_boundaries() {
+        let raw = "パスワード=\"秘密の値123\"\n秘密鍵='鍵の値456'\n日本語.キー-1=値789\n";
+
+        assert_eq!(
+            parsed(raw),
+            [
+                (Some("パスワード".into()), "秘密の値123".into()),
+                (Some("秘密鍵".into()), "鍵の値456".into()),
+                (Some("日本語.キー-1".into()), "値789".into()),
             ]
         );
     }

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -2391,6 +2391,27 @@ mod tests {
     }
 
     #[test]
+    fn env_values_under_unicode_keys_are_masked_and_reversible() {
+        let raw = "パスワード=\"秘密の値123\"\n秘密鍵='鍵の値456'\nシークレット=値789\n";
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Env,
+                data: raw.into(),
+            },
+            &Config::insecure_testing(),
+        );
+
+        for value in ["秘密の値123", "鍵の値456", "値789"] {
+            assert!(!result.masked.contains(value), "{}", result.masked);
+        }
+        for key in ["パスワード", "秘密鍵", "シークレット"] {
+            assert!(result.masked.contains(key), "{}", result.masked);
+        }
+        assert_eq!(result.summary.masked_count, 3);
+        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+    }
+
+    #[test]
     fn malformed_placeholder_lookalikes_cannot_bypass_env_masking() {
         let raw = "PASSWORD=<<MY_PASSWORD>>\nTOKEN=<<ghp_Ab3dE5fGh7Jk9Lm2Np4Qr6St8Uv1Wx3Yz5Bc>>\nLOWER=<<my_label_0123456789abcdef>>\nUPPER_HASH=<<LABEL_ABCDEF0123456789>>\nSHORT_HASH=<<LABEL_abc123>>\nVALID=<<SECRET_0123456789abcdef>>\n";
         let result = Engine::with_profile(Profile::Strict).mask(


### PR DESCRIPTION
## Root cause

`EnvParser` accepted only ASCII alphanumeric key characters. Explicit `.env` input with Japanese or other Unicode keys therefore emitted no value region, so the secret-bearing environment boundary never reached `EnvValueDetector`.

## Fix

Accept Unicode alphanumeric key characters while preserving the existing `_`, `.`, and `-` punctuation. Whitespace and assignment delimiters remain invalid inside keys.

## Verification

- Parser extracts Japanese and mixed Unicode keys with exact UTF-8 byte ranges
- Standard strict Engine masks all values while preserving keys and quoting
- Recovery reconstructs the exact original `.env` text
- pentect-core clippy with warnings denied

Closes #486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment parsing now supports keys containing Unicode letters and numbers.
  * Unicode-keyed environment values can be masked and restored while preserving their original keys and values.

* **Tests**
  * Added coverage for Unicode key parsing and reversible masking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->