### PR TITLE
fix: make exact release rollback usable

### DIFF
--- a/crates/pentect-cli/src/update.rs
+++ b/crates/pentect-cli/src/update.rs
@@ -274,9 +274,12 @@ fn update(options: UpdateOptions) -> Result<(), String> {
     let release: Release = get_response(&client, &release_api, MAX_CHECKSUM_BYTES * 16)?;
     let allow_prerelease =
         std::env::var("PENTECT_UPDATE_ALLOW_PRERELEASE").is_ok_and(|value| value == "1");
-    if release.draft || (release.prerelease && !allow_prerelease) {
-        return Err("latest GitHub release is not a stable release".to_string());
-    }
+    validate_release_channel(
+        release.draft,
+        release.prerelease,
+        options.target.is_some(),
+        allow_prerelease,
+    )?;
     let latest = release_version(&release.tag_name)?;
     if options
         .target
@@ -298,7 +301,18 @@ fn update(options: UpdateOptions) -> Result<(), String> {
         println!("installed version {current} is newer than latest release {latest}");
         return Ok(());
     }
-    println!("update available: {current} -> {latest}");
+    let operation = if options.target.is_some() && latest < current {
+        "rollback"
+    } else {
+        "update"
+    };
+    println!("{operation} available: {current} -> {latest}");
+    if release.prerelease && options.target.is_some() && !allow_prerelease {
+        eprintln!(
+            "[pentect] selected explicitly published prerelease {}; exact-version checksum verification remains required",
+            release.tag_name
+        );
+    }
     if options.check {
         return Ok(());
     }
@@ -309,6 +323,12 @@ fn update(options: UpdateOptions) -> Result<(), String> {
     {
         if installation.manager == "npm" {
             return install_npm_update(&latest);
+        }
+        if options.target.is_some() {
+            return Err(format!(
+                "Pentect is managed by {}; install exact version {latest} with that package manager; the recorded update command was not run because it may select a different release",
+                installation.manager
+            ));
         }
         return Err(installation.update_message());
     }
@@ -346,6 +366,21 @@ fn update(options: UpdateOptions) -> Result<(), String> {
         ));
     }
     install_update(&bytes, &latest, &expected)
+}
+
+fn validate_release_channel(
+    draft: bool,
+    prerelease: bool,
+    exact_version: bool,
+    allow_prerelease: bool,
+) -> Result<(), String> {
+    if draft {
+        return Err("selected GitHub release is still a draft".to_string());
+    }
+    if prerelease && !exact_version && !allow_prerelease {
+        return Err("latest GitHub release is not a stable release".to_string());
+    }
+    Ok(())
 }
 
 fn install_npm_update(version: &Version) -> Result<(), String> {
@@ -835,6 +870,14 @@ mod tests {
             hash
         );
         assert!(parse_sha256("abc").is_err());
+    }
+
+    #[test]
+    fn exact_versions_can_select_published_prereleases_for_rollback() {
+        assert!(validate_release_channel(false, true, true, false).is_ok());
+        assert!(validate_release_channel(false, true, false, false).is_err());
+        assert!(validate_release_channel(true, false, true, false).is_err());
+        assert!(validate_release_channel(false, true, false, true).is_ok());
     }
 
     #[test]

--- a/website/src/content/docs/protection/detectors.md
+++ b/website/src/content/docs/protection/detectors.md
@@ -47,6 +47,31 @@ revisions, test date, runner platform, finding totals, bounded ML difference,
 and per-rule gaps. Release publication stops if the evidence does not match the
 tag or either implementation reports a finding the other one does not.
 
+## CredSweeper disagreement and rollback
+
+A native/official mismatch is a security regression even when it is only an
+extra finding. Do not silently accept it, weaken the fixture, or describe a
+successful corpus run as proof for unseen input. Before release, the parity
+gate blocks publication. If a mismatch is discovered after release, identify
+the newest earlier Pentect release whose
+`pentect-credsweeper-compatibility.json` evidence names the intended
+CredSweeper version and reports no missing or extra findings, then validate and
+install that exact Pentect version:
+
+```sh
+pentect update v0.0.69 --check
+pentect update v0.0.69
+pentect version
+```
+
+This restores the complete known release binary, not only its rule assets, so
+independently implemented scanner behavior is rolled back as well. Exact
+published tags are selectable even when GitHub marks an older release as a
+prerelease; drafts remain unavailable and artifact checksum verification is
+unchanged. Startup checks only notify, so the selected version is not
+automatically replaced. Package-manager installations must select that exact
+version through their package manager if Pentect cannot replace it directly.
+
 ## Pentect-maintained detectors
 
 These detectors are maintained in this repository. They must not be attributed

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -200,11 +200,24 @@ Treat redirected or in-place resolved output as plaintext secret material.
 | `pentect doctor --json` | Print results as JSON |
 | `pentect doctor --fix` | Show and apply approved fixes |
 | `pentect doctor --fix --yes` | Apply all offered fixes without another prompt |
-| `pentect update [VERSION]` | Update directly or through the recorded package manager |
+| `pentect update [VERSION]` | Install the latest release, or an exact published version for rollback |
 | `pentect update --check` | Check without installing |
 | `pentect update --force` | Reinstall even when the selected version is already present |
 | `pentect uninstall` | Remove Pentect but keep project data |
 | `pentect version` | Print the installed version |
+
+An explicit version is exact: `pentect update v0.0.69 --check` confirms that the
+published tag can be selected without downloading it, and
+`pentect update v0.0.69` downloads and installs that version. Exact selection
+may install a release marked as a prerelease, but never a draft. Installation
+still verifies the platform artifact against its published SHA-256 checksum.
+Pentect does not automatically move the installation back to the latest version
+afterward.
+
+Direct and npm installations perform the exact-version replacement. For apt,
+Homebrew, AUR, or another recorded package manager, Pentect stops and names the
+exact requested version instead of running a generic upgrade command that could
+silently select a different release.
 
 ## Plugins
 


### PR DESCRIPTION
## Problem

The remaining production fallback documented in #399 was not actually usable. Although `pentect update VERSION` accepts an older version, it applied the generic prerelease rejection to explicit tags. The real command `pentect update v0.0.69 --check` therefore failed from v0.0.70 even though v0.0.69 has published, checksummed artifacts and release-bound CredSweeper compatibility evidence.

Package-managed installations also returned their generic upgrade instruction for an exact target, which could silently install latest instead of the requested known-good version.

## Change

- allow an explicitly selected published prerelease tag while continuing to reject drafts and implicit prerelease selection;
- retain exact tag matching and SHA-256 artifact verification;
- report an older explicit target as a rollback;
- refuse generic apt/Homebrew/AUR update instructions when an exact target was requested;
- document the post-release CredSweeper disagreement and whole-binary rollback procedure.

The fallback restores a complete earlier Pentect release, including native scanner behavior, rather than swapping only CredSweeper assets.

## Verification

- `cargo test -p pentect-cli --no-default-features update::tests --locked`: 11 passed
- `cargo clippy -p pentect-cli --all-targets --no-default-features --locked -- -D warnings`: passed
- `cargo fmt --check`: passed
- `git diff --check`: passed
- built v0.0.70 development binary against the live GitHub release API:
  - `pentect update v0.0.69 --check`
  - result: `rollback available: 0.0.70 -> 0.0.69`

Closes #399