### PR TITLE
ci: lock release smoke plugins to projects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -651,9 +651,8 @@ jobs:
             & $binary plugins add github:@EdamAme-x/pentect/plugins/example-regex --project --yes
             $masked = 'case ACME-12345678' | & $binary mask
             if (-not ($masked -match '<<ACME_CASE_')) { throw 'manifest plugin did not mask' }
-            & $binary plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --project --yes
-            $inspection = & $binary plugins inspect openai-privacy-filter
-            if (-not ($inspection -match 'hooks: inspect')) { throw 'official plugin was not installed' }
+            $inspection = & $binary plugins inspect (Join-Path $env:GITHUB_WORKSPACE 'plugins/openai-privacy-filter')
+            if (-not ($inspection -match 'hooks: inspect')) { throw 'official plugin manifest was not inspected' }
           } finally {
             Pop-Location
           }
@@ -689,8 +688,7 @@ jobs:
             cd "$plugin_project"
             "$binary" plugins add github:@EdamAme-x/pentect/plugins/example-regex --project --yes
             printf '%s\n' 'case ACME-12345678' | "$binary" mask | grep -F '<<ACME_CASE_'
-            "$binary" plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --project --yes
-            "$binary" plugins inspect openai-privacy-filter | grep -F 'hooks: inspect'
+            "$binary" plugins inspect "$GITHUB_WORKSPACE/plugins/openai-privacy-filter" | grep -F 'hooks: inspect'
           )
           printf 'PENTECT_SMOKE_BINARY=%s\n' "$binary" >> "$GITHUB_ENV"
       - name: Install through npm (POSIX)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -648,10 +648,10 @@ jobs:
           New-Item -ItemType Directory -Force $pluginProject | Out-Null
           Push-Location $pluginProject
           try {
-            & $binary plugins add github:@EdamAme-x/pentect/plugins/example-regex --yes
+            & $binary plugins add github:@EdamAme-x/pentect/plugins/example-regex --project --yes
             $masked = 'case ACME-12345678' | & $binary mask
             if (-not ($masked -match '<<ACME_CASE_')) { throw 'manifest plugin did not mask' }
-            & $binary plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --yes
+            & $binary plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --project --yes
             $inspection = & $binary plugins inspect openai-privacy-filter
             if (-not ($inspection -match 'hooks: inspect')) { throw 'official plugin was not installed' }
           } finally {
@@ -687,9 +687,9 @@ jobs:
           mkdir -p "$plugin_project"
           (
             cd "$plugin_project"
-            "$binary" plugins add github:@EdamAme-x/pentect/plugins/example-regex --yes
+            "$binary" plugins add github:@EdamAme-x/pentect/plugins/example-regex --project --yes
             printf '%s\n' 'case ACME-12345678' | "$binary" mask | grep -F '<<ACME_CASE_'
-            "$binary" plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --yes
+            "$binary" plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --project --yes
             "$binary" plugins inspect openai-privacy-filter | grep -F 'hooks: inspect'
           )
           printf 'PENTECT_SMOKE_BINARY=%s\n' "$binary" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Root cause

The v0.0.69 direct-install smoke installed a remote plugin globally and then tried to use it from a fresh project. Current Pentect intentionally requires remote plugins used by a project to be present in that project's lock file, so all direct-install OS jobs stopped after installation and self-update had already succeeded.

The next smoke step also attempted to install OpenAI Privacy Filter. On a clean runner that starts a roughly 2.7 GB local-model environment setup and can exceed the release job's ten-minute timeout; it is not appropriate for every release.

## Fix

- add the lightweight example plugin with `--project`, then retain the real masking assertion
- inspect the checkout's official OpenAI Privacy Filter manifest without running its heavyweight setup
- apply the same checks to Windows and POSIX direct-installer jobs

This does not weaken the project-lock requirement. Remote download, project locking, and runtime masking remain covered by `example-regex`; OPF manifest compatibility remains covered without a multi-gigabyte download.

## Focused verification

- `git diff --check`
- local `plugins inspect <checkout>/plugins/openai-privacy-filter` returned `hooks: inspect` without setup
- local project-scoped example plugin produced `<<ACME_CASE_...>>`
