### PR TITLE
ci: publish CredSweeper release evidence

### DIFF
--- a/.github/workflows/credsweeper-regression.yml
+++ b/.github/workflows/credsweeper-regression.yml
@@ -25,6 +25,8 @@ on:
       - 'tools/credsweeper-rust-port-status.json'
       - 'tools/creddata_shards.py'
       - 'tools/test_creddata_shards.py'
+      - 'tools/test_verify_credsweeper_evidence.py'
+      - 'tools/verify_credsweeper_evidence.py'
       - 'tools/credsweeper-sidecar/**'
       - 'tools/pentect-bench/**'
       - 'tools/update_credsweeper.py'
@@ -49,6 +51,8 @@ on:
       - 'tools/credsweeper-rust-port-status.json'
       - 'tools/creddata_shards.py'
       - 'tools/test_creddata_shards.py'
+      - 'tools/test_verify_credsweeper_evidence.py'
+      - 'tools/verify_credsweeper_evidence.py'
       - 'tools/credsweeper-sidecar/**'
       - 'tools/pentect-bench/**'
       - 'tools/update_credsweeper.py'
@@ -57,6 +61,10 @@ on:
     inputs:
       full:
         description: Run the full 333-repository parity matrix
+        type: boolean
+        default: false
+      sync_latest:
+        description: Test the latest upstream release instead of the version pinned by this ref
         type: boolean
         default: false
 
@@ -119,7 +127,7 @@ jobs:
           python-version: "3.12"
 
       - name: Test CredData shard tooling
-        run: python -m unittest tools/test_creddata_shards.py tools/test_update_credsweeper.py
+        run: python -m unittest tools/test_creddata_shards.py tools/test_update_credsweeper.py tools/test_verify_credsweeper_evidence.py
 
       - name: Install official CredSweeper oracle dependencies
         run: |
@@ -260,6 +268,7 @@ jobs:
           python-version: "3.12"
 
       - name: Sync latest CredSweeper release
+        if: github.event_name == 'schedule' || inputs.sync_latest
         # The parity build and exact oracle comparison below are the validation.
         # Avoid compiling and testing the same Rust code twice in every shard.
         run: python tools/update_credsweeper.py latest --skip-validation
@@ -341,7 +350,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Sync latest CredSweeper release for the scheduled audit
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || inputs.sync_latest
         run: python tools/update_credsweeper.py latest --skip-validation
       - name: Install official CredSweeper oracle dependencies
         run: |
@@ -392,7 +401,7 @@ jobs:
   weekly-summary:
     name: Weekly full CredData parity
     if: always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.full))
-    needs: weekly-parity
+    needs: [weekly-parity, full-filter-parity]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -406,15 +415,31 @@ jobs:
           path: ${{ runner.temp }}/weekly-parity
       - name: Verify complete CredData coverage and parity
         run: |
+          test '${{ needs.weekly-parity.result }}' = success
+          test '${{ needs.full-filter-parity.result }}' = success
           python tools/creddata_shards.py summarize \
             --root benchmarks/CredData \
             --artifacts "$RUNNER_TEMP/weekly-parity" \
             --count 16 \
-            --output "$RUNNER_TEMP/weekly-parity-summary.json"
-          test '${{ needs.weekly-parity.result }}' = success
+            --output "$RUNNER_TEMP/pentect-credsweeper-compatibility.json" \
+            --pentect-commit "$GITHUB_SHA" \
+            --tested-ref "$GITHUB_REF_NAME" \
+            --credsweeper-commit "$(git -C crates/pentect-core/vendors/CredSweeper rev-parse HEAD)" \
+            --creddata-commit "$(git -C benchmarks/CredData rev-parse HEAD)" \
+            --tested-at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --runner-os "$RUNNER_OS" \
+            --runner-arch "$RUNNER_ARCH" \
+            --workflow-run "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
       - name: Publish summary
         if: always()
         run: |
-          if [ -f "$RUNNER_TEMP/weekly-parity-summary.json" ]; then
-            cat "$RUNNER_TEMP/weekly-parity-summary.json" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$RUNNER_TEMP/pentect-credsweeper-compatibility.json" ]; then
+            cat "$RUNNER_TEMP/pentect-credsweeper-compatibility.json" >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Upload compatibility evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: credsweeper-compatibility-evidence
+          path: ${{ runner.temp }}/pentect-credsweeper-compatibility.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/release-guard.yml
+++ b/.github/workflows/release-guard.yml
@@ -26,6 +26,7 @@ jobs:
           required=(
             LICENSE
             THIRD_PARTY_LICENSES.txt
+            pentect-credsweeper-compatibility.json
             pentect-windows-x86_64.exe
             pentect-windows-x86_64.exe.gz
             pentect-windows-x86_64.exe.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,8 @@ jobs:
           bash -n .github/scripts/publish-aur.sh
           python tools/test_client_smoke_coverage.py
           python tools/test_release_package_metadata.py
-          python -m py_compile tools/client_smoke.py tools/install_portable_client_smoke.py tools/test_client_smoke_coverage.py tools/test_release_package_metadata.py tools/verify_client_smoke_log.py
+          python -m unittest tools/test_creddata_shards.py tools/test_verify_credsweeper_evidence.py
+          python -m py_compile tools/client_smoke.py tools/creddata_shards.py tools/install_portable_client_smoke.py tools/test_client_smoke_coverage.py tools/test_release_package_metadata.py tools/test_verify_credsweeper_evidence.py tools/verify_client_smoke_log.py tools/verify_credsweeper_evidence.py
           cc -std=c11 -Wall -Wextra -Werror tools/codex-app-smoke-fixture.c -o "$RUNNER_TEMP/codex-app-smoke-fixture"
           cc -std=c11 -Wall -Wextra -Werror tools/claude-app-smoke-fixture.c -o "$RUNNER_TEMP/claude-app-smoke-fixture"
           node --check tools/smoke_pi_package.mjs
@@ -106,6 +107,92 @@ jobs:
           path: |
             LICENSE
             THIRD_PARTY_LICENSES.txt
+          if-no-files-found: error
+          retention-days: 7
+
+  credsweeper-evidence:
+    name: CredSweeper release evidence
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 130
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - name: Run full parity for the exact release commit
+        id: parity
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow credsweeper-regression.yml \
+            --event workflow_dispatch \
+            --commit "$GITHUB_SHA" \
+            --limit 100 \
+            --json databaseId \
+            --jq '.[].databaseId' > "$RUNNER_TEMP/parity-runs-before"
+          gh workflow run credsweeper-regression.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$GITHUB_REF_NAME" \
+            -f full=true \
+            -f sync_latest=false
+
+          run_id=""
+          for _ in $(seq 1 30); do
+            while IFS= read -r candidate; do
+              if ! grep -Fxq "$candidate" "$RUNNER_TEMP/parity-runs-before"; then
+                run_id="$candidate"
+                break
+              fi
+            done < <(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow credsweeper-regression.yml \
+              --event workflow_dispatch \
+              --commit "$GITHUB_SHA" \
+              --limit 20 \
+              --json databaseId \
+              --jq '.[].databaseId')
+            test -n "$run_id" && break
+            sleep 2
+          done
+          if test -z "$run_id"; then
+            echo "Could not locate the dispatched CredSweeper parity run" >&2
+            exit 1
+          fi
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "Full release parity: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$run_id" \
+            >> "$GITHUB_STEP_SUMMARY"
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+      - name: Download and verify release evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PARITY_RUN_ID: ${{ steps.parity.outputs.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir evidence
+          gh run download "$PARITY_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name credsweeper-compatibility-evidence \
+            --dir evidence
+          python tools/verify_credsweeper_evidence.py \
+            evidence/pentect-credsweeper-compatibility.json \
+            --source crates/pentect-core/vendors/credsweeper-assets/SOURCE.json \
+            --creddata-snapshot benchmarks/CredData/snapshot.json \
+            --pentect-commit "$GITHUB_SHA" \
+            --tested-ref "$GITHUB_REF_NAME" \
+            --creddata-commit "$(git -C benchmarks/CredData rev-parse HEAD)"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: credsweeper-compatibility-evidence
+          path: evidence/pentect-credsweeper-compatibility.json
           if-no-files-found: error
           retention-days: 7
 
@@ -368,7 +455,7 @@ jobs:
           retention-days: 7
 
   publish:
-    needs: [build, compatibility-cli, package-deb]
+    needs: [build, compatibility-cli, package-deb, credsweeper-evidence]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -382,6 +469,10 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-notices
+          path: dist
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: credsweeper-compatibility-evidence
           path: dist
       - name: Stage prerelease
         env:

--- a/tools/creddata_shards.py
+++ b/tools/creddata_shards.py
@@ -90,7 +90,21 @@ def prepare(root: Path, index: int, count: int, manifest: Path, version: str) ->
     print(f"prepared CredData shard {index + 1}/{count}: {len(selected)} repositories")
 
 
-def summarize(root: Path, artifacts: Path, count: int, output: Path) -> None:
+def summarize(
+    root: Path,
+    artifacts: Path,
+    count: int,
+    output: Path,
+    *,
+    pentect_commit: str,
+    tested_ref: str,
+    credsweeper_commit: str,
+    creddata_commit: str,
+    tested_at: str,
+    runner_os: str,
+    runner_arch: str,
+    workflow_run: str,
+) -> None:
     expected: dict[str, str] = load_json(root / "snapshot.json")
     manifests = sorted(artifacts.glob("shard-*/manifest.json"))
     reports = sorted(artifacts.glob("shard-*/report.json"))
@@ -104,6 +118,8 @@ def summarize(root: Path, artifacts: Path, count: int, output: Path) -> None:
     totals = {key: 0 for key in ("rust", "oracle", "common", "missing", "extra")}
     by_rule: dict[str, dict[str, int]] = {}
     versions: set[str] = set()
+    ml_tolerances: set[float] = set()
+    ml_probability_max_delta = 0.0
     metadata_files = 0
     for manifest_path in manifests:
         manifest = load_json(manifest_path)
@@ -133,6 +149,10 @@ def summarize(root: Path, artifacts: Path, count: int, output: Path) -> None:
             raise SystemExit(f"CredSweeper mismatch in shard {index}: {report_path}")
         if not bool(report["ml_probability_within_tolerance"]):
             raise SystemExit(f"ML probability mismatch in shard {index}: {report_path}")
+        ml_probability_max_delta = max(
+            ml_probability_max_delta, float(report["ml_probability_max_delta"])
+        )
+        ml_tolerances.add(float(report["ml_probability_tolerance"]))
 
     expected_repositories = set(expected)
     missing = expected_repositories - seen_repositories
@@ -145,13 +165,39 @@ def summarize(root: Path, artifacts: Path, count: int, output: Path) -> None:
         raise SystemExit(f"shard index coverage mismatch: {sorted(seen_indices)}")
     if len(versions) != 1:
         raise SystemExit(f"shards used different CredSweeper versions: {sorted(versions)}")
+    if len(ml_tolerances) != 1:
+        raise SystemExit(f"shards used different ML tolerances: {sorted(ml_tolerances)}")
 
+    credsweeper_version = versions.pop()
     summary = {
-        "schema": 2,
+        "schema": 3,
+        "generated_at": tested_at,
+        "pentect": {"commit": pentect_commit, "ref": tested_ref},
+        "reference": {
+            "name": "CredSweeper",
+            "version": credsweeper_version,
+            "commit": credsweeper_commit,
+        },
+        "corpus": {
+            "name": "CredData",
+            "commit": creddata_commit,
+            "repositories": len(seen_repositories),
+            "metadata_files": metadata_files,
+        },
+        "environment": {"os": runner_os, "architecture": runner_arch},
+        "workflow_run": workflow_run,
+        "gates": {
+            "full_creddata_parity": True,
+            "full_filter_inventory_parity": True,
+            "whole_pipeline_fixtures": True,
+        },
         "shards": count,
         "repositories": len(seen_repositories),
         "metadata_files": metadata_files,
-        "credsweeper_version": versions.pop(),
+        "credsweeper_version": credsweeper_version,
+        "ml_probability_max_delta": ml_probability_max_delta,
+        "ml_probability_tolerance": ml_tolerances.pop(),
+        "ml_probability_within_tolerance": True,
         "by_rule": dict(sorted(by_rule.items())),
         **totals,
     }
@@ -173,6 +219,14 @@ def parse_args() -> argparse.Namespace:
     summary_parser.add_argument("--artifacts", type=Path, required=True)
     summary_parser.add_argument("--count", type=int, required=True)
     summary_parser.add_argument("--output", type=Path, required=True)
+    summary_parser.add_argument("--pentect-commit", required=True)
+    summary_parser.add_argument("--tested-ref", required=True)
+    summary_parser.add_argument("--credsweeper-commit", required=True)
+    summary_parser.add_argument("--creddata-commit", required=True)
+    summary_parser.add_argument("--tested-at", required=True)
+    summary_parser.add_argument("--runner-os", required=True)
+    summary_parser.add_argument("--runner-arch", required=True)
+    summary_parser.add_argument("--workflow-run", required=True)
     return parser.parse_args()
 
 
@@ -187,7 +241,20 @@ def main() -> None:
             args.credsweeper_version,
         )
     else:
-        summarize(args.root, args.artifacts, args.count, args.output)
+        summarize(
+            args.root,
+            args.artifacts,
+            args.count,
+            args.output,
+            pentect_commit=args.pentect_commit,
+            tested_ref=args.tested_ref,
+            credsweeper_commit=args.credsweeper_commit,
+            creddata_commit=args.creddata_commit,
+            tested_at=args.tested_at,
+            runner_os=args.runner_os,
+            runner_arch=args.runner_arch,
+            workflow_run=args.workflow_run,
+        )
 
 
 if __name__ == "__main__":

--- a/tools/test_creddata_shards.py
+++ b/tools/test_creddata_shards.py
@@ -48,6 +48,8 @@ class CredDataShardsTest(unittest.TestCase):
                         "common": repository_count,
                         "missing": 0,
                         "extra": 0,
+                        "ml_probability_max_delta": 0.00001,
+                        "ml_probability_tolerance": 0.0001,
                         "ml_probability_within_tolerance": True,
                         "by_rule": {
                             "Test Rule": {
@@ -62,14 +64,39 @@ class CredDataShardsTest(unittest.TestCase):
                 )
 
             output = workspace / "summary.json"
-            creddata_shards.summarize(source, artifacts, count=3, output=output)
+            creddata_shards.summarize(
+                source,
+                artifacts,
+                count=3,
+                output=output,
+                pentect_commit="a" * 40,
+                tested_ref="v9.8.7",
+                credsweeper_commit="b" * 40,
+                creddata_commit="c" * 40,
+                tested_at="2026-08-30T00:00:00Z",
+                runner_os="Linux",
+                runner_arch="X64",
+                workflow_run="https://github.com/example/project/actions/runs/123",
+            )
             summary = json.loads(output.read_text())
             self.assertEqual(summary["repositories"], len(snapshot))
             self.assertEqual(summary["shards"], 3)
             self.assertEqual(summary["credsweeper_version"], "v1.2.3")
             self.assertEqual(summary["missing"], 0)
             self.assertEqual(summary["extra"], 0)
-            self.assertEqual(summary["schema"], 2)
+            self.assertEqual(summary["schema"], 3)
+            self.assertEqual(summary["pentect"]["commit"], "a" * 40)
+            self.assertEqual(summary["pentect"]["ref"], "v9.8.7")
+            self.assertEqual(summary["reference"]["version"], "v1.2.3")
+            self.assertEqual(summary["reference"]["commit"], "b" * 40)
+            self.assertEqual(summary["corpus"]["commit"], "c" * 40)
+            self.assertEqual(
+                summary["environment"], {"os": "Linux", "architecture": "X64"}
+            )
+            self.assertTrue(all(summary["gates"].values()))
+            self.assertEqual(summary["ml_probability_max_delta"], 0.00001)
+            self.assertEqual(summary["ml_probability_tolerance"], 0.0001)
+            self.assertTrue(summary["ml_probability_within_tolerance"])
             rule = summary["by_rule"]["Test Rule"]
             self.assertEqual(rule["rust"], len(snapshot))
             self.assertEqual(rule["oracle"], len(snapshot))

--- a/tools/test_verify_credsweeper_evidence.py
+++ b/tools/test_verify_credsweeper_evidence.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from tools.verify_credsweeper_evidence import verify
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class VerifyCredSweeperEvidenceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.source = self.root / "SOURCE.json"
+        self.snapshot = self.root / "snapshot.json"
+        self.evidence = self.root / "evidence.json"
+        self.write(self.source, {"version": "v1.2.3", "commit": "b" * 40})
+        self.write(self.snapshot, {"1" * 64: "https://example.test/repository"})
+        self.valid = {
+            "schema": 3,
+            "generated_at": "2026-08-30T00:00:00Z",
+            "pentect": {"commit": "a" * 40, "ref": "v9.8.7"},
+            "reference": {
+                "name": "CredSweeper",
+                "version": "v1.2.3",
+                "commit": "b" * 40,
+            },
+            "corpus": {
+                "name": "CredData",
+                "commit": "c" * 40,
+                "repositories": 1,
+                "metadata_files": 2,
+            },
+            "environment": {"os": "Linux", "architecture": "X64"},
+            "workflow_run": "https://github.com/example/project/actions/runs/123",
+            "gates": {
+                "full_creddata_parity": True,
+                "full_filter_inventory_parity": True,
+                "whole_pipeline_fixtures": True,
+            },
+            "shards": 16,
+            "repositories": 1,
+            "metadata_files": 2,
+            "credsweeper_version": "v1.2.3",
+            "ml_probability_max_delta": 0.00001,
+            "ml_probability_tolerance": 0.0001,
+            "ml_probability_within_tolerance": True,
+            "rust": 1,
+            "oracle": 1,
+            "common": 1,
+            "missing": 0,
+            "extra": 0,
+            "by_rule": {
+                "Test Rule": {
+                    "rust": 1,
+                    "oracle": 1,
+                    "common": 1,
+                    "missing": 0,
+                    "extra": 0,
+                }
+            },
+        }
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_accepts_exact_release_evidence(self) -> None:
+        self.write(self.evidence, self.valid)
+        self.verify()
+
+    def test_rejects_a_different_release_commit(self) -> None:
+        self.write(self.evidence, self.valid)
+        with self.assertRaisesRegex(SystemExit, "commit or ref"):
+            verify(
+                self.evidence,
+                self.source,
+                self.snapshot,
+                pentect_commit="d" * 40,
+                tested_ref="v9.8.7",
+                creddata_commit="c" * 40,
+            )
+
+    def test_rejects_a_rule_gap(self) -> None:
+        self.valid["by_rule"]["Test Rule"]["missing"] = 1
+        self.write(self.evidence, self.valid)
+        with self.assertRaisesRegex(SystemExit, "differ for rule"):
+            self.verify()
+
+    def test_rejects_unapproved_fields_that_could_contain_values(self) -> None:
+        self.valid["examples"] = ["not-safe-for-release"]
+        self.write(self.evidence, self.valid)
+        with self.assertRaisesRegex(SystemExit, "unapproved data"):
+            self.verify()
+
+    def test_release_workflow_requires_and_publishes_exact_commit_evidence(self) -> None:
+        regression = (ROOT / ".github/workflows/credsweeper-regression.yml").read_text(
+            encoding="utf-8"
+        )
+        release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        guard = (ROOT / ".github/workflows/release-guard.yml").read_text(encoding="utf-8")
+        self.assertIn("sync_latest:", regression)
+        self.assertIn("name: credsweeper-compatibility-evidence", regression)
+        self.assertIn("-f sync_latest=false", release)
+        self.assertIn(
+            "needs: [build, compatibility-cli, package-deb, credsweeper-evidence]",
+            release,
+        )
+        self.assertIn("name: credsweeper-compatibility-evidence", release)
+        self.assertIn("pentect-credsweeper-compatibility.json", guard)
+
+    def verify(self) -> None:
+        verify(
+            self.evidence,
+            self.source,
+            self.snapshot,
+            pentect_commit="a" * 40,
+            tested_ref="v9.8.7",
+            creddata_commit="c" * 40,
+        )
+
+    @staticmethod
+    def write(path: Path, value: object) -> None:
+        path.write_text(json.dumps(value), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/verify_credsweeper_evidence.py
+++ b/tools/verify_credsweeper_evidence.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Validate value-free CredSweeper compatibility evidence for a release."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Any
+
+
+TOTAL_FIELDS = ("rust", "oracle", "common", "missing", "extra")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"invalid CredSweeper compatibility evidence: {message}")
+
+
+def require_object(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(f"{name} must be an object")
+    return value
+
+
+def verify(
+    evidence_path: Path,
+    source_path: Path,
+    creddata_snapshot: Path,
+    *,
+    pentect_commit: str,
+    tested_ref: str,
+    creddata_commit: str,
+) -> None:
+    evidence = require_object(
+        json.loads(evidence_path.read_text(encoding="utf-8")), "root"
+    )
+    source = require_object(json.loads(source_path.read_text(encoding="utf-8")), "source")
+    snapshot = require_object(
+        json.loads(creddata_snapshot.read_text(encoding="utf-8")), "CredData snapshot"
+    )
+
+    if evidence.get("schema") != 3:
+        fail("schema must be 3")
+    expected_fields = {
+        "schema",
+        "generated_at",
+        "pentect",
+        "reference",
+        "corpus",
+        "environment",
+        "workflow_run",
+        "gates",
+        "shards",
+        "repositories",
+        "metadata_files",
+        "credsweeper_version",
+        "ml_probability_max_delta",
+        "ml_probability_tolerance",
+        "ml_probability_within_tolerance",
+        "by_rule",
+        *TOTAL_FIELDS,
+    }
+    if set(evidence) != expected_fields:
+        fail("top-level fields are incomplete or contain unapproved data")
+    pentect = require_object(evidence.get("pentect"), "pentect")
+    if pentect != {"commit": pentect_commit, "ref": tested_ref}:
+        fail("Pentect commit or ref does not match the release")
+    reference = require_object(evidence.get("reference"), "reference")
+    if set(reference) != {"name", "version", "commit"}:
+        fail("reference fields are incomplete or contain unapproved data")
+    if reference.get("name") != "CredSweeper":
+        fail("oracle name is not CredSweeper")
+    if reference.get("version") != source.get("version"):
+        fail("CredSweeper version does not match the embedded source metadata")
+    if reference.get("commit") != source.get("commit"):
+        fail("CredSweeper commit does not match the embedded source metadata")
+    if evidence.get("credsweeper_version") != reference.get("version"):
+        fail("duplicate CredSweeper version fields differ")
+
+    corpus = require_object(evidence.get("corpus"), "corpus")
+    if set(corpus) != {"name", "commit", "repositories", "metadata_files"}:
+        fail("corpus fields are incomplete or contain unapproved data")
+    if corpus.get("name") != "CredData" or corpus.get("commit") != creddata_commit:
+        fail("CredData identity does not match the release checkout")
+    if corpus.get("repositories") != len(snapshot):
+        fail("CredData repository count does not match the pinned snapshot")
+    if corpus.get("repositories") != evidence.get("repositories"):
+        fail("top-level and corpus repository counts differ")
+    if corpus.get("metadata_files") != evidence.get("metadata_files"):
+        fail("top-level and corpus metadata counts differ")
+    for name in ("shards", "repositories", "metadata_files"):
+        value = evidence.get(name)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            fail(f"{name} must be a positive integer")
+
+    gates = require_object(evidence.get("gates"), "gates")
+    required_gates = {
+        "full_creddata_parity",
+        "full_filter_inventory_parity",
+        "whole_pipeline_fixtures",
+    }
+    if set(gates) != required_gates or any(value is not True for value in gates.values()):
+        fail("not every required compatibility gate passed")
+
+    totals = {name: evidence.get(name) for name in TOTAL_FIELDS}
+    if not all(
+        not isinstance(value, bool) and isinstance(value, int) and value >= 0
+        for value in totals.values()
+    ):
+        fail("finding totals must be non-negative integers")
+    if totals["missing"] != 0 or totals["extra"] != 0:
+        fail("native and official findings differ")
+    if not totals["rust"] == totals["oracle"] == totals["common"]:
+        fail("native, official, and common totals differ")
+    ml_delta = evidence.get("ml_probability_max_delta")
+    ml_tolerance = evidence.get("ml_probability_tolerance")
+    if (
+        isinstance(ml_delta, bool)
+        or not isinstance(ml_delta, (int, float))
+        or isinstance(ml_tolerance, bool)
+        or not isinstance(ml_tolerance, (int, float))
+    ):
+        fail("ML probability evidence is missing")
+    if ml_delta < 0 or ml_tolerance < 0 or ml_delta > ml_tolerance:
+        fail("ML probability delta exceeds tolerance")
+    if evidence.get("ml_probability_within_tolerance") is not True:
+        fail("ML probability gate did not pass")
+
+    by_rule = require_object(evidence.get("by_rule"), "by_rule")
+    if not by_rule:
+        fail("per-rule evidence is empty")
+    for rule, raw_counts in by_rule.items():
+        counts = require_object(raw_counts, f"by_rule[{rule!r}]")
+        if set(counts) != set(TOTAL_FIELDS):
+            fail(f"unexpected fields in per-rule evidence for {rule!r}")
+        if any(
+            isinstance(counts[name], bool)
+            or not isinstance(counts[name], int)
+            or counts[name] < 0
+            for name in TOTAL_FIELDS
+        ):
+            fail(f"invalid counts for rule {rule!r}")
+        if counts["missing"] or counts["extra"]:
+            fail(f"native and official findings differ for rule {rule!r}")
+
+    environment = require_object(evidence.get("environment"), "environment")
+    if set(environment) != {"os", "architecture"}:
+        fail("environment fields are incomplete or contain unapproved data")
+    if not environment.get("os") or not environment.get("architecture"):
+        fail("runner OS and architecture are required")
+    generated_at = evidence.get("generated_at")
+    if not isinstance(generated_at, str):
+        fail("generated_at is required")
+    try:
+        datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError:
+        fail("generated_at is not an ISO-8601 timestamp")
+    if not generated_at.endswith("Z"):
+        fail("generated_at must be UTC")
+    workflow_run = evidence.get("workflow_run")
+    if not isinstance(workflow_run, str) or "/actions/runs/" not in workflow_run:
+        fail("workflow run URL is missing")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("evidence", type=Path)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--creddata-snapshot", type=Path, required=True)
+    parser.add_argument("--pentect-commit", required=True)
+    parser.add_argument("--tested-ref", required=True)
+    parser.add_argument("--creddata-commit", required=True)
+    args = parser.parse_args()
+    verify(
+        args.evidence,
+        args.source,
+        args.creddata_snapshot,
+        pentect_commit=args.pentect_commit,
+        tested_ref=args.tested_ref,
+        creddata_commit=args.creddata_commit,
+    )
+    print("CredSweeper compatibility evidence matches the release")
+
+
+if __name__ == "__main__":
+    main()

--- a/website/src/content/docs/protection/detectors.md
+++ b/website/src/content/docs/protection/detectors.md
@@ -39,6 +39,14 @@ configuration, and configured candidate and line-data output field. Automated
 upstream updates regenerate that inventory and must pass the native/oracle gates
 before opening a pull request.
 
+Every stable release also runs the full 333-repository comparison and the
+complete filter/inventory and whole-pipeline fixture gates against the exact
+tagged commit. A value-free `pentect-credsweeper-compatibility.json` release
+asset records the tagged Pentect commit, pinned CredSweeper and CredData
+revisions, test date, runner platform, finding totals, bounded ML difference,
+and per-rule gaps. Release publication stops if the evidence does not match the
+tag or either implementation reports a finding the other one does not.
+
 ## Pentect-maintained detectors
 
 These detectors are maintained in this repository. They must not be attributed


### PR DESCRIPTION
## Root cause

Full native/oracle parity evidence existed only as an ephemeral Actions step summary. It did not record the exact Pentect commit, CredData revision, runner platform, or test date, and no evidence was attached to releases. In addition, manually dispatched full parity always synchronized the latest upstream CredSweeper release, so reusing it for a release tag could validate a different detector version than the one embedded in that release.

## Changes

- add an explicit `sync_latest` input; exact-ref validation keeps the version pinned by that ref
- aggregate full parity into a strict, value-free schema containing the Pentect ref/commit, CredSweeper and CredData revisions, timestamp, OS/architecture, finding counts, ML delta/tolerance, and per-rule gaps
- require the full filter/inventory and whole-pipeline fixture job before evidence is emitted
- reject evidence with a different release commit/ref, embedded source version, corpus revision, any finding gap, failed gate, ML tolerance violation, or unapproved field
- dispatch full exact-commit parity alongside release builds, gate publication on it, and attach `pentect-credsweeper-compatibility.json` to the GitHub release
- quarantine stable releases missing that evidence asset
- document the release evidence boundary

The parity matrix runs in parallel with platform builds, so it does not add serial build time unless it is the slower gate.

## Local verification

- `python -m unittest tools/test_creddata_shards.py tools/test_update_credsweeper.py tools/test_verify_credsweeper_evidence.py` (9 passed)
- `python tools/test_release_package_metadata.py`
- Python compile checks for all changed scripts
- YAML parsing for every workflow
- `git diff --check`

Progresses #399.
