### PR TITLE
test: preserve Twilio auth token masking

### DIFF
--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -2503,6 +2503,26 @@ mod tests {
     }
 
     #[test]
+    fn text_mode_masks_twilio_auth_token_environment_assignment() {
+        for value in [
+            "0123456789abcdef0123456789abcdef",
+            "7f3a9c2e8b1d4f6a0c5e9b2d7a4f8c1e",
+        ] {
+            let raw = format!("TWILIO_AUTH_TOKEN={value}");
+            let result = Engine::with_profile(Profile::Strict)
+                .mask(Input::text(&raw), &Config::insecure_testing());
+            assert_eq!(result.summary.masked_count, 1, "{}", result.masked);
+            assert!(
+                result.masked.starts_with("TWILIO_AUTH_TOKEN=<<") && result.masked.ends_with(">>"),
+                "{}",
+                result.masked
+            );
+            assert!(!result.masked.contains(value), "{}", result.masked);
+            assert_eq!(restore(&result.masked, &result.recovery).unwrap(), raw);
+        }
+    }
+
+    #[test]
     fn structured_credentials_mask_only_credential_fields() {
         let raw = concat!(
             "[pypi]\n",


### PR DESCRIPTION
## Summary

- add a final-Engine regression for Twilio auth-token environment assignments in text mode
- cover both the original sequential synthetic value and a mixed hexadecimal value
- verify one-handle masking, no plaintext survivor, and exact recovery

## Root cause and current status

The reported leak existed in v0.0.55 because a bare 32-character Twilio Auth Token has no vendor prefix and did not pass shape-only detection. It was fixed by the later shell environment-assignment path (`fb745f4`), which treats the right-hand side of an explicit environment assignment as secret independently of entropy.

No new detector rule is needed. This PR preserves the repaired behavior at the same `--kind text` boundary used by the report.

## Verification

- `cargo test -p pentect-core text_mode_masks_twilio_auth_token_environment_assignment`
- `cargo clippy -p pentect-core --all-targets -- -D warnings`

Closes #409
