### PR TITLE
test: gate releases on installed Codex handle flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
               - 'tools/client_smoke.py'
               - 'tools/install_client_smoke.sh'
               - 'tools/install_portable_client_smoke.py'
+              - 'tools/installed_agent_e2e.py'
               - 'tools/test_client_smoke_coverage.py'
               - 'tools/verify_client_smoke_log.py'
               - 'tools/codex-app-smoke-fixture.c'
@@ -418,7 +419,7 @@ jobs:
           python tools/update_package_metadata.py --metadata-file packaging/release.json --check
           python tools/test_client_smoke_coverage.py
           python tools/test_release_package_metadata.py
-          python -m py_compile tools/client_smoke.py tools/install_portable_client_smoke.py tools/test_client_smoke_coverage.py tools/test_release_package_metadata.py tools/verify_client_smoke_log.py
+          python -m py_compile tools/client_smoke.py tools/install_portable_client_smoke.py tools/installed_agent_e2e.py tools/test_client_smoke_coverage.py tools/test_release_package_metadata.py tools/verify_client_smoke_log.py
           sh -n tools/install.sh tools/install-apt.sh tools/package_deb.sh tools/build_apt_repository.sh tools/download_recent_stable_debs.sh tools/propose_automation_pr.sh tools/wait_for_automation_pr.sh tools/install_client_smoke.sh tools/test_install.sh tools/testdata/install-curl.sh
           sh tools/test_download_recent_stable_debs.sh
           sh tools/test_install.sh

--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -36,6 +36,7 @@ jobs:
               - 'tools/client_smoke.py'
               - 'tools/install_client_smoke.sh'
               - 'tools/install_portable_client_smoke.py'
+              - 'tools/installed_agent_e2e.py'
               - 'tools/test_client_smoke_coverage.py'
               - 'tools/verify_client_smoke_log.py'
               - 'tools/codex-app-smoke-fixture.c'
@@ -112,6 +113,8 @@ jobs:
         run: python tools/install_portable_client_smoke.py --mode latest
       - name: Start all current portable clients
         run: python tools/client_smoke.py --group portable
+      - name: Verify installed Codex handle flow
+        run: python tools/installed_agent_e2e.py --pentect "${{ env.PENTECT_SMOKE_BINARY }}"
       - name: Start both protected desktop app contracts (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           python tools/test_client_smoke_coverage.py
           python tools/test_release_package_metadata.py
           python -m unittest tools/test_creddata_shards.py tools/test_verify_credsweeper_evidence.py
-          python -m py_compile tools/client_smoke.py tools/creddata_shards.py tools/install_portable_client_smoke.py tools/test_client_smoke_coverage.py tools/test_release_package_metadata.py tools/test_verify_credsweeper_evidence.py tools/verify_client_smoke_log.py tools/verify_credsweeper_evidence.py
+          python -m py_compile tools/client_smoke.py tools/creddata_shards.py tools/install_portable_client_smoke.py tools/installed_agent_e2e.py tools/test_client_smoke_coverage.py tools/test_release_package_metadata.py tools/test_verify_credsweeper_evidence.py tools/verify_client_smoke_log.py tools/verify_credsweeper_evidence.py
           cc -std=c11 -Wall -Wextra -Werror tools/codex-app-smoke-fixture.c -o "$RUNNER_TEMP/codex-app-smoke-fixture"
           cc -std=c11 -Wall -Wextra -Werror tools/claude-app-smoke-fixture.c -o "$RUNNER_TEMP/claude-app-smoke-fixture"
           node --check tools/smoke_pi_package.mjs
@@ -756,6 +756,13 @@ jobs:
           claude_fixture="$RUNNER_TEMP/claude-app-fixture"
           cc -std=c11 -Wall -Wextra -Werror tools/claude-app-smoke-fixture.c -o "$claude_fixture"
           "$PENTECT_SMOKE_BINARY" claude app --yes --app "$claude_fixture" --upstream https://api.anthropic.com
+      - name: Verify installed Codex handle flow (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: python tools/installed_agent_e2e.py --pentect $env:PENTECT_SMOKE_BINARY
+      - name: Verify installed Codex handle flow (POSIX)
+        if: runner.os != 'Windows'
+        run: python tools/installed_agent_e2e.py --pentect "$PENTECT_SMOKE_BINARY"
       - name: Verify persistent diagnostics (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Run a paid-key-free Codex/Pentect boundary test against localhost fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+HANDLE = re.compile(r"<<[A-Z][A-Z0-9_]*_[0-9a-f]{16}>>")
+ENV_HANDLE = re.compile(r"<<(?:FIRST_KEY|SECOND_KEY)_[0-9a-f]{16}>>")
+
+
+def response_object(response_id: str, output: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "id": response_id,
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": "completed",
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "max_output_tokens": None,
+        "model": "gpt-5.6-luna",
+        "output": output,
+        "parallel_tool_calls": True,
+        "previous_response_id": None,
+        "reasoning": {"effort": "none", "summary": None},
+        "store": False,
+        "temperature": None,
+        "text": {"format": {"type": "text"}},
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": None,
+        "truncation": "disabled",
+        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        "metadata": {},
+    }
+
+
+def sse(events: list[dict[str, object]]) -> bytes:
+    return b"".join(
+        f"event: {event['type']}\ndata: {json.dumps(event, separators=(',', ':'))}\n\n".encode()
+        for event in events
+    ) + b"data: [DONE]\n\n"
+
+
+def shell_command(arguments: list[str]) -> str:
+    if os.name == "nt":
+        return subprocess.list2cmdline(arguments)
+    return shlex.join(arguments)
+
+
+def tool_response(sequence: int, source: str) -> bytes:
+    response_id = f"resp_e2e_{sequence}"
+    item_id = f"ct_e2e_{sequence}"
+    call_id = f"call_e2e_{sequence}"
+    item = {
+        "id": item_id,
+        "type": "custom_tool_call",
+        "status": "completed",
+        "call_id": call_id,
+        "name": "exec",
+        "input": source,
+    }
+    pending = dict(item, status="in_progress", input="")
+    return sse([
+        {"type": "response.output_item.added", "response_id": response_id, "output_index": 0, "item": pending},
+        {"type": "response.custom_tool_call_input.delta", "response_id": response_id, "item_id": item_id, "output_index": 0, "delta": source},
+        {"type": "response.custom_tool_call_input.done", "response_id": response_id, "item_id": item_id, "output_index": 0, "call_id": call_id, "name": "exec", "input": source},
+        {"type": "response.output_item.done", "response_id": response_id, "output_index": 0, "item": item},
+        {"type": "response.completed", "response": response_object(response_id, [item])},
+    ])
+
+
+def text_response(sequence: int, text: str) -> bytes:
+    response_id = f"resp_e2e_{sequence}"
+    item_id = f"msg_e2e_{sequence}"
+    item = {
+        "id": item_id,
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": text, "annotations": []}],
+    }
+    return sse([
+        {"type": "response.output_item.added", "response_id": response_id, "output_index": 0, "item": dict(item, status="in_progress", content=[])},
+        {"type": "response.content_part.added", "response_id": response_id, "item_id": item_id, "output_index": 0, "content_index": 0, "part": {"type": "output_text", "text": "", "annotations": []}},
+        {"type": "response.output_text.delta", "response_id": response_id, "item_id": item_id, "output_index": 0, "content_index": 0, "delta": text},
+        {"type": "response.output_text.done", "response_id": response_id, "item_id": item_id, "output_index": 0, "content_index": 0, "text": text},
+        {"type": "response.content_part.done", "response_id": response_id, "item_id": item_id, "output_index": 0, "content_index": 0, "part": item["content"][0]},
+        {"type": "response.output_item.done", "response_id": response_id, "output_index": 0, "item": item},
+        {"type": "response.completed", "response": response_object(response_id, [item])},
+    ])
+
+
+class State:
+    def __init__(self, valid: str, invalid: str) -> None:
+        self.valid = valid
+        self.invalid = invalid
+        self.model_requests: list[str] = []
+        self.service_attempts: list[str] = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    server: "FixtureServer"
+
+    def do_GET(self) -> None:
+        if self.path.startswith("/v1/models"):
+            self._json({"object": "list", "data": []})
+            return
+        self.send_error(404)
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length", "0"))
+        body = self.rfile.read(length)
+        if self.path == "/check":
+            authorization = self.headers.get("authorization", "")
+            self.server.state.service_attempts.append(authorization)
+            status = 200 if authorization == f"Bearer {self.server.state.valid}" else 401
+            self._json({"ok": status == 200}, status)
+            return
+        if self.path.endswith("/responses"):
+            request = body.decode("utf-8")
+            self.server.state.model_requests.append(request)
+            sequence = len(self.server.state.model_requests)
+            if sequence == 1:
+                command = shell_command([sys.executable, "e2e_helper.py", "read"])
+                payload = tool_response(
+                    sequence,
+                    f"const r = await tools.exec_command({{cmd:{json.dumps(command)}}}); text(r.output);",
+                )
+            else:
+                handles = list(dict.fromkeys(ENV_HANDLE.findall(request)))
+                if sequence == 2 and len(handles) >= 2:
+                    payload = tool_response(sequence, self._probe_source(handles[0]))
+                elif sequence == 3 and len(handles) >= 2:
+                    payload = tool_response(sequence, self._probe_source(handles[1]))
+                else:
+                    payload = text_response(sequence, "DONE")
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("cache-control", "no-cache")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        self.send_error(404)
+
+    def _probe_source(self, handle: str) -> str:
+        url = f"http://127.0.0.1:{self.server.server_port}/check"
+        command = shell_command([sys.executable, "e2e_helper.py", "probe", url, handle])
+        return f"const r = await tools.exec_command({{cmd:{json.dumps(command)}}}); text(r.output);"
+
+    def _json(self, value: object, status: int = 200) -> None:
+        payload = json.dumps(value).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, _format: str, *args: object) -> None:
+        pass
+
+
+class FixtureServer(ThreadingHTTPServer):
+    def __init__(self, state: State) -> None:
+        super().__init__(("127.0.0.1", 0), Handler)
+        self.state = state
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pentect", default="pentect")
+    args = parser.parse_args()
+    valid = "".join(("rpa_", "PENTECT_VALID_", "0123456789abcdef"))
+    invalid = "".join(("rpa_", "PENTECT_INVALID_", "fedcba9876543210"))
+    state = State(valid, invalid)
+    server = FixtureServer(state)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with tempfile.TemporaryDirectory(prefix="pentect-installed-e2e-") as raw_root:
+            root = Path(raw_root)
+            home = root / "home"
+            project = root / "project"
+            home.mkdir()
+            project.mkdir()
+            (project / ".env").write_text(f"FIRST_KEY={invalid}\nSECOND_KEY={valid}\n", encoding="utf-8")
+            (project / "e2e_helper.py").write_text(
+                """from pathlib import Path
+import sys
+import urllib.request
+
+if sys.argv[1] == "read":
+    print(Path(".env").read_text(encoding="utf-8"))
+elif sys.argv[1] == "probe":
+    request = urllib.request.Request(
+        sys.argv[2], data=b"", headers={"Authorization": f"Bearer {sys.argv[3]}"}
+    )
+    print(urllib.request.urlopen(request).status)
+else:
+    raise SystemExit("unknown operation")
+""",
+                encoding="utf-8",
+            )
+            environment = os.environ.copy()
+            environment.update({"HOME": str(home), "USERPROFILE": str(home), "OPENAI_API_KEY": "local-fixture", "PENTECT_LOG_DIR": str(root / "logs")})
+            command = [args.pentect, "codex", "--upstream", f"http://127.0.0.1:{server.server_port}/v1", "--model", "gpt-5.6-luna", "exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "Read .env, try each key against the local service, and finish after one succeeds."]
+            if os.name == "nt" and args.pentect.lower().endswith((".cmd", ".bat")):
+                command = [os.environ.get("COMSPEC", "cmd.exe"), "/d", "/s", "/c", *command]
+            completed = subprocess.run(command, cwd=project, env=environment, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=45)
+            if completed.returncode != 0:
+                output = completed.stdout.replace(valid, "<synthetic-key>").replace(invalid, "<synthetic-key>")
+                raise RuntimeError(f"Codex E2E exited with {completed.returncode}:\n{output}")
+            if state.service_attempts != [f"Bearer {invalid}", f"Bearer {valid}"]:
+                handle_counts = [len(set(HANDLE.findall(request))) for request in state.model_requests]
+                output = completed.stdout.replace(valid, "<synthetic-key>").replace(invalid, "<synthetic-key>")
+                raise RuntimeError(
+                    f"unexpected service attempts: {len(state.service_attempts)}; "
+                    f"model requests={len(state.model_requests)} handles={handle_counts}\n{output}"
+                )
+            upstream = "\n".join(state.model_requests)
+            if valid in upstream or invalid in upstream:
+                raise RuntimeError("a synthetic plaintext key reached the model simulator")
+            if len(set(HANDLE.findall(upstream))) < 2:
+                raise RuntimeError("the model simulator did not receive two distinct handles")
+            log_path = root / "logs" / "pentect.log"
+            logs = log_path.read_text(encoding="utf-8")
+            if valid in logs or invalid in logs:
+                raise RuntimeError("a synthetic plaintext key reached persistent diagnostics")
+            print("installed Codex E2E passed: two handles, invalid then valid, no model/log plaintext")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Advances #237

## Why

The existing release matrix proved installation and launcher startup, but it never exercised the core protected-agent flow. `tools/release_live_e2e.ps1` also depended on paid external model access and was not part of the release gate.

## What changed

- add a deterministic localhost Responses API simulator and synthetic key-validation service
- run the real installed Codex CLI through the installed Pentect binary
- make Codex read a synthetic `.env`, receive two opaque handles, try the invalid key, then try the valid key
- assert plaintext reaches only the intended localhost service boundary
- assert model requests and persistent Pentect diagnostics contain no plaintext synthetic key
- run this scenario for every Windows, Linux, and macOS release installer lifecycle job

## Local evidence

Tested with public `pentect 0.0.70` and `codex-cli 0.150.0`:

```text
installed Codex E2E passed: two handles, invalid then valid, no model/log plaintext
```

The simulator reports model `gpt-5.6-luna`, matching the requested Codex experiment identifier, while requiring no external API key.

## Remaining #237 scope

Keep #237 open for equivalent Claude/OpenCode/Pi flows and the requested OCR/image, cancellation, and authenticated evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end validation for the installed command-line agent.
  * Verifies streamed tool interactions, credential retry behavior, and secure handling of credentials.
  * Runs lifecycle smoke tests on both Windows and POSIX environments.
  * Expanded packaging and release checks to include the new validation tool.
* **Security**
  * Confirms plaintext credentials are not sent in model requests or written to logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->