### PR TITLE
Mask colon-bound PowerShell secret parameters

### DIFF
--- a/crates/pentect-core/src/detect/cli.rs
+++ b/crates/pentect-core/src/detect/cli.rs
@@ -89,26 +89,21 @@ fn inspect_convert_to_secure_string(
     }) else {
         return;
     };
-    if !tokens[command_index + 1..]
-        .iter()
-        .any(|token| token.value.eq_ignore_ascii_case("-AsPlainText"))
-    {
+    let arguments = &tokens[command_index + 1..];
+    if !shell::has_powershell_parameter(arguments, "-AsPlainText") {
         return;
     }
-    let arguments = &tokens[command_index + 1..];
-    let value = arguments
-        .windows(2)
-        .find(|pair| pair[0].value.eq_ignore_ascii_case("-String"))
-        .map(|pair| &pair[1])
-        .or_else(|| {
-            arguments
-                .iter()
-                .find(|token| !token.value.is_empty() && !token.value.starts_with('-'))
-        });
-    let Some(value) = value else {
+    let value = shell::powershell_parameter_value(arguments, "-String").or_else(|| {
+        arguments
+            .iter()
+            .position(|token| !token.value.is_empty() && !token.value.starts_with('-'))
+            .map(|index| (index, 0))
+    });
+    let Some((value_index, value_start)) = value else {
         return;
     };
-    push_cli_password(view, out, value, 0);
+    let value = &arguments[value_index];
+    push_cli_password(view, out, value, value_start);
 }
 
 fn is_powershell_command_name(value: &str) -> bool {
@@ -270,6 +265,40 @@ mod tests {
                 )
             ]
         );
+    }
+
+    #[test]
+    fn convert_to_secure_string_masks_bound_string_parameters() {
+        for (raw, expected) in [
+            (
+                "ConvertTo-SecureString -String:IaiA@eqhtlc -AsPlainText -Force",
+                "IaiA@eqhtlc",
+            ),
+            (
+                "ConvertTo-SecureString -STRING:'sécret value' -AsPlainText:$true -Force",
+                "sécret value",
+            ),
+            (
+                "ConvertTo-SecureString -String: '-starts-with-dash' -AsPlainText -Force",
+                "-starts-with-dash",
+            ),
+            (
+                "ConvertTo-SecureString -String=IaiA@eqhtlc -AsPlainText=$true -Force",
+                "IaiA@eqhtlc",
+            ),
+        ] {
+            assert_eq!(
+                labels(raw),
+                [("CMD_PASSWORD".to_string(), expected.to_string())],
+                "{raw}"
+            );
+        }
+        for raw in [
+            "ConvertTo-SecureString -Stringify:IaiA@eqhtlc -AsPlainText -Force",
+            "ConvertTo-SecureString -String:IaiA@eqhtlc -AsPlainTexts:$true -Force",
+        ] {
+            assert!(labels(raw).is_empty(), "{raw}: {:?}", labels(raw));
+        }
     }
 
     #[test]

--- a/crates/pentect-core/src/detect/shell.rs
+++ b/crates/pentect-core/src/detect/shell.rs
@@ -4,6 +4,45 @@ pub(crate) struct Token {
     pub(crate) byte_to_raw: Vec<usize>,
 }
 
+enum PowerShellParameterForm {
+    Separate,
+    Bound(usize),
+}
+
+/// Returns the token and decoded-byte offset of a PowerShell named parameter's
+/// value. PowerShell officially supports both `-Name Value` and `-Name:Value`.
+/// We also accept `-Name=Value` defensively, but only after an exact,
+/// case-insensitive parameter-name match.
+pub(crate) fn powershell_parameter_value(tokens: &[Token], name: &str) -> Option<(usize, usize)> {
+    tokens.iter().enumerate().find_map(|(index, token)| {
+        match powershell_parameter_form(&token.value, name)? {
+            PowerShellParameterForm::Separate => tokens.get(index + 1).map(|_| (index + 1, 0)),
+            PowerShellParameterForm::Bound(start) if start < token.value.len() => {
+                Some((index, start))
+            }
+            PowerShellParameterForm::Bound(_) => tokens.get(index + 1).map(|_| (index + 1, 0)),
+        }
+    })
+}
+
+pub(crate) fn has_powershell_parameter(tokens: &[Token], name: &str) -> bool {
+    tokens
+        .iter()
+        .any(|token| powershell_parameter_form(&token.value, name).is_some())
+}
+
+fn powershell_parameter_form(value: &str, name: &str) -> Option<PowerShellParameterForm> {
+    if value.eq_ignore_ascii_case(name) {
+        return Some(PowerShellParameterForm::Separate);
+    }
+    let prefix = value.get(..name.len())?;
+    if !prefix.eq_ignore_ascii_case(name) {
+        return None;
+    }
+    matches!(value.as_bytes().get(name.len()), Some(b':' | b'='))
+        .then_some(PowerShellParameterForm::Bound(name.len() + 1))
+}
+
 pub(crate) fn tokens(line: &str, base: usize) -> Vec<Token> {
     let mut out = Vec::new();
     let chars = line.char_indices().collect::<Vec<_>>();
@@ -93,5 +132,16 @@ mod tests {
         assert_eq!(value.byte_to_raw.len(), value.value.len());
         assert_eq!(value.byte_to_raw[0], 30);
         assert_eq!(basename("C:\\Tools\\CURL.EXE"), "CURL");
+    }
+
+    #[test]
+    fn powershell_parameters_require_an_exact_name_and_preserve_value_offsets() {
+        let tokens = tokens("Thing -VaLuE:'sécret' -Values:not-secret", 10);
+        let (index, start) = powershell_parameter_value(&tokens, "-Value").unwrap();
+        let value = &tokens[index];
+        assert_eq!(&value.value[start..], "sécret");
+        assert_eq!(value.byte_to_raw[start], 24);
+        assert!(!has_powershell_parameter(&tokens, "-ValuesX"));
+        assert!(powershell_parameter_value(&tokens, "-Val").is_none());
     }
 }

--- a/crates/pentect-core/src/detect/structural.rs
+++ b/crates/pentect-core/src/detect/structural.rs
@@ -147,33 +147,39 @@ fn scan_powershell_set_item(
     if !super::shell::basename(&command.value).eq_ignore_ascii_case("set-item") {
         return;
     }
-    let Some((env_index, key)) = tokens.iter().enumerate().find_map(|(index, token)| {
-        let (scope, key) = token.value.split_once(':')?;
-        scope.eq_ignore_ascii_case("env").then_some((index, key))
-    }) else {
+    let path = super::shell::powershell_parameter_value(tokens, "-Path")
+        .or_else(|| tokens.iter().enumerate().find_map(environment_path));
+    let Some((path_index, path_start)) = path else {
         return;
     };
-    if !valid_environment_name(key) || !is_sensitive_key_name(key) {
+    let path_token = &tokens[path_index];
+    let Some((scope, key)) = path_token.value[path_start..].split_once(':') else {
+        return;
+    };
+    if !scope.eq_ignore_ascii_case("env")
+        || !valid_environment_name(key)
+        || !is_sensitive_key_name(key)
+    {
         return;
     }
-    let value_index = tokens
-        .iter()
-        .enumerate()
-        .skip(1)
-        .find(|(_, token)| token.value.eq_ignore_ascii_case("-Value"))
-        .map(|(index, _)| index + 1)
-        .or_else(|| {
-            tokens
-                .get(env_index + 1)
-                .is_some_and(|token| !token.value.starts_with('-'))
-                .then_some(env_index + 1)
-        });
-    let Some(value) = value_index.and_then(|index| tokens.get(index)) else {
+    let value = super::shell::powershell_parameter_value(tokens, "-Value").or_else(|| {
+        tokens
+            .get(path_index + 1)
+            .filter(|token| !token.value.starts_with('-'))
+            .map(|_| (path_index + 1, 0))
+    });
+    let Some((value_index, value_start)) = value else {
         return;
     };
-    if let Some(range) = token_raw_range(value, 0) {
+    let value = &tokens[value_index];
+    if let Some(range) = token_raw_range(value, value_start) {
         push_environment_span(view, spans, range);
     }
+}
+
+fn environment_path((index, token): (usize, &super::shell::Token)) -> Option<(usize, usize)> {
+    let (scope, _) = token.value.split_once(':')?;
+    scope.eq_ignore_ascii_case("env").then_some((index, 0))
 }
 
 fn first_shell_command<'a>(
@@ -1048,6 +1054,37 @@ mod tests {
             "Set-Item -Path Env:SQUARE_ACCESS_TOKEN; Write-Output -Value NotTheEnvValue"
         )
         .is_empty());
+    }
+
+    #[test]
+    fn powershell_set_item_masks_bound_parameter_values() {
+        for (raw, expected) in [
+            (
+                "Set-Item -Path:Env:SQUARE_ACCESS_TOKEN -Value:SyntheticValue",
+                "SyntheticValue",
+            ),
+            (
+                "Set-Item -VALUE:'mail gun value' -PATH:Env:MAILGUN_API_KEY",
+                "mail gun value",
+            ),
+            (
+                "Set-Item -Path: Env:SQUARE_ACCESS_TOKEN -Value: sécret-value",
+                "sécret-value",
+            ),
+            (
+                "Set-Item -Path=Env:SQUARE_ACCESS_TOKEN -Value=SyntheticValue",
+                "SyntheticValue",
+            ),
+        ] {
+            assert_eq!(shell_env_values(raw), [expected], "{raw}");
+        }
+        for raw in [
+            "Set-Item -Paths:Env:SQUARE_ACCESS_TOKEN -Value:SyntheticValue",
+            "Set-Item -Path:Env:SQUARE_ACCESS_TOKEN -Values:SyntheticValue",
+            "Set-Item -Path:X:SQUARE_ACCESS_TOKEN -Value:SyntheticValue",
+        ] {
+            assert!(shell_env_values(raw).is_empty(), "{raw}");
+        }
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -903,6 +903,24 @@ mod tests {
             )
         })
     }
+
+    #[test]
+    fn powershell_bound_secrets_are_masked_and_recoverable_through_default_pipeline() {
+        for (input, secret) in [
+            (
+                "Set-Item -Path:Env:SQUARE_ACCESS_TOKEN -Value:SyntheticValue",
+                "SyntheticValue",
+            ),
+            (
+                "ConvertTo-SecureString -String:IaiA@eqhtlc -AsPlainText:$true -Force",
+                "IaiA@eqhtlc",
+            ),
+        ] {
+            let result = m(input);
+            assert!(!result.masked.contains(secret), "{}", result.masked);
+            assert_eq!(restore(&result.masked, &result.recovery).unwrap(), input);
+        }
+    }
     fn mj(s: &str) -> MaskResult {
         with_default_engine(|engine| {
             engine.mask(


### PR DESCRIPTION
## Root cause

The PowerShell tokenizer already preserved bound parameter tokens and their raw-byte mapping, but the downstream `Set-Item` and `ConvertTo-SecureString` detectors compared whole tokens only. Therefore `-Name:Value` never matched `-Name`, and the positional fallback could not reach values embedded in dash-prefixed tokens.

The `Set-Item` path side had the same gap: `-Path:Env:NAME` was not recognized as an environment-provider path.

## Changes

- add one bounded, case-insensitive PowerShell named-parameter helper
- support whitespace and inline/separated colon binding
- defensively support equals binding for exact known parameter names
- use the helper for `Set-Item -Path`, `Set-Item -Value`, and `ConvertTo-SecureString -String`
- recognize bound `-AsPlainText` forms
- preserve raw byte offsets through quotes and UTF-8
- reject prefix collisions and non-`Env:` paths

## Focused verification

- 5 `powershell_` tests pass
- 2 `convert_to_secure_string` tests pass
- default-pipeline test confirms masking and exact recovery
- existing positional, reordered, and dash-leading-value cases remain covered

Closes #1316