### PR TITLE
release: v0.0.69

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.68"
+version = "0.0.69"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.68"
+version = "0.0.69"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Release

Bump the CLI and npm package version from 0.0.68 to 0.0.69.

This release includes the CredSweeper multi-pattern parity fixes and exact-tag release evidence gate merged in #1266 and #1268, along with the other changes merged since v0.0.68.

## Verification

- Cargo metadata resolves `pentect-cli` as 0.0.69 with `--locked`
- `package.json` resolves as 0.0.69
- npm package tests: 9 passed
- tag and GitHub release `v0.0.69` do not already exist

After this PR is merged, tag `v0.0.69` will start the release workflow. The workflow builds every platform, runs installer/client lifecycle tests, runs exact-tag full CredSweeper compatibility in parallel, publishes the value-free compatibility evidence asset, and only then promotes the release to stable.
