### PR TITLE
release: v0.0.70

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.69"
+version = "0.0.70"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.69"
+version = "0.0.70"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Release

Prepare v0.0.70 from current `main` after the v0.0.69 prerelease lifecycle correctly caught an outdated direct-installer plugin smoke.

This release includes:

- recovery for existing Windows installations whose managed-install marker contains a PowerShell 5.1 UTF-8 BOM (#1265)
- corrected release smoke coverage that respects project plugin locks and does not download the multi-gigabyte OpenAI Privacy Filter environment on every release (#1272)
- truthful Claude `--dry-run` gateway settings output without exposing caller settings (#1267)
- exact-tag full CredSweeper compatibility evidence as a required release asset

## Verification

- versions agree at 0.0.70 in Cargo metadata, Cargo.lock, and npm metadata
- npm packaging tests: 9 passed
- `git diff --check`
- v0.0.70 tag and GitHub release do not already exist

The tag will be created only from the merge commit after required PR checks pass.
