### PR TITLE
fix: detect compact JWE credentials

### DIFF
--- a/crates/pentect-core/src/detect/jwt.rs
+++ b/crates/pentect-core/src/detect/jwt.rs
@@ -15,9 +15,17 @@ static JWT: LazyLock<Regex> = LazyLock::new(|| {
     .expect("JWT regex compiles")
 });
 
+static JWE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?:^|[^A-Za-z0-9_.-])(eyJ[A-Za-z0-9_-]{4,}(?:\.[A-Za-z0-9_-]*){4})(?:$|[^A-Za-z0-9_.-])",
+    )
+    .expect("JWE regex compiles")
+});
+
 impl Detector for JwtDetector {
     fn detect(&self, view: &NormalizedView) -> Vec<Span> {
-        JWT.captures_iter(view.text())
+        let mut spans = JWT
+            .captures_iter(view.text())
             .filter_map(|captures| {
                 let candidate = captures.get(1)?;
                 valid_compact_jwt(candidate.as_str()).then(|| Span {
@@ -28,7 +36,18 @@ impl Detector for JwtDetector {
                     source: DetectorId::Rule,
                 })
             })
-            .collect()
+            .collect::<Vec<_>>();
+        spans.extend(JWE.captures_iter(view.text()).filter_map(|captures| {
+            let candidate = captures.get(1)?;
+            valid_compact_jwe(candidate.as_str()).then(|| Span {
+                range: view.to_raw(ByteRange::new(candidate.start(), candidate.end())),
+                category: Category::Secret,
+                label: "JSON_WEB_ENCRYPTION".to_string(),
+                confidence: Confidence::High,
+                source: DetectorId::Rule,
+            })
+        }));
+        spans
     }
 }
 
@@ -57,6 +76,46 @@ fn valid_compact_jwt(value: &str) -> bool {
         return false;
     }
     signature.is_empty() || decode_base64url(signature).is_some_and(|bytes| !bytes.is_empty())
+}
+
+fn valid_compact_jwe(value: &str) -> bool {
+    // CredSweeper bounds each JOSE segment at 8,000 bytes. Keep the same
+    // denial-of-service ceiling while accounting for five segments.
+    const MAX_COMPACT_JWE_BYTES: usize = 40_004;
+    if value.len() > MAX_COMPACT_JWE_BYTES {
+        return false;
+    }
+    let mut parts = value.split('.');
+    let (Some(header), Some(encrypted_key), Some(iv), Some(ciphertext), Some(tag), None) = (
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+    ) else {
+        return false;
+    };
+    let Some(header) = decode_json_object(header) else {
+        return false;
+    };
+    let Some(algorithm) = header.get("alg").and_then(serde_json::Value::as_str) else {
+        return false;
+    };
+    let Some(encryption) = header.get("enc").and_then(serde_json::Value::as_str) else {
+        return false;
+    };
+    if algorithm.is_empty() || encryption.is_empty() {
+        return false;
+    }
+    if encrypted_key.is_empty() && !matches!(algorithm, "dir" | "ECDH-ES") {
+        return false;
+    }
+    [encrypted_key, iv, ciphertext, tag]
+        .into_iter()
+        .all(|part| decode_base64url(part).is_some())
+        && !iv.is_empty()
+        && !tag.is_empty()
 }
 
 fn decode_json_object(value: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
@@ -97,12 +156,51 @@ mod tests {
     }
 
     #[test]
-    fn rejects_lookalikes_and_five_part_jwe() {
+    fn rejects_jwt_lookalikes() {
         for value in [
             "eyJungle.abcdefghijklmnop.abcdefghijklmnop",
             "eyJhbGciOiJIUzI1NiJ9.not-json.abcdefghijklmnop",
-            "eyJhbGciOiJIUzI1NiJ9.e30.one.two.three",
             "aaa.bbb.ccc",
+        ] {
+            assert!(detect(value).is_empty(), "{value}");
+        }
+    }
+
+    #[test]
+    fn detects_rfc7516_compact_jwe() {
+        let token = concat!(
+            "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.",
+            "6KB707dmeXEIUpTwjEmnhcqcoGzoUCNDQ88baRINcvNetKXLEFsKqw.",
+            "AxY8DCtDaGlsbGljb3RoZQ.",
+            "KDlTtXchhZTGufWEd01mozbvYvdDxjie3IxIM1LduVsWQgTEP3agPlPqJdYTExWpOHTIWgnOsA.",
+            "48V1_ALb6US04U3bAQJYDg"
+        );
+        let spans = detect(token);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].range, ByteRange::new(0, token.len()));
+        assert_eq!(spans[0].label, "JSON_WEB_ENCRYPTION");
+    }
+
+    #[test]
+    fn accepts_direct_jwe_with_an_empty_encrypted_key() {
+        let token = concat!(
+            "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..",
+            "AxY8DCtDaGlsbGljb3RoZQ.",
+            "KDlTtXchhZTGufWEd01mozbvYvdDxg.",
+            "48V1_ALb6US04U3bAQJYDg"
+        );
+        assert_eq!(detect(token)[0].label, "JSON_WEB_ENCRYPTION");
+    }
+
+    #[test]
+    fn rejects_malformed_jwe_and_does_not_mask_a_five_part_prefix() {
+        for value in [
+            // Missing `enc` in the protected header.
+            "eyJhbGciOiJIUzI1NiJ9.key.iv.ciphertext.tag",
+            // RSA key management cannot use an empty encrypted-key segment.
+            "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ..aXY.Y2lwaGVydGV4dA.dGFn",
+            // Six segments must not be truncated into a five-segment finding.
+            "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..aXY.Y2lwaGVydGV4dA.dGFn.extra",
         ] {
             assert!(detect(value).is_empty(), "{value}");
         }


### PR DESCRIPTION
## Summary

- extend Pentect's existing JOSE detector with RFC 7516 compact JWE support
- validate exactly five Base64URL segments and require a protected JSON header with non-empty `alg` and `enc`
- support the RFC-defined empty encrypted-key segment only for direct `dir` and `ECDH-ES` key management
- keep JWS and malformed multi-segment lookalikes separate, with full-span boundary tests

## Root cause

CredSweeper's broad JOSE candidate regex reaches five-segment values, but its `ValueJsonWebTokenCheck` requires a JSON payload in the second segment. That is correct for JWS but rejects JWE because the second segment is an encrypted key. Pentect's supplemental JOSE detector also validated only three-segment JWS values.

This change leaves the pinned CredSweeper filter untouched and fills the JWE gap in the existing supplemental detector. [RFC 7516 section 7.1](https://www.rfc-editor.org/rfc/rfc7516.html#section-7.1) defines the five-part compact serialization, while [RFC 7518](https://www.rfc-editor.org/rfc/rfc7518.html) defines the empty encrypted-key behavior for direct modes.

## Verification

- `cargo test -p pentect-core detect::jwt::tests`
- `cargo clippy -p pentect-core --all-targets -- -D warnings`

Closes #433.
