### PR TITLE
fix: preserve Pi shell semantics on Windows

### DIFF
--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -141,7 +141,7 @@ jobs:
         run: python tools/install_portable_client_smoke.py --mode latest
       - name: Start all current portable clients
         run: python tools/client_smoke.py --group portable
-      - name: Verify installed Codex and OpenCode handle flows
+      - name: Verify installed Codex, OpenCode, and Pi handle flows
         run: python tools/installed_agent_e2e.py --pentect "${{ env.PENTECT_AGENT_E2E_BINARY }}"
       - name: Start both protected desktop app contracts (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -756,11 +756,11 @@ jobs:
           claude_fixture="$RUNNER_TEMP/claude-app-fixture"
           cc -std=c11 -Wall -Wextra -Werror tools/claude-app-smoke-fixture.c -o "$claude_fixture"
           "$PENTECT_SMOKE_BINARY" claude app --yes --app "$claude_fixture" --upstream https://api.anthropic.com
-      - name: Verify installed Codex and OpenCode handle flows (Windows)
+      - name: Verify installed Codex, OpenCode, and Pi handle flows (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: python tools/installed_agent_e2e.py --pentect $env:PENTECT_SMOKE_BINARY
-      - name: Verify installed Codex and OpenCode handle flows (POSIX)
+      - name: Verify installed Codex, OpenCode, and Pi handle flows (POSIX)
         if: runner.os != 'Windows'
         run: python tools/installed_agent_e2e.py --pentect "$PENTECT_SMOKE_BINARY"
       - name: Verify persistent diagnostics (Windows)

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1715,6 +1715,8 @@ fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::Exit
     let active_plugins = agent_tool_plugins(opts)?;
     let memory_store = start_memory_store(pentect)?;
     let _parent_env = agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
+    let _bash_dialect =
+        EnvVarGuard::set_optional([("PENTECT_AGENT_BASH_DIALECT", Some(OsString::from("bash")))]);
     let mut cmd = Command::new(&opts.command);
     clear_pentect_control_env(&mut cmd);
     upstream::hide_header_source_env(&mut cmd, &opts.upstream_header_env);

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -62,6 +62,16 @@ pub(crate) fn run(
     let active_plugins = crate::agent_tool_plugins(opts)?;
     let memory_store = crate::start_memory_store(pentect)?;
     let _parent_env = crate::agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
+    let _bash_dialect = crate::EnvVarGuard::set_optional([(
+        "PENTECT_AGENT_BASH_DIALECT",
+        Some(OsString::from(
+            if injection == crate::client_descriptor::OpenAiInjection::TempExtension {
+                "bash"
+            } else {
+                "powershell"
+            },
+        )),
+    )]);
     let standard_key_names = provider_key_env_names(injection);
     let standard_key_names = if crate::upstream::has_origin_auth_override(&opts.upstream_header_env)
     {
@@ -295,6 +305,10 @@ fn run_opencode(
     let active_plugins = crate::agent_tool_plugins(opts)?;
     let memory_store = crate::start_memory_store(pentect)?;
     let _parent_env = crate::agent_parent_env_guard(pentect, &memory_store, &active_plugins)?;
+    let _bash_dialect = crate::EnvVarGuard::set_optional([(
+        "PENTECT_AGENT_BASH_DIALECT",
+        Some(OsString::from("powershell")),
+    )]);
     if opts.model.is_none() && opts.upstream.is_none() {
         return run_opencode_picker(opts, pentect, &active_plugins, memory_store);
     }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -4048,8 +4048,27 @@ fn powershell_agent_script_fetch(suffix: &str, id: &str) -> String {
 }
 
 fn script_shell_for_tool(provider: HookProvider, tool_name: &str) -> ScriptShell {
+    let windows_bash_dialect = std::env::var("PENTECT_AGENT_BASH_DIALECT").ok();
+    script_shell_for_tool_with_windows_bash_dialect(
+        provider,
+        tool_name,
+        windows_bash_dialect.as_deref(),
+    )
+}
+
+fn script_shell_for_tool_with_windows_bash_dialect(
+    provider: HookProvider,
+    tool_name: &str,
+    windows_bash_dialect: Option<&str>,
+) -> ScriptShell {
     match tool_name.to_ascii_lowercase().as_str() {
-        "bash" if cfg!(windows) && provider == HookProvider::Generic => ScriptShell::PowerShell,
+        "bash"
+            if cfg!(windows)
+                && provider == HookProvider::Generic
+                && windows_bash_dialect != Some("bash") =>
+        {
+            ScriptShell::PowerShell
+        }
         "bash" => ScriptShell::Bash,
         "powershell" => ScriptShell::PowerShell,
         _ => ScriptShell::Native,

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -4596,15 +4596,23 @@ fn only_windows_generic_bash_uses_powershell_semantics() {
         ScriptShell::Bash
     };
     assert_eq!(
-        script_shell_for_tool(HookProvider::Generic, "bash"),
+        script_shell_for_tool_with_windows_bash_dialect(HookProvider::Generic, "bash", None),
         expected
     );
     assert_eq!(
-        script_shell_for_tool(HookProvider::Claude, "Bash"),
+        script_shell_for_tool_with_windows_bash_dialect(
+            HookProvider::Generic,
+            "bash",
+            Some("bash"),
+        ),
         ScriptShell::Bash
     );
     assert_eq!(
-        script_shell_for_tool(HookProvider::Generic, "PowerShell"),
+        script_shell_for_tool_with_windows_bash_dialect(HookProvider::Claude, "Bash", None),
+        ScriptShell::Bash
+    );
+    assert_eq!(
+        script_shell_for_tool_with_windows_bash_dialect(HookProvider::Generic, "PowerShell", None,),
         ScriptShell::PowerShell
     );
 }

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -275,6 +275,23 @@ def client_command(
             "--skip-git-repo-check",
             prompt,
         ]
+    if client == "pi":
+        return [
+            pentect,
+            "pi",
+            "--upstream",
+            upstream,
+            "--model",
+            "gpt-5.6-luna",
+            "--api",
+            "chat",
+            "--print",
+            "--no-session",
+            "--no-context-files",
+            "--tools",
+            "bash",
+            prompt,
+        ]
     return [
         pentect,
         "opencode",
@@ -379,10 +396,13 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--pentect", default="pentect")
     parser.add_argument(
-        "--client", action="append", choices=("codex", "opencode"), dest="clients"
+        "--client",
+        action="append",
+        choices=("codex", "opencode", "pi"),
+        dest="clients",
     )
     args = parser.parse_args()
-    for client in args.clients or ("codex", "opencode"):
+    for client in args.clients or ("codex", "opencode", "pi"):
         run_client(args.pentect, client)
     return 0
 

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -177,7 +177,7 @@ class Handler(BaseHTTPRequestHandler):
             self.server.state.model_requests.append(request)
             sequence = len(self.server.state.model_requests)
             if sequence == 1:
-                command = shell_command([sys.executable, "e2e_helper.py", "read"])
+                command = shell_command(["python", "e2e_helper.py", "read"])
                 payload = tool_response(
                     sequence,
                     f"const r = await tools.exec_command({{cmd:{json.dumps(command)}}}); text(r.output);",
@@ -211,7 +211,7 @@ class Handler(BaseHTTPRequestHandler):
                 handles = list(dict.fromkeys(ENV_HANDLE.findall(request)))
                 if sequence == 1:
                     payload = chat_tool_response(
-                        sequence, shell_command([sys.executable, "e2e_helper.py", "read"])
+                        sequence, shell_command(["python", "e2e_helper.py", "read"])
                     )
                 elif sequence == 2 and len(handles) >= 2:
                     payload = chat_tool_response(
@@ -238,7 +238,7 @@ class Handler(BaseHTTPRequestHandler):
 
     def _probe_command(self, handle: str) -> str:
         url = f"http://127.0.0.1:{self.server.server_port}/check"
-        return shell_command([sys.executable, "e2e_helper.py", "probe", url, handle])
+        return shell_command(["python", "e2e_helper.py", "probe", url, handle])
 
     def _json(self, value: object, status: int = 200) -> None:
         payload = json.dumps(value).encode()


### PR DESCRIPTION
## Summary
- add current Pi to the installed-agent handle E2E
- verify two masked `.env` values are restored only at local tool execution
- preserve Git Bash semantics for Pi and Claude on Windows while OpenCode continues to use PowerShell
- run the same Pi boundary test in current-client and release workflows

## Verified locally
- `python -m py_compile tools/installed_agent_e2e.py`
- `python tools/installed_agent_e2e.py --pentect pentect --client pi`
- `cargo test -p pentect-runtime only_windows_generic_bash_uses_powershell_semantics --locked`
- `cargo check -p pentect-cli --no-default-features --locked`

Advances #237
