### PR TITLE
Enforce Response plugin Partial coverage consistently

### DIFF
--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -3051,12 +3051,11 @@ where
             value,
             Some(serde_json::json!({"provider": "claude", "transport": "desktop-http"})),
         )?;
-    if block_unknown_formats && run.coverage == pentect_agent::MiddlewareCoverage::Partial {
-        return Err(
-            "unknown format blocked: a Claude App plugin reported partial response coverage"
-                .to_string(),
-        );
-    }
+    crate::plugins::enforce_response_plugin_coverage(
+        run.coverage,
+        block_unknown_formats,
+        "Claude App",
+    )?;
     if run.stopped == Some(pentect_agent::StopOutcome::Block) {
         return Err(format!(
             "plugin blocked: {}",

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -633,7 +633,8 @@ async fn proxy_request_inner(
         }
     }
     let response_body = if status.is_success() && messages_path {
-        let response_body = run_response_plugins(response_body, &state.plugins)?;
+        let response_body =
+            run_response_plugins(response_body, &state.plugins, state.block_unknown_formats)?;
         match rewrite_anthropic_json_response(&response_body, restore_output, &mut resolve) {
             Ok(rewritten) => Bytes::from(rewritten),
             Err(_error) => {
@@ -652,6 +653,7 @@ async fn proxy_request_inner(
 fn run_response_plugins(
     body: Bytes,
     plugins: &StdMutex<pentect_agent::PluginMiddleware>,
+    block_unknown_formats: bool,
 ) -> Result<Bytes, String> {
     let value: Value = match serde_json::from_slice(&body) {
         Ok(value) => value,
@@ -660,10 +662,35 @@ fn run_response_plugins(
     let plugins = plugins
         .lock()
         .map_err(|_| "Claude plugin lock was poisoned".to_string())?;
-    let run = plugins.run(
+    let mut payload = run_anthropic_response_plugin_with(
+        value,
+        block_unknown_formats,
+        |stage, payload, context| plugins.run(stage, payload, context),
+    )?;
+    run_anthropic_tool_plugins(&mut payload, &plugins)?;
+    serde_json::to_vec(&payload)
+        .map(Bytes::from)
+        .map_err(|error| format!("could not encode plugin response payload: {error}"))
+}
+
+fn run_anthropic_response_plugin_with(
+    value: Value,
+    block_unknown_formats: bool,
+    mut run: impl FnMut(
+        pentect_agent::MiddlewareStage,
+        Value,
+        Option<Value>,
+    ) -> Result<pentect_agent::MiddlewareRun, String>,
+) -> Result<Value, String> {
+    let run = run(
         pentect_agent::MiddlewareStage::Response,
         value,
         Some(serde_json::json!({"provider": "anthropic", "transport": "http"})),
+    )?;
+    crate::plugins::enforce_response_plugin_coverage(
+        run.coverage,
+        block_unknown_formats,
+        "Claude",
     )?;
     if run.stopped == Some(pentect_agent::StopOutcome::Block) {
         return Err(format!(
@@ -672,11 +699,7 @@ fn run_response_plugins(
                 .unwrap_or_else(|| "response blocked".to_string())
         ));
     }
-    let mut payload = run.payload;
-    run_anthropic_tool_plugins(&mut payload, &plugins)?;
-    serde_json::to_vec(&payload)
-        .map(Bytes::from)
-        .map_err(|error| format!("could not encode plugin response payload: {error}"))
+    Ok(run.payload)
 }
 
 fn run_anthropic_tool_plugins(
@@ -2690,6 +2713,63 @@ fn random_auth_token() -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn anthropic_response_partial_coverage_obeys_strict_and_ignore_policy() {
+        let strict_error = run_anthropic_response_plugin_with(
+            serde_json::json!({"id": "message"}),
+            true,
+            |stage, payload, context| {
+                assert_eq!(stage, pentect_agent::MiddlewareStage::Response);
+                assert_eq!(
+                    context.unwrap(),
+                    serde_json::json!({
+                        "provider": "anthropic",
+                        "transport": "http"
+                    })
+                );
+                Ok(pentect_agent::MiddlewareRun {
+                    payload,
+                    coverage: pentect_agent::MiddlewareCoverage::Partial,
+                    stopped: None,
+                    message: None,
+                })
+            },
+        )
+        .unwrap_err();
+        assert!(strict_error.contains("Claude Response plugin reported partial coverage"));
+
+        let allowed = run_anthropic_response_plugin_with(
+            serde_json::json!({"id": "message"}),
+            false,
+            |_stage, mut payload, _context| {
+                payload["plugin"] = Value::Bool(true);
+                Ok(pentect_agent::MiddlewareRun {
+                    payload,
+                    coverage: pentect_agent::MiddlewareCoverage::Partial,
+                    stopped: None,
+                    message: None,
+                })
+            },
+        )
+        .unwrap();
+        assert_eq!(allowed["plugin"], true);
+
+        let stop_error = run_anthropic_response_plugin_with(
+            serde_json::json!({"id": "message"}),
+            true,
+            |_stage, payload, _context| {
+                Ok(pentect_agent::MiddlewareRun {
+                    payload,
+                    coverage: pentect_agent::MiddlewareCoverage::Full,
+                    stopped: Some(pentect_agent::StopOutcome::Block),
+                    message: Some("test policy".to_string()),
+                })
+            },
+        )
+        .unwrap_err();
+        assert_eq!(stop_error, "plugin blocked: test policy");
+    }
 
     #[tokio::test]
     async fn uploaded_file_coverage_is_reused_after_anthropic_registry_restart() {

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -943,12 +943,11 @@ fn rewrite_response_value(
             value.clone(),
             Some(serde_json::json!({"provider": "google-cloud-code", "transport": "http"})),
         )?;
-    if block_unknown_formats && run.coverage == pentect_agent::MiddlewareCoverage::Partial {
-        return Err(
-            "unknown format blocked: a plugin reported partial Google Cloud Code response coverage"
-                .to_string(),
-        );
-    }
+    crate::plugins::enforce_response_plugin_coverage(
+        run.coverage,
+        block_unknown_formats,
+        "Google Cloud Code",
+    )?;
     if run.stopped == Some(pentect_agent::StopOutcome::Block) {
         return Err(format!(
             "plugin blocked: {}",

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -716,12 +716,11 @@ fn rewrite_response_body(
         value,
         Some(serde_json::json!({"provider": "gemini", "transport": "http"})),
     )?;
-    if block_unknown_formats && run.coverage == pentect_agent::MiddlewareCoverage::Partial {
-        return Err(
-            "unknown format blocked: a plugin reported partial Gemini response coverage"
-                .to_string(),
-        );
-    }
+    crate::plugins::enforce_response_plugin_coverage(
+        run.coverage,
+        block_unknown_formats,
+        "Gemini",
+    )?;
     if run.stopped == Some(pentect_agent::StopOutcome::Block) {
         return Err(format!(
             "plugin blocked: {}",

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -682,6 +682,7 @@ async fn proxy_request_inner(
                 },
                 Arc::clone(&state.plugins),
                 restore_output,
+                state.block_unknown_formats,
             ))
             .map_err(|error| format!("could not build OpenAI streaming response: {error}"));
     }
@@ -728,7 +729,12 @@ async fn proxy_request_inner(
         && status.is_success()
         && is_json_response
     {
-        let response_body = run_response_plugins(response_body, &state.plugins, "openai")?;
+        let response_body = run_response_plugins(
+            response_body,
+            &state.plugins,
+            "openai",
+            state.block_unknown_formats,
+        )?;
         let rewritten = if chat_response {
             rewrite_chat_completions_json_response(&response_body, restore_output)
         } else if completions_response {
@@ -760,12 +766,13 @@ fn run_response_plugins(
     body: Bytes,
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
     provider: &str,
+    block_unknown_formats: bool,
 ) -> Result<Bytes, String> {
     let value: Value = match serde_json::from_slice(&body) {
         Ok(value) => value,
         Err(_) => return Ok(body),
     };
-    let mut payload = run_response_plugins_value(value, plugins, provider)?;
+    let mut payload = run_response_plugins_value(value, plugins, provider, block_unknown_formats)?;
     let plugins = plugins
         .lock()
         .map_err(|_| "OpenAI plugin lock was poisoned".to_string())?;
@@ -779,14 +786,38 @@ fn run_response_plugins_value(
     value: Value,
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
     provider: &str,
+    block_unknown_formats: bool,
 ) -> Result<Value, String> {
     let plugins = plugins
         .lock()
         .map_err(|_| "OpenAI plugin lock was poisoned".to_string())?;
-    let run = plugins.run(
+    run_openai_response_plugin_with(
+        value,
+        provider,
+        block_unknown_formats,
+        |stage, payload, context| plugins.run(stage, payload, context),
+    )
+}
+
+fn run_openai_response_plugin_with(
+    value: Value,
+    provider: &str,
+    block_unknown_formats: bool,
+    mut run: impl FnMut(
+        pentect_agent::MiddlewareStage,
+        Value,
+        Option<Value>,
+    ) -> Result<pentect_agent::MiddlewareRun, String>,
+) -> Result<Value, String> {
+    let run = run(
         pentect_agent::MiddlewareStage::Response,
         value,
         Some(serde_json::json!({"provider": provider, "transport": "http"})),
+    )?;
+    crate::plugins::enforce_response_plugin_coverage(
+        run.coverage,
+        block_unknown_formats,
+        "OpenAI",
     )?;
     if run.stopped == Some(pentect_agent::StopOutcome::Block) {
         return Err(format!(
@@ -2477,6 +2508,7 @@ struct StreamState {
     finished: bool,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
     restore_output: bool,
+    block_unknown_formats: bool,
     output_text: HashMap<String, crate::claude_http_proxy::OutputTextRestorer>,
     output_resolve: HandleResolver,
 }
@@ -2490,7 +2522,7 @@ enum StreamTransform {
 }
 
 fn process_stream_block(state: &mut StreamState, block: Vec<u8>) -> Result<(), String> {
-    let block = run_sse_response_plugins(&block, &state.plugins)?;
+    let block = run_sse_response_plugins(&block, &state.plugins, state.block_unknown_formats)?;
     let rewritten = match state.transform {
         StreamTransform::Responses => rewrite_openai_sse_block(
             &block,
@@ -2533,6 +2565,7 @@ fn streaming_response_body(
     transform: StreamTransform,
     plugins: Arc<Mutex<pentect_agent::PluginMiddleware>>,
     restore_output: bool,
+    block_unknown_formats: bool,
 ) -> ProxyBody {
     let state = StreamState {
         upstream: Box::pin(response.bytes_stream()),
@@ -2544,6 +2577,7 @@ fn streaming_response_body(
         finished: false,
         plugins,
         restore_output,
+        block_unknown_formats,
         output_text: HashMap::new(),
         output_resolve: Box::new(crate::claude_http_proxy::request_scoped_resolver()),
     };
@@ -3018,6 +3052,7 @@ fn sse_data(text: &str) -> Option<Cow<'_, str>> {
 fn run_sse_response_plugins(
     block: &[u8],
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
+    block_unknown_formats: bool,
 ) -> Result<Vec<u8>, String> {
     let Ok(text) = std::str::from_utf8(block) else {
         return Ok(block.to_vec());
@@ -3031,7 +3066,7 @@ fn run_sse_response_plugins(
     let Ok(value) = serde_json::from_str::<Value>(data.as_ref()) else {
         return Ok(block.to_vec());
     };
-    let payload = run_response_plugins_value(value, plugins, "openai")?;
+    let payload = run_response_plugins_value(value, plugins, "openai", block_unknown_formats)?;
     encode_sse_value(text, &payload).map(|bytes| bytes.to_vec())
 }
 
@@ -3547,6 +3582,66 @@ fn random_auth_token() -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn openai_response_partial_coverage_obeys_strict_and_ignore_policy() {
+        let strict_error = run_openai_response_plugin_with(
+            serde_json::json!({"id": "response"}),
+            "openai",
+            true,
+            |stage, payload, context| {
+                assert_eq!(stage, pentect_agent::MiddlewareStage::Response);
+                assert_eq!(
+                    context.unwrap(),
+                    serde_json::json!({
+                        "provider": "openai",
+                        "transport": "http"
+                    })
+                );
+                Ok(pentect_agent::MiddlewareRun {
+                    payload,
+                    coverage: pentect_agent::MiddlewareCoverage::Partial,
+                    stopped: None,
+                    message: None,
+                })
+            },
+        )
+        .unwrap_err();
+        assert!(strict_error.contains("OpenAI Response plugin reported partial coverage"));
+
+        let allowed = run_openai_response_plugin_with(
+            serde_json::json!({"id": "response"}),
+            "openai",
+            false,
+            |_stage, mut payload, _context| {
+                payload["plugin"] = Value::Bool(true);
+                Ok(pentect_agent::MiddlewareRun {
+                    payload,
+                    coverage: pentect_agent::MiddlewareCoverage::Partial,
+                    stopped: None,
+                    message: None,
+                })
+            },
+        )
+        .unwrap();
+        assert_eq!(allowed["plugin"], true);
+
+        let stop_error = run_openai_response_plugin_with(
+            serde_json::json!({"id": "response"}),
+            "openai",
+            true,
+            |_stage, payload, _context| {
+                Ok(pentect_agent::MiddlewareRun {
+                    payload,
+                    coverage: pentect_agent::MiddlewareCoverage::Full,
+                    stopped: Some(pentect_agent::StopOutcome::Block),
+                    message: Some("test policy".to_string()),
+                })
+            },
+        )
+        .unwrap_err();
+        assert_eq!(stop_error, "plugin blocked: test policy");
+    }
 
     #[cfg(windows)]
     #[test]
@@ -4853,6 +4948,7 @@ mod tests {
             finished: false,
             plugins: Arc::new(Mutex::new(pentect_agent::PluginMiddleware::default())),
             restore_output: false,
+            block_unknown_formats: true,
             output_text: HashMap::new(),
             output_resolve: Box::new(|text| Ok(text.to_string())),
         };

--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -60,6 +60,19 @@ fn enforce_tool_plugin_coverage_with_policy(
     Ok(())
 }
 
+pub(crate) fn enforce_response_plugin_coverage(
+    coverage: pentect_agent::MiddlewareCoverage,
+    block_unknown_formats: bool,
+    provider: &str,
+) -> std::result::Result<(), String> {
+    if block_unknown_formats && coverage == pentect_agent::MiddlewareCoverage::Partial {
+        return Err(format!(
+            "unknown format blocked: a {provider} Response plugin reported partial coverage; set compatibility.unknown_formats = \"ignore\" in ~/.pentect/config.toml to allow it"
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum PluginScope {
     User,
@@ -2888,6 +2901,28 @@ label = "INLINE_SECRET"
         )
         .is_ok());
         assert!(enforce_tool_plugin_coverage_with_policy(
+            pentect_agent::MiddlewareCoverage::Full,
+            true,
+            "fixture"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn partial_response_plugin_coverage_only_blocks_in_strict_mode() {
+        assert!(enforce_response_plugin_coverage(
+            pentect_agent::MiddlewareCoverage::Partial,
+            true,
+            "fixture"
+        )
+        .is_err());
+        assert!(enforce_response_plugin_coverage(
+            pentect_agent::MiddlewareCoverage::Partial,
+            false,
+            "fixture"
+        )
+        .is_ok());
+        assert!(enforce_response_plugin_coverage(
             pentect_agent::MiddlewareCoverage::Full,
             true,
             "fixture"


### PR DESCRIPTION
## Summary

- centralize Response-stage Partial coverage policy for all five proxy implementations
- pass the effective strict/ignore setting into Anthropic non-streaming JSON response middleware
- carry the same setting through OpenAI JSON and per-event SSE response middleware
- preserve plugin payload mutation and Stop blocking behavior

## Root cause

Response coverage enforcement was duplicated across proxy implementations. The Anthropic and OpenAI response helpers did not receive `block_unknown_formats`, so they invoked Response middleware and handled Stop but could not enforce a Partial result. OpenAI's same helper is also used for parsed SSE events, which the original source-only report had missed.

Anthropic SSE does not invoke Response middleware at all; that separate stage-bypass bug is recorded in #1318 and is intentionally not folded into this PR.

## Behavior

- strict/block mode: Partial Response middleware coverage returns an actionable `unknown format blocked` error
- ignore mode: the plugin's payload is retained and processing continues
- Full coverage: unchanged
- Stop/Block: unchanged

Covered transports in this PR:

- Anthropic HTTP JSON
- OpenAI HTTP JSON
- OpenAI HTTP SSE events that parse as JSON

## Verification

- `cargo test -p pentect-cli response_partial_coverage -- --nocapture` — 2 passed
  - Anthropic and OpenAI callbacks assert the actual Response stage and provider/transport context
  - strict rejects Partial, ignore preserves a mutated payload, Full + Stop still blocks
- `cargo test -p pentect-cli partial_response_plugin_coverage_only_blocks_in_strict_mode -- --nocapture` — 1 passed
- `cargo test -p pentect-cli unterminated_final_chat_event_is_processed_at_eof -- --nocapture` — 1 passed
- `cargo fmt --all -- --check`
- `git diff --check`

These are local middleware-boundary and stream-state tests. They do not claim an authenticated provider or third-party plugin end-to-end run.

Closes #1288
