### PR TITLE
fix: verify Codex App protection before reporting it

### DIFF
--- a/crates/pentect-cli/src/codex_app.rs
+++ b/crates/pentect-cli/src/codex_app.rs
@@ -13,6 +13,7 @@ use std::{fs::OpenOptions, io::Write, thread, time::Duration};
 const APP_START_GRACE: Duration = Duration::from_secs(15);
 const APP_EXIT_GRACE: Duration = Duration::from_secs(30);
 const APP_MONITOR_INTERVAL: Duration = Duration::from_millis(500);
+const APP_PROTECTION_WARNING_AFTER: Duration = Duration::from_secs(30);
 const MAX_LIFECYCLE_LOG_BYTES: u64 = 1024 * 1024;
 
 pub(crate) fn cmd_codex_app(args: &[String]) -> i32 {
@@ -86,10 +87,8 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
     record_lifecycle(&lifecycle_log, "gateway-started", "loopback");
     eprintln!("[pentect] Codex App gateway ready at {}", proxy.base_url());
     eprintln!(
-        "[pentect] Codex provider '{}' is routed through the gateway for this App session",
-        routing.provider
+        "[pentect] Waiting for Codex App to send a protected Responses API request; use a non-sensitive test prompt first"
     );
-    eprintln!("[pentect] Responses API prompts, files, and completed tool calls are protected");
 
     let mut command = Command::new(&app);
     crate::upstream::hide_header_source_env(&mut command, &options.upstream_header_env);
@@ -143,7 +142,14 @@ fn run_codex_app(args: &[String]) -> Result<std::process::ExitStatus, String> {
             "could not install Codex App session cleanup handler: {error}"
         ));
     }
-    let status = monitor_codex_app(&mut child, &app, &proxy, &lifecycle_log)?;
+    let mut protection_reporter = CodexAppProtectionReporter::new(std::time::Instant::now());
+    let status = monitor_codex_app(
+        &mut child,
+        &app,
+        &proxy,
+        &lifecycle_log,
+        &mut protection_reporter,
+    )?;
     session_cleanup
         .lock()
         .map_err(|_| "Codex App session cleanup lock is unavailable".to_string())?
@@ -162,6 +168,7 @@ fn monitor_codex_app(
     app: &Path,
     proxy: &crate::openai_http_proxy::OpenAiHttpProxyGuard,
     lifecycle_log: &Option<CodexAppLifecycleLog>,
+    protection_reporter: &mut CodexAppProtectionReporter,
 ) -> Result<std::process::ExitStatus, String> {
     loop {
         if !proxy.is_running() {
@@ -175,6 +182,7 @@ fn monitor_codex_app(
                 "Codex App gateway stopped: {reason}; inspect the lifecycle entries with `pentect log`"
             ));
         }
+        report_codex_app_protection(proxy, lifecycle_log, protection_reporter);
         if let Some(status) = child
             .try_wait()
             .map_err(|error| format!("could not monitor Codex App launcher: {error}"))?
@@ -187,7 +195,7 @@ fn monitor_codex_app(
             if !status.success() {
                 return Ok(status);
             }
-            return monitor_handed_off_app(app, proxy, lifecycle_log, status);
+            return monitor_handed_off_app(app, proxy, lifecycle_log, protection_reporter, status);
         }
         thread::sleep(APP_MONITOR_INTERVAL);
     }
@@ -197,6 +205,7 @@ fn monitor_handed_off_app(
     app: &Path,
     proxy: &crate::openai_http_proxy::OpenAiHttpProxyGuard,
     lifecycle_log: &Option<CodexAppLifecycleLog>,
+    protection_reporter: &mut CodexAppProtectionReporter,
     launcher_status: std::process::ExitStatus,
 ) -> Result<std::process::ExitStatus, String> {
     let mut process_probe = CodexAppProcessProbe::new(app);
@@ -209,6 +218,7 @@ fn monitor_handed_off_app(
             terminate_codex_app_processes(app);
             return Err(error);
         }
+        report_codex_app_protection(proxy, lifecycle_log, protection_reporter);
         if process_probe.app_is_running() {
             if !observed {
                 record_lifecycle(lifecycle_log, "app-process-observed", "running");
@@ -244,6 +254,73 @@ fn monitor_handed_off_app(
             warned_unobservable = true;
         }
         thread::sleep(APP_MONITOR_INTERVAL);
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum CodexAppProtectionNotice {
+    Active,
+    NotObserved,
+}
+
+struct CodexAppProtectionReporter {
+    started_at: std::time::Instant,
+    active_reported: bool,
+    warning_reported: bool,
+}
+
+impl CodexAppProtectionReporter {
+    fn new(started_at: std::time::Instant) -> Self {
+        Self {
+            started_at,
+            active_reported: false,
+            warning_reported: false,
+        }
+    }
+
+    fn next_notice(
+        &mut self,
+        protected_request_observed: bool,
+        now: std::time::Instant,
+    ) -> Option<CodexAppProtectionNotice> {
+        if protected_request_observed && !self.active_reported {
+            self.active_reported = true;
+            return Some(CodexAppProtectionNotice::Active);
+        }
+        if !protected_request_observed
+            && !self.active_reported
+            && !self.warning_reported
+            && now.duration_since(self.started_at) >= APP_PROTECTION_WARNING_AFTER
+        {
+            self.warning_reported = true;
+            return Some(CodexAppProtectionNotice::NotObserved);
+        }
+        None
+    }
+}
+
+fn report_codex_app_protection(
+    proxy: &crate::openai_http_proxy::OpenAiHttpProxyGuard,
+    lifecycle_log: &Option<CodexAppLifecycleLog>,
+    reporter: &mut CodexAppProtectionReporter,
+) {
+    match reporter.next_notice(
+        proxy.protected_request_observed(),
+        std::time::Instant::now(),
+    ) {
+        Some(CodexAppProtectionNotice::Active) => {
+            record_lifecycle(lifecycle_log, "protected-request-observed", "active");
+            eprintln!(
+                "[pentect] Codex App is routed through the gateway; supported traffic is protected"
+            );
+        }
+        Some(CodexAppProtectionNotice::NotObserved) => {
+            record_lifecycle(lifecycle_log, "protected-request-not-observed", "warning");
+            eprintln!(
+                "[pentect] warning: Codex App has not sent a protected request after 30 seconds; confirm that this is the Pentect-launched App before sending sensitive data"
+            );
+        }
+        None => {}
     }
 }
 
@@ -1384,6 +1461,48 @@ fn success_status() -> std::process::ExitStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_protected_request_warns_once_and_later_reports_recovery() {
+        let started_at = std::time::Instant::now();
+        let mut reporter = CodexAppProtectionReporter::new(started_at);
+
+        assert_eq!(
+            reporter.next_notice(false, started_at + Duration::from_secs(29)),
+            None
+        );
+        assert_eq!(
+            reporter.next_notice(false, started_at + APP_PROTECTION_WARNING_AFTER),
+            Some(CodexAppProtectionNotice::NotObserved)
+        );
+        assert_eq!(
+            reporter.next_notice(false, started_at + Duration::from_secs(31)),
+            None
+        );
+        assert_eq!(
+            reporter.next_notice(true, started_at + Duration::from_secs(32)),
+            Some(CodexAppProtectionNotice::Active)
+        );
+        assert_eq!(
+            reporter.next_notice(true, started_at + Duration::from_secs(33)),
+            None
+        );
+    }
+
+    #[test]
+    fn observed_protected_request_does_not_emit_a_late_warning() {
+        let started_at = std::time::Instant::now();
+        let mut reporter = CodexAppProtectionReporter::new(started_at);
+
+        assert_eq!(
+            reporter.next_notice(true, started_at + Duration::from_secs(1)),
+            Some(CodexAppProtectionNotice::Active)
+        );
+        assert_eq!(
+            reporter.next_notice(false, started_at + APP_PROTECTION_WARNING_AFTER),
+            None
+        );
+    }
 
     #[test]
     fn process_matching_requires_install_root_component_boundary() {

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -71,6 +71,7 @@ pub(crate) struct OpenAiHttpProxyGuard {
     shutdown: Option<oneshot::Sender<()>>,
     thread: Option<thread::JoinHandle<()>>,
     failure: Arc<Mutex<Option<String>>>,
+    protected_request_observed: Arc<AtomicBool>,
 }
 
 impl OpenAiHttpProxyGuard {
@@ -99,6 +100,8 @@ impl OpenAiHttpProxyGuard {
         let thread_auth = auth.clone();
         let failure = Arc::new(Mutex::new(None));
         let thread_failure = Arc::clone(&failure);
+        let protected_request_observed = Arc::new(AtomicBool::new(false));
+        let thread_protected_request_observed = Arc::clone(&protected_request_observed);
         let thread = thread::spawn(move || {
             let runtime = match tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(2)
@@ -117,8 +120,15 @@ impl OpenAiHttpProxyGuard {
                 }
             };
             runtime.block_on(async move {
-                if let Err(error) =
-                    run_proxy(upstream, headers, thread_auth, ready_tx, shutdown_rx).await
+                if let Err(error) = run_proxy(
+                    upstream,
+                    headers,
+                    thread_auth,
+                    thread_protected_request_observed,
+                    ready_tx,
+                    shutdown_rx,
+                )
+                .await
                 {
                     if let Ok(mut failure) = thread_failure.lock() {
                         *failure = Some(error);
@@ -135,6 +145,7 @@ impl OpenAiHttpProxyGuard {
             shutdown: Some(shutdown_tx),
             thread: Some(thread),
             failure,
+            protected_request_observed,
         })
     }
 
@@ -150,6 +161,10 @@ impl OpenAiHttpProxyGuard {
         self.thread
             .as_ref()
             .is_some_and(|thread| !thread.is_finished())
+    }
+
+    pub(crate) fn protected_request_observed(&self) -> bool {
+        self.protected_request_observed.load(Ordering::Acquire)
     }
 }
 
@@ -176,6 +191,7 @@ struct ProxyState {
     requests: Arc<Semaphore>,
     block_unknown_formats: bool,
     headers: crate::upstream::HeaderOverrides,
+    protected_request_observed: Arc<AtomicBool>,
 }
 
 impl Drop for ProxyState {
@@ -188,10 +204,11 @@ async fn run_proxy(
     upstream: reqwest::Url,
     headers: crate::upstream::HeaderOverrides,
     auth: String,
+    protected_request_observed: Arc<AtomicBool>,
     ready_tx: mpsc::Sender<Result<String, String>>,
     mut shutdown_rx: oneshot::Receiver<()>,
 ) -> Result<(), String> {
-    let initialized = initialize_proxy(upstream, headers, auth).await;
+    let initialized = initialize_proxy(upstream, headers, auth, protected_request_observed).await;
     let (listener, state, local_base_url) = match initialized {
         Ok(initialized) => initialized,
         Err(error) => {
@@ -235,6 +252,7 @@ async fn initialize_proxy(
     upstream: reqwest::Url,
     headers: crate::upstream::HeaderOverrides,
     auth: String,
+    protected_request_observed: Arc<AtomicBool>,
 ) -> Result<(TcpListener, Arc<ProxyState>, String), String> {
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .await
@@ -257,6 +275,7 @@ async fn initialize_proxy(
         requests: Arc::new(Semaphore::new(32)),
         block_unknown_formats: pentect_agent::unknown_formats_should_block()?,
         headers,
+        protected_request_observed,
     });
     Ok((listener, state, local_base_url))
 }
@@ -548,6 +567,9 @@ async fn proxy_request_inner(
             .map_err(|_| "OpenAI request protection task failed".to_string())??;
             request_coverage = Some(protected.coverage);
             if let Some(response) = protected.local_response {
+                state
+                    .protected_request_observed
+                    .store(true, Ordering::Release);
                 if request_streaming {
                     return Ok(text_response(
                         StatusCode::UNPROCESSABLE_ENTITY,
@@ -564,6 +586,12 @@ async fn proxy_request_inner(
         });
         reqwest::Body::wrap_stream(stream)
     };
+
+    if (protected_request && inspect_protected_request) || files_upload || audio_upload {
+        state
+            .protected_request_observed
+            .store(true, Ordering::Release);
+    }
 
     let mut upstream_request = state.client.request(method.clone(), upstream_url);
     let connection_headers = connection_named_headers(&headers);
@@ -3862,6 +3890,7 @@ mod tests {
         let store = pentect_agent::start_in_process_memory_store().unwrap();
         let _env = ProviderBoundaryTestEnv::install(&store);
         let proxy = OpenAiHttpProxyGuard::start("http://127.0.0.1:9".to_string()).unwrap();
+        assert!(!proxy.protected_request_observed());
 
         let response = reqwest::blocking::Client::new()
             .get(format!("{}/responses", proxy.base_url()))
@@ -3871,6 +3900,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), reqwest::StatusCode::UPGRADE_REQUIRED);
+        assert!(!proxy.protected_request_observed());
     }
 
     #[test]
@@ -3895,6 +3925,7 @@ mod tests {
             Some("PENTECT_TEST_OPENAI_PROVIDER_KEY"),
         )
         .unwrap();
+        assert!(!proxy.protected_request_observed());
         let response = reqwest::blocking::Client::new()
             .post(format!("{}/v1/chat/completions", proxy.base_url()))
             .header(reqwest::header::CONTENT_TYPE, "application/json")
@@ -3930,6 +3961,7 @@ mod tests {
             .unwrap()
             .text()
             .unwrap();
+        assert!(proxy.protected_request_observed());
         let response: Value = serde_json::from_str(&response).unwrap();
         let (headers, request) = captured
             .recv_timeout(std::time::Duration::from_secs(5))
@@ -4321,6 +4353,7 @@ mod tests {
         let store = pentect_agent::start_in_process_memory_store().unwrap();
         let _env = ProviderBoundaryTestEnv::install(&store);
         let proxy = OpenAiHttpProxyGuard::start("http://127.0.0.1:9".to_string()).unwrap();
+        assert!(!proxy.protected_request_observed());
         let secret = ["rpa_", "MODELROUTE", "BODYMUST", "NOTLEAVE", "1234567890"].concat();
 
         let client = reqwest::blocking::Client::new();
@@ -4986,6 +5019,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(!proxy.protected_request_observed());
         let error = response.text().unwrap();
         assert!(
             error.contains("non-string response instructions"),

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -567,14 +567,16 @@ async fn proxy_request_inner(
             .map_err(|_| "OpenAI request protection task failed".to_string())??;
             request_coverage = Some(protected.coverage);
             if let Some(response) = protected.local_response {
-                state
-                    .protected_request_observed
-                    .store(true, Ordering::Release);
                 if request_streaming {
                     return Ok(text_response(
                         StatusCode::UNPROCESSABLE_ENTITY,
                         "Plugin local responses are unavailable for streaming OpenAI requests",
                     ));
+                }
+                if request_was_fully_protected(request_coverage) {
+                    state
+                        .protected_request_observed
+                        .store(true, Ordering::Release);
                 }
                 return Ok(json_response(StatusCode::OK, response));
             }
@@ -587,7 +589,7 @@ async fn proxy_request_inner(
         reqwest::Body::wrap_stream(stream)
     };
 
-    if (protected_request && inspect_protected_request) || files_upload || audio_upload {
+    if request_was_fully_protected(request_coverage) {
         state
             .protected_request_observed
             .store(true, Ordering::Release);
@@ -748,6 +750,10 @@ async fn proxy_request_inner(
     builder
         .body(full_body(response_body))
         .map_err(|error| format!("could not build OpenAI response: {error}"))
+}
+
+fn request_was_fully_protected(coverage: Option<crate::http_files::Coverage>) -> bool {
+    coverage == Some(crate::http_files::Coverage::Full)
 }
 
 fn run_response_plugins(
@@ -3904,6 +3910,23 @@ mod tests {
     }
 
     #[test]
+    fn empty_protected_route_does_not_count_as_observed_protection() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = ProviderBoundaryTestEnv::install(&store);
+        let proxy = OpenAiHttpProxyGuard::start("http://127.0.0.1:9".to_string()).unwrap();
+
+        let response = reqwest::blocking::Client::new()
+            .post(format!("{}/responses", proxy.base_url()))
+            .body(Vec::new())
+            .send()
+            .unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::BAD_GATEWAY);
+        assert!(!proxy.protected_request_observed());
+    }
+
+    #[test]
     fn provider_boundary_masks_chat_requests_and_restores_local_assistant_output() {
         let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let store = pentect_agent::start_in_process_memory_store().unwrap();
@@ -4513,6 +4536,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(protected.coverage, crate::http_files::Coverage::Partial);
+        assert!(!request_was_fully_protected(Some(protected.coverage)));
         let protected = String::from_utf8(protected.body.to_vec()).unwrap();
         assert!(!protected.contains(&secret));
         assert!(protected.contains("<<"));
@@ -5264,6 +5288,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(allowed.coverage, crate::http_files::Coverage::Partial);
+        assert!(!request_was_fully_protected(Some(allowed.coverage)));
         assert_eq!(allowed.body, body);
     }
 

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -116,6 +116,8 @@ events from previous sessions as well as live protection events.
 After launch, use a non-sensitive test prompt first. Pentect reports active
 protection only after the App sends a supported request through the gateway. A
 listening gateway by itself is not proof that the App is routed through it.
+See [Compatibility](/reference/compatibility/) for the routes and client modes
+covered by this status.
 
 ## Verify protection
 

--- a/website/src/content/docs/clients/codex.md
+++ b/website/src/content/docs/clients/codex.md
@@ -113,6 +113,10 @@ hands off to another App process, Pentect keeps the gateway alive until that
 process exits. `pentect log` includes value-free Codex App lifecycle and crash
 events from previous sessions as well as live protection events.
 
+After launch, use a non-sensitive test prompt first. Pentect reports active
+protection only after the App sends a supported request through the gateway. A
+listening gateway by itself is not proof that the App is routed through it.
+
 ## Verify protection
 
 Run `pentect log` in another terminal. Then ask Codex to read a test dotenv


### PR DESCRIPTION
## Summary

- stop claiming Codex App routing/protection when only the loopback listener is ready
- record observation only after an authenticated supported POST completes its applicable request-protection path
- keep WebSocket fallback probes, blocked/malformed bodies, unknown routes, and skipped inspection from satisfying the signal
- emit one warning after 30 seconds without terminating an idle/login App
- emit one active event if a valid protected request arrives before or after that warning
- persist both states in the value-free Codex App lifecycle log
- document the non-sensitive first-prompt verification flow

## Root cause

`run_codex_app` treated gateway listener startup as proof that the App inherited and used the session routing. The OpenAI guard exposed no protected-request observation state, so a different App instance or failed handoff still produced an unverified safety claim.

## Focused verification

- all 26 `codex_app::tests`
- reporter warns once and reports later recovery once
- early observation suppresses a late warning
- a WebSocket fallback probe does not activate the signal
- a successfully masked Chat request activates the signal
- a locally blocked malformed Responses body does not activate the signal
- `git diff --check`

Signed-in real-account Codex App UI validation remains unverified.

Closes #1308
Part of #352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer protection status reporting for the Codex App.
  * Shows when protected traffic is detected and warns if no protected request is observed after 30 seconds.
  * Detects protected requests across supported request types, including uploads and plugin responses.

* **Documentation**
  * Added guidance to send a non-sensitive test prompt after launching the Codex App to verify protection is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->