### PR TITLE
ci: enforce CredSweeper filter parity

### DIFF
--- a/.github/workflows/credsweeper-regression.yml
+++ b/.github/workflows/credsweeper-regression.yml
@@ -27,6 +27,7 @@ on:
       - 'tools/credsweeper-sidecar/**'
       - 'tools/pentect-bench/**'
       - 'tools/update_credsweeper.py'
+      - 'tools/test_update_credsweeper.py'
   pull_request:
     paths:
       - '.github/workflows/credsweeper-regression.yml'
@@ -49,6 +50,7 @@ on:
       - 'tools/credsweeper-sidecar/**'
       - 'tools/pentect-bench/**'
       - 'tools/update_credsweeper.py'
+      - 'tools/test_update_credsweeper.py'
   workflow_dispatch:
     inputs:
       full:
@@ -115,7 +117,7 @@ jobs:
           python-version: "3.12"
 
       - name: Test CredData shard tooling
-        run: python -m unittest tools/test_creddata_shards.py
+        run: python -m unittest tools/test_creddata_shards.py tools/test_update_credsweeper.py
 
       - name: Install official CredSweeper oracle dependencies
         run: |

--- a/.github/workflows/credsweeper-regression.yml
+++ b/.github/workflows/credsweeper-regression.yml
@@ -17,6 +17,11 @@ on:
       - 'crates/pentect-core/vendors/CredSweeper'
       - 'crates/pentect-core/vendors/credsweeper-assets/**'
       - 'tools/check_credsweeper_regression.py'
+      - 'tools/audit_credsweeper_reference.py'
+      - 'tools/check_credsweeper_filter_parity.py'
+      - 'tools/check_credsweeper_port_inventory.py'
+      - 'tools/credsweeper-reference-inventory.json'
+      - 'tools/credsweeper-rust-port-status.json'
       - 'tools/creddata_shards.py'
       - 'tools/test_creddata_shards.py'
       - 'tools/credsweeper-sidecar/**'
@@ -34,6 +39,11 @@ on:
       - 'crates/pentect-core/vendors/CredSweeper'
       - 'crates/pentect-core/vendors/credsweeper-assets/**'
       - 'tools/check_credsweeper_regression.py'
+      - 'tools/audit_credsweeper_reference.py'
+      - 'tools/check_credsweeper_filter_parity.py'
+      - 'tools/check_credsweeper_port_inventory.py'
+      - 'tools/credsweeper-reference-inventory.json'
+      - 'tools/credsweeper-rust-port-status.json'
       - 'tools/creddata_shards.py'
       - 'tools/test_creddata_shards.py'
       - 'tools/credsweeper-sidecar/**'
@@ -111,6 +121,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tools/credsweeper-sidecar/runtime-requirements.txt
+          python -m pip install pytest==9.0.2
 
       - name: Prepare pinned CredData shard
         shell: bash
@@ -151,6 +162,25 @@ jobs:
             --manifest-path "$RUNNER_TEMP/credsweeper-baseline/tools/pentect-bench/Cargo.toml" \
             --target-dir "$target"
           cp "$target/release/pentect-bench" "$RUNNER_TEMP/pentect-bench-baseline"
+
+      - name: Verify complete rule and filter inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="$PWD/crates/pentect-core/vendors/CredSweeper" \
+            python tools/audit_credsweeper_reference.py \
+              --output "$RUNNER_TEMP/credsweeper-reference-inventory.json"
+          diff -u \
+            tools/credsweeper-reference-inventory.json \
+            "$RUNNER_TEMP/credsweeper-reference-inventory.json"
+          python tools/check_credsweeper_port_inventory.py --require-exact
+
+      - name: Verify every official filter against the native port
+        run: |
+          PYTHONPATH="$PWD/crates/pentect-core/vendors/CredSweeper" \
+            python tools/check_credsweeper_filter_parity.py \
+              --rust "$RUNNER_TEMP/pentect-bench-candidate" \
+              --work "$RUNNER_TEMP/credsweeper-filter-parity"
 
       - name: Check detection quality and speed against baseline
         shell: bash
@@ -272,6 +302,56 @@ jobs:
             ${{ runner.temp }}/shard-${{ matrix.shard }}/report.json
           if-no-files-found: error
           retention-days: 14
+
+  full-filter-parity:
+    name: Full filter and inventory parity
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.full)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: ./.github/actions/rust-toolchain
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: credsweeper-filter-parity
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - name: Sync latest CredSweeper release for the scheduled audit
+        if: github.event_name == 'schedule'
+        run: python tools/update_credsweeper.py latest --skip-validation
+      - name: Install official CredSweeper oracle dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r tools/credsweeper-sidecar/runtime-requirements.txt
+          python -m pip install pytest==9.0.2
+      - name: Build native filter probe
+        run: |
+          cargo build --release --manifest-path tools/pentect-bench/Cargo.toml \
+            --target-dir "$RUNNER_TEMP/target"
+      - name: Verify complete rule and filter inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="$PWD/crates/pentect-core/vendors/CredSweeper" \
+            python tools/audit_credsweeper_reference.py \
+              --output "$RUNNER_TEMP/credsweeper-reference-inventory.json"
+          if [ '${{ github.event_name }}' != schedule ]; then
+            diff -u \
+              tools/credsweeper-reference-inventory.json \
+              "$RUNNER_TEMP/credsweeper-reference-inventory.json"
+            python tools/check_credsweeper_port_inventory.py --require-exact
+          fi
+      - name: Verify every official filter against the native port
+        run: |
+          PYTHONPATH="$PWD/crates/pentect-core/vendors/CredSweeper" \
+            python tools/check_credsweeper_filter_parity.py \
+              --rust "$RUNNER_TEMP/target/release/pentect-bench" \
+              --inventory "$RUNNER_TEMP/credsweeper-reference-inventory.json" \
+              --work "$RUNNER_TEMP/credsweeper-filter-parity"
 
   weekly-summary:
     name: Weekly full CredData parity

--- a/.github/workflows/update-credsweeper.yml
+++ b/.github/workflows/update-credsweeper.yml
@@ -24,9 +24,21 @@ jobs:
           submodules: true
 
       - uses: ./.github/actions/rust-toolchain
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
 
       - name: Sync latest CredSweeper release
         run: python tools/update_credsweeper.py latest
+
+      - name: Refresh official rule and filter inventory
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r tools/credsweeper-sidecar/runtime-requirements.txt
+          PYTHONPATH="$PWD/crates/pentect-core/vendors/CredSweeper" \
+            python tools/audit_credsweeper_reference.py \
+              --output tools/credsweeper-reference-inventory.json \
+              --status-output tools/credsweeper-rust-port-status.json
 
       - name: Validate candidate against the full official oracle
         id: candidate
@@ -49,6 +61,8 @@ jobs:
             crates/pentect-core/vendors/credsweeper-assets \
             tools/credsweeper-sidecar/runtime-requirements.txt \
             tools/credsweeper-sidecar/patches/lazy-imports.patch \
+            tools/credsweeper-reference-inventory.json \
+            tools/credsweeper-rust-port-status.json \
             THIRD_PARTY_LICENSES.txt
           git commit -m "chore: update CredSweeper to $version"
           git push origin "HEAD:$validation_branch"

--- a/.github/workflows/update-credsweeper.yml
+++ b/.github/workflows/update-credsweeper.yml
@@ -63,6 +63,7 @@ jobs:
             tools/credsweeper-sidecar/patches/lazy-imports.patch \
             tools/credsweeper-reference-inventory.json \
             tools/credsweeper-rust-port-status.json \
+            website/src/content/docs/protection/detectors.md \
             THIRD_PARTY_LICENSES.txt
           git commit -m "chore: update CredSweeper to $version"
           git push origin "HEAD:$validation_branch"

--- a/tools/audit_credsweeper_reference.py
+++ b/tools/audit_credsweeper_reference.py
@@ -106,12 +106,30 @@ def inventory() -> dict[str, Any]:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--status-output",
+        type=Path,
+        help="also write the matching native filter-status inventory",
+    )
     args = parser.parse_args()
-    rendered = json.dumps(inventory(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    result = inventory()
+    rendered = json.dumps(result, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
     if args.output:
         args.output.write_text(rendered, encoding="utf-8")
     else:
         print(rendered, end="")
+    if args.status_output:
+        # Update automation writes this candidate declaration, then blocks the
+        # resulting branch on check_credsweeper_filter_parity.py before a PR is
+        # opened. The declaration alone is not compatibility evidence.
+        status = {
+            "credsweeper_version": result["credsweeper_version"],
+            "filters": {name: "exact" for name in result["filter_classes"]},
+        }
+        args.status_output.write_text(
+            json.dumps(status, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     return 0
 
 

--- a/tools/test_update_credsweeper.py
+++ b/tools/test_update_credsweeper.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import tempfile
+import unittest
+
+from tools.update_credsweeper import DETECTOR_DOCS, sync_detector_docs
+
+
+class SyncDetectorDocsTests(unittest.TestCase):
+    def test_replaces_the_unique_pinned_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            path = repo / DETECTOR_DOCS
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                "before Samsung CredSweeper `v1.17.4`, commit "
+                "`c7ad63b95ce0941954465a3b759046b14b88807b`; after\n",
+                encoding="utf-8",
+            )
+
+            sync_detector_docs(repo, "v1.18.1", "a" * 40)
+
+            self.assertEqual(
+                path.read_text(encoding="utf-8"),
+                f"before Samsung CredSweeper `v1.18.1`, commit `{'a' * 40}`; after\n",
+            )
+
+    def test_rejects_missing_source_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            path = repo / DETECTOR_DOCS
+            path.parent.mkdir(parents=True)
+            path.write_text("no pinned source here\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "no unique CredSweeper"):
+                sync_detector_docs(repo, "v1.18.1", "a" * 40)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/update_credsweeper.py
+++ b/tools/update_credsweeper.py
@@ -26,6 +26,7 @@ ASSETS = {
     "credsweeper/secret/config.json": "secret/config.json",
 }
 SIDECAR_PATCH = Path("tools/credsweeper-sidecar/patches/lazy-imports.patch")
+DETECTOR_DOCS = Path("website/src/content/docs/protection/detectors.md")
 
 
 def run(*args: str, cwd: Path, capture: bool = False) -> str:
@@ -155,6 +156,20 @@ def sync_license_bundle(repo: Path) -> None:
     run(sys.executable, "tools/generate_licenses.py", cwd=repo)
 
 
+def sync_detector_docs(repo: Path, tag: str, commit: str) -> None:
+    path = repo / DETECTOR_DOCS
+    text = path.read_text(encoding="utf-8")
+    updated, count = re.subn(
+        r"(Samsung CredSweeper `)v\d+\.\d+\.\d+(`, commit `)[0-9a-f]{40}(`;)",
+        rf"\g<1>{tag}\g<2>{commit}\g<3>",
+        text,
+        count=1,
+    )
+    if count != 1:
+        raise RuntimeError("detector docs have no unique CredSweeper source reference")
+    path.write_text(updated, encoding="utf-8", newline="\n")
+
+
 def validate(repo: Path) -> None:
     run("cargo", "check", "-p", "pentect-core", cwd=repo)
     run("cargo", "test", "-p", "pentect-core", "migration_coverage_is_explicit", cwd=repo)
@@ -237,6 +252,7 @@ def main() -> int:
     sync_runtime_requirements(submodule, runtime_requirements)
     sync_sidecar_patch(repo, requested)
     sync_license_bundle(repo)
+    sync_detector_docs(repo, requested, commit)
     if not args.skip_validation:
         validate(repo)
     print(f"CredSweeper {requested} synced at {commit}")

--- a/website/src/content/docs/protection/detectors.md
+++ b/website/src/content/docs/protection/detectors.md
@@ -16,7 +16,7 @@ built-in coverage claims.
 
 | Detector | Source and pinned version | Enabled coverage | Evidence and limit |
 | --- | --- | --- | --- |
-| `CredSweeperNativeDetector` | Samsung CredSweeper `v1.17.4`, commit `c7ad63b95ce0941954465a3b759046b14b88807b`; rule, keyword, allowlist, and ML assets are pinned in the binary | Credential and secret rules represented by the pinned assets | Pull requests compare the native result with official Python CredSweeper on one pinned CredData repository. A 16-shard weekly or manually dispatched job is configured to compare all 333 CredData repositories, including rule identity, value and variable spans, path and line context, entropy, and bounded ML probability. This is corpus evidence, not proof of general CredSweeper parity. |
+| `CredSweeperNativeDetector` | Samsung CredSweeper `v1.17.4`, commit `c7ad63b95ce0941954465a3b759046b14b88807b`; rule, keyword, allowlist, and ML assets are pinned in the binary | Credential and secret rules represented by the pinned assets | Pull requests regenerate the complete official rule/filter inventory, exercise every official filter through its upstream tests and deterministic boundary inputs, and compare one pinned CredData repository end to end. A 16-shard weekly or manually dispatched job compares all 333 CredData repositories, including rule identity, value and variable spans, path and line context, entropy, and bounded ML probability. This remains corpus and fixture evidence, not proof of general CredSweeper parity. |
 | `AlcatrazDetector` | Hoop Alcatraz `0.20.2`, commit `cd2e19b7d0f08b113c52ef52d3485c64a0871455`, compiled as a static Go helper and compressed into the Pentect binary | `EMAIL_ADDRESS`, `PHONE_NUMBER`, `CREDIT_CARD`, `IBAN_CODE`, `UK_NINO`, `IN_PAN`, `IT_FISCAL_CODE`, `ES_NIF`, `ES_NIE`, `SG_FIN`, `KR_RRN`, and `FI_PERSONAL_IDENTITY_CODE` | Helper tests cover each enabled entity and release smoke tests check representative findings on supported release platforms. Other Alcatraz entities are disabled. Alcatraz can still miss valid values or produce false positives. |
 
 Pentect does not call the CredSweeper Python package at runtime. The native
@@ -65,6 +65,7 @@ their own sources. They must not be counted as upstream-detector evidence.
 ## What the checks prove
 
 A passing unit fixture proves only that the named case works. The pinned
+filter comparison proves agreement on the recorded filter invocations, and the
 CredData comparison proves agreement on the exact corpus fields it compares.
 Release smoke tests prove that representative detector behavior is present in
 the produced binaries. None of these proves complete secret detection,


### PR DESCRIPTION
## Summary

- make the existing official filter/inventory comparisons mandatory in CredSweeper regression CI
- run one complete filter-parity job alongside full 333-repository scheduled and update-candidate runs
- regenerate and commit the version-bound rule/filter inventory during automated CredSweeper updates
- document what the new fixture evidence proves and does not prove

## Root cause

Pentect already had a machine-readable inventory and a differential runner for every official CredSweeper filter, but no GitHub Actions workflow invoked either script. The checked-in status could therefore claim all filters were exact while pull requests and automated upstream updates only exercised corpus findings. Filters or boundary behavior absent from that corpus could drift without blocking a merge.

## Verification

- regenerated CredSweeper v1.17.4 inventory matches the checked-in 134-rule/43-filter inventory byte-for-byte
- generated native status matches the checked-in status byte-for-byte
- official filter tests: 425 passed
- native/oracle filter parity: 12,950 probes, 43/43 classes, 0 mismatches, 0 generated-input exceptions
- `npm run build`: 42 pages, 42 agent-readable pages, 113 internal links
- Python compilation, YAML parsing, and `git diff --check`

## Scope

This advances #399 but does not close it. Production mismatch fallback/rollback, dedicated whole-pipeline malformed and path-sensitive fixtures beyond CredData, and release-level evidence publication remain open.

Refs #399
