### PR TITLE
test: inventory complete CredSweeper behavior

### DIFF
--- a/tools/audit_credsweeper_reference.py
+++ b/tools/audit_credsweeper_reference.py
@@ -78,7 +78,10 @@ def inventory() -> dict[str, Any]:
     rules = [Rule(config, raw) for raw in raw_rules]
     definitions: dict[str, dict[str, Any]] = {}
     rule_records = []
-    for rule in rules:
+    filter_groups: dict[str, set[str]] = {}
+    rule_types: dict[str, list[str]] = {}
+    ml_rules = []
+    for raw, rule in zip(raw_rules, rules):
         filter_ids = []
         for item in rule.filters:
             record = filter_record(item)
@@ -86,19 +89,51 @@ def inventory() -> dict[str, Any]:
             identifier = hashlib.sha256(canonical.encode()).hexdigest()
             definitions[identifier] = record
             filter_ids.append(identifier)
+        raw_filter_type = raw.get(Rule.FILTER_TYPE)
+        if isinstance(raw_filter_type, str):
+            filter_groups.setdefault(raw_filter_type, set()).update(filter_ids)
+        rule_types.setdefault(rule.rule_type.value, []).append(rule.rule_name)
+        if rule.use_ml:
+            ml_rules.append(rule.rule_name)
         rule_records.append(
             {
                 "name": rule.rule_name,
                 "type": rule.rule_type.value,
                 "filters": filter_ids,
+                "source": stable_value(raw),
+                "runtime": {
+                    "confidence": rule.confidence.value,
+                    "min_line_len": rule.min_line_len,
+                    "patterns": stable_value(rule.patterns),
+                    "required_regex": stable_value(rule.required_regex),
+                    "required_substrings": sorted(rule.required_substrings),
+                    "severity": rule.severity.value,
+                    "target": stable_value(rule.target),
+                    "use_ml": rule.use_ml,
+                },
             }
         )
     filter_classes = sorted({record["class"] for record in definitions.values()})
     return {
+        "schema": 2,
         "credsweeper_version": __import__("credsweeper").__version__,
         "rule_count": len(rules),
         "filter_classes": filter_classes,
         "filter_definitions": dict(sorted(definitions.items())),
+        "filter_groups": {
+            name: sorted(identifiers) for name, identifiers in sorted(filter_groups.items())
+        },
+        "ml": {
+            "config": stable_value(Util.json_load(APP_PATH / "ml_model" / "ml_config.json")),
+            "rules": sorted(ml_rules),
+        },
+        "output_fields": {
+            "candidate": list(config.candidate_output),
+            "line_data": list(config.line_data_output),
+        },
+        "rule_types": {
+            name: sorted(rule_names) for name, rule_names in sorted(rule_types.items())
+        },
         "rules": rule_records,
     }
 

--- a/tools/check_credsweeper_port_inventory.py
+++ b/tools/check_credsweeper_port_inventory.py
@@ -17,7 +17,34 @@ def main() -> int:
 
     inventory = json.loads(args.inventory.read_text(encoding="utf-8"))
     status = json.loads(args.status.read_text(encoding="utf-8"))
+    if inventory.get("schema") != 2:
+        raise SystemExit("CredSweeper reference inventory schema must be 2")
+    rules = inventory["rules"]
+    if inventory["rule_count"] != len(rules):
+        raise SystemExit("CredSweeper rule_count does not match the rule inventory")
+    rule_names = [rule["name"] for rule in rules]
+    if len(rule_names) != len(set(rule_names)):
+        raise SystemExit("CredSweeper rule inventory contains duplicate names")
+    typed_rules = {
+        name for names in inventory["rule_types"].values() for name in names
+    }
+    if typed_rules != set(rule_names):
+        raise SystemExit("CredSweeper rule-type inventory does not cover every rule")
+    ml_rules = {rule["name"] for rule in rules if rule["runtime"]["use_ml"]}
+    if ml_rules != set(inventory["ml"]["rules"]):
+        raise SystemExit("CredSweeper ML rule inventory differs from runtime rule state")
+    if not inventory["output_fields"]["candidate"] or not inventory["output_fields"]["line_data"]:
+        raise SystemExit("CredSweeper output-field inventory is empty")
     expected = set(inventory["filter_classes"])
+    definitions = set(inventory["filter_definitions"])
+    referenced = {identifier for rule in rules for identifier in rule["filters"]}
+    grouped = {
+        identifier for identifiers in inventory["filter_groups"].values() for identifier in identifiers
+    }
+    if referenced != definitions:
+        raise SystemExit("CredSweeper rule filter references differ from filter definitions")
+    if not grouped.issubset(definitions):
+        raise SystemExit("CredSweeper filter group references an unknown definition")
     declared = set(status["filters"])
     missing = sorted(expected - declared)
     stale = sorted(declared - expected)

--- a/tools/credsweeper-reference-inventory.json
+++ b/tools/credsweeper-reference-inventory.json
@@ -5578,7 +5578,1005 @@
       "state": {}
     }
   },
+  "filter_groups": {
+    "GeneralKeyword": [
+      "0301e5c43eac4b8f1e17aefec9d959bddddf688911be5b1007e0a0d24aeaabfb",
+      "04a905e8f114a72ccc291aa0f2c235bd8e15118716a76fd41c68453a1bc108f2",
+      "23be6d335ddff5b829c60ad4a3bc2d78763006222fbaf48a038c929b8a3e9b4a",
+      "38bf214df4fbe8a0e67b7f99be8af5678e37d3ac230f1cc486ad151879c43a20",
+      "450a06fc337c21b5c9e358304039716d24f2d3b0be1439d9e5f93527d3bdaf9d",
+      "4853545a8b268d9d7b3f316d28eb132e1dc47ed34ab6b57b76b175e48421854a",
+      "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462",
+      "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe",
+      "69bf6c78773debc5248d7d6d0716fcb8f7b0e53888a3cf2052a586c53019b54b",
+      "7b5cee4822fd6022f0e4280aff80765498b879279828c6c93e078c94a31f421b",
+      "834aa4212c1b2163f49e64e670b37d709621878e144e19b65b02f39de2ae7863",
+      "b857000585d8ebff0cf9784fc43d545c92ab31e8b207a7a5a373d64a88ace71d",
+      "b85d5e06126b69912a17366f73a9449df73380733941cceae6835fe3c979b285",
+      "d79325171910104ff78bba622b3bfef3e8fc09b1863395d105f9e1f8f146c71f",
+      "ec3fcbf9808c16a50b10e3f188b97e914e38daa798ef00a2d198a3f7c60896fc"
+    ],
+    "GeneralPattern": [
+      "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462",
+      "51b048d0c4e7ce0dfc9fa24b814a09387746c96a186131908c32412adee38479"
+    ],
+    "PasswordKeyword": [
+      "0301e5c43eac4b8f1e17aefec9d959bddddf688911be5b1007e0a0d24aeaabfb",
+      "04a905e8f114a72ccc291aa0f2c235bd8e15118716a76fd41c68453a1bc108f2",
+      "23be6d335ddff5b829c60ad4a3bc2d78763006222fbaf48a038c929b8a3e9b4a",
+      "38bf214df4fbe8a0e67b7f99be8af5678e37d3ac230f1cc486ad151879c43a20",
+      "450a06fc337c21b5c9e358304039716d24f2d3b0be1439d9e5f93527d3bdaf9d",
+      "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462",
+      "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe",
+      "5f3f3ef9da8fcec786fdca8b9811a2469ce368cadc837c66a9d65e75e8a294c8",
+      "69bf6c78773debc5248d7d6d0716fcb8f7b0e53888a3cf2052a586c53019b54b",
+      "735fcc960dbeaf3afc33b941c14a8a886ece4671a5b370671fc0776686598d47",
+      "7b5cee4822fd6022f0e4280aff80765498b879279828c6c93e078c94a31f421b",
+      "834aa4212c1b2163f49e64e670b37d709621878e144e19b65b02f39de2ae7863",
+      "b857000585d8ebff0cf9784fc43d545c92ab31e8b207a7a5a373d64a88ace71d",
+      "b85d5e06126b69912a17366f73a9449df73380733941cceae6835fe3c979b285",
+      "c8bba64c98471bc8a7b590549744f8e44be46595e74ac07338bfc48347c9b78c",
+      "d79325171910104ff78bba622b3bfef3e8fc09b1863395d105f9e1f8f146c71f",
+      "ec3fcbf9808c16a50b10e3f188b97e914e38daa798ef00a2d198a3f7c60896fc",
+      "f9161efbe7223f14041dcaf215eb7aa9b9a8749104eca8efcb707727bb6cd8db"
+    ],
+    "TokenPattern": [
+      "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462",
+      "5cabcbb31f39853e721fd8409ef421127a4e733cb9f312e4e831356751d2407f",
+      "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b",
+      "ec3fcbf9808c16a50b10e3f188b97e914e38daa798ef00a2d198a3f7c60896fc"
+    ],
+    "UrlCredentialsGroup": [
+      "0301e5c43eac4b8f1e17aefec9d959bddddf688911be5b1007e0a0d24aeaabfb",
+      "04a905e8f114a72ccc291aa0f2c235bd8e15118716a76fd41c68453a1bc108f2",
+      "23be6d335ddff5b829c60ad4a3bc2d78763006222fbaf48a038c929b8a3e9b4a",
+      "38bf214df4fbe8a0e67b7f99be8af5678e37d3ac230f1cc486ad151879c43a20",
+      "450a06fc337c21b5c9e358304039716d24f2d3b0be1439d9e5f93527d3bdaf9d",
+      "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462",
+      "69bf6c78773debc5248d7d6d0716fcb8f7b0e53888a3cf2052a586c53019b54b",
+      "7b5cee4822fd6022f0e4280aff80765498b879279828c6c93e078c94a31f421b",
+      "b857000585d8ebff0cf9784fc43d545c92ab31e8b207a7a5a373d64a88ace71d",
+      "b85d5e06126b69912a17366f73a9449df73380733941cceae6835fe3c979b285",
+      "bf80841b4e48beff8aebe8fc1edbc8dcb53854082f8a27e684ffb93f6455f23d",
+      "ec3fcbf9808c16a50b10e3f188b97e914e38daa798ef00a2d198a3f7c60896fc"
+    ],
+    "WeirdBase36Token": [
+      "0b6b6039683167b47b139db85f3045aa2b7e82d43bd487d34ff7f5cf5e266c94",
+      "20aa163c60c3054e008d463a2fe0b80ebb5da1863998a44d12eedc858aa13713",
+      "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462",
+      "5cabcbb31f39853e721fd8409ef421127a4e733cb9f312e4e831356751d2407f",
+      "a5f9c28c844a1943c02e95db28879e7c4e95f7d93ecb5f7bdecebaa77d0d685b"
+    ]
+  },
+  "ml": {
+    "config": {
+      "char_set": "\u001b\t\n\r !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+      "features": [
+        {
+          "comment": "INFO=0.0, LOW=0.25, MEDIUM=0.5, HIGH=0.75, CRITICAL=1.0",
+          "kwargs": {},
+          "type": "RuleSeverity"
+        },
+        {
+          "kwargs": {},
+          "type": "EntropyEvaluation"
+        },
+        {
+          "kwargs": {
+            "attribute": "line"
+          },
+          "type": "LengthOfAttribute"
+        },
+        {
+          "kwargs": {
+            "attribute": "variable"
+          },
+          "type": "LengthOfAttribute"
+        },
+        {
+          "kwargs": {
+            "attribute": "value"
+          },
+          "type": "LengthOfAttribute"
+        },
+        {
+          "comment": "Bash variable",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "^\\$([A-Za-z_][0-9A-Za-z_]*|\\{[A-Za-z_][0-9A-Za-z_]*\\})"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "PossibleComment replacing",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "^\\s*(#|\\*|/\\*|//|--\\s)"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "Example pattern",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "^<[\\w\\s.-]*>"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "Repeated symbol",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "(?:(\\S)(\\S))((\\1.)|(.\\2)){7,}"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "SHA marker",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "(?i:sha)[_-]?(224|256|384|512)"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "ASN1 prefix for PEM keys",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "\\b(MII|LS0t)"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "camelStyle naming detection",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "^[a-z][a-z]{1,16}[0-9]*([A-Z]([a-z]{1,16}[0-9]*|[0-9]{1,16})){1,8}$"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "PascalStyle naming detection",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "^([A-Z]([a-z]{1,16}[0-9]*|[0-9]{1,16})){1,8}$"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "UPPERCASE naming detection",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "^(_+[0-9]{1,16}|_*[A-Z]{1,16}[0-9]*)(_+([0-9]{1,16}|[A-Z]{1,16}[0-9]*)){1,8}_*$"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "lowercase naming detection",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "^(_+[0-9]{1,16}|_*[a-z]{1,16}[0-9]*)(_+([0-9]{1,16}|[a-z]{1,16}[0-9]*)){1,8}_*$"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "VariableNotAllowedPatternCheck",
+          "kwargs": {
+            "attribute": "variable",
+            "pattern": "(^(@|<|\\{\\{))|([!><+*/^|)](\\s)?$)"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "VariableNotAllowedNameCheck - hash mentioned",
+          "kwargs": {
+            "attribute": "variable",
+            "pattern": "(?i:( h1$|md5|sha[_-]?(224|256|384|512)))"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "VariableNotAllowedNameCheck - ID detect",
+          "kwargs": {
+            "attribute": "variable",
+            "pattern": "(guid|[^a-z](?i:u?id)|([^A-Z](G?U)?I[dD])s?)$"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "AWS Key ID - true ID",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "^A[0-9A-Z]{19,20}$"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "UUID pattern",
+          "kwargs": {
+            "attribute": "value",
+            "pattern": "^(?i:[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12})$"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "VariableNotAllowedNameCheck - key rule",
+          "kwargs": {
+            "attribute": "variable",
+            "pattern": "(?i:(?:uniq(?:ue)?|escap(?:e|ing)|resources?|projects?|filters?|pub(?:lic)?)_?keys?)"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "VariableNotAllowedNameCheck - word at end",
+          "kwargs": {
+            "attribute": "variable",
+            "pattern": "(?i:(icon|label|mode|field|format|number|sum|size|len(gth)?|name|type|manager|algorithm|pattern|view|error|date(time)?|time(stamp)?|tag|version|hash|rate|code|fingerprint)s?$)"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "comment": "PWD invocation",
+          "kwargs": {
+            "attribute": "variable",
+            "pattern": "(?i:(^\\$pwd$)|(^\\$\\{#?pwd[^}]*\\}$)|(^\\$\\(pwd\\)$)|(^`pwd`$))"
+          },
+          "type": "SearchInAttribute"
+        },
+        {
+          "kwargs": {
+            "words": [
+              " ",
+              ".",
+              ",",
+              "]",
+              "#",
+              "@",
+              "/",
+              "\\",
+              "!!!",
+              "_at",
+              "_len",
+              "256",
+              "512",
+              "access",
+              "assert",
+              "cache",
+              "client",
+              "control",
+              "crypt",
+              "crypted",
+              "decrypt",
+              "encrypt",
+              "dummy",
+              "disable",
+              "example",
+              "expect",
+              "expir",
+              "fake",
+              "file",
+              "filter",
+              "fingerprint",
+              "guid",
+              "hash",
+              "keyguid",
+              "keyid",
+              "key_id",
+              "label",
+              "length",
+              "md5",
+              "manager",
+              "mock",
+              "name",
+              "native",
+              "obj",
+              "opt",
+              "p/w",
+              "param",
+              "pass",
+              "path",
+              "project",
+              "public",
+              "pw",
+              "query",
+              "secret",
+              "size",
+              "sha",
+              "space",
+              "status",
+              "sword",
+              "temp",
+              "test",
+              "thumbprint",
+              "time",
+              "timestamp",
+              "title",
+              "token",
+              "type",
+              "uniq",
+              "valid",
+              "version",
+              "view"
+            ]
+          },
+          "type": "WordInVariable"
+        },
+        {
+          "kwargs": {
+            "words": [
+              "%",
+              " ",
+              ":",
+              "=",
+              "$(",
+              "${",
+              "{$",
+              "(",
+              "->",
+              ".",
+              "...",
+              "123",
+              "141592653",
+              "718281828",
+              "<",
+              ">",
+              "[",
+              "_id",
+              "abc",
+              "aaaa",
+              "asdf",
+              "allow",
+              "arn:aws:",
+              "bar",
+              "disable",
+              "changeme",
+              "crypt",
+              "crypted",
+              "decrypt",
+              "edited",
+              "encrypt",
+              "example",
+              "expir",
+              "fake",
+              "file",
+              "foo",
+              "hash",
+              "hex",
+              "key",
+              "min",
+              "mock",
+              "my",
+              "nil",
+              "oprst",
+              "other",
+              "pass",
+              "public",
+              "pwd",
+              "redacted",
+              "rsa",
+              "salt",
+              "secret",
+              "sha",
+              "ssh",
+              "test",
+              "word",
+              "xxx",
+              "xyz"
+            ]
+          },
+          "type": "WordInValue"
+        },
+        {
+          "kwargs": {
+            "words": [
+              "$",
+              "%2",
+              "%3",
+              "&",
+              "&amp;",
+              "(",
+              "->",
+              ".",
+              "://",
+              "?",
+              "@",
+              "[",
+              "approval",
+              "arn:aws:",
+              "assert",
+              "case",
+              "circle",
+              "color",
+              "e.g.",
+              "equal",
+              "example",
+              "expect",
+              "fake",
+              "false",
+              "height",
+              "image",
+              "line",
+              "media",
+              "nil",
+              "none",
+              "null",
+              "pass",
+              "path",
+              "pwd",
+              "sqa",
+              "test",
+              "true",
+              "undefined",
+              "unit",
+              "where",
+              "width",
+              "word"
+            ]
+          },
+          "type": "WordInPreamble"
+        },
+        {
+          "kwargs": {
+            "words": [
+              "%2",
+              "%3",
+              "&",
+              "(",
+              "->",
+              "=>",
+              "'",
+              "\"",
+              ".",
+              ",",
+              "?",
+              "@",
+              "[",
+              "{",
+              "basic",
+              "bearer",
+              "get",
+              "e.g.",
+              "equal",
+              "env",
+              "example",
+              "expect",
+              "line",
+              "media",
+              "pass",
+              "password",
+              "path",
+              "test",
+              "unit"
+            ]
+          },
+          "type": "WordInTransition"
+        },
+        {
+          "kwargs": {
+            "words": [
+              "$",
+              "%2",
+              "%3",
+              "&",
+              "&amp;",
+              "(",
+              "->",
+              "'",
+              "\"",
+              ".",
+              "://",
+              "?",
+              "@",
+              "[",
+              "]",
+              "}",
+              "\\",
+              "assert",
+              "case",
+              "circle",
+              "color",
+              "e.g.",
+              "equal",
+              "example",
+              "expect",
+              "fake",
+              "false",
+              "height",
+              "image",
+              "line",
+              "media",
+              "nil",
+              "none",
+              "null",
+              "pass",
+              "path",
+              "pwd",
+              "sqa",
+              "test",
+              "true",
+              "undefined",
+              "unit",
+              "width",
+              "word"
+            ]
+          },
+          "type": "WordInPostamble"
+        },
+        {
+          "kwargs": {
+            "words": [
+              "test",
+              "mock",
+              "/src",
+              "code",
+              "/include",
+              "internal",
+              "tool",
+              "util",
+              "example",
+              "sample",
+              "conf",
+              "secret",
+              "setting",
+              "security",
+              "secure",
+              "resource",
+              "fixture",
+              "docker",
+              "/docs",
+              "/doc/",
+              "document",
+              "/lang",
+              "/local/",
+              "/locale",
+              "/lib",
+              "/spec",
+              "/pkg",
+              "/api",
+              "/rest",
+              "/opt",
+              "/sys",
+              "kube",
+              "kafka",
+              "cluster",
+              "template",
+              "other",
+              "public",
+              "init",
+              "client",
+              "server",
+              "/model",
+              "/modul",
+              "browser",
+              "/env/",
+              "/app",
+              "/assets/",
+              "vendor",
+              "readme",
+              "build",
+              "/dist-packages",
+              "/record",
+              "/script",
+              "/site-packages",
+              "python",
+              "/usr",
+              "/etc",
+              "/fuzz"
+            ]
+          },
+          "type": "WordInPath"
+        },
+        {
+          "type": "MorphemeDense"
+        },
+        {
+          "type": "HasHtmlTag"
+        },
+        {
+          "type": "IsSecretNumeric"
+        },
+        {
+          "kwargs": {
+            "extensions": [
+              "",
+              ".04",
+              ".1",
+              ".adoc",
+              ".asciidoc",
+              ".axaml",
+              ".bash",
+              ".bat",
+              ".bats",
+              ".bazel",
+              ".bin",
+              ".build",
+              ".bundle",
+              ".bzl",
+              ".c",
+              ".cast",
+              ".cc",
+              ".cf",
+              ".cjs",
+              ".cljc",
+              ".cmd",
+              ".cnf",
+              ".coffee",
+              ".conf",
+              ".config",
+              ".cpp",
+              ".crt",
+              ".cs",
+              ".csp",
+              ".csv",
+              ".dart",
+              ".dist",
+              ".dockerfile",
+              ".edited",
+              ".eex",
+              ".env",
+              ".erb",
+              ".erl",
+              ".ex",
+              ".example",
+              ".exs",
+              ".ext",
+              ".fsproj",
+              ".g4",
+              ".gml",
+              ".go",
+              ".golden",
+              ".gradle",
+              ".graphql",
+              ".groovy",
+              ".gtpl",
+              ".h",
+              ".haml",
+              ".har",
+              ".hpp",
+              ".hs",
+              ".html",
+              ".idl",
+              ".iml",
+              ".in",
+              ".inc",
+              ".ini",
+              ".ipynb",
+              ".j",
+              ".j2",
+              ".java",
+              ".jenkinsfile",
+              ".js",
+              ".json",
+              ".jsp",
+              ".jsx",
+              ".ks",
+              ".kt",
+              ".kts",
+              ".las",
+              ".ldif",
+              ".ldml",
+              ".less",
+              ".libsonnet",
+              ".lkml",
+              ".lock",
+              ".log",
+              ".lua",
+              ".m",
+              ".manifest",
+              ".markdown",
+              ".markerb",
+              ".md",
+              ".mdx",
+              ".mjs",
+              ".mk",
+              ".ml",
+              ".mlir",
+              ".mod",
+              ".moo",
+              ".ndjson",
+              ".nolint",
+              ".odd",
+              ".onnx",
+              ".oracle",
+              ".original",
+              ".pan",
+              ".patch",
+              ".php",
+              ".pl",
+              ".pm",
+              ".po",
+              ".pod",
+              ".postinst",
+              ".pp",
+              ".ppk",
+              ".proj",
+              ".properties",
+              ".proto",
+              ".ps1",
+              ".purs",
+              ".pxd",
+              ".py",
+              ".pyi",
+              ".pyx",
+              ".r",
+              ".rake",
+              ".rb",
+              ".re",
+              ".response",
+              ".resx",
+              ".rexx",
+              ".rrc",
+              ".rs",
+              ".rsa",
+              ".rsp",
+              ".rst",
+              ".rules",
+              ".sample",
+              ".sbt",
+              ".scala",
+              ".secrets",
+              ".sh",
+              ".snap",
+              ".sql",
+              ".storyboard",
+              ".strings",
+              ".sty",
+              ".swift",
+              ".t",
+              ".td",
+              ".tdf",
+              ".template",
+              ".test",
+              ".testsettings",
+              ".tf",
+              ".tfstate",
+              ".tfvars",
+              ".tl",
+              ".tmpl",
+              ".token",
+              ".toml",
+              ".travis",
+              ".ts",
+              ".tsx",
+              ".txt",
+              ".var",
+              ".vsmdi",
+              ".vue",
+              ".xaml",
+              ".xib",
+              ".xml",
+              ".yaml",
+              ".yml",
+              ".zsh"
+            ]
+          },
+          "type": "FileExtension"
+        },
+        {
+          "kwargs": {
+            "rule_names": [
+              "API",
+              "Auth",
+              "CMD ConvertTo-SecureString",
+              "CMD Password",
+              "CMD Secret",
+              "CMD Token",
+              "CURL User Password",
+              "Credential",
+              "Key",
+              "Nonce",
+              "Password",
+              "SQL Password",
+              "Salt",
+              "Secret",
+              "Token",
+              "URL Credentials"
+            ]
+          },
+          "type": "RuleName"
+        }
+      ],
+      "thresholds": {
+        "high": 0.79791,
+        "highest": 0.92996,
+        "low": 0.35739,
+        "lowest": 0.22917,
+        "medium": 0.62204
+      }
+    },
+    "rules": [
+      "API",
+      "Auth",
+      "CMD ConvertTo-SecureString",
+      "CMD Password",
+      "CMD Secret",
+      "CMD Token",
+      "CURL User Password",
+      "Credential",
+      "DOC_CREDENTIALS",
+      "DOC_GET",
+      "ID_PAIR_PASSWD_PAIR",
+      "ID_PASSWD_PAIR",
+      "IP_ID_PASSWORD_TRIPLE",
+      "Key",
+      "Nonce",
+      "PASSWD_PAIR",
+      "Password",
+      "SECRET_PAIR",
+      "SQL Password",
+      "Salt",
+      "Secret",
+      "Token",
+      "URL Credentials"
+    ]
+  },
+  "output_fields": {
+    "candidate": [
+      "rule",
+      "severity",
+      "confidence",
+      "ml_probability",
+      "line_data_list"
+    ],
+    "line_data": [
+      "line",
+      "line_num",
+      "path",
+      "info",
+      "variable",
+      "variable_start",
+      "variable_end",
+      "value",
+      "value_start",
+      "value_end",
+      "entropy"
+    ]
+  },
   "rule_count": 134,
+  "rule_types": {
+    "keyword": [
+      "API",
+      "Auth",
+      "Credential",
+      "Key",
+      "Nonce",
+      "Password",
+      "Salt",
+      "Secret",
+      "Token"
+    ],
+    "multi": [
+      "AWS Multi",
+      "Alibaba Multi",
+      "Google Multi",
+      "JWK"
+    ],
+    "pattern": [
+      "1Password Account Token",
+      "AWS AppSync GraphQL API Key",
+      "AWS Client ID",
+      "AWS MWS Key",
+      "AWS S3 Bucket",
+      "Age Secret Key",
+      "Akamai Credentials",
+      "Alibaba Access Key ID",
+      "Amazon Bedrock API Key",
+      "Anthropic API Key",
+      "Atlassian PAT token",
+      "Azure Access Token",
+      "Azure Secret Value",
+      "Azure Storage Account Key",
+      "BASE64 Private Key",
+      "BASE64 encoded PEM Private Key",
+      "Basic Authorization",
+      "Bearer Authorization",
+      "Bitbucket App Password",
+      "Bitbucket HTTP Access Token",
+      "Bitbucket Repository Access Token",
+      "Brevo API Key",
+      "CMD ConvertTo-SecureString",
+      "CMD Password",
+      "CMD Secret",
+      "CMD Token",
+      "CURL User Password",
+      "Clojars Deploy Token",
+      "CloudFlare API Token",
+      "DOC_CREDENTIALS",
+      "DOC_GET",
+      "Databricks Access Token",
+      "DeepSeek API Key",
+      "Defined Networking API Key",
+      "Digital Ocean Token",
+      "Discord Bot Token",
+      "Discord Webhook",
+      "Docker Access Token",
+      "Docker Swarm Key",
+      "Docker Swarm Token",
+      "Doppler API Key",
+      "Dropbox API secret (long term)",
+      "Dropbox App secret",
+      "Dropbox OAuth2 API Access Token",
+      "Dynatrace API Token",
+      "Facebook Access Token",
+      "Facebook App Token",
+      "Figma Personal Access Token",
+      "Firebase Domain",
+      "Github App Installation Token",
+      "Github Classic Token",
+      "Github Fine-granted Token",
+      "Gitlab Prefix Token",
+      "Google API Key",
+      "Google OAuth Access Token",
+      "Google OAuth Refresh Token",
+      "Google OAuth Secret",
+      "Grafana Access Policy Token",
+      "Grafana Provisioned API Key",
+      "Grafana Service Account Token",
+      "Groq API Key",
+      "Hashicorp Terraform Token",
+      "Hashicorp Vault Token",
+      "Heroku Credentials",
+      "Hugging Face User Access Token",
+      "ID_PAIR_PASSWD_PAIR",
+      "ID_PASSWD_PAIR",
+      "IP_ID_PASSWORD_TRIPLE",
+      "Instagram Access Token",
+      "JSON Web Key",
+      "JSON Web Token",
+      "Jfrog Token",
+      "Jira / Confluence PAT token",
+      "LLAMA API Key",
+      "Linear API Key",
+      "MailChimp API Key",
+      "MailGun API Key",
+      "NKEY Seed",
+      "NPM Token",
+      "NTLM Token",
+      "Netlify Token",
+      "NewRelic Credentials",
+      "Notion Integration Token",
+      "NuGet API key",
+      "OTP / 2FA Secret",
+      "OpenAI Token",
+      "PASSWD_PAIR",
+      "PayPal Braintree Access Token",
+      "Perplexity API Key",
+      "Picatic API Key",
+      "PlanetScale Credentials",
+      "PostHog Credentials",
+      "Postman Credentials",
+      "PyPi API Token",
+      "RubyGems API Key",
+      "SECRET_PAIR",
+      "SQL Password",
+      "Salesforce Credentials",
+      "SendGrid API Key",
+      "Sentry Organization Auth Token",
+      "Sentry User Auth Token",
+      "Shopify Token",
+      "Slack Token",
+      "Slack Webhook",
+      "SonarQube Credentials",
+      "Square Access Token",
+      "Square Credentials",
+      "Stripe Credentials",
+      "Supabase Credentials",
+      "Tavily API Key",
+      "Telegram Bot API Token",
+      "Tencent WeChat API App ID",
+      "Together AI API Key",
+      "Twilio Credentials",
+      "URL Credentials",
+      "UUID",
+      "Vercel Token",
+      "WunderGraph API Key",
+      "X AI API Key",
+      "X App-Only Authentication Bearer Token"
+    ],
+    "pem_key": [
+      "PEM Private Key"
+    ]
+  },
   "rules": [
     {
       "filters": [
@@ -5590,6 +6588,74 @@
         "39d8effdc969c490c4ea656bda97b7e58eac64f26fe8f90c083d0e37a72b2805"
       ],
       "name": "DOC_GET",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 8,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>(\\w*(?i:비밀번호|비번|패스워드|키|암호화?|토큰|(?<!by)pass(?!e[dns]|ing|ion|age)|pswd|\\bpwd?\\b|token(?!ize)|secret|key(?!word|board|pad)|cred)\\w*)\\s*(설정은|[=:!]{1,3}))?\\s*([._0-9A-Za-z\\[\\]]*get(env)?\\s*\\(\\s*(?(variable)[^,]+|[\\\"'\\\\]*(\\\\*([\\\"']|&(quot|apos|#3[49]);)){0,4}(\\w*(?i:(?<!by)pass(?!e[dns]|ing|ion|age|\\s+[a-z]{3,64})|\\bpwd?\\b|token|secret|key|cred)\\w*))(\\\\*([\\\"']|&(quot|apos|#3[49]);)){0,4})\\s*(,(\\s*default\\s*=)?|\\)\\s*or)\\s*([brufl@]{1,2}(?=\\\\*[\\\"'&]))?(?P<lq>(\\\\*([\\\"']|&(quot|apos|#3[49]);)){1,4})(?P<value>(.(?!(?P=lq))){4,8000}.?)"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "cred",
+          "key",
+          "pass",
+          "pswd",
+          "pw",
+          "secret",
+          "token",
+          "비밀번호",
+          "비번",
+          "암호",
+          "키",
+          "토큰",
+          "패스워드"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValueAllowlistCheck",
+          "ValueBlocklistCheck",
+          "LineGitBinaryCheck",
+          "LineUUEPartCheck",
+          "ValueFilePathCheck",
+          "ValuePatternCheck(5)"
+        ],
+        "min_line_len": 8,
+        "name": "DOC_GET",
+        "required_substrings": [
+          "pass",
+          "pswd",
+          "pw",
+          "token",
+          "secret",
+          "key",
+          "cred",
+          "비밀번호",
+          "비번",
+          "패스워드",
+          "암호",
+          "키",
+          "토큰"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(?P<variable>(\\w*(?i:비밀번호|비번|패스워드|키|암호화?|토큰|(?<!by)pass(?!e[dns]|ing|ion|age)|pswd|\\bpwd?\\b|token(?!ize)|secret|key(?!word|board|pad)|cred)\\w*)\\s*(설정은|[=:!]{1,3}))?\\s*([._0-9A-Za-z\\[\\]]*get(env)?\\s*\\(\\s*(?(variable)[^,]+|[\\\"'\\\\]*(\\\\*([\\\"']|&(quot|apos|#3[49]);)){0,4}(\\w*(?i:(?<!by)pass(?!e[dns]|ing|ion|age|\\s+[a-z]{3,64})|\\bpwd?\\b|token|secret|key|cred)\\w*))(\\\\*([\\\"']|&(quot|apos|#3[49]);)){0,4})\\s*(,(\\s*default\\s*=)?|\\)\\s*or)\\s*([brufl@]{1,2}(?=\\\\*[\\\"'&]))?(?P<lq>(\\\\*([\\\"']|&(quot|apos|#3[49]);)){1,4})(?P<value>(.(?!(?P=lq))){4,8000}.?)"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5603,6 +6669,81 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "DOC_CREDENTIALS",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 8,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<wrap>[\\\"'`(])?\\s*(?P<variable>(\\w*(?i:(?<!by)passw?o?r?d?s?(?!e[dns]|ing|ion|age)|pswd|pwd?\\b|\\bp/w\\b|token(?!ize)|secret|key(?!word|board|pad)|credential)\\w*|비밀번호|비번|패스워드|키|암호화?|토큰))[\\\"'`]*(\\s+(?i:is|are|was|were)(\\s*[:-])?\\s+|\\s*(?P<separator>설정은|:=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|%3[Dd])\\s*)(?P<quote>[\\\"'`]{1,6})?(?P<value>(?(quote)(?(wrap)[^\\\"'`)]{4,8000}|[^\\\"'`]{4,8000})|(?(wrap)[^\\\"'`)]{4,8000}|\\S{4,8000})))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "credential",
+          "key",
+          "p/w",
+          "paasw",
+          "pass",
+          "pswd",
+          "pw",
+          "secret",
+          "sword",
+          "token",
+          "비밀번호",
+          "비번",
+          "암호",
+          "키",
+          "토큰",
+          "패스워드"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValueAllowlistCheck",
+          "ValueBlocklistCheck",
+          "LineGitBinaryCheck",
+          "LineUUEPartCheck",
+          "ValueFilePathCheck",
+          "ValuePatternCheck(5)",
+          "ValueSealedSecretCheck"
+        ],
+        "min_line_len": 8,
+        "name": "DOC_CREDENTIALS",
+        "required_substrings": [
+          "pass",
+          "sword",
+          "pswd",
+          "pw",
+          "p/w",
+          "paasw",
+          "비밀번호",
+          "비번",
+          "패스워드",
+          "암호",
+          "token",
+          "secret",
+          "key",
+          "credential",
+          "키",
+          "토큰"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(?P<wrap>[\\\"'`(])?\\s*(?P<variable>(\\w*(?i:(?<!by)passw?o?r?d?s?(?!e[dns]|ing|ion|age)|pswd|pwd?\\b|\\bp/w\\b|token(?!ize)|secret|key(?!word|board|pad)|credential)\\w*|비밀번호|비번|패스워드|키|암호화?|토큰))[\\\"'`]*(\\s+(?i:is|are|was|were)(\\s*[:-])?\\s+|\\s*(?P<separator>설정은|:=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|%3[Dd])\\s*)(?P<quote>[\\\"'`]{1,6})?(?P<value>(?(quote)(?(wrap)[^\\\"'`)]{4,8000}|[^\\\"'`]{4,8000})|(?(wrap)[^\\\"'`)]{4,8000}|\\S{4,8000})))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5614,6 +6755,59 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "SECRET_PAIR",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 16,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>[\\\"'`]?(?i:token|secret|key|키|암호화?|토큰)[\\\"'`]?)((\\s)*(?P<separator>설정은|:=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|%3[Dd])(\\s)*)(?P<quote>[\\\"'`(])?(?P<value>(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/_+=~!@#$%^&*;:?-])){8,80}(?(a)(?(b)(?(c)((?(quote)[^)\\\"'`]{1,8000}|([0-9A-Za-z/_+=~!@#$%^&*;:?-]{1,8000}|\\b))|$)|(?!x)x)|(?!x)x)|(?!x)x))(?(quote)[)\\\"'`])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "key",
+          "secret",
+          "token",
+          "암호",
+          "키",
+          "토큰"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValueAllowlistCheck",
+          "ValuePatternCheck(4)",
+          "ValueEntropyBase64Check",
+          "ValueMorphemesCheck",
+          "ValueSealedSecretCheck"
+        ],
+        "min_line_len": 16,
+        "name": "SECRET_PAIR",
+        "required_substrings": [
+          "token",
+          "secret",
+          "key",
+          "키",
+          "암호",
+          "토큰"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(?P<variable>[\\\"'`]?(?i:token|secret|key|키|암호화?|토큰)[\\\"'`]?)((\\s)*(?P<separator>설정은|:=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|%3[Dd])(\\s)*)(?P<quote>[\\\"'`(])?(?P<value>(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/_+=~!@#$%^&*;:?-])){8,80}(?(a)(?(b)(?(c)((?(quote)[^)\\\"'`]{1,8000}|([0-9A-Za-z/_+=~!@#$%^&*;:?-]{1,8000}|\\b))|$)|(?!x)x)|(?!x)x)|(?!x)x))(?(quote)[)\\\"'`])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5628,6 +6822,70 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "PASSWD_PAIR",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 10,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>[\\\"'`]?(?i:(?<!id[ :/])pa[as]swo?r?ds?|pswd|pwd?|p/w|비밀번호|비번|패스워드|암호)[\\\"'`]?)((\\s)*(?P<separator>설정은|:=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|%3[Dd])(\\s)*)(?P<quote>[\\\"'`(])?(?P<value>(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/_+=~!@#$%^&*;:?-])){8,64}(?(a)(?(b)(?(c)((?(quote)[^)\\\"'`]{1,8000}|([0-9A-Za-z/_+=~!@#$%^&*;:?-]{1,8000}|\\b))|$)|(?!x)x)|(?!x)x)|(?!x)x))(?(quote)[)\\\"'`])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "p/w",
+          "paasw",
+          "pass",
+          "pswd",
+          "pw",
+          "sword",
+          "비밀번호",
+          "비번",
+          "암호",
+          "패스워드"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValueAllowlistCheck",
+          "ValuePatternCheck(4)",
+          "ValueDictionaryKeywordCheck",
+          "LineGitBinaryCheck",
+          "LineUUEPartCheck",
+          "ValueFilePathCheck",
+          "ValueHexNumberCheck",
+          "ValueSealedSecretCheck"
+        ],
+        "min_line_len": 10,
+        "name": "PASSWD_PAIR",
+        "required_substrings": [
+          "pass",
+          "sword",
+          "pswd",
+          "pw",
+          "p/w",
+          "paasw",
+          "비밀번호",
+          "비번",
+          "패스워드",
+          "암호"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(?P<variable>[\\\"'`]?(?i:(?<!id[ :/])pa[as]swo?r?ds?|pswd|pwd?|p/w|비밀번호|비번|패스워드|암호)[\\\"'`]?)((\\s)*(?P<separator>설정은|:=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|%3[Dd])(\\s)*)(?P<quote>[\\\"'`(])?(?P<value>(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/_+=~!@#$%^&*;:?-])){8,64}(?(a)(?(b)(?(c)((?(quote)[^)\\\"'`]{1,8000}|([0-9A-Za-z/_+=~!@#$%^&*;:?-]{1,8000}|\\b))|$)|(?!x)x)|(?!x)x)|(?!x)x))(?(quote)[)\\\"'`])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5637,6 +6895,47 @@
         "4853545a8b268d9d7b3f316d28eb132e1dc47ed34ab6b57b76b175e48421854a"
       ],
       "name": "IP_ID_PASSWORD_TRIPLE",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 10,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(^|\\s|(?P<variable>(?i:\\bip[\\s/]{1,80}id[\\s/]{1,80}pw[\\s/:]{0,80}))|(?P<url>://))(?P<ip>(?<![0-9.])[0-2]?[0-9]{1,2}\\.[0-2]?[0-9]{1,2}\\.[0-2]?[0-9]{1,2}\\.[0-2]?[0-9]{1,2}(?![0-9.]))((\\s*[(])?|(?(variable)[\\s,/]{1,80}|(?(url)[,]|[,/])))\\s*\\w[\\w.-]{3,80}[\\s,/]{1,80}(?P<value>(?(url)(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9_+=~!@#$%^&*;?-])){7,64}(?(a)(?(b)(?(c)(\\S|$)|(?!x)x)|(?!x)x)|(?!x)x)|(?-i:(?P<e>[A-Z])|(?P<f>[a-z])|(?P<g>[0-9/_+=~!@#$%^&*;?-])){7,64}(?(e)(?(f)(?(g)(\\S|$)|(?!x)x)|(?!x)x)|(?!x)x)))(?:\\s|[^/]|$)"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "."
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValueAllowlistCheck",
+          "ValuePatternCheck(4)",
+          "ValueDictionaryKeywordCheck"
+        ],
+        "min_line_len": 10,
+        "name": "IP_ID_PASSWORD_TRIPLE",
+        "required_substrings": [
+          "."
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(^|\\s|(?P<variable>(?i:\\bip[\\s/]{1,80}id[\\s/]{1,80}pw[\\s/:]{0,80}))|(?P<url>://))(?P<ip>(?<![0-9.])[0-2]?[0-9]{1,2}\\.[0-2]?[0-9]{1,2}\\.[0-2]?[0-9]{1,2}\\.[0-2]?[0-9]{1,2}(?![0-9.]))((\\s*[(])?|(?(variable)[\\s,/]{1,80}|(?(url)[,]|[,/])))\\s*\\w[\\w.-]{3,80}[\\s,/]{1,80}(?P<value>(?(url)(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9_+=~!@#$%^&*;?-])){7,64}(?(a)(?(b)(?(c)(\\S|$)|(?!x)x)|(?!x)x)|(?!x)x)|(?-i:(?P<e>[A-Z])|(?P<f>[a-z])|(?P<g>[0-9/_+=~!@#$%^&*;?-])){7,64}(?(e)(?(f)(?(g)(\\S|$)|(?!x)x)|(?!x)x)|(?!x)x)))(?:\\s|[^/]|$)"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5645,6 +6944,67 @@
         "a60f1d2cba7216f85cda49a984d6f3cb2f8955bf7dab23c05eac368822dbe4f7"
       ],
       "name": "ID_PAIR_PASSWD_PAIR",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 10,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<ddash>--)?(?P<variable>\\w*(?i:pa[as]swords?|passwd?|pswd|pwd|\\bp/w|\\bpw|비밀번호|비번|패스워드|암호))\\s*?(?(ddash)[ =]|[:=/>-]{1,2})\\s*(?P<quote>[\\\"'`]{1,8})?(?P<value>(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/_+=~!@#$%^&*;:?-])){4,64}(?(a)(?(b)(?(c)(\\S|$)|(?!x)x)|(?!x)x)|(?!x)x))(?(quote)(?P=quote)|(\\s|$))"
+          },
+          {
+            "flags": 32,
+            "regex": "(?P<ddash>--)?(?P<variable>(?i:user\\s*)?(?i:id|login|account|root|admin|user|name|wifi|role|host|default|계정|아이디))\\s*?(?(ddash)[ =]|[ :=])\\s*?(?P<value>\\S+)"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "p/w",
+          "pass",
+          "pswd",
+          "pw",
+          "sword",
+          "비밀번호",
+          "비번",
+          "암호",
+          "패스워드"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValueAllowlistCheck",
+          "ValuePatternCheck(4)"
+        ],
+        "min_line_len": 10,
+        "name": "ID_PAIR_PASSWD_PAIR",
+        "required_substrings": [
+          "pass",
+          "sword",
+          "pswd",
+          "p/w",
+          "pw",
+          "비밀번호",
+          "비번",
+          "패스워드",
+          "암호"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(?P<ddash>--)?(?P<variable>\\w*(?i:pa[as]swords?|passwd?|pswd|pwd|\\bp/w|\\bpw|비밀번호|비번|패스워드|암호))\\s*?(?(ddash)[ =]|[:=/>-]{1,2})\\s*(?P<quote>[\\\"'`]{1,8})?(?P<value>(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/_+=~!@#$%^&*;:?-])){4,64}(?(a)(?(b)(?(c)(\\S|$)|(?!x)x)|(?!x)x)|(?!x)x))(?(quote)(?P=quote)|(\\s|$))",
+          "(?P<ddash>--)?(?P<variable>(?i:user\\s*)?(?i:id|login|account|root|admin|user|name|wifi|role|host|default|계정|아이디))\\s*?(?(ddash)[ =]|[ :=])\\s*?(?P<value>\\S+)"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5654,6 +7014,61 @@
         "4853545a8b268d9d7b3f316d28eb132e1dc47ed34ab6b57b76b175e48421854a"
       ],
       "name": "ID_PASSWD_PAIR",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 10,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>[\\w.-]{0,80}(?i:(?P<id>\\bid\\b)|id\\b|user|name|계정|아이디)[\\w.-]{0,80}(?(id)[ :(/]{1,80}|[:(/]{1,80})(?i:pa[as]swo?r?ds?|pswd|pwd?|비밀번호|비번|패스워드|암호))\\)?(\\s*->\\s*|[ =:)(/]{1,80}|\\s+is\\s+|\\s+are\\s+|\\s*는\\s*|\\s*은\\s*|\\s*설정은\\s*)\\(?(?P<id_value>[\\w.-]{2,64})[ :\\(/\\\"',]{1,80}(?P<value>(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/_+=~!@#$%^&*;:?-])){4,64}(?(a)(?(b)(?(c)(\\S|$)|(?!x)x)|(?!x)x)|(?!x)x))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "pass",
+          "pswd",
+          "pw",
+          "sword",
+          "비밀번호",
+          "비번",
+          "암호",
+          "패스워드"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValueAllowlistCheck",
+          "ValuePatternCheck(4)",
+          "ValueDictionaryKeywordCheck"
+        ],
+        "min_line_len": 10,
+        "name": "ID_PASSWD_PAIR",
+        "required_substrings": [
+          "pw",
+          "pswd",
+          "pass",
+          "sword",
+          "비밀번호",
+          "비번",
+          "패스워드",
+          "암호"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(?P<variable>[\\w.-]{0,80}(?i:(?P<id>\\bid\\b)|id\\b|user|name|계정|아이디)[\\w.-]{0,80}(?(id)[ :(/]{1,80}|[:(/]{1,80})(?i:pa[as]swo?r?ds?|pswd|pwd?|비밀번호|비번|패스워드|암호))\\)?(\\s*->\\s*|[ =:)(/]{1,80}|\\s+is\\s+|\\s+are\\s+|\\s*는\\s*|\\s*은\\s*|\\s*설정은\\s*)\\(?(?P<id_value>[\\w.-]{2,64})[ :\\(/\\\"',]{1,80}(?P<value>(?-i:(?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/_+=~!@#$%^&*;:?-])){4,64}(?(a)(?(b)(?(c)(\\S|$)|(?!x)x)|(?!x)x)|(?!x)x))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5661,6 +7076,47 @@
         "a60f1d2cba7216f85cda49a984d6f3cb2f8955bf7dab23c05eac368822dbe4f7"
       ],
       "name": "UUID",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 36,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9A-F]{8}(-[0-9A-F]{4}){3}-[0-9A-F]{12}|[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12})(?![0-9A-Za-z_+-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "-"
+        ],
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck(4)"
+        ],
+        "min_line_len": 36,
+        "name": "UUID",
+        "required_substrings": [
+          "-"
+        ],
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "use_ml": false,
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9A-F]{8}(-[0-9A-F]{4}){3}-[0-9A-F]{12}|[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12})(?![0-9A-Za-z_+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5669,6 +7125,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Akamai Credentials",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 38,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>akab-[0-9a-z]{16}-[0-9a-z]{16})(?!\\.[0-9a-z-]{1,80}\\.akamaiapis\\.net)"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "akab-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 38,
+        "name": "Akamai Credentials",
+        "required_substrings": [
+          "akab-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>akab-[0-9a-z]{16}-[0-9a-z]{16})(?!\\.[0-9a-z-]{1,80}\\.akamaiapis\\.net)"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5677,6 +7171,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Amazon Bedrock API Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 44,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>(ABSK|bedrock-api-key-)[0-9A-Za-z/+]{28,800})(?![0-9A-Za-z/+])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "absk",
+          "bedrock-api-key-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 44,
+        "name": "Amazon Bedrock API Key",
+        "required_substrings": [
+          "ABSK",
+          "bedrock-api-key-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>(ABSK|bedrock-api-key-)[0-9A-Za-z/+]{28,800})(?![0-9A-Za-z/+])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5685,6 +7219,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "AWS AppSync GraphQL API Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 40,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>da2-[a-z0-9]{26})(?![0-9A-Za-z/+])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "da2-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 40,
+        "name": "AWS AppSync GraphQL API Key",
+        "required_substrings": [
+          "da2-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>da2-[a-z0-9]{26})(?![0-9A-Za-z/+])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5693,6 +7265,72 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "AWS Client ID",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 20,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>(A3T[0-9A-Z]|ABIA|ACCA|AGPA|AIDA|AIPA|AKIA|ANPA|ANVA|AROA|APKA|ASCA|ASIA)[0-9A-Z]{16,17})(?![0-9A-Za-z_+-])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [
+          "a3t",
+          "abia",
+          "acca",
+          "agpa",
+          "aida",
+          "aipa",
+          "akia",
+          "anpa",
+          "anva",
+          "apka",
+          "aroa",
+          "asca",
+          "asia"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 20,
+        "name": "AWS Client ID",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "required_substrings": [
+          "A3T",
+          "ABIA",
+          "ACCA",
+          "AGPA",
+          "AIDA",
+          "AIPA",
+          "AKIA",
+          "ANPA",
+          "ANVA",
+          "AROA",
+          "APKA",
+          "ASCA",
+          "ASIA"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>(A3T[0-9A-Z]|ABIA|ACCA|AGPA|AIDA|AIPA|AKIA|ANPA|ANVA|AROA|APKA|ASCA|ASIA)[0-9A-Z]{16,17})(?![0-9A-Za-z_+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5703,6 +7341,60 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "AWS Multi",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 20,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>A(KIA|SIA)[0-9A-Z]{16})(?![0-9A-Za-z_])"
+          },
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>((?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/+])){40,44}(?(a)(?(b)(?(c)\\b|(?!x)x)|(?!x)x)|(?!x)x))(?![0-9A-Za-z/+])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [
+          "akia",
+          "asia"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "LineSpecificKeyCheck",
+          "ValuePatternCheck",
+          "ValueBase64PartCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 20,
+        "name": "AWS Multi",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "required_substrings": [
+          "AKIA",
+          "ASIA"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "multi",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>A(KIA|SIA)[0-9A-Z]{16})(?![0-9A-Za-z_])",
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>((?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/+])){40,44}(?(a)(?(b)(?(c)\\b|(?!x)x)|(?!x)x)|(?!x)x))(?![0-9A-Za-z/+])"
+        ]
+      },
       "type": "multi"
     },
     {
@@ -5711,6 +7403,48 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Alibaba Access Key ID",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 16,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>LTAI[0-9A-Za-z]{12,20})(?![0-9A-Za-z_+-])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [
+          "ltai"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 16,
+        "name": "Alibaba Access Key ID",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "required_substrings": [
+          "LTAI"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>LTAI[0-9A-Za-z]{12,20})(?![0-9A-Za-z_+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5721,6 +7455,58 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "Alibaba Multi",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 20,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>LTAI[0-9A-Za-z]{12,20})(?![0-9A-Za-z_+-])"
+          },
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>((?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/+])){30}(?(a)(?(b)(?(c)\\b|(?!x)x)|(?!x)x)|(?!x)x))(?![0-9A-Za-z/+])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [
+          "ltai"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "LineSpecificKeyCheck",
+          "ValuePatternCheck",
+          "ValueBase64PartCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 20,
+        "name": "Alibaba Multi",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "required_substrings": [
+          "LTAI"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "multi",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>LTAI[0-9A-Za-z]{12,20})(?![0-9A-Za-z_+-])",
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>((?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9/+])){30}(?(a)(?(b)(?(c)\\b|(?!x)x)|(?!x)x)|(?!x)x))(?![0-9A-Za-z/+])"
+        ]
+      },
       "type": "multi"
     },
     {
@@ -5729,6 +7515,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "AWS MWS Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 30,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>amzn\\.mws\\.[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "amzn.mws."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 30,
+        "name": "AWS MWS Key",
+        "required_substrings": [
+          "amzn.mws."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>amzn\\.mws\\.[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5737,6 +7561,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Defined Networking API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 85,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>dnkey-[A-Z2-7]{26}-[A-Z2-7]{52})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "dnkey-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 85,
+        "name": "Defined Networking API Key",
+        "required_substrings": [
+          "dnkey-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>dnkey-[A-Z2-7]{26}-[A-Z2-7]{52})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5747,6 +7609,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Dynatrace API Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 90,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>dt0[a-z]{1}[0-9]{2}\\.[0-9A-Z]{24}\\.[0-9A-Z]{64})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "dt0"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 90,
+        "name": "Dynatrace API Token",
+        "required_substrings": [
+          "dt0"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>dt0[a-z]{1}[0-9]{2}\\.[0-9A-Z]{24}\\.[0-9A-Z]{64})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5755,6 +7655,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Doppler API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 49,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>dp\\.pt\\.[0-9A-Za-z]{43})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "dp.pt."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 49,
+        "name": "Doppler API Key",
+        "required_substrings": [
+          "dp.pt."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>dp\\.pt\\.[0-9A-Za-z]{43})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5764,6 +7702,48 @@
         "8aaaa3f33bb9a51a95ba1b0155e66fd86a2956a7ec15b01118606b5939cd86f3"
       ],
       "name": "Facebook Access Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 80,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>EAA[0-9A-Za-z]{80,800})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "eaa"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueBase64PartCheck",
+          "ValueNotPartEncodedCheck"
+        ],
+        "min_line_len": 80,
+        "name": "Facebook Access Token",
+        "required_substrings": [
+          "EAA"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>EAA[0-9A-Za-z]{80,800})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5774,6 +7754,48 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Facebook App Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 33,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9]{12,18}\\|[0-9A-Za-z_-]{24,28})(?![0-9A-Za-z_+-])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [
+          "|"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 33,
+        "name": "Facebook App Token",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "required_substrings": [
+          "|"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9]{12,18}\\|[0-9A-Za-z_-]{24,28})(?![0-9A-Za-z_+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5784,6 +7806,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Google API Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 39,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>AIza[0-9A-Za-z_-]{35})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "aiza"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 39,
+        "name": "Google API Key",
+        "required_substrings": [
+          "AIza"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>AIza[0-9A-Za-z_-]{35})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5792,6 +7852,49 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Google Multi",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 40,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>[0-9]{3,80}-[0-9a-z_]{32}\\.apps\\.googleusercontent\\.com)"
+          },
+          {
+            "flags": 32,
+            "regex": "\\b(?P<value>GOCSPX-[0-9A-Za-z_-]{28}|((?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9_-])){24,80}(?(a)(?(b)(?(c)\\b|(?!x)x)|(?!x)x)|(?!x)x))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          ".apps.googleusercontent.com"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 40,
+        "name": "Google Multi",
+        "required_substrings": [
+          ".apps.googleusercontent.com"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "multi",
+        "values": [
+          "(?P<value>[0-9]{3,80}-[0-9a-z_]{32}\\.apps\\.googleusercontent\\.com)",
+          "\\b(?P<value>GOCSPX-[0-9A-Za-z_-]{28}|((?P<a>[A-Z])|(?P<b>[a-z])|(?P<c>[0-9_-])){24,80}(?(a)(?(b)(?(c)\\b|(?!x)x)|(?!x)x)|(?!x)x))"
+        ]
+      },
       "type": "multi"
     },
     {
@@ -5802,6 +7905,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Google OAuth Secret",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 40,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>GOCSPX-[0-9A-Za-z_-]{28})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "gocspx-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 40,
+        "name": "Google OAuth Secret",
+        "required_substrings": [
+          "GOCSPX-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>GOCSPX-[0-9A-Za-z_-]{28})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5812,6 +7953,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Google OAuth Access Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 27,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>ya29\\.[0-9A-Za-z_-]{22,8000})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "ya29."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 27,
+        "name": "Google OAuth Access Token",
+        "required_substrings": [
+          "ya29."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>ya29\\.[0-9A-Za-z_-]{22,8000})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5822,6 +8001,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Google OAuth Refresh Token",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 84,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>1//0[0-9A-Za-z_-]{80,8000})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "1//0"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": "TokenPattern",
+        "min_line_len": 84,
+        "name": "Google OAuth Refresh Token",
+        "required_substrings": [
+          "1//0"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>1//0[0-9A-Za-z_-]{80,8000})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5832,6 +8049,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Heroku Credentials",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 41,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>HRKU-([0-9A-Za-z_-]{60}|[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "hrku-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 41,
+        "name": "Heroku Credentials",
+        "required_substrings": [
+          "HRKU-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>HRKU-([0-9A-Za-z_-]{60}|[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5842,6 +8097,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Instagram Access Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 105,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>IGQVJ[=0-9A-Za-z_-]{100,8000})(?![=0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "igqvj"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 105,
+        "name": "Instagram Access Token",
+        "required_substrings": [
+          "IGQVJ"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>IGQVJ[=0-9A-Za-z_-]{100,8000})(?![=0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5849,6 +8142,46 @@
         "a208bfe5e76775675c9219eedf06175745c49be6b9705aa12d71c693430a0fda"
       ],
       "name": "JSON Web Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 64,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>eyJ[=0-9A-Za-z_+/-]{15,8000}(\\.[=0-9A-Za-z_+/-]{0,8000}){2,16})(?![=0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "eyj"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueJsonWebTokenCheck"
+        ],
+        "min_line_len": 64,
+        "name": "JSON Web Token",
+        "required_substrings": [
+          "eyJ"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>eyJ[=0-9A-Za-z_+/-]{15,8000}(\\.[=0-9A-Za-z_+/-]{0,8000}){2,16})(?![=0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5856,6 +8189,66 @@
         "fc6abda15ff5da9cf8a1677f9a0e190d92b30ef517f74f341b003552ab1dcb60"
       ],
       "name": "JSON Web Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 64,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>\\b(e(yJ|yAi|woi|wog|w0K)|W(yJ|3si|wp7|wog|w0K|3sK))[0-9A-Za-z_+/-]{60,8000})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "ew0k",
+          "ewog",
+          "ewoi",
+          "eyai",
+          "eyj",
+          "w3si",
+          "w3sk",
+          "ww0k",
+          "wwog",
+          "wwp7",
+          "wyj"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueJsonWebKeyCheck"
+        ],
+        "min_line_len": 64,
+        "name": "JSON Web Key",
+        "required_substrings": [
+          "eyJ",
+          "eyAi",
+          "ewoi",
+          "ewog",
+          "ew0K",
+          "WyJ",
+          "W3si",
+          "Wwp7",
+          "Wwog",
+          "Ww0K",
+          "W3sK"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>\\b(e(yJ|yAi|woi|wog|w0K)|W(yJ|3si|wp7|wog|w0K|3sK))[0-9A-Za-z_+/-]{60,8000})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5864,6 +8257,52 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "JWK",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 8,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>['\"]?\\b(?P<variable>kty)[^0-9A-Za-z_-]{1,8}(RSA|EC|oct)\\b['\"]?)"
+          },
+          {
+            "flags": 32,
+            "regex": "(?P<variable>\\b[dk])[^0-9A-Za-z_-]{1,8}(?P<value>[0-9A-Za-z_-]{22,8000})(?![=0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "kty"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 8,
+        "name": "JWK",
+        "required_substrings": [
+          "kty"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "multi",
+        "values": [
+          "(?P<value>['\"]?\\b(?P<variable>kty)[^0-9A-Za-z_-]{1,8}(RSA|EC|oct)\\b['\"]?)",
+          "(?P<variable>\\b[dk])[^0-9A-Za-z_-]{1,8}(?P<value>[0-9A-Za-z_-]{22,8000})(?![=0-9A-Za-z_-])"
+        ]
+      },
       "type": "multi"
     },
     {
@@ -5874,6 +8313,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "MailChimp API Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 35,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9A-Za-z_-]{32}-us[0-9]{1,2})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "-us"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 35,
+        "name": "MailChimp API Key",
+        "required_substrings": [
+          "-us"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9A-Za-z_-]{32}-us[0-9]{1,2})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5884,6 +8361,43 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "MailGun API Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 36,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>key-[0-9a-z]{32}|[0-9a-f]{32}-[0-9a-f]{8}-[0-9a-f]{8})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 36,
+        "name": "MailGun API Key",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>key-[0-9a-z]{32}|[0-9a-f]{32}-[0-9a-f]{8}-[0-9a-f]{8})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5892,11 +8406,81 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "PayPal Braintree Access Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 72,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>access_token\\$production\\$[0-9a-z]{16}\\$[0-9a-z]{32})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "access_token$production$"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 72,
+        "name": "PayPal Braintree Access Token",
+        "required_substrings": [
+          "access_token$production$"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>access_token\\$production\\$[0-9a-z]{16}\\$[0-9a-z]{32})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
       "filters": [],
       "name": "PEM Private Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 27,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>-----BEGIN(?![^-]*ENCRYPTED)[^-]*PRIVATE[^-]*KEY[^-]*-----)"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "min_line_len": 27,
+        "name": "PEM Private Key",
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pem_key",
+        "values": [
+          "(?P<value>-----BEGIN(?![^-]*ENCRYPTED)[^-]*PRIVATE[^-]*KEY[^-]*-----)"
+        ]
+      },
       "type": "pem_key"
     },
     {
@@ -5904,6 +8488,50 @@
         "5081847842f1123aa3b40b12ced70cd9afe9153cf8e93fc57fbdae0bb7d6ce50"
       ],
       "name": "BASE64 encoded PEM Private Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 300,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>[0-9A-Za-z_/+-]{0,8000}LS0t(LS1CRUdJTiB|LUJFR0lOI|QkVHSU4g)[0-9A-Za-z_/+-]{0,11}(UFJJVkFURSBLRVkt|QUklWQVRFIEtFWS0t|FBSSVZBVEUgS0VZ)[0-9A-Za-z_/+-]{1,8000}LS0t[0-9A-Za-z_/+-]{1,8000})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "fbssvzbveugs0vz",
+          "quklwqvrfietfws0t",
+          "ufjjvkfursblrvkt"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueBase64EncodedPem"
+        ],
+        "min_line_len": 300,
+        "name": "BASE64 encoded PEM Private Key",
+        "required_substrings": [
+          "UFJJVkFURSBLRVkt",
+          "QUklWQVRFIEtFWS0t",
+          "FBSSVZBVEUgS0VZ"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>[0-9A-Za-z_/+-]{0,8000}LS0t(LS1CRUdJTiB|LUJFR0lOI|QkVHSU4g)[0-9A-Za-z_/+-]{0,11}(UFJJVkFURSBLRVkt|QUklWQVRFIEtFWS0t|FBSSVZBVEUgS0VZ)[0-9A-Za-z_/+-]{1,8000}LS0t[0-9A-Za-z_/+-]{1,8000})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5911,6 +8539,46 @@
         "9b445cc2b3a8d0784597d4952dc38207e8be508c3fac8b1d29f52e5b345c891f"
       ],
       "name": "BASE64 Private Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 160,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>MII[A-Za-f][0-9A-Za-z/+]{8}(?s:[^!#$&()*\\-.:;<=>?@\\[\\]^_{|}~]{8,8000}))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "mii"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueBase64KeyCheck"
+        ],
+        "min_line_len": 160,
+        "name": "BASE64 Private Key",
+        "required_substrings": [
+          "MII"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>MII[A-Za-f][0-9A-Za-z/+]{8}(?s:[^!#$&()*\\-.:;<=>?@\\[\\]^_{|}~]{8,8000}))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5919,6 +8587,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Picatic API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 40,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>sk_live_[0-9a-z]{32})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sk_live_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 40,
+        "name": "Picatic API Key",
+        "required_substrings": [
+          "sk_live_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>sk_live_[0-9a-z]{32})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5929,6 +8635,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "SendGrid API Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 34,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>SG\\.[0-9A-Za-z_-]{16,32}\\.[0-9A-Za-z_-]{16,64})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sg."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 34,
+        "name": "SendGrid API Key",
+        "required_substrings": [
+          "SG."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>SG\\.[0-9A-Za-z_-]{16,32}\\.[0-9A-Za-z_-]{16,64})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5939,6 +8683,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Clojars Deploy Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 68,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>CLOJARS_[0-9a-f]{60})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "clojars_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 68,
+        "name": "Clojars Deploy Token",
+        "required_substrings": [
+          "CLOJARS_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>CLOJARS_[0-9a-f]{60})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5949,6 +8731,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Shopify Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 38,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>shp(at|ca|pa|ss|tka)_[0-9A-Fa-f]{32})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "shp"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 38,
+        "name": "Shopify Token",
+        "required_substrings": [
+          "shp"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>shp(at|ca|pa|ss|tka)_[0-9A-Fa-f]{32})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5959,6 +8779,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Slack Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 15,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>(xapp|xox[a-z])\\-[0-9A-Za-z-]{10,250})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "xapp",
+          "xox"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 15,
+        "name": "Slack Token",
+        "required_substrings": [
+          "xox",
+          "xapp"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>(xapp|xox[a-z])\\-[0-9A-Za-z-]{10,250})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5967,6 +8827,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Slack Webhook",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 61,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>hooks\\.slack\\.com/services)(?P<value>/T[0-9A-Z]{8,16}/B[0-9A-Z]{8,16}/[0-9A-Za-z_]{24})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "hooks.slack.com/services/t"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 61,
+        "name": "Slack Webhook",
+        "required_substrings": [
+          "hooks.slack.com/services/T"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<variable>hooks\\.slack\\.com/services)(?P<value>/T[0-9A-Z]{8,16}/B[0-9A-Z]{8,16}/[0-9A-Za-z_]{24})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5975,6 +8873,48 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Stripe Credentials",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 32,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>(whsec|[prs]k_(test|live))_[0-9A-Za-z]{24,160})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "k_live_",
+          "k_test_",
+          "whsec_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 32,
+        "name": "Stripe Credentials",
+        "required_substrings": [
+          "k_live_",
+          "k_test_",
+          "whsec_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>(whsec|[prs]k_(test|live))_[0-9A-Za-z]{24,160})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5983,6 +8923,47 @@
         "d7dfad4b76abb1ad185fd4cafffbe87677b1e2df4c6ccee415e4e7d2f8e64f2e"
       ],
       "name": "Square Access Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 64,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>EAAA[0-9A-Za-z_-]{60})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "eaaa"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueBase64PartCheck"
+        ],
+        "min_line_len": 64,
+        "name": "Square Access Token",
+        "required_substrings": [
+          "EAAA"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>EAAA[0-9A-Za-z_-]{60})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -5993,6 +8974,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Square Credentials",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 29,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>sq0[a-z]{3}-[0-9A-Za-z_-]{22}([0-9A-Za-z_-]{21})?)(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sq0"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 29,
+        "name": "Square Credentials",
+        "required_substrings": [
+          "sq0"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>sq0[a-z]{3}-[0-9A-Za-z_-]{22}([0-9A-Za-z_-]{21})?)(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6003,6 +9022,92 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Twilio Credentials",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 34,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>(AC|AD|AL|CA|CF|CL|CN|CR|FW|IP|KS|MM|NO|PK|PN|QU|RE|SC|SD|SK|SM|TR|UT|XE|XR)[0-9A-Fa-f]{32})(?![0-9A-Za-z_+-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "ac",
+          "ad",
+          "al",
+          "ca",
+          "cf",
+          "cl",
+          "cn",
+          "cr",
+          "fw",
+          "ip",
+          "ks",
+          "mm",
+          "no",
+          "pk",
+          "pn",
+          "qu",
+          "re",
+          "sc",
+          "sd",
+          "sk",
+          "sm",
+          "tr",
+          "ut",
+          "xe",
+          "xr"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 34,
+        "name": "Twilio Credentials",
+        "required_substrings": [
+          "AC",
+          "AD",
+          "AL",
+          "CA",
+          "CF",
+          "CL",
+          "CN",
+          "CR",
+          "FW",
+          "IP",
+          "KS",
+          "MM",
+          "NO",
+          "PK",
+          "PN",
+          "QU",
+          "RE",
+          "SC",
+          "SD",
+          "SK",
+          "SM",
+          "TR",
+          "UT",
+          "XE",
+          "XR"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>(AC|AD|AL|CA|CF|CL|CN|CR|FW|IP|KS|MM|NO|PK|PN|QU|RE|SC|SD|SK|SM|TR|UT|XE|XR)[0-9A-Fa-f]{32})(?![0-9A-Za-z_+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6013,6 +9118,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Telegram Bot API Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 45,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9]{8,10}:[0-9A-Za-z_-]{35})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          ":aa"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 45,
+        "name": "Telegram Bot API Token",
+        "required_substrings": [
+          ":AA"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9]{8,10}:[0-9A-Za-z_-]{35})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6023,6 +9166,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "PyPi API Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 155,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>pypi-[0-9A-Za-z_-]{150,255})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "pypi-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 155,
+        "name": "PyPi API Token",
+        "required_substrings": [
+          "pypi-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>pypi-[0-9A-Za-z_-]{150,255})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6030,6 +9211,46 @@
         "fe0b4a7ac33c75bd39c06b8b6be6095ed0465e6fcdad53102c2a484518d2bd9e"
       ],
       "name": "NPM Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 40,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>npm_[0-9A-Za-z_-]{36,255})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "npm_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueGitHubCheck"
+        ],
+        "min_line_len": 40,
+        "name": "NPM Token",
+        "required_substrings": [
+          "npm_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>npm_[0-9A-Za-z_-]{36,255})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6037,6 +9258,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Github App Installation Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 40,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>ghs_[0-9]{1,20}_eyJ[0-9A-Za-z_-]{15,800}(\\.[0-9A-Za-z_-]{0,800}){2,8})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "ghs_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 40,
+        "name": "Github App Installation Token",
+        "required_substrings": [
+          "ghs_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>ghs_[0-9]{1,20}_eyJ[0-9A-Za-z_-]{15,800}(\\.[0-9A-Za-z_-]{0,800}){2,8})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6044,6 +9305,54 @@
         "fe0b4a7ac33c75bd39c06b8b6be6095ed0465e6fcdad53102c2a484518d2bd9e"
       ],
       "name": "Github Classic Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 40,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>gh[pousr]_[0-9A-Za-z_-]{36,255})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "gho_",
+          "ghp_",
+          "ghr_",
+          "ghs_",
+          "ghu_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueGitHubCheck"
+        ],
+        "min_line_len": 40,
+        "name": "Github Classic Token",
+        "required_substrings": [
+          "ghp_",
+          "gho_",
+          "ghu_",
+          "ghs_",
+          "ghr_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>gh[pousr]_[0-9A-Za-z_-]{36,255})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6052,6 +9361,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Github Fine-granted Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 90,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>github_pat_[0-9A-Za-z_]{80,255})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "github_pat_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 90,
+        "name": "Github Fine-granted Token",
+        "required_substrings": [
+          "github_pat_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>github_pat_[0-9A-Za-z_]{80,255})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6060,6 +9407,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Firebase Domain",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 16,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[a-z0-9.-]{1,80}\\.firebaseio\\.com|[a-z0-9.-]{1,80}\\.firebaseapp\\.com)"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          ".firebase"
+        ],
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 16,
+        "name": "Firebase Domain",
+        "required_substrings": [
+          ".firebase"
+        ],
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[a-z0-9.-]{1,80}\\.firebaseio\\.com|[a-z0-9.-]{1,80}\\.firebaseapp\\.com)"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6068,6 +9453,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "AWS S3 Bucket",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 14,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[a-z0-9.-]{3,63}\\.s3\\.amazonaws\\.com|[a-z0-9.-]{3,63}\\.s3-website[.-](eu|ap|us|ca|sa|cn))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          ".s3-website",
+          ".s3.amazonaws.com"
+        ],
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralPattern",
+        "min_line_len": 14,
+        "name": "AWS S3 Bucket",
+        "required_substrings": [
+          ".s3-website",
+          ".s3.amazonaws.com"
+        ],
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[a-z0-9.-]{3,63}\\.s3\\.amazonaws\\.com|[a-z0-9.-]{3,63}\\.s3-website[.-](eu|ap|us|ca|sa|cn))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6075,6 +9500,48 @@
         "6efa5879216495785e5f6f1a138248eccabb8d885ba25c3a0c32ec967e73d886"
       ],
       "name": "Jfrog Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 64,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>(cmVmdGtuO[0-9A-Za-z_-]{55}|AKCp[0-9A-Za-z_-]{69}))(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "akcp",
+          "cmvmdgtuo"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueJfrogTokenCheck"
+        ],
+        "min_line_len": 64,
+        "name": "Jfrog Token",
+        "required_substrings": [
+          "cmVmdGtuO",
+          "AKCp"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>(cmVmdGtuO[0-9A-Za-z_-]{55}|AKCp[0-9A-Za-z_-]{69}))(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6082,6 +9549,46 @@
         "4ee731f4f0aa387e4107cba7eac3f91f8e8fdda513364caca6d46b7bd4b4d659"
       ],
       "name": "Azure Access Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 148,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>eyJ[=0-9A-Za-z_-]{50,500}\\.eyJ[=0-9A-Za-z_-]{8,8000}\\.[=0-9A-Za-z_-]{18,800})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "eyj"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueAzureTokenCheck"
+        ],
+        "min_line_len": 148,
+        "name": "Azure Access Token",
+        "required_substrings": [
+          "eyJ"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>eyJ[=0-9A-Za-z_-]{50,500}\\.eyJ[=0-9A-Za-z_-]{8,8000}\\.[=0-9A-Za-z_-]{18,800})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6092,6 +9599,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Azure Secret Value",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 40,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9A-Za-z_~.-]{3}8Q~[0-9A-Za-z_~.-]{34})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "8q~"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 40,
+        "name": "Azure Secret Value",
+        "required_substrings": [
+          "8Q~"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9A-Za-z_~.-]{3}8Q~[0-9A-Za-z_~.-]{34})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6099,6 +9644,50 @@
         "cd536b2aff357e4afbfa4f063e83fd78056b6cb9143446b50e196089795b5086"
       ],
       "name": "Azure Storage Account Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 80,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9A-Za-z]{52}JQQJ9[9DH][0-9A-Za-z]{26}([0-9A-Za-z=]{4})?)(?![0-9A-Za-z_/+-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "jqqj99",
+          "jqqj9d",
+          "jqqj9h"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck(17)"
+        ],
+        "min_line_len": 80,
+        "name": "Azure Storage Account Key",
+        "required_substrings": [
+          "JQQJ99",
+          "JQQJ9D",
+          "JQQJ9H"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[0-9A-Za-z]{52}JQQJ9[9DH][0-9A-Za-z]{26}([0-9A-Za-z=]{4})?)(?![0-9A-Za-z_/+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6106,6 +9695,46 @@
         "761dfe887bca32847e5729fc7b5e0b6ae322f03721308153beaaed808490414c"
       ],
       "name": "Bitbucket App Password",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 28,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>ATBB[0-9A-Za-z]{24}[A-F0-9]{8})(?![0-9A-Za-z_])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "atbb"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueAtlassianTokenCheck"
+        ],
+        "min_line_len": 28,
+        "name": "Bitbucket App Password",
+        "required_substrings": [
+          "ATBB"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>ATBB[0-9A-Za-z]{24}[A-F0-9]{8})(?![0-9A-Za-z_])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6113,6 +9742,46 @@
         "761dfe887bca32847e5729fc7b5e0b6ae322f03721308153beaaed808490414c"
       ],
       "name": "Bitbucket Repository Access Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 160,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>ATCTT3xFfGN0[0-9A-Za-z_-]{80,800}(\\\\?=|%3[dD])[A-F0-9]{8})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "atctt3xffgn0"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueAtlassianTokenCheck"
+        ],
+        "min_line_len": 160,
+        "name": "Bitbucket Repository Access Token",
+        "required_substrings": [
+          "ATCTT3xFfGN0"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>ATCTT3xFfGN0[0-9A-Za-z_-]{80,800}(\\\\?=|%3[dD])[A-F0-9]{8})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6120,6 +9789,46 @@
         "761dfe887bca32847e5729fc7b5e0b6ae322f03721308153beaaed808490414c"
       ],
       "name": "Bitbucket HTTP Access Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 49,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>BBDC-[MNO][ADQTgjwz][AEIMQUYcgk][012345wxyz][0-9A-Za-z_-]{40})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "bbdc-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueAtlassianTokenCheck"
+        ],
+        "min_line_len": 49,
+        "name": "Bitbucket HTTP Access Token",
+        "required_substrings": [
+          "BBDC-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>BBDC-[MNO][ADQTgjwz][AEIMQUYcgk][012345wxyz][0-9A-Za-z_-]{40})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6127,6 +9836,54 @@
         "761dfe887bca32847e5729fc7b5e0b6ae322f03721308153beaaed808490414c"
       ],
       "name": "Jira / Confluence PAT token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 44,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?<!BBDC-)(?P<value>[MNO][ADQTgjwz][AEIMQUYcgk][012345wxyz][0-9A-Za-z_-]{40})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [
+          "m",
+          "n",
+          "o"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueAtlassianTokenCheck"
+        ],
+        "min_line_len": 44,
+        "name": "Jira / Confluence PAT token",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "required_substrings": [
+          "M",
+          "N",
+          "O"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?<!BBDC-)(?P<value>[MNO][ADQTgjwz][AEIMQUYcgk][012345wxyz][0-9A-Za-z_-]{40})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6134,6 +9891,46 @@
         "761dfe887bca32847e5729fc7b5e0b6ae322f03721308153beaaed808490414c"
       ],
       "name": "Atlassian PAT token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 160,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>ATATT3xFfGF0[0-9A-Za-z_-]{80,800}(\\\\?=|%3[dD])[A-F0-9]{8})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "atatt3xffgf0"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueAtlassianTokenCheck"
+        ],
+        "min_line_len": 160,
+        "name": "Atlassian PAT token",
+        "required_substrings": [
+          "ATATT3xFfGF0"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>ATATT3xFfGF0[0-9A-Za-z_-]{80,800}(\\\\?=|%3[dD])[A-F0-9]{8})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6144,6 +9941,48 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Digital Ocean Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 71,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>do[opr]_v1_[a-f0-9]{64})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "doo_v1_",
+          "dop_v1_",
+          "dor_v1_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 71,
+        "name": "Digital Ocean Token",
+        "required_substrings": [
+          "doo_v1_",
+          "dop_v1_",
+          "dor_v1_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>do[opr]_v1_[a-f0-9]{64})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6154,6 +9993,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Dropbox OAuth2 API Access Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 80,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>sl\\.(u\\.)?[0-9A-Za-z_-]{77,177})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sl."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 80,
+        "name": "Dropbox OAuth2 API Access Token",
+        "required_substrings": [
+          "sl."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>sl\\.(u\\.)?[0-9A-Za-z_-]{77,177})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6164,6 +10041,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "NuGet API key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 46,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>oy2[a-z0-9]{43})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "oy2"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "TokenPattern",
+        "min_line_len": 46,
+        "name": "NuGet API key",
+        "required_substrings": [
+          "oy2"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>oy2[a-z0-9]{43})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6171,6 +10086,74 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Gitlab Prefix Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 25,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>(_gitlab_session=|GR1348941|gl(agent|soat|ffct|p[at]t|oas|cbt|imt|rtr|[dfrw]t)-)[0-9A-Za-z_-]{20,64}(\\.[0-9A-Za-z_-]{2,16}){0,2})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "_gitlab_session=",
+          "glagent-",
+          "glcbt-",
+          "gldt-",
+          "glffct-",
+          "glft-",
+          "glimt-",
+          "gloas-",
+          "glpat-",
+          "glptt-",
+          "glrt-",
+          "glrtr-",
+          "glsoat-",
+          "glwt-",
+          "gr1348941"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 25,
+        "name": "Gitlab Prefix Token",
+        "required_substrings": [
+          "_gitlab_session=",
+          "GR1348941",
+          "glagent-",
+          "glsoat-",
+          "glffct-",
+          "glpat-",
+          "gloas-",
+          "glptt-",
+          "glcbt-",
+          "glimt-",
+          "gldt-",
+          "glft-",
+          "glrt-",
+          "glrtr-",
+          "glwt-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>(_gitlab_session=|GR1348941|gl(agent|soat|ffct|p[at]t|oas|cbt|imt|rtr|[dfrw]t)-)[0-9A-Za-z_-]{20,64}(\\.[0-9A-Za-z_-]{2,16}){0,2})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6178,6 +10161,46 @@
         "ef63827dc9d629a3baf7cd3d65f3ba4721fa840fc24c0c65dece4d2ccd1dff07"
       ],
       "name": "Grafana Provisioned API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 67,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>eyJ[=0-9A-Za-z_-]{64,360})(?![=0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "eyj"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueGrafanaCheck"
+        ],
+        "min_line_len": 67,
+        "name": "Grafana Provisioned API Key",
+        "required_substrings": [
+          "eyJ"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>eyJ[=0-9A-Za-z_-]{64,360})(?![=0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6185,6 +10208,46 @@
         "ef63827dc9d629a3baf7cd3d65f3ba4721fa840fc24c0c65dece4d2ccd1dff07"
       ],
       "name": "Grafana Access Policy Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 87,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>glc_eyJ[0-9A-Za-z_-]{80,360})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "glc_eyj"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueGrafanaCheck"
+        ],
+        "min_line_len": 87,
+        "name": "Grafana Access Policy Token",
+        "required_substrings": [
+          "glc_eyJ"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>glc_eyJ[0-9A-Za-z_-]{80,360})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6192,16 +10255,132 @@
         "f79c6f9de2d6f46d454c22e5b46e6643d0d0023a634cb0926e315ecdd8f9c475"
       ],
       "name": "Grafana Service Account Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 46,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>glsa_[0-9A-Za-z_-]{32}_[0-9A-Fa-f]{8})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "glsa_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueGrafanaServiceCheck"
+        ],
+        "min_line_len": 46,
+        "name": "Grafana Service Account Token",
+        "required_substrings": [
+          "glsa_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>glsa_[0-9A-Za-z_-]{32}_[0-9A-Fa-f]{8})"
+        ]
+      },
       "type": "pattern"
     },
     {
       "filters": [],
       "name": "Dropbox API secret (long term)",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 43,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?=[0-9A-Za-z]{64})(?P<value>[0-9A-Za-z]{10,12}[B-Za-z0-9]A{10,12}[B-Za-z0-9][0-9A-Za-z]{40,44})(?![=0-9A-Za-z_/+-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "aaaaaaaaaa"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": [],
+        "min_line_len": 43,
+        "name": "Dropbox API secret (long term)",
+        "required_substrings": [
+          "AAAAAAAAAA"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?=[0-9A-Za-z]{64})(?P<value>[0-9A-Za-z]{10,12}[B-Za-z0-9]A{10,12}[B-Za-z0-9][0-9A-Za-z]{40,44})(?![=0-9A-Za-z_/+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
       "filters": [],
       "name": "X App-Only Authentication Bearer Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 100,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>AAAAAAAAAAAAAAAAAAAAA[0-9A-Za-z%]{40,42}%3D[0-9A-Za-z]{50})(?![=0-9A-Za-z_/+-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "aaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [],
+        "min_line_len": 100,
+        "name": "X App-Only Authentication Bearer Token",
+        "required_substrings": [
+          "AAAAAAAAAAAAAAAAAAAAA"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>AAAAAAAAAAAAAAAAAAAAA[0-9A-Za-z%]{40,42}%3D[0-9A-Za-z]{50})(?![=0-9A-Za-z_/+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6209,6 +10388,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "PlanetScale Credentials",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 42,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>pscale_(tkn|oauth|pw)_[.0-9A-Za-z_-]{32,64})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "pscale_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 42,
+        "name": "PlanetScale Credentials",
+        "required_substrings": [
+          "pscale_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>pscale_(tkn|oauth|pw)_[.0-9A-Za-z_-]{32,64})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6217,6 +10436,55 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "NewRelic Credentials",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 24,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>NRAK-[0-9A-Z]{27}|NRBR-[0-9a-f]{19,20}|NRII-[0-9A-Za-z_-]{25}|NRJS-[0-9a-z]{19}|[0-9a-z]{5}[0-9a-f]{31}NRAL)"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "nrak-",
+          "nral",
+          "nrbr-",
+          "nrii-",
+          "nrjs-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 24,
+        "name": "NewRelic Credentials",
+        "required_substrings": [
+          "NRAK-",
+          "NRBR-",
+          "NRII-",
+          "NRJS-",
+          "NRAL"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>NRAK-[0-9A-Z]{27}|NRBR-[0-9a-f]{19,20}|NRII-[0-9A-Za-z_-]{25}|NRJS-[0-9a-z]{19}|[0-9a-z]{5}[0-9a-f]{31}NRAL)"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6224,6 +10492,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Linear API Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 48,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>lin_api_[0-9A-Za-z]{40})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "lin_api_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 48,
+        "name": "Linear API Key",
+        "required_substrings": [
+          "lin_api_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>lin_api_[0-9A-Za-z]{40})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6232,6 +10540,51 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "CloudFlare API Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 24,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>cf(at|ut|k)_[0-9A-Za-z]{48})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "cfat_",
+          "cfk_",
+          "cfut_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 24,
+        "name": "CloudFlare API Token",
+        "required_substrings": [
+          "cfat_",
+          "cfut_",
+          "cfk_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>cf(at|ut|k)_[0-9A-Za-z]{48})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6239,6 +10592,46 @@
         "b91c403120dbf0fdc48344dae9c40f9d088d25d174a4934c92cc44d829ea41bc"
       ],
       "name": "Age Secret Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 74,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>AGE-SECRET-KEY-1[0-9A-Z]{58})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "age-secret-key-1"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueBech32Check"
+        ],
+        "min_line_len": 74,
+        "name": "Age Secret Key",
+        "required_substrings": [
+          "AGE-SECRET-KEY-1"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>AGE-SECRET-KEY-1[0-9A-Z]{58})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6250,6 +10643,43 @@
         "0b6b6039683167b47b139db85f3045aa2b7e82d43bd487d34ff7f5cf5e266c94"
       ],
       "name": "Dropbox App secret",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 15,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[a-z0-9]{15})(?![=0-9A-Za-z_/+-])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [],
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": "WeirdBase36Token",
+        "min_line_len": 15,
+        "name": "Dropbox App secret",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>[a-z0-9]{15})(?![=0-9A-Za-z_/+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6258,6 +10688,51 @@
         "f2096d9c47a88c6d0255babb2f35ebc20cc80aa6903847dc7de7cfa14df73788"
       ],
       "name": "Hashicorp Vault Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 90,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>hv[brs]\\.[0-9A-Za-z_-]{80,160})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "hvb.",
+          "hvr.",
+          "hvs."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueEntropyBase64Check"
+        ],
+        "min_line_len": 90,
+        "name": "Hashicorp Vault Token",
+        "required_substrings": [
+          "hvb.",
+          "hvr.",
+          "hvs."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>hv[brs]\\.[0-9A-Za-z_-]{80,160})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6266,6 +10741,47 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "Hashicorp Terraform Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 90,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>[0-9A-Za-z_-]{14}\\.atlasv1\\.[0-9A-Za-z_-]{67})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          ".atlasv1."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 90,
+        "name": "Hashicorp Terraform Token",
+        "required_substrings": [
+          ".atlasv1."
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>[0-9A-Za-z_-]{14}\\.atlasv1\\.[0-9A-Za-z_-]{67})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6277,6 +10793,66 @@
         "c49abfa4db0c75c1e60a0f7f9dd30e7111443c8c7a4ce982738b3c067fe2686a"
       ],
       "name": "NKEY Seed",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 42,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>S[ACNOPUX][A-Z2-7]{40,200})(?![=0-9A-Za-z_+-])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [
+          "sa",
+          "sc",
+          "sn",
+          "so",
+          "sp",
+          "su",
+          "sx"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": [
+          "ValueMorphemesCheck",
+          "ValuePatternCheck",
+          "ValueEntropyBase32Check",
+          "ValueBase32DataCheck",
+          "ValueTokenBase32Check"
+        ],
+        "min_line_len": 42,
+        "name": "NKEY Seed",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "required_substrings": [
+          "SA",
+          "SC",
+          "SN",
+          "SO",
+          "SP",
+          "SU",
+          "SX"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>S[ACNOPUX][A-Z2-7]{40,200})(?![=0-9A-Za-z_+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6289,6 +10865,50 @@
         "d7dfad4b76abb1ad185fd4cafffbe87677b1e2df4c6ccee415e4e7d2f8e64f2e"
       ],
       "name": "OTP / 2FA Secret",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 16,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>([A-Z2-7]{16}){1,2})(?![=0-9A-Za-z_+-])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [],
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": [
+          "ValueMorphemesCheck",
+          "ValuePatternCheck",
+          "ValueEntropyBase32Check",
+          "ValueBase32DataCheck",
+          "ValueTokenBase32Check",
+          "ValueBase64PartCheck"
+        ],
+        "min_line_len": 16,
+        "name": "OTP / 2FA Secret",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "severity": "info",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>([A-Z2-7]{16}){1,2})(?![=0-9A-Za-z_+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6297,6 +10917,51 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "OpenAI Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 51,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>sk-[0-9A-Za-z_-]{16,160}(T3BlbkFJ|9wZW5BS|PcGVuQU)[0-9A-Za-z_-]{16,160})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "9wzw5bs",
+          "pcgvuqu",
+          "t3blbkfj"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 51,
+        "name": "OpenAI Token",
+        "required_substrings": [
+          "T3BlbkFJ",
+          "9wZW5BS",
+          "PcGVuQU"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>sk-[0-9A-Za-z_-]{16,160}(T3BlbkFJ|9wZW5BS|PcGVuQU)[0-9A-Za-z_-]{16,160})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6305,6 +10970,49 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "Docker Access Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 36,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>dckr_[op]at_[0-9A-Za-z_-]{27,32})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "dckr_oat_",
+          "dckr_pat_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 36,
+        "name": "Docker Access Token",
+        "required_substrings": [
+          "dckr_pat_",
+          "dckr_oat_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>dckr_[op]at_[0-9A-Za-z_-]{27,32})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6313,6 +11021,47 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "Docker Swarm Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 85,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>SWMTKN-1-[0-9a-z]{50}-[0-9a-z]{25})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "swmtkn-1-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 85,
+        "name": "Docker Swarm Token",
+        "required_substrings": [
+          "SWMTKN-1-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>SWMTKN-1-[0-9a-z]{50}-[0-9a-z]{25})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6321,6 +11070,47 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "Docker Swarm Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 52,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>SWMKEY-1-[0-9A-Za-z]{43})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "swmkey-1-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 52,
+        "name": "Docker Swarm Key",
+        "required_substrings": [
+          "SWMKEY-1-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>SWMKEY-1-[0-9A-Za-z]{43})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6328,6 +11118,50 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Groq API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 56,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>gsk_[0-9A-Za-z_-]{8,40}(WGdyb3FY|hncm9xW|YZ3JvcV)[0-9A-Za-z_-]{8,40})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "hncm9xw",
+          "wgdyb3fy",
+          "yz3jvcv"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 56,
+        "name": "Groq API Key",
+        "required_substrings": [
+          "WGdyb3FY",
+          "hncm9xW",
+          "YZ3JvcV"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>gsk_[0-9A-Za-z_-]{8,40}(WGdyb3FY|hncm9xW|YZ3JvcV)[0-9A-Za-z_-]{8,40})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6336,6 +11170,47 @@
         "f2096d9c47a88c6d0255babb2f35ebc20cc80aa6903847dc7de7cfa14df73788"
       ],
       "name": "X AI API Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 84,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>xai-[0-9A-Za-z_-]{80})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "xai-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueEntropyBase64Check"
+        ],
+        "min_line_len": 84,
+        "name": "X AI API Key",
+        "required_substrings": [
+          "xai-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>xai-[0-9A-Za-z_-]{80})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6344,6 +11219,47 @@
         "f2096d9c47a88c6d0255babb2f35ebc20cc80aa6903847dc7de7cfa14df73788"
       ],
       "name": "Notion Integration Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 50,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>ntn_[0-9]{9}[0-9A-Za-z_-]{36,255})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "ntn_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueEntropyBase64Check"
+        ],
+        "min_line_len": 50,
+        "name": "Notion Integration Token",
+        "required_substrings": [
+          "ntn_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>ntn_[0-9]{9}[0-9A-Za-z_-]{36,255})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6352,6 +11268,47 @@
         "f2096d9c47a88c6d0255babb2f35ebc20cc80aa6903847dc7de7cfa14df73788"
       ],
       "name": "Hugging Face User Access Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 37,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>hf_[0-9A-Za-z_-]{34})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "hf_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck",
+          "ValueEntropyBase64Check"
+        ],
+        "min_line_len": 37,
+        "name": "Hugging Face User Access Token",
+        "required_substrings": [
+          "hf_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>hf_[0-9A-Za-z_-]{34})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6359,6 +11316,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Anthropic API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 77,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>sk-ant-api03-[0-9A-Za-z_-]{64,128})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sk-ant-api03-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 77,
+        "name": "Anthropic API Key",
+        "required_substrings": [
+          "sk-ant-api03-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>sk-ant-api03-[0-9A-Za-z_-]{64,128})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6366,6 +11363,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Perplexity API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 45,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>pplx-[0-9A-Za-z_-]{40,64})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "pplx-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 45,
+        "name": "Perplexity API Key",
+        "required_substrings": [
+          "pplx-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>pplx-[0-9A-Za-z_-]{40,64})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6373,6 +11410,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "DeepSeek API Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 35,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>sk-[0-9a-f]{32,64})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sk-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 35,
+        "name": "DeepSeek API Key",
+        "required_substrings": [
+          "sk-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>sk-[0-9a-f]{32,64})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6380,6 +11457,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Tavily API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 37,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>tvly-[0-9A-Za-z_-]{32,40})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "tvly-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 37,
+        "name": "Tavily API Key",
+        "required_substrings": [
+          "tvly-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>tvly-[0-9A-Za-z_-]{32,40})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6387,6 +11504,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Figma Personal Access Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 45,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>figd_[0-9A-Za-z_-]{40})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "figd_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 45,
+        "name": "Figma Personal Access Token",
+        "required_substrings": [
+          "figd_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>figd_[0-9A-Za-z_-]{40})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6394,6 +11551,50 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "1Password Account Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 192,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>ops_eyJ[0-9A-Za-z_-]{168,8000})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "ic2vjcmv0s2v5ij",
+          "innly3jldetlesi6",
+          "jzzwnyzxrlzxkio"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 192,
+        "name": "1Password Account Token",
+        "required_substrings": [
+          "InNlY3JldEtleSI6",
+          "JzZWNyZXRLZXkiO",
+          "ic2VjcmV0S2V5Ij"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>ops_eyJ[0-9A-Za-z_-]{168,8000})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6401,6 +11602,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Brevo API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 89,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>xkeysib-[0-9a-f]{64}-[0-9A-Za-z_-]{16})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "xkeysib-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 89,
+        "name": "Brevo API Key",
+        "required_substrings": [
+          "xkeysib-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>xkeysib-[0-9a-f]{64}-[0-9A-Za-z_-]{16})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6408,6 +11649,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Together AI API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 50,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>tgp_v1_[0-9A-Za-z_-]{43})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "tgp_v1_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 50,
+        "name": "Together AI API Key",
+        "required_substrings": [
+          "tgp_v1_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>tgp_v1_[0-9A-Za-z_-]{43})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6415,6 +11696,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "LLAMA API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 52,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>llx-[0-9A-Za-z_-]{48})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "llx-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 52,
+        "name": "LLAMA API Key",
+        "required_substrings": [
+          "llx-"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>llx-[0-9A-Za-z_-]{48})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6422,6 +11743,50 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "SonarQube Credentials",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 44,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>sq[apu]_[0-9a-f]{40})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sqa_",
+          "sqp_",
+          "squ_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 44,
+        "name": "SonarQube Credentials",
+        "required_substrings": [
+          "sqa_",
+          "sqp_",
+          "squ_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>sq[apu]_[0-9a-f]{40})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6429,6 +11794,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Sentry Organization Auth Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 37,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>sntrys_eyJ[0-9A-Za-z_-]{80,8000}=*([0-9A-Za-z_-]{32,256})?)(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sntrys_eyj"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 37,
+        "name": "Sentry Organization Auth Token",
+        "required_substrings": [
+          "sntrys_eyJ"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>sntrys_eyJ[0-9A-Za-z_-]{80,8000}=*([0-9A-Za-z_-]{32,256})?)(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6436,6 +11841,46 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Sentry User Auth Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 37,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>sntryu_[0-9a-f]{64})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sntryu_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 37,
+        "name": "Sentry User Auth Token",
+        "required_substrings": [
+          "sntryu_"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>sntryu_[0-9a-f]{64})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6443,6 +11888,54 @@
         "266efa6461dabc4aa9f918ef59c0d7894256bbd87ab7b0f8b98295ede8fceee1"
       ],
       "name": "Discord Bot Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 62,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>[MNO][ADQTgjwz][AEIMQUYcgk][012345wxyz][0-9A-Za-z_-]{20,24}\\.[0-9A-Za-z_-]{6}\\.[0-9A-Za-z_-]{30,40})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": {
+          "flags": 32,
+          "regex": "[0-9A-Za-z_/+-]{15}"
+        },
+        "required_substrings": [
+          "m",
+          "n",
+          "o"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueDiscordBotCheck"
+        ],
+        "min_line_len": 62,
+        "name": "Discord Bot Token",
+        "required_regex": "[0-9A-Za-z_/+-]{15}",
+        "required_substrings": [
+          "M",
+          "N",
+          "O"
+        ],
+        "severity": "high",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>[MNO][ADQTgjwz][AEIMQUYcgk][012345wxyz][0-9A-Za-z_-]{20,24}\\.[0-9A-Za-z_-]{6}\\.[0-9A-Za-z_-]{30,40})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6450,6 +11943,48 @@
         "d1d95e9b2554cfe993d62d95e317f310cedb3b4ce0eaf347273da06572557d4b"
       ],
       "name": "Discord Webhook",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 61,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>discord(?:app)?\\.com/api/webhooks)(?P<value>/[0-9]{16,22}/[0-9A-Za-z_-]{40,100})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "discord.com/api/webhooks",
+          "discordapp.com/api/webhooks"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueMorphemesCheck"
+        ],
+        "min_line_len": 61,
+        "name": "Discord Webhook",
+        "required_substrings": [
+          "discordapp.com/api/webhooks",
+          "discord.com/api/webhooks"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<variable>discord(?:app)?\\.com/api/webhooks)(?P<value>/[0-9]{16,22}/[0-9A-Za-z_-]{40,100})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6460,6 +11995,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Vercel Token",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 60,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>vcp_[0-9A-Za-z]{56})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "vcp_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": "TokenPattern",
+        "min_line_len": 60,
+        "name": "Vercel Token",
+        "required_substrings": [
+          "vcp_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>vcp_[0-9A-Za-z]{56})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6470,6 +12043,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Netlify Token",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 40,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>nfp_[0-9A-Za-z]{36})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "nfp_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": "TokenPattern",
+        "min_line_len": 40,
+        "name": "Netlify Token",
+        "required_substrings": [
+          "nfp_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>nfp_[0-9A-Za-z]{36})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6480,6 +12091,52 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "PostHog Credentials",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 44,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>ph[acrsx]_[0-9A-Za-z]{40,60})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "pha_",
+          "phc_",
+          "phr_",
+          "phs_",
+          "phx_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": "TokenPattern",
+        "min_line_len": 44,
+        "name": "PostHog Credentials",
+        "required_substrings": [
+          "phx_",
+          "phs_",
+          "phr_",
+          "pha_",
+          "phc_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>ph[acrsx]_[0-9A-Za-z]{40,60})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6490,6 +12147,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "RubyGems API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 57,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>rubygems_[0-9a-f]{48})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "rubygems_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 57,
+        "name": "RubyGems API Key",
+        "required_substrings": [
+          "rubygems_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>rubygems_[0-9a-f]{48})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6500,6 +12195,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Databricks Access Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 36,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>dapi[0-9a-f]{32})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "dapi"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 36,
+        "name": "Databricks Access Token",
+        "required_substrings": [
+          "dapi"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>dapi[0-9a-f]{32})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6510,6 +12243,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Tencent WeChat API App ID",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 18,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>wx[0-9a-f]{16})(?![0-9A-Za-z_-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "wx"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": "TokenPattern",
+        "min_line_len": 18,
+        "name": "Tencent WeChat API App ID",
+        "required_substrings": [
+          "wx"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>wx[0-9a-f]{16})(?![0-9A-Za-z_-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6520,6 +12291,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "WunderGraph API Key",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 38,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>cosmo_[0-9a-f]{32})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "cosmo_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 38,
+        "name": "WunderGraph API Key",
+        "required_substrings": [
+          "cosmo_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>cosmo_[0-9a-f]{32})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6530,6 +12339,44 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Supabase Credentials",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 44,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>sbp_(v0_)?[0-9a-f]{40})"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "sbp_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": "TokenPattern",
+        "min_line_len": 44,
+        "name": "Supabase Credentials",
+        "required_substrings": [
+          "sbp_"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>sbp_(v0_)?[0-9a-f]{40})"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6539,6 +12386,50 @@
         "d7dfad4b76abb1ad185fd4cafffbe87677b1e2df4c6ccee415e4e7d2f8e64f2e"
       ],
       "name": "Salesforce Credentials",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 12,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>(3MVG[0-9A-Za-z_.]{24,200}|00D[0-9A-Za-z]{9,15}(![0-9A-Za-z_.]{24,200})?))(?![0-9A-Za-z_.])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "00d",
+          "3mvg"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": [
+          "ValuePatternCheck(9)",
+          "ValueNumberCheck",
+          "ValueBase64PartCheck"
+        ],
+        "min_line_len": 12,
+        "name": "Salesforce Credentials",
+        "required_substrings": [
+          "3MVG",
+          "00D"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?:^|/|[^\\\\0-9A-Za-z+_-]|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<value>(3MVG[0-9A-Za-z_.]{24,200}|00D[0-9A-Za-z]{9,15}(![0-9A-Za-z_.]{24,200})?))(?![0-9A-Za-z_.])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6546,6 +12437,48 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "Postman Credentials",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 29,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>(PMAK-[0-9a-f]{24}-[0-9a-f]{34}|PMAT-[0-9A-Z]{26}))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "pmak-",
+          "pmat-"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": [
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 29,
+        "name": "Postman Credentials",
+        "required_substrings": [
+          "PMAK-",
+          "PMAT-"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>(PMAK-[0-9a-f]{24}-[0-9a-f]{34}|PMAT-[0-9A-Z]{26}))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6554,6 +12487,47 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "NTLM Token",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 160,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value>TlRMTVNTUAADAAAA[=0-9A-Za-z_/+-]{8,8000})(?![0-9A-Za-z_/+-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "tlrmtvntuaadaaaa"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueMorphemesCheck(2)",
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 160,
+        "name": "NTLM Token",
+        "required_substrings": [
+          "TlRMTVNTUAADAAAA"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<value>TlRMTVNTUAADAAAA[=0-9A-Za-z_/+-]{8,8000})(?![0-9A-Za-z_/+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6561,6 +12535,46 @@
         "9fa3da562941b237ed4d8285f6052568f97eae560f670f7c230b18a5f6d9fd69"
       ],
       "name": "Basic Authorization",
+      "runtime": {
+        "confidence": "strong",
+        "min_line_len": 18,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>(?i:basic))(?P<separator>\\s+)(?P<value>[=0-9A-Za-z_/+-]{8,8000})(?![0-9A-Za-z_/+-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "basic"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "strong",
+        "filter_type": [
+          "ValueBasicAuthCheck"
+        ],
+        "min_line_len": 18,
+        "name": "Basic Authorization",
+        "required_substrings": [
+          "basic"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<variable>(?i:basic))(?P<separator>\\s+)(?P<value>[=0-9A-Za-z_/+-]{8,8000})(?![0-9A-Za-z_/+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6582,6 +12596,46 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "Bearer Authorization",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 37,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>(?i:bearer|ntlm))(?P<separator>\\s+)(?P<value>[.0-9A-Za-z_/+-]{32,8000}=*)(?![0-9A-Za-z_/+-])"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "bearer",
+          "ntlm"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "use_ml": false
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 37,
+        "name": "Bearer Authorization",
+        "required_substrings": [
+          "bearer",
+          "ntlm"
+        ],
+        "severity": "medium",
+        "target": [
+          "code",
+          "doc"
+        ],
+        "type": "pattern",
+        "values": [
+          "(?P<variable>(?i:bearer|ntlm))(?P<separator>\\s+)(?P<value>[.0-9A-Za-z_/+-]{32,8000}=*)(?![0-9A-Za-z_/+-])"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6590,6 +12644,50 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "SQL Password",
+      "runtime": {
+        "confidence": "weak",
+        "min_line_len": 8,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(\\\\[nrt]|\\b)(?i:(?P<variable>(CREATE|ALTER|SET\\s{1,8}PASSWORD|INSERT(\\s{1,8}IGNORE)?|UPDATE\\s{1,8}[^\\s;]{1,80})\\s{1,8}(LOGIN|USER|ROLE|FOR|INTO|SET)\\s{1,8}((?!IDENTIFIED|PASSWORD)[^\\s;]{1,80}\\s{1,8}|VALUES\\s{0,8}\\(){1,8}(IDENTIFIED((\\s{1,8}WITH\\s{1,8}\\S{1,80})?\\s{1,8}(BY|AS))|(=|WITH)?\\s{0,8}PASSWORD\\b(\\s{0,8}=)?)))\\s{0,8}(?P<wrap>[(]\\s{0,8})?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4})?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|[^\\s\\\"'`,;\\\\])){3,80})(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote))|(?(wrap)[)]|[\\s\\\"'`,;]))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "identified",
+          "password"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "weak",
+        "filter_type": [
+          "ValueAllowlistCheck",
+          "ValuePatternCheck"
+        ],
+        "min_line_len": 8,
+        "name": "SQL Password",
+        "required_substrings": [
+          "password",
+          "identified"
+        ],
+        "severity": "medium",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(\\\\[nrt]|\\b)(?i:(?P<variable>(CREATE|ALTER|SET\\s{1,8}PASSWORD|INSERT(\\s{1,8}IGNORE)?|UPDATE\\s{1,8}[^\\s;]{1,80})\\s{1,8}(LOGIN|USER|ROLE|FOR|INTO|SET)\\s{1,8}((?!IDENTIFIED|PASSWORD)[^\\s;]{1,80}\\s{1,8}|VALUES\\s{0,8}\\(){1,8}(IDENTIFIED((\\s{1,8}WITH\\s{1,8}\\S{1,80})?\\s{1,8}(BY|AS))|(=|WITH)?\\s{0,8}PASSWORD\\b(\\s{0,8}=)?)))\\s{0,8}(?P<wrap>[(]\\s{0,8})?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4})?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|[^\\s\\\"'`,;\\\\])){3,80})(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote))|(?(wrap)[)]|[\\s\\\"'`,;]))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6611,6 +12709,45 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "CURL User Password",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 16,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>curl)\\s.*(-[uU]|--(proxy-)?user)\\s\\s*(?P<value_leftquote>(\\\\*[\\\"']){1,3})?(?(value_leftquote)[^\\\"'\\\\:]|[^\\s\\\"'\\\\:]){0,64}:(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,64})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "curl"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 16,
+        "name": "CURL User Password",
+        "required_substrings": [
+          "curl"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(?P<variable>curl)\\s.*(-[uU]|--(proxy-)?user)\\s\\s*(?P<value_leftquote>(\\\\*[\\\"']){1,3})?(?(value_leftquote)[^\\\"'\\\\:]|[^\\s\\\"'\\\\:]){0,64}:(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,64})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6632,6 +12769,45 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "CMD ConvertTo-SecureString",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 27,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<variable>ConvertTo-SecureString(\\s\\s*-(String|AsPlainText|Force))*)\\s\\s*(?P<value_leftquote>(\\\\?[\\\"']){1,3})?(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,800})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "convertto-securestring"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 27,
+        "name": "CMD ConvertTo-SecureString",
+        "required_substrings": [
+          "convertto-securestring"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(?P<variable>ConvertTo-SecureString(\\s\\s*-(String|AsPlainText|Force))*)\\s\\s*(?P<value_leftquote>(\\\\?[\\\"']){1,3})?(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,800})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6653,6 +12829,45 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "CMD Password",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 12,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(^|\\W|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<variable>-[A-Za-z_-]*(?i:pass(in|out|word|phrase)))(\\s|\\\\?[\\\"'],)\\s*(?!-)(?P<value_leftquote>(\\\\?[\\\"']){1,3})?(pass:)?(?!file:|env:|fd:)(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,80})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "pass"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 12,
+        "name": "CMD Password",
+        "required_substrings": [
+          "pass"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(^|\\W|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<variable>-[A-Za-z_-]*(?i:pass(in|out|word|phrase)))(\\s|\\\\?[\\\"'],)\\s*(?!-)(?P<value_leftquote>(\\\\?[\\\"']){1,3})?(pass:)?(?!file:|env:|fd:)(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,80})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6674,6 +12889,47 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "CMD Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 12,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(^|\\W|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<variable>-[A-Za-z_-]*(?i:token|oauth2-bearer))(\\s|\\\\?[\\\"'],)\\s*(?!-)(?P<value_leftquote>(\\\\?[\\\"']){1,3})?(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,4000})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "oauth2-bearer",
+          "token"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 12,
+        "name": "CMD Token",
+        "required_substrings": [
+          "token",
+          "oauth2-bearer"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(^|\\W|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<variable>-[A-Za-z_-]*(?i:token|oauth2-bearer))(\\s|\\\\?[\\\"'],)\\s*(?!-)(?P<value_leftquote>(\\\\?[\\\"']){1,3})?(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,4000})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6695,6 +12951,45 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "CMD Secret",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 12,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(^|\\W|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<variable>-[A-Za-z_-]*(?i:secret)[A-Za-z_-]*)(\\s|\\\\?[\\\"'],)\\s*(?!-)(?P<value_leftquote>(\\\\?[\\\"']){1,3})?(pass:)?(?!file:|env:|fd:)(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,4000})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "secret"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 12,
+        "name": "CMD Secret",
+        "required_substrings": [
+          "secret"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(^|\\W|\\\\[0abfnrtv]|(?:%|\\\\x)[0-9A-Fa-f]{2}|\\\\[0-7]{3}|\\\\[Uu][0-9A-Fa-f]{4}|\\x1B\\[[0-9;]{0,80}m)(?P<variable>-[A-Za-z_-]*(?i:secret)[A-Za-z_-]*)(\\s|\\\\?[\\\"'],)\\s*(?!-)(?P<value_leftquote>(\\\\?[\\\"']){1,3})?(pass:)?(?!file:|env:|fd:)(?P<value>(?(value_leftquote)[^\\\"'\\\\]|[^\\s\\\"'\\\\]){4,4000})(?(value_leftquote)(?P<value_rightquote>(\\\\?[\\\"']){1,3}))"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6713,6 +13008,45 @@
         "51203034b5ad491182cd3dced2882f9dd35f175add9364dd1709ab786b501462"
       ],
       "name": "URL Credentials",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 10,
+        "patterns": [
+          {
+            "flags": 32,
+            "regex": "(?P<value_leftquote>[\\\"'])?(?P<variable>[+0-9A-Za-z-]{2,80}://)([^\\s\\'\"<>\\[\\]^~`{|}:/]{0,80}:){1,3}(?P<value>[^\\s\\'\"<>\\[\\]^~`{|}@:/]{3,80})@[^\\s\\'\"<>\\[\\]^~`{|}@:/]{1,800}\\\\{0,8}(?P<value_rightquote>[\\\"'])?"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "://"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "UrlCredentialsGroup",
+        "min_line_len": 10,
+        "name": "URL Credentials",
+        "required_substrings": [
+          "://"
+        ],
+        "severity": "high",
+        "target": [
+          "doc",
+          "code"
+        ],
+        "type": "pattern",
+        "use_ml": true,
+        "values": [
+          "(?P<value_leftquote>[\\\"'])?(?P<variable>[+0-9A-Za-z-]{2,80}://)([^\\s\\'\"<>\\[\\]^~`{|}:/]{0,80}:){1,3}(?P<value>[^\\s\\'\"<>\\[\\]^~`{|}@:/]{3,80})@[^\\s\\'\"<>\\[\\]^~`{|}@:/]{1,800}\\\\{0,8}(?P<value_rightquote>[\\\"'])?"
+        ]
+      },
       "type": "pattern"
     },
     {
@@ -6734,6 +13068,43 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "API",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 11,
+        "patterns": [
+          {
+            "flags": 50,
+            "regex": "(?P<directive>(?:(?:[#%]define|define(?=(\\s|\\\\{1,8}[tnr])*\\()|%global)(?:\\s?\\(|\\s|\\\\{1,8}[tnr]){1,8}|\\bset(?=\\b|\\w*(\\s|\\\\{1,8}[tnr])*\\()))?(?:\\\\[nrt]|(\\\\\\\\*u00|%)[0-9a-f]{2}|\\s)*(?P<variable>(([\\\"'`]{1,8}[^:=\\\"'`}<>\\\\/&?]*|[^:=\\\"'`}<>\\s()\\\\/&?;,%]*)(?P<keyword>api(?!tal))[^%:=\\\"'`<>({?!&;\\n]{0,80})(&(quot|apos|#3[49]);|(\\\\\\\\*u00|%)[0-9a-f]{2}|[\\\"'`])*)(?(directive)|(\\s|\\\\{1,8}[tnr])*\\]?(\\s|\\\\{1,8}[tnr])*)(?P<separator>:(\\s[a-z]{3,9}[?]?\\s)?=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|(?(directive)(,|\\\\t|\\s|\\((?!\\))){1,80}|%3d))(\\s|\\\\{1,8}[tnr])*(?P<wrap>(((\\s|\\\\{1,8}[tnr]|new|byte|char|string|\\[\\]){1,8})?(?P<get>([_a-z][0-9a-z_.\\[\\]]*\\.)get|(os\\.)?getenv)?([0-9a-z_.]|::|-(>|&gt;))*\\s*(\\[(?!\\])|\\((?!\\))|\\{(?!\\}))(\\s|\\\\{1,8}[tnr])*(?(get)('[^']{1,31}'|\\\"[^\\\"]{1,31}\\\")\\s*(,|\\)\\s*or)\\s*|)([0-9a-z_]{1,32}\\s*[:=]\\s*)?){1,8})?(((b|r|br|rb|u|t|f|rf|fr|l|@)(?=(\\\\*[\\\"'`])))?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4}))?(\\s?(oauth|bot|basic|bearer|apikey|accesskey|ssws|ntlm|token)\\s)?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|(?P<url_esc>%[0-9a-f]{2})|(?(url_esc)[^\\s\\\"'`,;\\\\&]|[^\\s\\\"'`,;\\\\]))){4,8000}|(<[^>]{4,8000}>)|(\\$?\\({1,3}[^)]{4,8000}\\){1,3})|(\\$?\\{{1,3}[^}]{4,8000}\\}{1,3})|(?(wrap)(?(value_leftquote)(?!\\\\(?P=value_leftquote))|[^\\]\\)\\}]){16,8000}))(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote)|\\\\$|(?<=[0-9a-z+_/-])$)|(?(wrap)(\\]|\\)|\\}|;|\\\\|$)))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "api"
+        ],
+        "severity": "low",
+        "target": [
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 11,
+        "name": "API",
+        "required_substrings": [
+          "api"
+        ],
+        "severity": "low",
+        "target": [
+          "code"
+        ],
+        "type": "keyword",
+        "use_ml": true,
+        "values": [
+          "api(?!tal)"
+        ]
+      },
       "type": "keyword"
     },
     {
@@ -6755,6 +13126,43 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "Auth",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 12,
+        "patterns": [
+          {
+            "flags": 50,
+            "regex": "(?P<directive>(?:(?:[#%]define|define(?=(\\s|\\\\{1,8}[tnr])*\\()|%global)(?:\\s?\\(|\\s|\\\\{1,8}[tnr]){1,8}|\\bset(?=\\b|\\w*(\\s|\\\\{1,8}[tnr])*\\()))?(?:\\\\[nrt]|(\\\\\\\\*u00|%)[0-9a-f]{2}|\\s)*(?P<variable>(([\\\"'`]{1,8}[^:=\\\"'`}<>\\\\/&?]*|[^:=\\\"'`}<>\\s()\\\\/&?;,%]*)(?P<keyword>auth(?!ors?(?!i[tz])))[^%:=\\\"'`<>({?!&;\\n]{0,80})(&(quot|apos|#3[49]);|(\\\\\\\\*u00|%)[0-9a-f]{2}|[\\\"'`])*)(?(directive)|(\\s|\\\\{1,8}[tnr])*\\]?(\\s|\\\\{1,8}[tnr])*)(?P<separator>:(\\s[a-z]{3,9}[?]?\\s)?=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|(?(directive)(,|\\\\t|\\s|\\((?!\\))){1,80}|%3d))(\\s|\\\\{1,8}[tnr])*(?P<wrap>(((\\s|\\\\{1,8}[tnr]|new|byte|char|string|\\[\\]){1,8})?(?P<get>([_a-z][0-9a-z_.\\[\\]]*\\.)get|(os\\.)?getenv)?([0-9a-z_.]|::|-(>|&gt;))*\\s*(\\[(?!\\])|\\((?!\\))|\\{(?!\\}))(\\s|\\\\{1,8}[tnr])*(?(get)('[^']{1,31}'|\\\"[^\\\"]{1,31}\\\")\\s*(,|\\)\\s*or)\\s*|)([0-9a-z_]{1,32}\\s*[:=]\\s*)?){1,8})?(((b|r|br|rb|u|t|f|rf|fr|l|@)(?=(\\\\*[\\\"'`])))?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4}))?(\\s?(oauth|bot|basic|bearer|apikey|accesskey|ssws|ntlm|token)\\s)?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|(?P<url_esc>%[0-9a-f]{2})|(?(url_esc)[^\\s\\\"'`,;\\\\&]|[^\\s\\\"'`,;\\\\]))){4,8000}|(<[^>]{4,8000}>)|(\\$?\\({1,3}[^)]{4,8000}\\){1,3})|(\\$?\\{{1,3}[^}]{4,8000}\\}{1,3})|(?(wrap)(?(value_leftquote)(?!\\\\(?P=value_leftquote))|[^\\]\\)\\}]){16,8000}))(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote)|\\\\$|(?<=[0-9a-z+_/-])$)|(?(wrap)(\\]|\\)|\\}|;|\\\\|$)))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "auth"
+        ],
+        "severity": "medium",
+        "target": [
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 12,
+        "name": "Auth",
+        "required_substrings": [
+          "auth"
+        ],
+        "severity": "medium",
+        "target": [
+          "code"
+        ],
+        "type": "keyword",
+        "use_ml": true,
+        "values": [
+          "auth(?!ors?(?!i[tz]))"
+        ]
+      },
       "type": "keyword"
     },
     {
@@ -6776,6 +13184,43 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "Credential",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 18,
+        "patterns": [
+          {
+            "flags": 50,
+            "regex": "(?P<directive>(?:(?:[#%]define|define(?=(\\s|\\\\{1,8}[tnr])*\\()|%global)(?:\\s?\\(|\\s|\\\\{1,8}[tnr]){1,8}|\\bset(?=\\b|\\w*(\\s|\\\\{1,8}[tnr])*\\()))?(?:\\\\[nrt]|(\\\\\\\\*u00|%)[0-9a-f]{2}|\\s)*(?P<variable>(([\\\"'`]{1,8}[^:=\\\"'`}<>\\\\/&?]*|[^:=\\\"'`}<>\\s()\\\\/&?;,%]*)(?P<keyword>credential)[^%:=\\\"'`<>({?!&;\\n]{0,80})(&(quot|apos|#3[49]);|(\\\\\\\\*u00|%)[0-9a-f]{2}|[\\\"'`])*)(?(directive)|(\\s|\\\\{1,8}[tnr])*\\]?(\\s|\\\\{1,8}[tnr])*)(?P<separator>:(\\s[a-z]{3,9}[?]?\\s)?=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|(?(directive)(,|\\\\t|\\s|\\((?!\\))){1,80}|%3d))(\\s|\\\\{1,8}[tnr])*(?P<wrap>(((\\s|\\\\{1,8}[tnr]|new|byte|char|string|\\[\\]){1,8})?(?P<get>([_a-z][0-9a-z_.\\[\\]]*\\.)get|(os\\.)?getenv)?([0-9a-z_.]|::|-(>|&gt;))*\\s*(\\[(?!\\])|\\((?!\\))|\\{(?!\\}))(\\s|\\\\{1,8}[tnr])*(?(get)('[^']{1,31}'|\\\"[^\\\"]{1,31}\\\")\\s*(,|\\)\\s*or)\\s*|)([0-9a-z_]{1,32}\\s*[:=]\\s*)?){1,8})?(((b|r|br|rb|u|t|f|rf|fr|l|@)(?=(\\\\*[\\\"'`])))?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4}))?(\\s?(oauth|bot|basic|bearer|apikey|accesskey|ssws|ntlm|token)\\s)?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|(?P<url_esc>%[0-9a-f]{2})|(?(url_esc)[^\\s\\\"'`,;\\\\&]|[^\\s\\\"'`,;\\\\]))){4,8000}|(<[^>]{4,8000}>)|(\\$?\\({1,3}[^)]{4,8000}\\){1,3})|(\\$?\\{{1,3}[^}]{4,8000}\\}{1,3})|(?(wrap)(?(value_leftquote)(?!\\\\(?P=value_leftquote))|[^\\]\\)\\}]){16,8000}))(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote)|\\\\$|(?<=[0-9a-z+_/-])$)|(?(wrap)(\\]|\\)|\\}|;|\\\\|$)))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "credential"
+        ],
+        "severity": "medium",
+        "target": [
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 18,
+        "name": "Credential",
+        "required_substrings": [
+          "credential"
+        ],
+        "severity": "medium",
+        "target": [
+          "code"
+        ],
+        "type": "keyword",
+        "use_ml": true,
+        "values": [
+          "credential"
+        ]
+      },
       "type": "keyword"
     },
     {
@@ -6797,6 +13242,43 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "Key",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 11,
+        "patterns": [
+          {
+            "flags": 50,
+            "regex": "(?P<directive>(?:(?:[#%]define|define(?=(\\s|\\\\{1,8}[tnr])*\\()|%global)(?:\\s?\\(|\\s|\\\\{1,8}[tnr]){1,8}|\\bset(?=\\b|\\w*(\\s|\\\\{1,8}[tnr])*\\()))?(?:\\\\[nrt]|(\\\\\\\\*u00|%)[0-9a-f]{2}|\\s)*(?P<variable>(([\\\"'`]{1,8}[^:=\\\"'`}<>\\\\/&?]*|[^:=\\\"'`}<>\\s()\\\\/&?;,%]*)(?P<keyword>key(?!word|board|pad|name))[^%:=\\\"'`<>({?!&;\\n]{0,80})(&(quot|apos|#3[49]);|(\\\\\\\\*u00|%)[0-9a-f]{2}|[\\\"'`])*)(?(directive)|(\\s|\\\\{1,8}[tnr])*\\]?(\\s|\\\\{1,8}[tnr])*)(?P<separator>:(\\s[a-z]{3,9}[?]?\\s)?=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|(?(directive)(,|\\\\t|\\s|\\((?!\\))){1,80}|%3d))(\\s|\\\\{1,8}[tnr])*(?P<wrap>(((\\s|\\\\{1,8}[tnr]|new|byte|char|string|\\[\\]){1,8})?(?P<get>([_a-z][0-9a-z_.\\[\\]]*\\.)get|(os\\.)?getenv)?([0-9a-z_.]|::|-(>|&gt;))*\\s*(\\[(?!\\])|\\((?!\\))|\\{(?!\\}))(\\s|\\\\{1,8}[tnr])*(?(get)('[^']{1,31}'|\\\"[^\\\"]{1,31}\\\")\\s*(,|\\)\\s*or)\\s*|)([0-9a-z_]{1,32}\\s*[:=]\\s*)?){1,8})?(((b|r|br|rb|u|t|f|rf|fr|l|@)(?=(\\\\*[\\\"'`])))?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4}))?(\\s?(oauth|bot|basic|bearer|apikey|accesskey|ssws|ntlm|token)\\s)?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|(?P<url_esc>%[0-9a-f]{2})|(?(url_esc)[^\\s\\\"'`,;\\\\&]|[^\\s\\\"'`,;\\\\]))){4,8000}|(<[^>]{4,8000}>)|(\\$?\\({1,3}[^)]{4,8000}\\){1,3})|(\\$?\\{{1,3}[^}]{4,8000}\\}{1,3})|(?(wrap)(?(value_leftquote)(?!\\\\(?P=value_leftquote))|[^\\]\\)\\}]){16,8000}))(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote)|\\\\$|(?<=[0-9a-z+_/-])$)|(?(wrap)(\\]|\\)|\\}|;|\\\\|$)))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "key"
+        ],
+        "severity": "high",
+        "target": [
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 11,
+        "name": "Key",
+        "required_substrings": [
+          "key"
+        ],
+        "severity": "high",
+        "target": [
+          "code"
+        ],
+        "type": "keyword",
+        "use_ml": true,
+        "values": [
+          "key(?!word|board|pad|name)"
+        ]
+      },
       "type": "keyword"
     },
     {
@@ -6818,6 +13300,43 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "Nonce",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 13,
+        "patterns": [
+          {
+            "flags": 50,
+            "regex": "(?P<directive>(?:(?:[#%]define|define(?=(\\s|\\\\{1,8}[tnr])*\\()|%global)(?:\\s?\\(|\\s|\\\\{1,8}[tnr]){1,8}|\\bset(?=\\b|\\w*(\\s|\\\\{1,8}[tnr])*\\()))?(?:\\\\[nrt]|(\\\\\\\\*u00|%)[0-9a-f]{2}|\\s)*(?P<variable>(([\\\"'`]{1,8}[^:=\\\"'`}<>\\\\/&?]*|[^:=\\\"'`}<>\\s()\\\\/&?;,%]*)(?P<keyword>(?<!\\\\)nonce)[^%:=\\\"'`<>({?!&;\\n]{0,80})(&(quot|apos|#3[49]);|(\\\\\\\\*u00|%)[0-9a-f]{2}|[\\\"'`])*)(?(directive)|(\\s|\\\\{1,8}[tnr])*\\]?(\\s|\\\\{1,8}[tnr])*)(?P<separator>:(\\s[a-z]{3,9}[?]?\\s)?=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|(?(directive)(,|\\\\t|\\s|\\((?!\\))){1,80}|%3d))(\\s|\\\\{1,8}[tnr])*(?P<wrap>(((\\s|\\\\{1,8}[tnr]|new|byte|char|string|\\[\\]){1,8})?(?P<get>([_a-z][0-9a-z_.\\[\\]]*\\.)get|(os\\.)?getenv)?([0-9a-z_.]|::|-(>|&gt;))*\\s*(\\[(?!\\])|\\((?!\\))|\\{(?!\\}))(\\s|\\\\{1,8}[tnr])*(?(get)('[^']{1,31}'|\\\"[^\\\"]{1,31}\\\")\\s*(,|\\)\\s*or)\\s*|)([0-9a-z_]{1,32}\\s*[:=]\\s*)?){1,8})?(((b|r|br|rb|u|t|f|rf|fr|l|@)(?=(\\\\*[\\\"'`])))?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4}))?(\\s?(oauth|bot|basic|bearer|apikey|accesskey|ssws|ntlm|token)\\s)?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|(?P<url_esc>%[0-9a-f]{2})|(?(url_esc)[^\\s\\\"'`,;\\\\&]|[^\\s\\\"'`,;\\\\]))){4,8000}|(<[^>]{4,8000}>)|(\\$?\\({1,3}[^)]{4,8000}\\){1,3})|(\\$?\\{{1,3}[^}]{4,8000}\\}{1,3})|(?(wrap)(?(value_leftquote)(?!\\\\(?P=value_leftquote))|[^\\]\\)\\}]){16,8000}))(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote)|\\\\$|(?<=[0-9a-z+_/-])$)|(?(wrap)(\\]|\\)|\\}|;|\\\\|$)))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "nonce"
+        ],
+        "severity": "low",
+        "target": [
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 13,
+        "name": "Nonce",
+        "required_substrings": [
+          "nonce"
+        ],
+        "severity": "low",
+        "target": [
+          "code"
+        ],
+        "type": "keyword",
+        "use_ml": true,
+        "values": [
+          "(?<!\\\\)nonce"
+        ]
+      },
       "type": "keyword"
     },
     {
@@ -6842,6 +13361,51 @@
         "c8bba64c98471bc8a7b590549744f8e44be46595e74ac07338bfc48347c9b78c"
       ],
       "name": "Password",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 10,
+        "patterns": [
+          {
+            "flags": 50,
+            "regex": "(?P<directive>(?:(?:[#%]define|define(?=(\\s|\\\\{1,8}[tnr])*\\()|%global)(?:\\s?\\(|\\s|\\\\{1,8}[tnr]){1,8}|\\bset(?=\\b|\\w*(\\s|\\\\{1,8}[tnr])*\\()))?(?:\\\\[nrt]|(\\\\\\\\*u00|%)[0-9a-f]{2}|\\s)*(?P<variable>(([\\\"'`]{1,8}[^:=\\\"'`}<>\\\\/&?]*|[^:=\\\"'`}<>\\s()\\\\/&?;,%]*)(?P<keyword>(?<!by)pass(?!e[dns]|ing|ion|age|\\s+[a-z]{3,80})|(?<!pro|sto)p(s|ss|as)?w(o?r)?d(?!ump)|pswr?\\b|(\\b|_)pw(_|\\b))[^%:=\\\"'`<>({?!&;\\n]{0,80})(&(quot|apos|#3[49]);|(\\\\\\\\*u00|%)[0-9a-f]{2}|[\\\"'`])*)(?(directive)|(\\s|\\\\{1,8}[tnr])*\\]?(\\s|\\\\{1,8}[tnr])*)(?P<separator>:(\\s[a-z]{3,9}[?]?\\s)?=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|(?(directive)(,|\\\\t|\\s|\\((?!\\))){1,80}|%3d))(\\s|\\\\{1,8}[tnr])*(?P<wrap>(((\\s|\\\\{1,8}[tnr]|new|byte|char|string|\\[\\]){1,8})?(?P<get>([_a-z][0-9a-z_.\\[\\]]*\\.)get|(os\\.)?getenv)?([0-9a-z_.]|::|-(>|&gt;))*\\s*(\\[(?!\\])|\\((?!\\))|\\{(?!\\}))(\\s|\\\\{1,8}[tnr])*(?(get)('[^']{1,31}'|\\\"[^\\\"]{1,31}\\\")\\s*(,|\\)\\s*or)\\s*|)([0-9a-z_]{1,32}\\s*[:=]\\s*)?){1,8})?(((b|r|br|rb|u|t|f|rf|fr|l|@)(?=(\\\\*[\\\"'`])))?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4}))?(\\s?(oauth|bot|basic|bearer|apikey|accesskey|ssws|ntlm|token)\\s)?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|(?P<url_esc>%[0-9a-f]{2})|(?(url_esc)[^\\s\\\"'`,;\\\\&]|[^\\s\\\"'`,;\\\\]))){4,8000}|(<[^>]{4,8000}>)|(\\$?\\({1,3}[^)]{4,8000}\\){1,3})|(\\$?\\{{1,3}[^}]{4,8000}\\}{1,3})|(?(wrap)(?(value_leftquote)(?!\\\\(?P=value_leftquote))|[^\\]\\)\\}]){16,8000}))(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote)|\\\\$|(?<=[0-9a-z+_/-])$)|(?(wrap)(\\]|\\)|\\}|;|\\\\|$)))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "pass",
+          "pasw",
+          "pssw",
+          "psw",
+          "pw"
+        ],
+        "severity": "high",
+        "target": [
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "PasswordKeyword",
+        "min_line_len": 10,
+        "name": "Password",
+        "required_substrings": [
+          "pass",
+          "pasw",
+          "pssw",
+          "psw",
+          "pw"
+        ],
+        "severity": "high",
+        "target": [
+          "code"
+        ],
+        "type": "keyword",
+        "use_ml": true,
+        "values": [
+          "(?<!by)pass(?!e[dns]|ing|ion|age|\\s+[a-z]{3,80})|(?<!pro|sto)p(s|ss|as)?w(o?r)?d(?!ump)|pswr?\\b|(\\b|_)pw(_|\\b)"
+        ]
+      },
       "type": "keyword"
     },
     {
@@ -6863,6 +13427,43 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "Salt",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 12,
+        "patterns": [
+          {
+            "flags": 50,
+            "regex": "(?P<directive>(?:(?:[#%]define|define(?=(\\s|\\\\{1,8}[tnr])*\\()|%global)(?:\\s?\\(|\\s|\\\\{1,8}[tnr]){1,8}|\\bset(?=\\b|\\w*(\\s|\\\\{1,8}[tnr])*\\()))?(?:\\\\[nrt]|(\\\\\\\\*u00|%)[0-9a-f]{2}|\\s)*(?P<variable>(([\\\"'`]{1,8}[^:=\\\"'`}<>\\\\/&?]*|[^:=\\\"'`}<>\\s()\\\\/&?;,%]*)(?P<keyword>salt)[^%:=\\\"'`<>({?!&;\\n]{0,80})(&(quot|apos|#3[49]);|(\\\\\\\\*u00|%)[0-9a-f]{2}|[\\\"'`])*)(?(directive)|(\\s|\\\\{1,8}[tnr])*\\]?(\\s|\\\\{1,8}[tnr])*)(?P<separator>:(\\s[a-z]{3,9}[?]?\\s)?=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|(?(directive)(,|\\\\t|\\s|\\((?!\\))){1,80}|%3d))(\\s|\\\\{1,8}[tnr])*(?P<wrap>(((\\s|\\\\{1,8}[tnr]|new|byte|char|string|\\[\\]){1,8})?(?P<get>([_a-z][0-9a-z_.\\[\\]]*\\.)get|(os\\.)?getenv)?([0-9a-z_.]|::|-(>|&gt;))*\\s*(\\[(?!\\])|\\((?!\\))|\\{(?!\\}))(\\s|\\\\{1,8}[tnr])*(?(get)('[^']{1,31}'|\\\"[^\\\"]{1,31}\\\")\\s*(,|\\)\\s*or)\\s*|)([0-9a-z_]{1,32}\\s*[:=]\\s*)?){1,8})?(((b|r|br|rb|u|t|f|rf|fr|l|@)(?=(\\\\*[\\\"'`])))?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4}))?(\\s?(oauth|bot|basic|bearer|apikey|accesskey|ssws|ntlm|token)\\s)?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|(?P<url_esc>%[0-9a-f]{2})|(?(url_esc)[^\\s\\\"'`,;\\\\&]|[^\\s\\\"'`,;\\\\]))){4,8000}|(<[^>]{4,8000}>)|(\\$?\\({1,3}[^)]{4,8000}\\){1,3})|(\\$?\\{{1,3}[^}]{4,8000}\\}{1,3})|(?(wrap)(?(value_leftquote)(?!\\\\(?P=value_leftquote))|[^\\]\\)\\}]){16,8000}))(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote)|\\\\$|(?<=[0-9a-z+_/-])$)|(?(wrap)(\\]|\\)|\\}|;|\\\\|$)))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "salt"
+        ],
+        "severity": "low",
+        "target": [
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 12,
+        "name": "Salt",
+        "required_substrings": [
+          "salt"
+        ],
+        "severity": "low",
+        "target": [
+          "code"
+        ],
+        "type": "keyword",
+        "use_ml": true,
+        "values": [
+          "salt"
+        ]
+      },
       "type": "keyword"
     },
     {
@@ -6884,6 +13485,43 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "Secret",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 14,
+        "patterns": [
+          {
+            "flags": 50,
+            "regex": "(?P<directive>(?:(?:[#%]define|define(?=(\\s|\\\\{1,8}[tnr])*\\()|%global)(?:\\s?\\(|\\s|\\\\{1,8}[tnr]){1,8}|\\bset(?=\\b|\\w*(\\s|\\\\{1,8}[tnr])*\\()))?(?:\\\\[nrt]|(\\\\\\\\*u00|%)[0-9a-f]{2}|\\s)*(?P<variable>(([\\\"'`]{1,8}[^:=\\\"'`}<>\\\\/&?]*|[^:=\\\"'`}<>\\s()\\\\/&?;,%]*)(?P<keyword>secret)[^%:=\\\"'`<>({?!&;\\n]{0,80})(&(quot|apos|#3[49]);|(\\\\\\\\*u00|%)[0-9a-f]{2}|[\\\"'`])*)(?(directive)|(\\s|\\\\{1,8}[tnr])*\\]?(\\s|\\\\{1,8}[tnr])*)(?P<separator>:(\\s[a-z]{3,9}[?]?\\s)?=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|(?(directive)(,|\\\\t|\\s|\\((?!\\))){1,80}|%3d))(\\s|\\\\{1,8}[tnr])*(?P<wrap>(((\\s|\\\\{1,8}[tnr]|new|byte|char|string|\\[\\]){1,8})?(?P<get>([_a-z][0-9a-z_.\\[\\]]*\\.)get|(os\\.)?getenv)?([0-9a-z_.]|::|-(>|&gt;))*\\s*(\\[(?!\\])|\\((?!\\))|\\{(?!\\}))(\\s|\\\\{1,8}[tnr])*(?(get)('[^']{1,31}'|\\\"[^\\\"]{1,31}\\\")\\s*(,|\\)\\s*or)\\s*|)([0-9a-z_]{1,32}\\s*[:=]\\s*)?){1,8})?(((b|r|br|rb|u|t|f|rf|fr|l|@)(?=(\\\\*[\\\"'`])))?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4}))?(\\s?(oauth|bot|basic|bearer|apikey|accesskey|ssws|ntlm|token)\\s)?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|(?P<url_esc>%[0-9a-f]{2})|(?(url_esc)[^\\s\\\"'`,;\\\\&]|[^\\s\\\"'`,;\\\\]))){4,8000}|(<[^>]{4,8000}>)|(\\$?\\({1,3}[^)]{4,8000}\\){1,3})|(\\$?\\{{1,3}[^}]{4,8000}\\}{1,3})|(?(wrap)(?(value_leftquote)(?!\\\\(?P=value_leftquote))|[^\\]\\)\\}]){16,8000}))(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote)|\\\\$|(?<=[0-9a-z+_/-])$)|(?(wrap)(\\]|\\)|\\}|;|\\\\|$)))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "secret"
+        ],
+        "severity": "medium",
+        "target": [
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 14,
+        "name": "Secret",
+        "required_substrings": [
+          "secret"
+        ],
+        "severity": "medium",
+        "target": [
+          "code"
+        ],
+        "type": "keyword",
+        "use_ml": true,
+        "values": [
+          "secret"
+        ]
+      },
       "type": "keyword"
     },
     {
@@ -6905,7 +13543,45 @@
         "5b9ea725802b9f80ee9d2655d8a3c49da1f605540c00bc13b267c6042fb71cbe"
       ],
       "name": "Token",
+      "runtime": {
+        "confidence": "moderate",
+        "min_line_len": 13,
+        "patterns": [
+          {
+            "flags": 50,
+            "regex": "(?P<directive>(?:(?:[#%]define|define(?=(\\s|\\\\{1,8}[tnr])*\\()|%global)(?:\\s?\\(|\\s|\\\\{1,8}[tnr]){1,8}|\\bset(?=\\b|\\w*(\\s|\\\\{1,8}[tnr])*\\()))?(?:\\\\[nrt]|(\\\\\\\\*u00|%)[0-9a-f]{2}|\\s)*(?P<variable>(([\\\"'`]{1,8}[^:=\\\"'`}<>\\\\/&?]*|[^:=\\\"'`}<>\\s()\\\\/&?;,%]*)(?P<keyword>token(?!ize))[^%:=\\\"'`<>({?!&;\\n]{0,80})(&(quot|apos|#3[49]);|(\\\\\\\\*u00|%)[0-9a-f]{2}|[\\\"'`])*)(?(directive)|(\\s|\\\\{1,8}[tnr])*\\]?(\\s|\\\\{1,8}[tnr])*)(?P<separator>:(\\s[a-z]{3,9}[?]?\\s)?=|:(?!:)|=(>|&gt;|(\\\\\\\\*u00|%)26gt;)|!==|!=|===|==|=~|=|(?(directive)(,|\\\\t|\\s|\\((?!\\))){1,80}|%3d))(\\s|\\\\{1,8}[tnr])*(?P<wrap>(((\\s|\\\\{1,8}[tnr]|new|byte|char|string|\\[\\]){1,8})?(?P<get>([_a-z][0-9a-z_.\\[\\]]*\\.)get|(os\\.)?getenv)?([0-9a-z_.]|::|-(>|&gt;))*\\s*(\\[(?!\\])|\\((?!\\))|\\{(?!\\}))(\\s|\\\\{1,8}[tnr])*(?(get)('[^']{1,31}'|\\\"[^\\\"]{1,31}\\\")\\s*(,|\\)\\s*or)\\s*|)([0-9a-z_]{1,32}\\s*[:=]\\s*)?){1,8})?(((b|r|br|rb|u|t|f|rf|fr|l|@)(?=(\\\\*[\\\"'`])))?(?P<value_leftquote>((?P<esq>\\\\{1,8})?([\\\"'`]|&(quot|apos|#3[49]);)){1,4}))?(\\s?(oauth|bot|basic|bearer|apikey|accesskey|ssws|ntlm|token)\\s)?(?P<value>(?(value_leftquote)((?!(?P=value_leftquote))(?(esq)((?!(?P=esq)([\\\"'`]|&(quot|apos|#3[49]);)).)|((?!(?P=value_leftquote)).)))|(?!&(quot|apos|#3[49]);)(\\\\{1,8}([ tnr]|[^\\s\\\"'`])|(?P<url_esc>%[0-9a-f]{2})|(?(url_esc)[^\\s\\\"'`,;\\\\&]|[^\\s\\\"'`,;\\\\]))){4,8000}|(<[^>]{4,8000}>)|(\\$?\\({1,3}[^)]{4,8000}\\){1,3})|(\\$?\\{{1,3}[^}]{4,8000}\\}{1,3})|(?(wrap)(?(value_leftquote)(?!\\\\(?P=value_leftquote))|[^\\]\\)\\}]){16,8000}))(?(value_leftquote)(?P<value_rightquote>(?<!\\\\)(?P=value_leftquote)|\\\\$|(?<=[0-9a-z+_/-])$)|(?(wrap)(\\]|\\)|\\}|;|\\\\|$)))"
+          }
+        ],
+        "required_regex": null,
+        "required_substrings": [
+          "token"
+        ],
+        "severity": "high",
+        "target": [
+          "code"
+        ],
+        "use_ml": true
+      },
+      "source": {
+        "confidence": "moderate",
+        "filter_type": "GeneralKeyword",
+        "min_line_len": 13,
+        "name": "Token",
+        "required_substrings": [
+          "token"
+        ],
+        "severity": "high",
+        "target": [
+          "code"
+        ],
+        "type": "keyword",
+        "use_ml": true,
+        "values": [
+          "token(?!ize)"
+        ]
+      },
       "type": "keyword"
     }
-  ]
+  ],
+  "schema": 2
 }

--- a/website/src/content/docs/protection/detectors.md
+++ b/website/src/content/docs/protection/detectors.md
@@ -24,6 +24,21 @@ implementation consumes pinned upstream assets and reimplements their behavior
 in Rust. “CredSweeper-derived” therefore does not mean that every future,
 unseen, or unsupported input is proven identical to official CredSweeper.
 
+The binary embeds unchanged copies of the pinned upstream rule and scanner
+configuration, keyword and morpheme checklists, ONNX model and model
+configuration, and license. Rust code independently performs rule parsing,
+keyword-pattern expansion, candidate and line construction, regular-expression
+matching, filter-group expansion and filter execution, path and target checks,
+multiline and PEM handling, ML feature extraction and inference, and output-span
+construction. The official Python implementation is an Actions oracle; it is
+not installed or used by the released binary.
+
+The version-bound compatibility inventory records every source rule, its
+expanded runtime state, filter and filter group, rule type, ML-gated rule, model
+configuration, and configured candidate and line-data output field. Automated
+upstream updates regenerate that inventory and must pass the native/oracle gates
+before opening a pull request.
+
 ## Pentect-maintained detectors
 
 These detectors are maintained in this repository. They must not be attributed


### PR DESCRIPTION
## Summary

- expand the version-bound official inventory from rule names/types/filter IDs to complete source and expanded runtime rule state
- inventory filter groups, special rule types, ML-gated rules and model configuration, and configured output fields
- reject internally incomplete or inconsistent inventories in the required compatibility gate
- document the exact boundary between embedded upstream assets and independently implemented Rust behavior

## Root cause

The original inventory omitted patterns, severity, confidence, targets, required context, minimum lengths, ML gating, and the original `filter_type`. In particular, retaining only expanded filter IDs discarded filter-group identity—the same class of information whose loss previously caused the native `GeneralPattern` divergence. It also had no machine-readable record of keyword/multi/PEM paths or official output fields.

## Verification

- generated inventory: 134 rules, 43 filter classes, 6 used filter groups
- rule types: 120 pattern, 9 keyword, 4 multi, 1 PEM
- ML inventory: 23 gated rules plus pinned model configuration
- output inventory: 5 candidate fields and 11 line-data fields
- official tests: 425 passed
- native/oracle filter parity: 12,950 probes, 43/43 classes, 0 mismatches
- `npm run build`: 42 pages, 42 agent-readable pages, 113 internal links
- Python compilation and `git diff --check`

## Scope

This advances #399 but does not close it. A machine-readable surface does not itself prove every whole-pipeline behavior. Production disagreement fallback/rollback, additional malformed/Unicode/path-sensitive end-to-end fixtures, and release evidence publication remain open.

Refs #399
