### PR TITLE
fix: reject bodies on model endpoints

### DIFF
--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -428,8 +428,9 @@ async fn proxy_request_inner(
             .split('?')
             .next()
             .is_some_and(|path| path.ends_with("/v1/files"));
+    let body_forbidden = endpoint == AnthropicEndpoint::Models;
     let mut request_coverage = None;
-    let body = if protected_request || files_upload {
+    let body = if protected_request || files_upload || body_forbidden {
         let body = match Limited::new(request.into_body(), MAX_HTTP_BODY_BYTES)
             .collect()
             .await
@@ -443,6 +444,12 @@ async fn proxy_request_inner(
             }
             Err(error) => return Err(format!("could not read Claude request body: {error}")),
         };
+        if body_forbidden && !body.is_empty() {
+            return Err(
+                "request body blocked: Anthropic models endpoints do not accept request bodies"
+                    .to_string(),
+            );
+        }
         if body.is_empty() {
             reqwest::Body::from(body)
         } else if files_upload {
@@ -521,7 +528,8 @@ async fn proxy_request_inner(
     let connection_headers = connection_named_headers(&headers);
     for (name, value) in &headers {
         if state.headers.forward_incoming_header(name.as_str())
-            && ((!(protected_request || files_upload) && name == hyper::header::CONTENT_LENGTH)
+            && ((!(protected_request || files_upload || body_forbidden)
+                && name == hyper::header::CONTENT_LENGTH)
                 || should_forward_request_header(name.as_str()))
             && !connection_headers.contains(&name.as_str().to_ascii_lowercase())
         {
@@ -3643,6 +3651,36 @@ mod tests {
         );
         assert!(enforce_known_anthropic_endpoint(AnthropicEndpoint::Unknown, true).is_err());
         assert!(enforce_known_anthropic_endpoint(AnthropicEndpoint::Unknown, false).is_ok());
+    }
+
+    #[test]
+    fn models_request_body_is_rejected_before_anthropic_upstream() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        let proxy = ClaudeHttpProxyGuard::start("http://127.0.0.1:9".to_string()).unwrap();
+        let secret = ["rpa_", "MODELROUTE", "BODYMUST", "NOTLEAVE", "1234567890"].concat();
+
+        let client = reqwest::blocking::Client::new();
+        for path in ["/v1/models", "/v1/models/model_test"] {
+            let response = client
+                .post(format!("{}{path}", proxy.base_url()))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(serde_json::json!({"note": secret}).to_string())
+                .send()
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+            assert!(response
+                .text()
+                .unwrap()
+                .contains("models endpoints do not accept request bodies"));
+        }
+
+        let empty_get = client
+            .get(format!("{}/v1/models", proxy.base_url()))
+            .send()
+            .unwrap();
+        assert_eq!(empty_get.status(), reqwest::StatusCode::BAD_GATEWAY);
     }
 
     #[test]

--- a/crates/pentect-cli/src/gateway_diagnostics.rs
+++ b/crates/pentect-cli/src/gateway_diagnostics.rs
@@ -92,6 +92,7 @@ pub(crate) fn is_local_rejection(error: &str) -> bool {
         || error.starts_with("file upload blocked:")
         || error.starts_with("Files API upload ")
         || error.starts_with("plugin blocked:")
+        || error.starts_with("request body blocked:")
         || error.starts_with("unknown format blocked:")
 }
 
@@ -154,6 +155,10 @@ mod tests {
             ("connect", true)
         );
         assert_eq!(failure_kind("plugin blocked: fixture"), ("policy", false));
+        assert_eq!(
+            failure_kind("request body blocked: fixture"),
+            ("policy", false)
+        );
         assert_eq!(
             failure_kind("arbitrary secret-bearing detail"),
             ("unclassified", false)

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -382,6 +382,7 @@ async fn proxy_request_inner(
             endpoint,
             OpenAiEndpoint::AudioTranscription | OpenAiEndpoint::AudioTranslation
         );
+    let body_forbidden = endpoint == OpenAiEndpoint::Models;
     let upstream_url = join_upstream_url(&state.upstream, path_and_query)?;
     let headers = request.headers().clone();
     let credential_material = state.headers.credential_scope_material(&headers);
@@ -389,7 +390,7 @@ async fn proxy_request_inner(
     let mut request_coverage = None;
     let mut request_streaming = false;
     let mut inspect_protected_request = protected_request;
-    let body = if protected_request || files_upload || audio_upload {
+    let body = if protected_request || files_upload || audio_upload || body_forbidden {
         let body = match Limited::new(request.into_body(), MAX_HTTP_BODY_BYTES)
             .collect()
             .await
@@ -403,6 +404,12 @@ async fn proxy_request_inner(
             }
             Err(error) => return Err(format!("could not read OpenAI request body: {error}")),
         };
+        if body_forbidden && !body.is_empty() {
+            return Err(
+                "request body blocked: OpenAI models endpoints do not accept request bodies"
+                    .to_string(),
+            );
+        }
         let body = if protected_request {
             let original = body.clone();
             match decode_openai_request_body(body, &headers) {
@@ -562,7 +569,7 @@ async fn proxy_request_inner(
     let connection_headers = connection_named_headers(&headers);
     for (name, value) in &headers {
         if state.headers.forward_incoming_header(name.as_str())
-            && ((!(protected_request || files_upload || audio_upload)
+            && ((!(protected_request || files_upload || audio_upload || body_forbidden)
                 && name == hyper::header::CONTENT_LENGTH)
                 || should_forward_request_header(name.as_str()))
             && (!inspect_protected_request || name != hyper::header::CONTENT_ENCODING)
@@ -4551,6 +4558,36 @@ mod tests {
         );
         assert!(enforce_known_openai_endpoint(OpenAiEndpoint::Unknown, true).is_err());
         assert!(enforce_known_openai_endpoint(OpenAiEndpoint::Unknown, false).is_ok());
+    }
+
+    #[test]
+    fn models_request_body_is_rejected_before_openai_upstream() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = ProviderBoundaryTestEnv::install(&store);
+        let proxy = OpenAiHttpProxyGuard::start("http://127.0.0.1:9".to_string()).unwrap();
+        let secret = ["rpa_", "MODELROUTE", "BODYMUST", "NOTLEAVE", "1234567890"].concat();
+
+        let client = reqwest::blocking::Client::new();
+        for path in ["/v1/models", "/v1/models/model_test"] {
+            let response = client
+                .post(format!("{}{path}", proxy.base_url()))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(serde_json::json!({"note": secret}).to_string())
+                .send()
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+            assert!(response
+                .text()
+                .unwrap()
+                .contains("models endpoints do not accept request bodies"));
+        }
+
+        let empty_get = client
+            .get(format!("{}/v1/models", proxy.base_url()))
+            .send()
+            .unwrap();
+        assert_eq!(empty_get.status(), reqwest::StatusCode::BAD_GATEWAY);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- collect requests to OpenAI and Anthropic model collection/resource endpoints instead of streaming them through unchecked
- reject every non-empty models request body locally with HTTP 422 before opening an upstream connection
- preserve normal empty-body model listing, retrieval, and resource methods
- classify this rejection as a value-free local policy event in persistent diagnostics
- add live-proxy regressions for both providers, collection and resource paths, and the empty-body passthrough path

## Root cause

Endpoint classification and request-body handling were maintained as separate sets of booleans. `Models` was accepted as a known endpoint but was absent from every body-collection branch, so its body fell into raw streaming passthrough. Detection accuracy was irrelevant because the body never reached a detector.

The fix encodes the provider protocol rule at this boundary: model endpoints have no supported request body. Rejecting any non-empty body avoids depending on content type, secret shape, or detector recall while retaining valid empty-body requests.

## Verification

- `cargo test -p pentect-cli models_request_body_is_rejected -- --nocapture`
- `cargo test -p pentect-cli failures_are_reduced_to_fixed_safe_categories -- --nocapture`
- `cargo clippy -p pentect-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The provider tests start the real local gateways with an unreachable upstream. Secret-bearing POST bodies on `/v1/models` and `/v1/models/{id}` return 422; empty GET requests proceed to the upstream boundary and therefore return 502 from the deliberately unreachable recorder target.

Closes #403
