### PR TITLE
Fix low-entropy credential classification boundaries

### DIFF
--- a/crates/pentect-core/src/detect/key_value.rs
+++ b/crates/pentect-core/src/detect/key_value.rs
@@ -613,6 +613,11 @@ fn try_push(ctx: &mut ScanCtx<'_, '_, '_>, separator: SeparatorCandidate) -> boo
     };
     let key = trim_key_edge(&ctx.text[key_start..left_end]);
     let mut semantic_key = declared_identifier_key(key).unwrap_or_else(|| key.to_string());
+    if matches!(separator.kind, Separator::Assignment | Separator::Colon) {
+        if let Some(trailing) = trailing_log_field_key(key) {
+            semantic_key = trailing.to_string();
+        }
+    }
     let mut tuple_target = None;
     if separator.kind == Separator::Assignment {
         if let Some(targets) = tuple_assignment_targets(&ctx.text[ctx.line_start..left_end]) {
@@ -940,6 +945,7 @@ fn sensitive_key_kind(key: &str) -> Option<KeyKind> {
             "auth_token",
             "bearer_token",
             "session_token",
+            "session_id",
         ],
     ) || matches!(name.as_str(), "token" | "session" | "cookie" | "jwt")
         || name.ends_with("_token")
@@ -1025,6 +1031,20 @@ fn trailing_sensitive_key_kind(key: &str) -> Option<KeyKind> {
         }
     }
     None
+}
+
+fn trailing_log_field_key(key: &str) -> Option<&str> {
+    let key = key.trim_end();
+    let start = key
+        .char_indices()
+        .rev()
+        .find_map(|(index, ch)| {
+            (!(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')))
+                .then_some(index + ch.len_utf8())
+        })
+        .unwrap_or(0);
+    let candidate = &key[start..];
+    (!candidate.is_empty() && sensitive_key_kind(candidate).is_some()).then_some(candidate)
 }
 
 fn implicit_key_name_kind(name: &str) -> Option<KeyKind> {
@@ -2538,12 +2558,28 @@ fn is_unquoted_alpha_prose_continuation(
         || rest.starts_with("//")
         || rest.starts_with("/*")
         || rest.starts_with('\\')
+        || starts_sensitive_assignment(rest)
     {
         return false;
     }
     rest.chars()
         .next()
         .is_some_and(|ch| ch.is_ascii_alphabetic())
+}
+
+fn starts_sensitive_assignment(text: &str) -> bool {
+    let text = text.trim_start();
+    let key_end = text
+        .char_indices()
+        .find_map(|(index, ch)| {
+            (!(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))).then_some(index)
+        })
+        .unwrap_or(text.len());
+    let key = &text[..key_end];
+    if key.is_empty() || sensitive_key_kind(key).is_none() {
+        return false;
+    }
+    text[key_end..].trim_start().starts_with(['=', ':'])
 }
 
 fn is_powershell_command_name(value: &str) -> bool {
@@ -6907,6 +6943,7 @@ fn key_allows_low_entropy_literal(name: &str, kind: KeyKind) -> bool {
                 | "id_token"
                 | "bearer_token"
                 | "session_token"
+                | "session_id"
                 | "token"
         ) || name.ends_with("_token")
             || name.ends_with("_apitoken");
@@ -6981,6 +7018,7 @@ fn compact_key_context_allows_low_entropy_literal(name: &str, kind: KeyKind) -> 
                 | "idtoken"
                 | "bearertoken"
                 | "sessiontoken"
+                | "sessionid"
                 | "token"
         ) || compact.ends_with("token");
     }
@@ -7027,6 +7065,10 @@ fn is_explicit_slot_low_entropy_literal(value: &str, key_name: &str, kind: KeyKi
     // unquoted (`admin_password: abcdef`). Once the key name explicitly names
     // material and the value survived source/prose suppressors, the slot is
     // stronger evidence than entropy alone.
+    if matches!(kind, KeyKind::Token) {
+        return is_lowercase_compact_alpha_literal(value)
+            && key_allows_low_entropy_literal(key_name, kind);
+    }
     if is_exact_password_low_entropy_slot(key_name, kind) {
         return is_lowercase_compact_alpha_literal(value);
     }
@@ -7743,6 +7785,31 @@ mod tests {
         assert!(has(r#"password = "6.hours""#, "6.hours"));
         assert!(has(r#"password1: "munpsmt""#, "munpsmt"));
         assert!(has(r#"new_password2: "kmyhawmjaydc""#, "kmyhawmjaydc"));
+    }
+
+    #[test]
+    fn masks_each_short_credential_in_a_prefixed_log_line() {
+        let raw = "audit: session_id=abc123 csrf_token=short refresh_token=refresh";
+        let got = hits(raw);
+        for value in ["abc123", "short", "refresh"] {
+            assert!(
+                got.iter().any(|(_, candidate)| candidate == value),
+                "{value:?} missing from {got:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn short_log_field_support_does_not_turn_code_or_status_fields_into_secrets() {
+        for raw in [
+            "let session_id = current_session;",
+            "const csrf_token = token_value;",
+            "audit: session is active",
+            "status=active session=ready",
+        ] {
+            let got = hits(raw);
+            assert!(got.is_empty(), "unexpected findings for {raw:?}: {got:?}");
+        }
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -1300,6 +1300,146 @@ mod tests {
     }
 
     #[test]
+    fn low_entropy_credential_classes_are_covered_across_text_env_and_logs() {
+        let cases = [
+            (Kind::Text, "my password is letmein", vec!["letmein"]),
+            (
+                Kind::Env,
+                "PASSWORD=password\nSESSION_TOKEN=abc123\n",
+                vec!["PASSWORD=password", "SESSION_TOKEN=abc123"],
+            ),
+            (
+                Kind::ToolResult,
+                "audit: session_id=abc123 csrf_token=short refresh_token=refresh",
+                vec![
+                    "session_id=abc123",
+                    "csrf_token=short",
+                    "refresh_token=refresh",
+                ],
+            ),
+            (
+                Kind::Json,
+                r#"{"password":"hunter2","session_id":"abc123","csrf_token":"short","refresh_token":"refresh"}"#,
+                vec![
+                    r#""password":"hunter2""#,
+                    r#""session_id":"abc123""#,
+                    r#""csrf_token":"short""#,
+                    r#""refresh_token":"refresh""#,
+                ],
+            ),
+            (
+                Kind::Json,
+                r#"{"extension":{"sessionToken":"abc123"}}"#,
+                vec![r#""sessionToken":"abc123""#],
+            ),
+            (
+                Kind::Text,
+                concat!(
+                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.",
+                    "eyJ1c2VyIjoiYWxpY2UifQ.",
+                    "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+                ),
+                vec!["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"],
+            ),
+        ];
+
+        let engine = Engine::with_profile(Profile::Strict);
+        for (kind, input, leaked_fragments) in cases {
+            let result = engine.mask(
+                Input {
+                    kind,
+                    data: input.to_string(),
+                },
+                &Config::insecure_testing(),
+            );
+            for leaked_fragment in leaked_fragments {
+                assert!(
+                    !result.masked.contains(leaked_fragment),
+                    "{leaked_fragment:?} remained in {:?}: {}",
+                    input,
+                    result.masked
+                );
+            }
+            assert_eq!(restore(&result.masked, &result.recovery).unwrap(), input);
+        }
+    }
+
+    #[test]
+    fn ambiguous_low_entropy_prose_requires_an_explicit_mask_marker() {
+        let ambiguous = "my password is password";
+        assert_eq!(m(ambiguous).masked, ambiguous);
+
+        let forced = m("my password is mask(password)");
+        assert!(!forced.masked.contains("password)"), "{}", forced.masked);
+        assert!(
+            forced.masked.contains("my password is <<KEYED_SECRET_"),
+            "{}",
+            forced.masked
+        );
+
+        let structured_label = mj(r#"{"password":"password"}"#);
+        assert_eq!(structured_label.masked, r#"{"password":"password"}"#);
+        let structured_forced = mj(r#"{"password":"mask(password)"}"#);
+        assert!(
+            structured_forced
+                .masked
+                .contains(r#""password":"<<KEYED_SECRET_"#),
+            "{}",
+            structured_forced.masked
+        );
+    }
+
+    #[test]
+    fn http_credential_headers_mask_short_values_without_masking_public_headers() {
+        let engine = Engine::with_profile(Profile::Strict);
+        let cases = [
+            (RegionKind::Cookie, None, "abc"),
+            (RegionKind::Header, Some("Cookie"), "sid=abc"),
+            (RegionKind::Header, Some("Authorization"), "Bearer x"),
+        ];
+
+        for (kind, key, value) in cases {
+            let result = engine.mask_context(
+                value.to_string(),
+                Context {
+                    path: None,
+                    key: key.map(str::to_string),
+                    hints: Vec::new(),
+                    kind,
+                    format: Kind::Har,
+                },
+                &Config::insecure_testing(),
+            );
+            assert!(!result.masked.contains(value), "{key:?}: {}", result.masked);
+        }
+
+        let public = engine.mask_context(
+            "application/json".to_string(),
+            Context {
+                path: None,
+                key: Some("Content-Type".to_string()),
+                hints: Vec::new(),
+                kind: RegionKind::Header,
+                format: Kind::Har,
+            },
+            &Config::insecure_testing(),
+        );
+        assert_eq!(public.masked, "application/json");
+    }
+
+    #[test]
+    fn public_identifiers_are_measured_separately_from_credential_context() {
+        let input = concat!(
+            "request_id=550e8400-e29b-41d4-a716-446655440000 ",
+            "order_id=123456 trace_id=4bf92f3577b34da6a3ce929d0e0e4736 ",
+            "commit=0123456789abcdef0123456789abcdef01234567"
+        );
+        let result = m(input);
+        assert_eq!(result.masked, input);
+        assert_eq!(result.summary.masked_count, 0);
+    }
+
+    #[test]
     fn json_sibling_secret_context_is_order_independent() {
         for input in [
             r#"{"value":"correcthorsebattery","name":"db_password"}"#,

--- a/crates/pentect-runtime/src/image_ocr.rs
+++ b/crates/pentect-runtime/src/image_ocr.rs
@@ -3385,6 +3385,26 @@ mod tests {
     }
 
     #[test]
+    fn recognized_ocr_text_masks_low_entropy_credential_fields() {
+        let key = [7; 32];
+        let text =
+            "password: hunter2\nsession_token: abc123\ncsrf_token: short\nrefresh_token: refresh";
+        let hits = image_text_secret_hits(text, &key).unwrap();
+        let entries = secret_entries(text, &hits, &key);
+        let values = entries
+            .iter()
+            .map(|(_, value)| value.as_str())
+            .collect::<Vec<_>>();
+
+        for expected in ["hunter2", "abc123", "short", "refresh"] {
+            assert!(
+                values.contains(&expected),
+                "{expected:?} missing from {values:?}"
+            );
+        }
+    }
+
+    #[test]
     fn ocr_explicit_markers_preserve_exact_values_and_survive_malformed_prefixes() {
         let key = [7; 32];
         let text = "pentect(unclosed\nmask( pa(ss), 日本語 )\npentect(alpha!\nbeta)";

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -839,6 +839,27 @@ fn active_prompt_explicit_marker_masks_low_entropy_value_and_removes_wrapper() {
 }
 
 #[test]
+fn active_tool_output_masks_low_entropy_session_log_fields() {
+    let _env_guard = TEST_ENV_LOCK.lock().unwrap();
+    let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-output-session-fields");
+    let mut masker = ActiveToolOutputMasker::new().unwrap();
+    let output = "audit session_id=abc123 csrf_token=short refresh_token=refresh";
+    let masked = masker.mask_tool_output(output).unwrap().unwrap();
+
+    for leaked_fragment in [
+        "session_id=abc123",
+        "csrf_token=short",
+        "refresh_token=refresh",
+    ] {
+        assert!(
+            !masked.contains(leaked_fragment),
+            "{leaked_fragment:?} remained in {masked}"
+        );
+    }
+    assert_eq!(masked.matches("<<").count(), 3, "{masked}");
+}
+
+#[test]
 fn active_prompt_supports_mask_and_prompt_only_unmask_aliases() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (_active_store, _, _) = ActiveMemoryStoreEnv::start("active-prompt-marker-aliases");

--- a/website/src/content/docs/protection/detectors.md
+++ b/website/src/content/docs/protection/detectors.md
@@ -12,6 +12,33 @@ This inventory describes the default built-in engine. A plugin can add rules,
 but plugin findings are plugin-provided evidence and are not part of the
 built-in coverage claims.
 
+## Credential-class boundaries
+
+Detection depends on both the value and its trusted context. A short string can
+be a real password and an ordinary word at the same time, so Pentect does not
+claim that every credential is recognizable from the value alone.
+
+| Class | Default behavior | Evidence boundary |
+| --- | --- | --- |
+| Low-entropy password | Built in when a parser supplies a password field or plaintext has a supported password assignment/prose shape | A bare common word or very short string is intentionally not treated as a secret without context. A structured value identical to its key, such as `"password": "Password"`, is also left visible because that shape is common localization UI text. Use `pentect(...)` or `mask(...)` when the intended meaning is known only to the user. |
+| Cookie | Built in for parser-identified cookie values and `Cookie`/`Set-Cookie` headers; supported keyed plaintext forms are also detected | A bare cookie value has no unique syntax and is not a separate value-only claim. |
+| Session ID or session token | Built in for sensitive structured keys, supported key/value text, and structurally valid token formats such as JWT | A bare UUID remains visible unless trusted cookie, session, or identifier-bearing context says otherwise. UUID shape alone is not proof of a credential. |
+| Refresh, access, or CSRF token | Built in for sensitive structured keys, supported key/value text, credential-bearing URL fields, and token-specific formats | A bare word or public identifier is not automatically classified as a token. |
+| JWT or JWE | Built in through `JwtDetector` when compact JOSE structure validates | Structural validation does not prove that the token is live or accepted by a service. |
+| Editor-extension credential | No product-name-wide claim. Built-in detectors protect supported generic token formats and sensitive fields regardless of which editor produced them | An extension-specific storage envelope needs a verified parser or plugin before Pentect can claim full coverage for that extension. |
+
+The same standard engine handles `pentect mask`, supported AI prompt and tool
+result paths, and text extracted from logs. HTTP adapters add only the protocol
+fields they explicitly recognize, including credential-bearing headers,
+cookies, and protected JSON fields. OCR sends recognized text through the same
+engine, but this proves only masking after successful text recognition; OCR
+accuracy and unscanned-image policy are separate boundaries.
+
+Plugins may add extra formats or rules. They do not turn a heuristic or an
+intentionally unsupported bare value into built-in coverage. Explicit
+`pentect(...)` and `mask(...)` markers are user instructions, not automatic
+detections, and are the safe control for an ambiguous value.
+
 ## Upstream-derived detectors
 
 | Detector | Source and pinned version | Enabled coverage | Evidence and limit |


### PR DESCRIPTION
## Why

Short credentials were not consistently classified when several key/value fields appeared on one prefixed log line. The key scanner retained the line prefix and preceding values as part of later field names, so low-entropy token evidence was lost. Coverage claims also did not clearly separate contextual detection from ambiguous bare values.

## What changed

- isolate the trailing sensitive field name for assignment and colon-separated log fields
- recognize `session_id` as a token field and protect compact low-entropy token values in explicit slots
- keep source-code variables, ordinary status fields, bare UUIDs, and other public identifiers visible
- add class fixtures for passwords, cookies, session/refresh/CSRF tokens, JWT, and generic editor-extension storage
- exercise text, dotenv, JSON payload, tool output/log, HTTP header/cookie, and post-OCR masking paths
- document built-in, contextual, plugin, unsupported, and explicit-force-mask boundaries

## Focused verification

- `cargo test -p pentect-core detect::key_value::tests -- --nocapture`
- `cargo test -p pentect-core pipeline::tests::low_entropy_credential_classes_are_covered_across_text_env_and_logs -- --exact --nocapture`
- `cargo test -p pentect-core pipeline::tests::ambiguous_low_entropy_prose_requires_an_explicit_mask_marker -- --exact --nocapture`
- `cargo test -p pentect-core pipeline::tests::http_credential_headers_mask_short_values_without_masking_public_headers -- --exact --nocapture`
- `cargo test -p pentect-core pipeline::tests::guard_spares_uuid_unless_anchored -- --exact --nocapture`
- `cargo test -p pentect-core pipeline::tests::public_identifiers_are_measured_separately_from_credential_context -- --exact --nocapture`
- `cargo test -p pentect-runtime tests::active_tool_output_masks_low_entropy_session_log_fields -- --exact --nocapture`
- `cargo test -p pentect-runtime image_ocr::tests::recognized_ocr_text_masks_low_entropy_credential_fields -- --exact --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #353