### PR TITLE
test: cover Supabase CredSweeper fixtures

### DIFF
--- a/crates/pentect-core/src/detect/credsweeper.rs
+++ b/crates/pentect-core/src/detect/credsweeper.rs
@@ -7137,6 +7137,14 @@ mod tests {
                 "SENTRY_USER_AUTH_TOKEN",
                 ["sntryu_", "b42e3f39e6e16d5c822ac2e6ae368a1bc24fd9678bc6a6411926acdafea59851"].concat(),
             ),
+            (
+                "SUPABASE_CREDENTIALS",
+                ["sbp_", "7558c5a93d6f38dd038df5cc2a7c3d4d7b6bc76d"].concat(),
+            ),
+            (
+                "SUPABASE_CREDENTIALS",
+                ["sbp_", "v0_", "7558c5a93d6f38dd038df5cc2a7c3d4d7b6bc76d"].concat(),
+            ),
         ];
         let detector = CredSweeperNativeDetector::builtin();
 


### PR DESCRIPTION
## Summary

- add pinned CredSweeper regression coverage for both Supabase access-token forms: `sbp_` and `sbp_v0_`
- verify complete native findings use the upstream `SUPABASE_CREDENTIALS` label

## Root cause

The issue predates the complete native CredSweeper rule import. Current `main` already generates the Supabase rule from the pinned v1.17.4 YAML and masks real upstream fixtures. The original reproduction is a deliberately repetitive synthetic value, which CredSweeper's `TokenPattern` filter rejects upstream as well.

This PR locks the already-correct behavior without adding a looser duplicate detector or diverging from the canonical baseline.

## Verification

- `cargo test -p pentect-core vendor_token_rules_match_pinned_credsweeper_fixtures`
- `cargo clippy -p pentect-core --all-targets -- -D warnings`

Closes #434.
