### PR TITLE
Anchor plugin discovery and state to the project root

### DIFF
--- a/crates/pentect-cli/src/plugins.rs
+++ b/crates/pentect-cli/src/plugins.rs
@@ -565,7 +565,7 @@ fn plugin_paths_for_named_scoped(
 ) -> Result<PluginPaths> {
     validate_plugin_name(name)?;
     let project_dir = plugins_root()?.join(name);
-    let official_dir = official_plugins_root().join(name);
+    let official_dir = official_plugins_root()?.join(name);
 
     if scope == PluginScope::Project {
         if project_dir.is_dir() {
@@ -754,8 +754,10 @@ pub(crate) fn plugins_root() -> Result<PathBuf> {
         .join(PLUGINS_DIR))
 }
 
-fn official_plugins_root() -> PathBuf {
-    PathBuf::from(OFFICIAL_PLUGINS_DIR)
+pub(crate) fn official_plugins_root() -> Result<PathBuf> {
+    Ok(pentect_agent::project_root()
+        .map_err(anyhow::Error::msg)?
+        .join(OFFICIAL_PLUGINS_DIR))
 }
 
 pub(crate) fn plugin_source(spec: &str) -> Result<PluginSource> {
@@ -980,7 +982,7 @@ fn plugin_source_with_refresh(
         for (root, repository) in [
             (plugins_root()?.join(spec), None),
             (
-                official_plugins_root().join(spec),
+                official_plugins_root()?.join(spec),
                 Some(DEFAULT_PLUGIN_REPOSITORY.to_string()),
             ),
         ] {

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -3794,7 +3794,7 @@ fn plugin_rows() -> Result<Vec<PluginRow>, String> {
         "project",
     )?);
     rows.extend(plugin_rows_in(
-        Path::new("plugins").to_path_buf(),
+        plugins::official_plugins_root().map_err(|error| error.to_string())?,
         "official",
     )?);
     Ok(rows)

--- a/crates/pentect-cli/tests/plugin_scope.rs
+++ b/crates/pentect-cli/tests/plugin_scope.rs
@@ -163,6 +163,55 @@ fn project_plugin_directory_is_visible_from_nested_working_directory() {
 }
 
 #[test]
+fn official_plugin_directory_is_visible_from_nested_working_directory() {
+    let root = temp_dir("official-plugin-nested");
+    let home = root.join("home");
+    let project = root.join("project");
+    let nested = project.join("src/nested");
+    std::fs::create_dir_all(project.join(".git")).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&nested).unwrap();
+    write_manifest(
+        &project.join("plugins/nested-official"),
+        "nested-official",
+        "NESTED_OFFICIAL",
+        r"OFFICIAL-[0-9]{6}",
+    );
+
+    let output = command(&home, &nested)
+        .args(["plugins", "list"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("nested-official: official ok configs=1 binary=no"),
+        "{stdout}"
+    );
+
+    let mut child = command(&home, &nested)
+        .args(["mask", "--plugins", "nested-official"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"OFFICIAL-123456")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("<<NESTED_OFFICIAL_"), "{stdout}");
+    assert!(!nested.join("plugins").exists());
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn nearest_nested_pentect_directory_defines_a_separate_project_root() {
     let root = temp_dir("plugin-explicit-nested-root");
     let home = root.join("home");

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -3237,6 +3237,10 @@ impl PlatformCommandsFile {
     }
 }
 
+fn plugin_project_root() -> Result<PathBuf, String> {
+    crate::project_root()
+}
+
 fn validate_permissions(
     name: &str,
     permissions: Option<PermissionsFile>,
@@ -3261,8 +3265,7 @@ fn validate_permissions(
     {
         return Ok(None);
     }
-    let project_root = std::env::current_dir()
-        .and_then(std::fs::canonicalize)
+    let project_root = plugin_project_root()
         .map_err(|_| format!("plugin '{name}' project directory is unavailable"))?;
     let plugin_root = manifest
         .parent()
@@ -3605,8 +3608,7 @@ pub struct PluginRuntimeDirs {
 
 pub fn plugin_runtime_dirs(id_or_name: &str) -> Result<PluginRuntimeDirs, String> {
     let id = plugin_id(id_or_name);
-    let project = std::env::current_dir()
-        .and_then(std::fs::canonicalize)
+    let project = plugin_project_root()
         .map_err(|error| format!("could not resolve plugin project directory: {error}"))?;
     let mut digest = sha2::Sha256::new();
     use sha2::Digest as _;

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -3823,6 +3823,30 @@ fn file_pointer_manager_uses_project_root_across_nested_working_directories() {
 }
 
 #[test]
+fn plugin_runtime_storage_uses_project_root_across_nested_working_directories() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let root = temp_root("plugin-runtime-project-root");
+    let _cwd = enter_temp_cwd(&root);
+    std::fs::create_dir_all(root.join(".git")).unwrap();
+    let nested = root.join("src/nested");
+    std::fs::create_dir_all(&nested).unwrap();
+    let plugin = format!("nested-runtime-{}", std::process::id());
+
+    let from_root = plugin_runtime_dirs(&plugin).unwrap();
+    std::env::set_current_dir(&nested).unwrap();
+    let from_nested = plugin_runtime_dirs(&plugin).unwrap();
+
+    assert_eq!(from_nested.data_dir, from_root.data_dir);
+    assert_eq!(from_nested.cache_dir, from_root.cache_dir);
+    assert_eq!(from_nested.config_file, from_root.config_file);
+    assert!(!nested.join(".pentect").exists());
+
+    let _ = std::fs::remove_dir_all(&from_root.data_dir);
+    drop(_cwd);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn file_pointer_manager_refuses_changed_source_file() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let root = temp_root("file-pointer-changed");


### PR DESCRIPTION
## Summary

- resolve the repository `plugins/` directory from Pentect's canonical project root
- use that same root for plugin listing, filesystem permissions, and runtime storage identity
- preserve nearest nested `.pentect` projects and CWD fallback outside a project
- add nested-directory regressions for official plugin discovery/use and runtime data stability

## Root cause

Four plugin paths bypassed `pentect_agent::project_root()` and read the process working directory directly. The same project therefore behaved differently when Pentect started from a subdirectory: official plugins disappeared, `project:` permission scope narrowed, and runtime configuration/cache/approval paths split.

Permissions and runtime storage now share one small `plugin_project_root()` helper so they cannot silently choose different roots again.

## Focused verification

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/home/edamame/sub/pentect-1303/target cargo test -p pentect-cli --test plugin_scope -- --nocapture`
  - 4 passed, including actual nested `plugins list` and `mask --plugins` use
- `CARGO_TARGET_DIR=/home/edamame/sub/pentect-1303/target cargo test -p pentect-runtime tests::plugin_runtime_storage_uses_project_root_across_nested_working_directories -- --exact --nocapture`
  - 1 passed

Closes #1284
