### PR TITLE
fix: recover Windows installs with BOM markers

### DIFF
--- a/crates/pentect-cli/src/installation.rs
+++ b/crates/pentect-cli/src/installation.rs
@@ -138,13 +138,18 @@ pub(crate) fn installation_for_executable(
                 marker.display()
             )
         })?;
-        let installation: ManagedInstallation =
-            serde_json::from_slice(&bytes).map_err(|error| {
-                format!(
-                    "invalid installation marker '{}': {error}",
-                    marker.display()
-                )
-            })?;
+        // Windows PowerShell 5.1 writes a UTF-8 BOM for `-Encoding utf8`.
+        // Older official installers used that encoding for this marker, so the
+        // reader must remain able to recover those existing installations.
+        let json = bytes
+            .strip_prefix(&[0xef, 0xbb, 0xbf])
+            .unwrap_or(bytes.as_slice());
+        let installation: ManagedInstallation = serde_json::from_slice(json).map_err(|error| {
+            format!(
+                "invalid installation marker '{}': {error}",
+                marker.display()
+            )
+        })?;
         if !valid_installation(&installation) {
             return Err(format!(
                 "installation marker '{}' contains invalid instructions",
@@ -202,6 +207,29 @@ mod tests {
         let marker: ManagedInstallation =
             serde_json::from_str(r#"{"version":1,"path_added":false}"#).unwrap();
         assert!(marker.is_self_managed());
+    }
+
+    #[test]
+    fn reads_a_utf8_bom_marker_written_by_windows_powershell() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "pentect-installation-bom-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let executable = root.join("pentect.exe");
+        std::fs::write(&executable, b"fixture").unwrap();
+        let mut marker = vec![0xef, 0xbb, 0xbf];
+        marker.extend_from_slice(br#"{"version":1,"manager":"pentect","path_added":false}"#);
+        std::fs::write(root.join(INSTALL_MARKER), marker).unwrap();
+
+        let installation = installation_for_executable(&executable).unwrap().unwrap();
+        assert!(installation.is_self_managed());
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -94,6 +94,17 @@ function Expand-PentectGzip {
     }
 }
 
+function Write-PentectManagedInstallMarker {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][bool]$PathAdded
+    )
+
+    $json = @{ version = 1; manager = 'pentect'; path_added = $PathAdded } | ConvertTo-Json -Compress
+    $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $json, $utf8WithoutBom)
+}
+
 $repository = 'EdamAme-x/pentect'
 $requestedVersion = $Version
 if ($requestedVersion) {
@@ -200,7 +211,7 @@ try {
         }
     }
     Write-Output "[4/4] PATH: $pathStatus"
-    @{ version = 1; manager = 'pentect'; path_added = $pathAdded } | ConvertTo-Json -Compress | Set-Content -Encoding utf8 -LiteralPath $marker
+    Write-PentectManagedInstallMarker -Path $marker -PathAdded $pathAdded
     Write-Output ''
     Write-Output "Installed Pentect $releaseTag"
     Write-Output 'Next: pentect doctor'

--- a/tools/test_install.ps1
+++ b/tools/test_install.ps1
@@ -25,6 +25,21 @@ try {
     if ($arm64 -ne 'Arm64') {
         throw "expected Arm64 fallback result, received $arm64"
     }
+
+    $marker = Join-Path ([System.IO.Path]::GetTempPath()) ("pentect-marker-test-" + [guid]::NewGuid() + '.json')
+    try {
+        Write-PentectManagedInstallMarker -Path $marker -PathAdded $true
+        $bytes = [System.IO.File]::ReadAllBytes($marker)
+        if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+            throw 'managed installation marker contains a UTF-8 BOM'
+        }
+        $decoded = Get-Content -Raw -LiteralPath $marker | ConvertFrom-Json
+        if ($decoded.manager -ne 'pentect' -or -not [bool]$decoded.path_added) {
+            throw 'managed installation marker has unexpected contents'
+        }
+    } finally {
+        if (Test-Path -LiteralPath $marker) { Remove-Item -LiteralPath $marker -Force }
+    }
 } finally {
     $env:PENTECT_INSTALL_DRY_RUN = $savedDryRun
     $env:PENTECT_INSTALL_SKIP_PATH = $savedSkipPath


### PR DESCRIPTION
Closes #1265.

## Root cause

Windows PowerShell 5.1 writes a UTF-8 BOM for `Set-Content -Encoding utf8`. The official installer used that command for `.pentect-managed-install.json`, while the Rust reader passed the complete byte sequence directly to `serde_json`, which rejects the BOM. Reinstalling recreated the same broken marker, so existing Windows installations could not self-update.

## Changes

- write new Windows installation markers as UTF-8 without a BOM on both PowerShell 5.1 and newer PowerShell
- accept the exact UTF-8 BOM on the read side so already-installed users recover
- keep the existing file-size, regular-file, JSON, and instruction validation boundaries
- test the real file-reading path with a BOM-prefixed marker
- test the writer's raw bytes in the existing Windows PowerShell 5.1 installer job

## Focused verification

- `cargo fmt --all --check`
- `cargo test -p pentect-cli --no-default-features installation::tests --locked` (4 passed)
- `git diff --check`

The PowerShell writer test is intentionally exercised by the Windows PowerShell 5.1 Actions job because this Linux host has no PowerShell runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation detection for markers created by older Windows PowerShell versions.
  * Updated marker writing to use UTF-8 without a byte-order mark for improved compatibility.

* **Tests**
  * Added coverage for reading legacy BOM-prefixed markers.
  * Added validation that newly written markers have the expected encoding and contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->