### PR TITLE
Protect credential artifacts in URL queries

### DIFF
--- a/crates/pentect-core/src/detect/url.rs
+++ b/crates/pentect-core/src/detect/url.rs
@@ -1121,6 +1121,9 @@ enum QuerySecretKind {
     Password,
     Token,
     Secret,
+    CallbackArtifact,
+    CredentialArtifact,
+    OneTimeCode,
 }
 
 fn query_secret_kind(key: &str) -> Option<QuerySecretKind> {
@@ -1154,6 +1157,29 @@ fn query_secret_kind(key: &str) -> Option<QuerySecretKind> {
         || compact.ends_with("apikey")
     {
         return Some(QuerySecretKind::Secret);
+    }
+    if matches!(
+        compact.as_str(),
+        "code" | "authorizationcode" | "state" | "nonce" | "ticket" | "codeverifier" | "assertion"
+    ) {
+        return Some(QuerySecretKind::CallbackArtifact);
+    }
+    if matches!(
+        compact.as_str(),
+        "signature"
+            | "auth"
+            | "jwt"
+            | "credential"
+            | "sig"
+            | "hmac"
+            | "session"
+            | "sessionid"
+            | "sid"
+    ) {
+        return Some(QuerySecretKind::CredentialArtifact);
+    }
+    if matches!(compact.as_str(), "otp" | "pin" | "verificationcode") {
+        return Some(QuerySecretKind::OneTimeCode);
     }
     None
 }
@@ -1203,19 +1229,56 @@ fn query_secret_value_has_signal(
                 && len >= 6
                 && (len >= 12 || (has_alpha && has_digit) || has_token_punct)
         }
+        QuerySecretKind::CallbackArtifact => {
+            !is_name_reference && len >= 8 && (len >= 12 || has_digit || has_token_punct)
+        }
+        QuerySecretKind::CredentialArtifact => {
+            !is_name_reference
+                && len >= 6
+                && (len >= 12 || (has_alpha && has_digit) || has_token_punct)
+        }
+        QuerySecretKind::OneTimeCode => {
+            !is_name_reference
+                && ((len >= 4 && value.bytes().all(|byte| byte.is_ascii_digit()))
+                    || (len >= 6 && (len >= 12 || (has_alpha && has_digit) || has_token_punct)))
+        }
     }
 }
 
 fn query_value_is_name_reference(value: &str) -> bool {
     let value = value.trim();
-    if value.is_empty()
-        || !value
-            .bytes()
-            .all(|b| b.is_ascii_alphabetic() || matches!(b, b'_' | b'-'))
-    {
+    if value.is_empty() {
         return false;
     }
     let compact = normalized_userinfo_component(value).replace('_', "");
+    if matches!(
+        compact.as_str(),
+        "active"
+            | "inactive"
+            | "pending"
+            | "required"
+            | "optional"
+            | "enabled"
+            | "disabled"
+            | "default"
+            | "none"
+            | "sha1"
+            | "sha256"
+            | "sha384"
+            | "sha512"
+            | "md5"
+            | "oauth"
+            | "oidc"
+            | "bearer"
+    ) {
+        return true;
+    }
+    if !value
+        .bytes()
+        .all(|b| b.is_ascii_alphabetic() || matches!(b, b'_' | b'-'))
+    {
+        return false;
+    }
     compact.contains("token")
         || compact.contains("secret")
         || compact.contains("password")
@@ -1315,6 +1378,7 @@ fn looks_uuid(s: &str) -> bool {
 mod tests {
     use super::*;
     use crate::detect::region;
+    use crate::{Config, Engine, Input, Profile};
 
     fn labels(raw: &str) -> Vec<(String, String)> {
         let reg = region(raw);
@@ -1398,6 +1462,97 @@ mod tests {
                 .iter()
                 .all(|(label, _)| label != "URL_CREDENTIAL")
         );
+    }
+
+    #[test]
+    fn callback_session_and_one_time_query_values_are_credentials() {
+        let keys = [
+            "code",
+            "authorization_code",
+            "state",
+            "nonce",
+            "ticket",
+            "code_verifier",
+            "signature",
+            "auth",
+            "jwt",
+            "assertion",
+            "credential",
+            "sig",
+            "hmac",
+            "otp",
+            "pin",
+            "verification_code",
+            "session",
+            "session_id",
+            "sid",
+        ];
+        for key in keys {
+            let raw = format!("https://example.test/callback?{key}=correcthorsebattery");
+            assert_eq!(
+                labels(&raw),
+                [(
+                    "URL_CREDENTIAL".to_string(),
+                    "correcthorsebattery".to_string()
+                )],
+                "{raw}"
+            );
+        }
+
+        let websocket = "wss://example.test/socket?auth=correcthorsebattery";
+        assert_eq!(
+            labels(websocket),
+            [(
+                "URL_CREDENTIAL".to_string(),
+                "correcthorsebattery".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn callback_query_credentials_mask_and_restore_through_the_canonical_engine() {
+        let input = [
+            "https://example.test/callback?code=correcthorsebattery",
+            "https://example.test/callback?state=correcthorsebattery",
+            "https://example.test/callback?nonce=correcthorsebattery",
+            "https://example.test/callback?code_verifier=correcthorsebattery",
+            "https://example.test/callback?session_id=correcthorsebattery",
+            "https://example.test/callback?otp=482931",
+            "wss://example.test/socket?auth=correcthorsebattery",
+        ]
+        .join("\n");
+        let result = Engine::with_profile(Profile::Strict)
+            .mask(Input::text(&input), &Config::insecure_testing());
+
+        assert!(
+            !result.masked.contains("correcthorsebattery"),
+            "{}",
+            result.masked
+        );
+        assert!(!result.masked.contains("482931"), "{}", result.masked);
+        assert_eq!(result.recovery.resolve(&result.masked), input);
+    }
+
+    #[test]
+    fn query_artifact_keys_preserve_obvious_navigation_metadata() {
+        for raw in [
+            "https://example.test/callback?state=ok",
+            "https://example.test/source?code=main",
+            "https://example.test/page?nonce=xyz",
+            "https://example.test/page?session=active",
+            "https://example.test/page?credential=default",
+            "https://example.test/page?hmac=sha256",
+            "https://example.test/page?otp=123",
+            "https://example.test/page?pin=12",
+        ] {
+            assert!(
+                labels(raw)
+                    .iter()
+                    .all(|(label, _)| label != "URL_CREDENTIAL"),
+                "{raw}: {:?}",
+                labels(raw)
+            );
+        }
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -1428,6 +1428,32 @@ mod tests {
     }
 
     #[test]
+    fn har_set_cookie_header_masks_and_restores_the_complete_value() {
+        let input = r#"{"log":{"entries":[{"response":{"headers":[{"name":"Set-Cookie","value":"sessionid=correcthorsebattery; Path=/; HttpOnly; Secure"}]}}]}}"#;
+        let result = Engine::with_profile(Profile::Strict).mask(
+            Input {
+                kind: Kind::Har,
+                data: input.to_string(),
+            },
+            &Config::insecure_testing(),
+        );
+
+        assert!(
+            !result.masked.contains("correcthorsebattery"),
+            "{}",
+            result.masked
+        );
+        let masked: serde_json::Value = serde_json::from_str(&result.masked).unwrap();
+        assert!(
+            masked["log"]["entries"][0]["response"]["headers"][0]["value"]
+                .as_str()
+                .unwrap()
+                .starts_with("<<SET_COOKIE_")
+        );
+        assert_eq!(result.recovery.resolve(&result.masked), input);
+    }
+
+    #[test]
     fn public_identifiers_are_measured_separately_from_credential_context() {
         let input = concat!(
             "request_id=550e8400-e29b-41d4-a716-446655440000 ",

--- a/website/src/content/docs/protection/detectors.md
+++ b/website/src/content/docs/protection/detectors.md
@@ -108,7 +108,7 @@ have separate component versions.
 | Detector | Finding category | What it masks by default | Evidence boundary |
 | --- | --- | --- | --- |
 | `ExplicitSecretDetector` | Secret | Non-empty values deliberately wrapped in `pentect(...)` or `mask(...)` | Unit and end-to-end handle tests; explicit user instruction, not inference |
-| `UrlDetector` | Secret, identifier, or endpoint | Credential-bearing URL and URI components, selected sensitive query values, `curl -u/-U` credentials, and selected cloud endpoint identifiers | Syntax and regression fixtures in the detector module |
+| `UrlDetector` | Secret, identifier, or endpoint | Credential-bearing URL and URI components; password/token/secret, OAuth/OIDC callback, signature/session, and one-time-code query fields; `curl -u/-U` credentials; and selected cloud endpoint identifiers | Syntax, HTTP/WebSocket query, navigation-metadata, and mask/restore regressions in the detector module |
 | `CliCredentialDetector` | Secret | Plaintext password arguments in supported PowerShell command shapes | Shell-token and command-shape regression fixtures |
 | `JwtDetector` | Secret | Structurally valid compact JWT and JWE values | JOSE structure, JSON header/payload, and size-bound tests; it does not establish token validity |
 | `KeyValueDetector` | Secret | Values in plaintext `key=value`, `key: value`, and similar secret-key contexts when key, separator, boundary, and value checks agree | Positive and benign-corpus regression fixtures; independently maintained heuristics |


### PR DESCRIPTION
## Why

The URL detector classified only password, token, and secret query names. OAuth/OIDC callback artifacts, signatures, sessions, and one-time codes therefore stayed plaintext even when their query key supplied explicit credential context. The same gap affected non-HTTP URI schemes such as `wss://`.

SEC-013 (`Set-Cookie`) is already protected by the current structured-header path; this change adds an exact HAR mask/restore regression so that stale report is classified with evidence.

## What changed

- classify OAuth/OIDC callback values (`code`, `state`, `nonce`, `code_verifier`, and related names)
- classify signature/session credential values (`auth`, `jwt`, `session_id`, `sig`, and related names)
- classify OTP/PIN/verification-code values
- apply the same query handling to HTTP and WebSocket/other URI schemes
- retain empty/template/redacted values and obvious navigation metadata such as `state=ok`, `code=main`, `session=active`, and `hmac=sha256`
- verify canonical masking and exact recovery, not detector spans alone
- document the expanded `UrlDetector` boundary

The classification follows the security role of query artifacts defined by [OAuth 2.0 (RFC 6749)](https://www.rfc-editor.org/rfc/rfc6749.html), [PKCE (RFC 7636)](https://datatracker.ietf.org/doc/html/rfc7636), and [OpenID Connect Core](https://openid.net/specs/openid-connect-core-1_0.html). Cookie evidence follows [RFC 6265](https://www.rfc-editor.org/rfc/rfc6265.html).

## Focused verification

- `cargo test -p pentect-core detect::url::tests -- --nocapture` (34 passed)
- `cargo test -p pentect-core har_set_cookie_header_masks_and_restores_the_complete_value -- --nocapture`
- `cargo clippy -p pentect-core -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run build` (42 pages, 114 links)

Refs #711 (SEC-013 through SEC-033)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded URL protection to detect additional OAuth/OIDC callback data, credential artifacts, one-time codes, navigation metadata, and related sensitive query values.
  * Improved recognition of common non-secret parameter values to reduce unnecessary masking.

* **Bug Fixes**
  * Set-Cookie header values are now fully masked while preserving valid JSON and restoring correctly.

* **Documentation**
  * Updated detector documentation with expanded coverage and masking/restoration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->