### PR TITLE
fix: keep internal project paths out of diagnostics

### DIFF
--- a/crates/pentect-cli/src/doctor.rs
+++ b/crates/pentect-cli/src/doctor.rs
@@ -208,19 +208,19 @@ fn check_config(name: &'static str, path: PathBuf) -> Check {
     }
     let source = match std::fs::read_to_string(&path) {
         Ok(source) => source,
-        Err(error) => return Check::fail(name, format!("{}: {error}", path.display())),
+        Err(error) => return Check::fail(name, format!("{}: {error}", compact_path(&path))),
     };
     match migrate_removed_config_keys(&source) {
         Ok(Some(_)) => Check::repairable_warn(
             name,
-            format!("{} uses removed settings", path.display()),
+            format!("{} uses removed settings", compact_path(&path)),
             Repair::MigrateConfig { path },
         ),
         Ok(None) => match pentect_agent::validate_config_file(&path) {
             Ok(()) => Check::ok(name, "ready"),
-            Err(error) => Check::fail(name, format!("{}: {error}", path.display())),
+            Err(error) => Check::fail(name, format!("{}: {error}", compact_path(&path))),
         },
-        Err(error) => Check::fail(name, format!("{}: {error}", path.display())),
+        Err(error) => Check::fail(name, format!("{}: {error}", compact_path(&path))),
     }
 }
 
@@ -878,7 +878,8 @@ mod tests {
                 .find(|check| check.name == "config-project")
                 .unwrap();
             assert_eq!(check.status, Status::Fail);
-            assert!(check.detail.contains(&config.display().to_string()));
+            assert!(check.detail.contains("config.toml"));
+            assert!(!check.detail.contains(&root.display().to_string()));
             assert!(check.detail.contains("output.restore must be a boolean"));
         }
         let _ = std::fs::remove_dir_all(root);

--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -605,11 +605,14 @@ fn plugin_paths_for_named_scoped(
 
     let mut message = match scope {
         PluginScope::User => format!("global plugin '{name}' was not found in the remote catalog"),
-        PluginScope::Project => format!(
-            "plugin '{name}' was not found at '{}' or '{}'",
-            project_dir.display(),
-            official_dir.display()
-        ),
+        PluginScope::Project => {
+            let project_display = Path::new(PENTECT_DIR).join(PLUGINS_DIR).join(name);
+            format!(
+                "plugin '{name}' was not found at '{}' or '{}'",
+                project_display.display(),
+                official_dir.display()
+            )
+        }
     };
     if let Some(error) = remote_error {
         message.push_str(&format!("; remote lookup failed: {error}"));
@@ -2730,6 +2733,20 @@ label = "INLINE_SECRET"
         );
         let err = plugin_paths_for_named(&name, true).unwrap_err().to_string();
         assert!(err.contains("was not found"), "{err}");
+        assert!(
+            err.contains(
+                &Path::new(PENTECT_DIR)
+                    .join(PLUGINS_DIR)
+                    .join(&name)
+                    .display()
+                    .to_string()
+            ),
+            "{err}"
+        );
+        assert!(
+            !err.contains(&plugins_root().unwrap().display().to_string()),
+            "{err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1269.

## Root cause

Project discovery correctly canonicalizes its result for identity and ancestor resolution. Two user-facing error paths printed that internal path directly, which exposes Windows extended-length prefixes such as `\\?\\` and unnecessary home-directory components. The configuration check already had a filename-only display helper but did not use it.

## Fix

- render doctor configuration errors with the existing compact path helper
- render missing project plugin locations relative to the project root (`.pentect/plugins/<name>`)
- retain canonical paths internally and retain nested-directory project config discovery

## Focused verification

- `cargo test -p pentect-cli --no-default-features doctor_checks_the_project_config_from_a_nested_working_directory --locked`
- `cargo test -p pentect-cli --no-default-features named_plugin_missing_is_an_error --locked`
- `cargo fmt --all --check`
- `git diff --check`

The tests assert that the correct project-root config is still checked while its absolute root is absent from diagnostics, and that missing-plugin errors contain only the project-relative location.
