### PR TITLE
test: add installed OpenCode handle flow

### DIFF
--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -33,6 +33,8 @@ jobs:
               - '.github/workflows/current-clients.yml'
               - '.github/workflows/release.yml'
               - 'crates/pentect-cli/src/client_descriptor.rs'
+              - 'crates/pentect-runtime/src/main.rs'
+              - 'crates/pentect-runtime/src/tests.rs'
               - 'tools/client_smoke.py'
               - 'tools/install_client_smoke.sh'
               - 'tools/install_portable_client_smoke.py'
@@ -92,6 +94,7 @@ jobs:
           $installed = (& $binary version).Trim() -replace '^pentect\s+', ''
           if ($installed -ne $latest) { throw "public installer installed $installed, expected $latest" }
           "PENTECT_SMOKE_BINARY=$binary" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+          "PENTECT_AGENT_E2E_BINARY=$binary" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Install latest Pentect from public endpoint (POSIX)
         if: runner.os != 'Windows'
         shell: sh
@@ -109,12 +112,37 @@ jobs:
           installed=$("$install_dir/pentect" version | sed 's/^pentect //')
           test "$installed" = "$latest"
           printf 'PENTECT_SMOKE_BINARY=%s\n' "$install_dir/pentect" >> "$GITHUB_ENV"
+          printf 'PENTECT_AGENT_E2E_BINARY=%s\n' "$install_dir/pentect" >> "$GITHUB_ENV"
+      - name: Fetch candidate build dependencies (Windows PR)
+        if: github.event_name == 'pull_request' && runner.os == 'Windows'
+        run: git submodule update --init --recursive
+      - uses: ./.github/actions/rust-toolchain
+        if: github.event_name == 'pull_request' && runner.os == 'Windows'
+      - name: Configure fast candidate linking (Windows PR)
+        if: github.event_name == 'pull_request' && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $linker = (Get-Command lld-link.exe -ErrorAction Stop).Source
+          "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linker" >> $env:GITHUB_ENV
+          "CARGO_PROFILE_DEV_DEBUG=0" >> $env:GITHUB_ENV
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: github.event_name == 'pull_request' && runner.os == 'Windows'
+        with:
+          save-if: false
+      - name: Build candidate Pentect for agent E2E (Windows PR)
+        if: github.event_name == 'pull_request' && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cargo build -p pentect-cli --no-default-features --locked
+          $binary = Join-Path $PWD 'target\debug\pentect.exe'
+          if (-not (Test-Path -LiteralPath $binary)) { throw 'candidate build did not produce pentect.exe' }
+          "PENTECT_AGENT_E2E_BINARY=$binary" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Install current portable clients
         run: python tools/install_portable_client_smoke.py --mode latest
       - name: Start all current portable clients
         run: python tools/client_smoke.py --group portable
       - name: Verify installed Codex and OpenCode handle flows
-        run: python tools/installed_agent_e2e.py --pentect "${{ env.PENTECT_SMOKE_BINARY }}"
+        run: python tools/installed_agent_e2e.py --pentect "${{ env.PENTECT_AGENT_E2E_BINARY }}"
       - name: Start both protected desktop app contracts (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -113,7 +113,7 @@ jobs:
         run: python tools/install_portable_client_smoke.py --mode latest
       - name: Start all current portable clients
         run: python tools/client_smoke.py --group portable
-      - name: Verify installed Codex handle flow
+      - name: Verify installed Codex and OpenCode handle flows
         run: python tools/installed_agent_e2e.py --pentect "${{ env.PENTECT_SMOKE_BINARY }}"
       - name: Start both protected desktop app contracts (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -756,11 +756,11 @@ jobs:
           claude_fixture="$RUNNER_TEMP/claude-app-fixture"
           cc -std=c11 -Wall -Wextra -Werror tools/claude-app-smoke-fixture.c -o "$claude_fixture"
           "$PENTECT_SMOKE_BINARY" claude app --yes --app "$claude_fixture" --upstream https://api.anthropic.com
-      - name: Verify installed Codex handle flow (Windows)
+      - name: Verify installed Codex and OpenCode handle flows (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: python tools/installed_agent_e2e.py --pentect $env:PENTECT_SMOKE_BINARY
-      - name: Verify installed Codex handle flow (POSIX)
+      - name: Verify installed Codex and OpenCode handle flows (POSIX)
         if: runner.os != 'Windows'
         run: python tools/installed_agent_e2e.py --pentect "$PENTECT_SMOKE_BINARY"
       - name: Verify persistent diagnostics (Windows)

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -3937,7 +3937,7 @@ fn wrap_shell_command(
     tool_name: &str,
     masked_command: &str,
 ) -> Result<String, String> {
-    let shell = script_shell_for_tool(tool_name);
+    let shell = script_shell_for_tool(provider, tool_name);
     if matches!(provider, HookProvider::Claude | HookProvider::Generic)
         && matches!(shell, ScriptShell::Bash | ScriptShell::PowerShell)
     {
@@ -4047,8 +4047,9 @@ fn powershell_agent_script_fetch(suffix: &str, id: &str) -> String {
     )
 }
 
-fn script_shell_for_tool(tool_name: &str) -> ScriptShell {
+fn script_shell_for_tool(provider: HookProvider, tool_name: &str) -> ScriptShell {
     match tool_name.to_ascii_lowercase().as_str() {
+        "bash" if cfg!(windows) && provider == HookProvider::Generic => ScriptShell::PowerShell,
         "bash" => ScriptShell::Bash,
         "powershell" => ScriptShell::PowerShell,
         _ => ScriptShell::Native,

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -4576,10 +4576,37 @@ fn generic_bridge_bash_uses_the_host_shell() {
         "printf '%s\\n' ok",
     )
     .unwrap();
-    assert!(command.contains("eval"), "{command}");
     assert!(command.contains("__agent-script"), "{command}");
-    assert!(command.contains("__agent-stream"), "{command}");
     assert!(!command.contains("--script-shell"), "{command}");
+    if cfg!(windows) {
+        assert!(command.contains("Invoke-Expression"), "{command}");
+        assert!(command.contains("SCRIPT_RENDER"), "{command}");
+        assert!(!command.contains("set +x"), "{command}");
+    } else {
+        assert!(command.contains("eval"), "{command}");
+        assert!(command.contains("__agent-stream"), "{command}");
+    }
+}
+
+#[test]
+fn only_windows_generic_bash_uses_powershell_semantics() {
+    let expected = if cfg!(windows) {
+        ScriptShell::PowerShell
+    } else {
+        ScriptShell::Bash
+    };
+    assert_eq!(
+        script_shell_for_tool(HookProvider::Generic, "bash"),
+        expected
+    );
+    assert_eq!(
+        script_shell_for_tool(HookProvider::Claude, "Bash"),
+        ScriptShell::Bash
+    );
+    assert_eq!(
+        script_shell_for_tool(HookProvider::Generic, "PowerShell"),
+        ScriptShell::PowerShell
+    );
 }
 
 #[cfg(windows)]

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run a paid-key-free Codex/Pentect boundary test against localhost fixtures."""
+"""Run paid-key-free installed-agent boundary tests against localhost fixtures."""
 
 from __future__ import annotations
 
@@ -104,6 +104,48 @@ def text_response(sequence: int, text: str) -> bytes:
     ])
 
 
+def chat_sse(chunks: list[dict[str, object]]) -> bytes:
+    return b"".join(
+        f"data: {json.dumps(chunk, separators=(',', ':'))}\n\n".encode()
+        for chunk in chunks
+    ) + b"data: [DONE]\n\n"
+
+
+def chat_text_response(sequence: int, text: str) -> bytes:
+    base = {
+        "id": f"chatcmpl_e2e_{sequence}",
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": "gpt-5.6-luna",
+    }
+    return chat_sse([
+        dict(base, choices=[{"index": 0, "delta": {"role": "assistant", "content": text}, "finish_reason": None}]),
+        dict(base, choices=[{"index": 0, "delta": {}, "finish_reason": "stop"}]),
+    ])
+
+
+def chat_tool_response(sequence: int, command: str) -> bytes:
+    base = {
+        "id": f"chatcmpl_e2e_{sequence}",
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": "gpt-5.6-luna",
+    }
+    call = {
+        "index": 0,
+        "id": f"call_e2e_{sequence}",
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "arguments": json.dumps({"command": command}, separators=(",", ":")),
+        },
+    }
+    return chat_sse([
+        dict(base, choices=[{"index": 0, "delta": {"role": "assistant", "tool_calls": [call]}, "finish_reason": None}]),
+        dict(base, choices=[{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]),
+    ])
+
+
 class State:
     def __init__(self, valid: str, invalid: str) -> None:
         self.valid = valid
@@ -155,12 +197,48 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(payload)
             return
+        if self.path.endswith("/chat/completions"):
+            request = body.decode("utf-8")
+            self.server.state.model_requests.append(request)
+            parsed = json.loads(request)
+            if not parsed.get("tools"):
+                payload = chat_text_response(0, "Local key check")
+            else:
+                sequence = sum(
+                    bool(json.loads(item).get("tools"))
+                    for item in self.server.state.model_requests
+                )
+                handles = list(dict.fromkeys(ENV_HANDLE.findall(request)))
+                if sequence == 1:
+                    payload = chat_tool_response(
+                        sequence, shell_command([sys.executable, "e2e_helper.py", "read"])
+                    )
+                elif sequence == 2 and len(handles) >= 2:
+                    payload = chat_tool_response(
+                        sequence, self._probe_command(handles[0])
+                    )
+                elif sequence == 3 and len(handles) >= 2:
+                    payload = chat_tool_response(
+                        sequence, self._probe_command(handles[1])
+                    )
+                else:
+                    payload = chat_text_response(sequence, "DONE")
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("cache-control", "no-cache")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
         self.send_error(404)
 
     def _probe_source(self, handle: str) -> str:
-        url = f"http://127.0.0.1:{self.server.server_port}/check"
-        command = shell_command([sys.executable, "e2e_helper.py", "probe", url, handle])
+        command = self._probe_command(handle)
         return f"const r = await tools.exec_command({{cmd:{json.dumps(command)}}}); text(r.output);"
+
+    def _probe_command(self, handle: str) -> str:
+        url = f"http://127.0.0.1:{self.server.server_port}/check"
+        return shell_command([sys.executable, "e2e_helper.py", "probe", url, handle])
 
     def _json(self, value: object, status: int = 200) -> None:
         payload = json.dumps(value).encode()
@@ -180,10 +258,43 @@ class FixtureServer(ThreadingHTTPServer):
         self.state = state
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--pentect", default="pentect")
-    args = parser.parse_args()
+def client_command(
+    pentect: str, client: str, project: Path, upstream: str
+) -> list[str]:
+    prompt = "Read .env, try each key against the local service, and finish after one succeeds."
+    if client == "codex":
+        return [
+            pentect,
+            "codex",
+            "--upstream",
+            upstream,
+            "--model",
+            "gpt-5.6-luna",
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--skip-git-repo-check",
+            prompt,
+        ]
+    return [
+        pentect,
+        "opencode",
+        "--upstream",
+        upstream,
+        "--model",
+        "gpt-5.6-luna",
+        "--api",
+        "chat",
+        "run",
+        "--format",
+        "json",
+        "--pure",
+        "--dir",
+        str(project),
+        prompt,
+    ]
+
+
+def run_client(pentect: str, client: str) -> None:
     valid = "".join(("rpa_", "PENTECT_VALID_", "0123456789abcdef"))
     invalid = "".join(("rpa_", "PENTECT_INVALID_", "fedcba9876543210"))
     state = State(valid, invalid)
@@ -191,7 +302,7 @@ def main() -> int:
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        with tempfile.TemporaryDirectory(prefix="pentect-installed-e2e-") as raw_root:
+        with tempfile.TemporaryDirectory(prefix=f"pentect-{client}-e2e-") as raw_root:
             root = Path(raw_root)
             home = root / "home"
             project = root / "project"
@@ -216,14 +327,28 @@ else:
                 encoding="utf-8",
             )
             environment = os.environ.copy()
-            environment.update({"HOME": str(home), "USERPROFILE": str(home), "OPENAI_API_KEY": "local-fixture", "PENTECT_LOG_DIR": str(root / "logs")})
-            command = [args.pentect, "codex", "--upstream", f"http://127.0.0.1:{server.server_port}/v1", "--model", "gpt-5.6-luna", "exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "Read .env, try each key against the local service, and finish after one succeeds."]
-            if os.name == "nt" and args.pentect.lower().endswith((".cmd", ".bat")):
+            environment.update({
+                "HOME": str(home),
+                "USERPROFILE": str(home),
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                "XDG_CACHE_HOME": str(home / ".cache"),
+                "XDG_DATA_HOME": str(home / ".local" / "share"),
+                "XDG_STATE_HOME": str(home / ".local" / "state"),
+                "OPENAI_API_KEY": "local-fixture",
+                "PENTECT_LOG_DIR": str(root / "logs"),
+            })
+            command = client_command(
+                pentect,
+                client,
+                project,
+                f"http://127.0.0.1:{server.server_port}/v1",
+            )
+            if os.name == "nt" and pentect.lower().endswith((".cmd", ".bat")):
                 command = [os.environ.get("COMSPEC", "cmd.exe"), "/d", "/s", "/c", *command]
             completed = subprocess.run(command, cwd=project, env=environment, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=45)
             if completed.returncode != 0:
                 output = completed.stdout.replace(valid, "<synthetic-key>").replace(invalid, "<synthetic-key>")
-                raise RuntimeError(f"Codex E2E exited with {completed.returncode}:\n{output}")
+                raise RuntimeError(f"{client} E2E exited with {completed.returncode}:\n{output}")
             if state.service_attempts != [f"Bearer {invalid}", f"Bearer {valid}"]:
                 handle_counts = [len(set(HANDLE.findall(request))) for request in state.model_requests]
                 output = completed.stdout.replace(valid, "<synthetic-key>").replace(invalid, "<synthetic-key>")
@@ -240,11 +365,25 @@ else:
             logs = log_path.read_text(encoding="utf-8")
             if valid in logs or invalid in logs:
                 raise RuntimeError("a synthetic plaintext key reached persistent diagnostics")
-            print("installed Codex E2E passed: two handles, invalid then valid, no model/log plaintext")
+            print(
+                f"installed {client} E2E passed: two handles, invalid then valid, "
+                "no model/log plaintext"
+            )
     finally:
         server.shutdown()
         server.server_close()
         thread.join()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pentect", default="pentect")
+    parser.add_argument(
+        "--client", action="append", choices=("codex", "opencode"), dest="clients"
+    )
+    args = parser.parse_args()
+    for client in args.clients or ("codex", "opencode"):
+        run_client(args.pentect, client)
     return 0
 
 


### PR DESCRIPTION
## Problems found

The release gate proved the installed Codex handle flow, but OpenCode was only started with a version command. That did not prove that its real model and tool protocol could carry opaque handles and restore them only for local execution.

Two concrete integration bugs were found by running the real client:

1. Relying on process cwd is insufficient because OpenCode can select a parent Git repository as its workspace. The fixture now passes the isolated project through public `run --dir`.
2. OpenCode names its command tool `bash` on Windows but executes the command with PowerShell. Pentect selected its wrapper only from the tool name and emitted POSIX `(set +x; ...)`, so protected local commands failed before restoration. Generic/OpenCode `bash` calls now use the PowerShell same-shell wrapper on Windows; explicit Claude Bash behavior is unchanged.

## Change

- extend the paid-key-free localhost simulator with the real streaming Chat Completions tool-call shape used by OpenCode 1.18.20;
- run the installed OpenCode CLI through `pentect opencode`, using public `run --dir ... --pure` options;
- make OpenCode read a synthetic `.env`, receive two opaque handles, try the invalid handle, then the valid handle through its real `bash` tool;
- select PowerShell semantics for Generic/OpenCode bash tool calls on Windows;
- require both Codex and OpenCode flows in current-client CI and every release installer lifecycle job;
- isolate HOME and XDG state for each client.

No external model or paid key is used.

## Verification

Local public Pentect v0.0.70, Codex 0.150.0, and OpenCode 1.18.20:

```text
installed codex E2E passed: two handles, invalid then valid, no model/log plaintext
installed opencode E2E passed: two handles, invalid then valid, no model/log plaintext
```

Focused verification:
- two runtime shell-selection regressions passed;
- runtime clippy passed with warnings denied;
- Python bytecode compilation passed;
- workflow YAML parsing passed;
- `git diff --check` passed.

The first Actions run reproduced the Windows PowerShell mismatch while Linux and macOS passed. The updated run must prove the fix on all three systems before merge.

Advances #237. Claude, Pi, OCR/image, and cancellation coverage remain open.