### PR TITLE
fix: show Claude gateway settings in dry runs

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1699,11 +1699,12 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
 
 fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
     let args = opts.tool_args.clone();
+    let caller_settings = ClaudeCallerSettings::from_args(&args)?;
     if opts.dry_run {
+        let args = caller_settings.gateway_args(&args, "<pentect-settings>");
         print_dry_run(&opts.command, &args);
         return Ok(success_status());
     }
-    let caller_settings = ClaudeCallerSettings::from_args(&args)?;
     reject_unsupported_claude_provider(&caller_settings)?;
     preflight_managed_claude_routing()?;
     let upstream = claude_effective_upstream(opts, &caller_settings)?;
@@ -1942,22 +1943,27 @@ impl ClaudeCallerSettings {
             "Claude settings",
         )?;
         let path = file.path().to_string_lossy().into_owned();
-        let mut out = args.to_vec();
-        if let Some(index) = self.settings_at {
-            if self.inline {
-                out[index] = format!("--settings={path}");
-            } else {
-                out[index + 1] = path;
-            }
-        } else {
-            out.insert(0, path);
-            out.insert(0, "--settings".to_string());
-        }
+        let out = self.gateway_args(args, &path);
         Ok(ClaudeGatewaySettings {
             args: out,
             _file: file,
             _directory: directory,
         })
+    }
+
+    fn gateway_args(&self, args: &[String], settings_path: &str) -> Vec<String> {
+        let mut out = args.to_vec();
+        if let Some(index) = self.settings_at {
+            if self.inline {
+                out[index] = format!("--settings={settings_path}");
+            } else {
+                out[index + 1] = settings_path.to_string();
+            }
+        } else {
+            out.insert(0, settings_path.to_string());
+            out.insert(0, "--settings".to_string());
+        }
+        out
     }
 }
 
@@ -4144,6 +4150,28 @@ mod tests {
         drop(gateway);
         assert!(!path.exists());
         assert!(!directory.exists());
+    }
+
+    #[test]
+    fn claude_gateway_args_replace_inline_caller_settings() {
+        let settings = ClaudeCallerSettings {
+            value: serde_json::json!({}),
+            effective_env: serde_json::Map::new(),
+            settings_at: Some(0),
+            inline: true,
+        };
+        let args = vec![
+            r#"--settings={"env":{"ANTHROPIC_API_KEY":"secret-sentinel"}}"#.to_string(),
+            "--model=claude-test".to_string(),
+        ];
+
+        assert_eq!(
+            settings.gateway_args(&args, "<pentect-settings>"),
+            vec![
+                "--settings=<pentect-settings>".to_string(),
+                "--model=claude-test".to_string(),
+            ]
+        );
     }
 
     #[cfg(unix)]

--- a/crates/pentect-cli/tests/process_host.rs
+++ b/crates/pentect-cli/tests/process_host.rs
@@ -54,6 +54,51 @@ fn codex_dry_run_routes_through_the_http_gateway() {
 }
 
 #[test]
+fn claude_dry_run_shows_the_generated_gateway_settings() {
+    let root = test_root();
+    std::fs::create_dir_all(&root).unwrap();
+    let _cleanup = Cleanup {
+        root: root.clone(),
+        host_pid: None,
+        command_pids: Vec::new(),
+    };
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+    command
+        .args(["claude", "--dry-run"])
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("HOME", &root)
+        .env("USERPROFILE", &root)
+        .env("APPDATA", &root)
+        .env("PROGRAMDATA", &root)
+        .env("CLAUDE_CONFIG_DIR", root.join("claude"));
+    for name in PRIVATE_ENV.iter().chain(
+        [
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_CODE_USE_VERTEX",
+            "CLAUDE_CODE_USE_FOUNDRY",
+            "CLAUDE_CODE_USE_MANTLE",
+        ]
+        .iter(),
+    ) {
+        command.env_remove(name);
+    }
+    let output = command.output().unwrap();
+    assert!(output.status.success(), "{:?}", output.status);
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(rendered.contains("--settings"), "{rendered}");
+    assert!(rendered.contains("<pentect-settings>"), "{rendered}");
+    assert!(!rendered.contains("pentect-claude-settings-"), "{rendered}");
+}
+
+#[test]
 fn log_hosts_while_running_but_help_does_not() {
     let root = test_root();
     std::fs::create_dir_all(&root).unwrap();


### PR DESCRIPTION
Closes #1267.

## Root cause

`run_claude` returned from `--dry-run` before parsing caller settings or constructing the gateway settings arguments. It therefore printed only the upstream Claude command, unlike Codex, even though a real launch always replaces or adds `--settings` with a private generated file containing the local gateway route.

## Fix

- parse Claude settings before the dry-run boundary, matching real-launch validation
- reuse one argument-rewrite function for real launches and dry runs
- show `<pentect-settings>` instead of creating a temporary file during dry run
- replace caller-provided inline settings in the rendered command, so their contents and secrets are not echoed

## Focused verification

- `cargo test -p pentect-cli --no-default-features claude_gateway_args_replace_inline_caller_settings --locked`
- `cargo test -p pentect-cli --no-default-features --test process_host claude_dry_run_shows_the_generated_gateway_settings --locked`
- `cargo fmt --all --check`
- `git diff --check`
