### PR TITLE
fix: clean up CLI agent sessions after interrupt

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -39,9 +39,10 @@ use std::ffi::OsString;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, OnceLock};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use zeroize::Zeroize;
 
 pub(crate) type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
@@ -65,8 +66,12 @@ const PENTECT_MEMORY_STORE_ADDR_ENV: &str = "PENTECT_MEMORY_STORE_ADDR";
 const PENTECT_MEMORY_STORE_TOKEN_ENV: &str = "PENTECT_MEMORY_STORE_TOKEN";
 const MEMORY_STORE_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const GATEWAY_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
+const NATIVE_INTERRUPT_GRACE: Duration = Duration::from_secs(2);
+const NATIVE_CHILD_POLL: Duration = Duration::from_millis(20);
 const MAX_MEMORY_STORE_STARTUP_STDERR: usize = 64 * 1024;
 const ISSUE_NEW_URL: &str = "https://github.com/EdamAme-x/pentect/issues/new";
+static NATIVE_COMMAND_INTERRUPTED: AtomicBool = AtomicBool::new(false);
+static NATIVE_INTERRUPT_HANDLER: OnceLock<std::result::Result<(), String>> = OnceLock::new();
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum CommandAudience {
@@ -2312,11 +2317,54 @@ fn run_native_command_with_guards<G>(
     display: &Path,
     _guards: G,
 ) -> Result<std::process::ExitStatus, String> {
+    install_native_interrupt_handler()?;
+    NATIVE_COMMAND_INTERRUPTED.store(false, Ordering::SeqCst);
     cmd.stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
-    cmd.status()
-        .map_err(|error| format!("could not run '{}': {error}", display.display()))
+    let mut child = cmd
+        .spawn()
+        .map_err(|error| format!("could not run '{}': {error}", display.display()))?;
+    let status = wait_for_native_child(
+        &mut child,
+        &NATIVE_COMMAND_INTERRUPTED,
+        NATIVE_INTERRUPT_GRACE,
+    )
+    .map_err(|error| format!("could not wait for '{}': {error}", display.display()))?;
+    NATIVE_COMMAND_INTERRUPTED.store(false, Ordering::SeqCst);
+    Ok(status)
+}
+
+fn install_native_interrupt_handler() -> Result<(), String> {
+    NATIVE_INTERRUPT_HANDLER
+        .get_or_init(|| {
+            ctrlc::set_handler(|| {
+                NATIVE_COMMAND_INTERRUPTED.store(true, Ordering::SeqCst);
+            })
+            .map_err(|error| format!("could not install client cleanup handler: {error}"))
+        })
+        .clone()
+}
+
+fn wait_for_native_child(
+    child: &mut Child,
+    interrupted: &AtomicBool,
+    grace: Duration,
+) -> std::io::Result<std::process::ExitStatus> {
+    let mut interrupted_at = None;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if interrupted.load(Ordering::SeqCst) {
+            let started = interrupted_at.get_or_insert_with(Instant::now);
+            if started.elapsed() >= grace {
+                let _ = child.kill();
+                return child.wait();
+            }
+        }
+        thread::sleep(NATIVE_CHILD_POLL);
+    }
 }
 
 struct MemoryStoreGuard {
@@ -4027,6 +4075,48 @@ mod tests {
         let (reason, action) = classify_memory_store_startup_stderr(b"unexpected child crash");
         assert_eq!(reason, "child-exited");
         assert!(action.contains("pentect log"));
+    }
+
+    #[test]
+    fn interrupted_native_child_is_forced_down_after_the_grace_period() {
+        let interrupted = std::sync::Arc::new(AtomicBool::new(false));
+        let mut command;
+        #[cfg(windows)]
+        {
+            command = Command::new(windows_system_executable(
+                "WindowsPowerShell\\v1.0\\powershell.exe",
+            ));
+            command.args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Start-Sleep -Seconds 30",
+            ]);
+        }
+        #[cfg(unix)]
+        {
+            command = Command::new("sh");
+            command.args(["-c", "trap '' INT TERM; sleep 30"]);
+        }
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut child = command.spawn().unwrap();
+        let setter = std::sync::Arc::clone(&interrupted);
+        let trigger = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(50));
+            setter.store(true, Ordering::SeqCst);
+        });
+
+        let started = Instant::now();
+        let status =
+            wait_for_native_child(&mut child, &interrupted, Duration::from_millis(50)).unwrap();
+        trigger.join().unwrap();
+
+        assert!(!status.success());
+        assert!(started.elapsed() < Duration::from_secs(5));
     }
 
     #[test]

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -660,7 +660,7 @@ def run_cancellation(pentect: str) -> None:
             codex_home.mkdir()
             config = codex_home / "config.toml"
             sentinel = (
-                f"[projects.{json.dumps(str(project))}]\n"
+                f"[projects.{json.dumps(str(project.resolve()))}]\n"
                 'trust_level = "trusted"\n'
                 "# cancellation E2E sentinel\n"
             )

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import signal
 import shlex
 import shutil
 import subprocess
@@ -226,9 +227,12 @@ def anthropic_text_response(sequence: int, text: str) -> bytes:
 
 
 class State:
-    def __init__(self, valid: str, invalid: str) -> None:
+    def __init__(self, valid: str, invalid: str, *, hold_model: bool = False) -> None:
         self.valid = valid
         self.invalid = invalid
+        self.hold_model = hold_model
+        self.model_request_seen = threading.Event()
+        self.release_model_request = threading.Event()
         self.model_requests: list[str] = []
         self.service_attempts: list[str] = []
         self.anthropic_probe_responses = [0, 0]
@@ -309,6 +313,10 @@ class Handler(BaseHTTPRequestHandler):
         if self.path.endswith("/responses"):
             request = body.decode("utf-8")
             self.server.state.model_requests.append(request)
+            if self.server.state.hold_model:
+                self.server.state.model_request_seen.set()
+                self.server.state.release_model_request.wait(timeout=30)
+                return
             sequence = len(self.server.state.model_requests)
             if sequence == 1:
                 command = shell_command(["python", "e2e_helper.py", "read"])
@@ -628,6 +636,127 @@ else:
         thread.join()
 
 
+def run_cancellation(pentect: str) -> None:
+    valid = "rpa_PENTECT_CANCEL_VALID_0123456789abcdef"
+    invalid = "rpa_PENTECT_CANCEL_INVALID_fedcba9876543210"
+    state = State(valid, invalid, hold_model=True)
+    server = FixtureServer(state)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    process: subprocess.Popen[str] | None = None
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix="pentect-cancel-e2e-", ignore_cleanup_errors=True
+        ) as raw_root:
+            root = Path(raw_root)
+            home = root / "home"
+            project = root / "project"
+            home.mkdir()
+            project.mkdir()
+            (project / ".env").write_text(
+                f"FIRST_KEY={invalid}\nSECOND_KEY={valid}\n", encoding="utf-8"
+            )
+            codex_home = home / ".codex"
+            codex_home.mkdir()
+            config = codex_home / "config.toml"
+            sentinel = (
+                f"[projects.{json.dumps(str(project))}]\n"
+                'trust_level = "trusted"\n'
+                "# cancellation E2E sentinel\n"
+            )
+            config.write_text(sentinel, encoding="utf-8")
+            environment = os.environ.copy()
+            environment.update({
+                "HOME": str(home),
+                "USERPROFILE": str(home),
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                "XDG_CACHE_HOME": str(home / ".cache"),
+                "XDG_DATA_HOME": str(home / ".local" / "share"),
+                "XDG_STATE_HOME": str(home / ".local" / "state"),
+                "OPENAI_API_KEY": "local-fixture",
+                "PENTECT_LOG_DIR": str(root / "logs"),
+            })
+            command = client_command(
+                pentect,
+                "codex",
+                project,
+                f"http://127.0.0.1:{server.server_port}/v1",
+            )
+            if os.name == "nt" and pentect.lower().endswith((".cmd", ".bat")):
+                command = [
+                    os.environ.get("COMSPEC", "cmd.exe"),
+                    "/d",
+                    "/s",
+                    "/c",
+                    *command,
+                ]
+            popen_options: dict[str, object] = {}
+            if os.name == "nt":
+                popen_options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+            else:
+                popen_options["start_new_session"] = True
+            process = subprocess.Popen(
+                command,
+                cwd=project,
+                env=environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                **popen_options,
+            )
+            if not state.model_request_seen.wait(timeout=20):
+                raise RuntimeError("cancellation E2E never reached the model fixture")
+            if os.name == "nt":
+                process.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                os.killpg(process.pid, signal.SIGINT)
+            try:
+                output, _ = process.communicate(timeout=8)
+            except subprocess.TimeoutExpired as error:
+                raise RuntimeError(
+                    "Pentect did not finish client cleanup within 8 seconds after interrupt"
+                ) from error
+            sanitized = output.replace(valid, "<synthetic-key>").replace(
+                invalid, "<synthetic-key>"
+            )
+            if process.returncode == 0:
+                raise RuntimeError(
+                    "interrupted Pentect unexpectedly returned success:\n" + sanitized
+                )
+            config_after = config.read_text(encoding="utf-8")
+            if config_after != sentinel:
+                sanitized_config = config_after.replace(
+                    valid, "<synthetic-key>"
+                ).replace(invalid, "<synthetic-key>")
+                raise RuntimeError(
+                    "Codex configuration changed across cancellation: "
+                    + repr(sanitized_config[:2000])
+                )
+            runtime = home / ".cache" / "pentect" / "runtime"
+            residue = list(runtime.glob("process-host-candidate-*.json"))
+            residue.extend(runtime.glob("delegated-process-host.json"))
+            if residue:
+                raise RuntimeError(
+                    "Pentect left process-host registration after cancellation: "
+                    + ", ".join(path.name for path in residue)
+                )
+            upstream = "\n".join(state.model_requests)
+            if valid in upstream or invalid in upstream:
+                raise RuntimeError("cancellation request exposed plaintext to the model fixture")
+            print(
+                "installed codex cancellation E2E passed: bounded exit, "
+                "config restored, no process-host residue"
+            )
+    finally:
+        if process is not None and process.poll() is None:
+            process.kill()
+            process.wait()
+        state.release_model_request.set()
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--pentect", default="pentect")
@@ -642,6 +771,8 @@ def main() -> int:
     # transport. A regression should fail before the slower Codex startup.
     for client in args.clients or ("claude", "codex", "opencode", "pi"):
         run_client(args.pentect, client)
+    if args.clients is None or "codex" in args.clients:
+        run_cancellation(args.pentect)
     return 0
 
 


### PR DESCRIPTION
## What was wrong

The normal CLI client path waited with `Command::status()` and did not install an interrupt handler. A terminal interrupt could terminate Pentect before Rust destructors ran, so the memory store, local provider gateway, process-host registration, and temporary client settings were not guaranteed to be cleaned up. App launchers already had explicit signal cleanup, but Codex, Claude, OpenCode, and Pi CLI launches did not.

## Fix

- install one process-wide cleanup handler for native CLI client launches;
- allow the client two seconds to handle the terminal interrupt normally;
- force-stop and reap a client that does not exit within that bound;
- return through the normal Rust stack so all gateway, memory-store, and temporary-settings guards are dropped;
- extend the installed Codex E2E with a blocked localhost model request, a real process-group interrupt, bounded exit, exact config restoration, process-host residue checks, and provider-plaintext checks.

The wait path is shared by the supported native CLI clients; it does not add client-specific shell parsing or command rewriting.

## Local verification

- `cargo test -p pentect-cli --no-default-features --locked interrupted_native_child_is_forced_down_after_the_grace_period`
- `cargo clippy -p pentect-cli --no-default-features --locked -- -D warnings`
- `python -m py_compile tools/installed_agent_e2e.py`
- candidate Pentect with installed Claude, Codex, OpenCode, and Pi localhost key-selection E2E
- candidate Pentect Codex cancellation E2E

Advances #237.
