### PR TITLE
Keep optional plugin failures from aborting agent startup

### DIFF
--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -649,10 +649,6 @@ impl PluginBinary {
         Self::load_scoped(path, None)
     }
 
-    fn load_global(path: &Path, id: &str) -> Result<Self, String> {
-        Self::load_scoped(path, Some(id))
-    }
-
     fn load_from_environment(path: &Path, global_id: Option<&str>) -> Result<Option<Self>, String> {
         match Self::load_scoped(path, global_id) {
             Ok(plugin) => Ok(Some(plugin)),
@@ -4464,7 +4460,7 @@ for line in sys.stdin:
         )
         .unwrap();
         let global = PluginMiddleware {
-            plugins: vec![PluginBinary::load_global(&manifest, &global_id).unwrap()],
+            plugins: vec![PluginBinary::load_scoped(&manifest, Some(&global_id)).unwrap()],
         };
         let result = global.detect_spans(&Input::text("SECRET"), None).unwrap();
         assert_eq!(result.spans.len(), 1);

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -332,12 +332,16 @@ impl PluginMiddleware {
                 let id = id
                     .to_str()
                     .ok_or_else(|| "global plugin identity is not UTF-8".to_string())?;
-                plugins.push(PluginBinary::load_global(&path, id)?);
+                if let Some(plugin) = PluginBinary::load_from_environment(&path, Some(id))? {
+                    plugins.push(plugin);
+                }
             }
         }
         if let Some(value) = std::env::var_os(BINARIES_ENV) {
             for path in std::env::split_paths(&value).filter(|path| !path.as_os_str().is_empty()) {
-                plugins.push(PluginBinary::load(&path)?);
+                if let Some(plugin) = PluginBinary::load_from_environment(&path, None)? {
+                    plugins.push(plugin);
+                }
             }
         }
         Ok(Self { plugins })
@@ -649,6 +653,19 @@ impl PluginBinary {
         Self::load_scoped(path, Some(id))
     }
 
+    fn load_from_environment(path: &Path, global_id: Option<&str>) -> Result<Option<Self>, String> {
+        match Self::load_scoped(path, global_id) {
+            Ok(plugin) => Ok(Some(plugin)),
+            Err(error) => {
+                let Some(name) = optional_plugin_name(path) else {
+                    return Err(error);
+                };
+                eprintln!("[pentect] optional plugin '{name}' skipped during startup: {error}");
+                Ok(None)
+            }
+        }
+    }
+
     fn load_scoped(path: &Path, global_id: Option<&str>) -> Result<Self, String> {
         if !path.is_file() {
             return Err(format!(
@@ -948,6 +965,19 @@ impl PluginBinary {
         }
         Ok(response)
     }
+}
+
+fn optional_plugin_name(path: &Path) -> Option<String> {
+    let source = read_bounded_utf8(path, MAX_PLUGIN_MANIFEST_BYTES, "plugin manifest").ok()?;
+    let file = toml::from_str::<PluginFile>(&source).ok()?;
+    if file.required {
+        return None;
+    }
+    Some(
+        file.name
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(|| plugin_default_name(path)),
+    )
 }
 
 fn parse_declared_hooks(
@@ -3794,6 +3824,47 @@ fn plugin_id(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn invalid_startup_manifest(required: bool) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "pentect-optional-plugin-startup-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let manifest = root.join("plugin.toml");
+        std::fs::write(
+            &manifest,
+            format!(
+                "schema = \"pentect.plugin.v1\"\nname = \"startup-fixture\"\ncommand = [\"missing-pentect-plugin-command\"]\nhooks = [\"inspect\"]\nrequired = {required}\n\n[execution]\ntimeout_ms = 0\n"
+            ),
+        )
+        .unwrap();
+        manifest
+    }
+
+    #[test]
+    fn environment_loading_skips_optional_plugin_initialization_failure() {
+        let manifest = invalid_startup_manifest(false);
+        let loaded = PluginBinary::load_from_environment(&manifest, None).unwrap();
+        assert!(loaded.is_none());
+
+        // Explicit validation remains strict even for an optional plugin.
+        let error = PluginBinary::load(&manifest).unwrap_err();
+        assert!(error.contains("execution limits"), "{error}");
+        let _ = std::fs::remove_dir_all(manifest.parent().unwrap());
+    }
+
+    #[test]
+    fn environment_loading_keeps_required_plugin_initialization_fail_closed() {
+        let manifest = invalid_startup_manifest(true);
+        let error = PluginBinary::load_from_environment(&manifest, None).unwrap_err();
+        assert!(error.contains("execution limits"), "{error}");
+        let _ = std::fs::remove_dir_all(manifest.parent().unwrap());
+    }
 
     fn oversized_output_command() -> Option<Vec<String>> {
         let bytes = HOST_MAX_COMMAND_STREAM_BYTES + 64 * 1024;


### PR DESCRIPTION
## Summary

- skip a project or global plugin during environment-driven startup when its readable manifest declares `required = false` and initialization fails
- retain fail-closed startup for `required = true` plugins
- preserve strict errors for explicit plugin validation paths
- emit a value-free warning with the plugin name and concrete initialization reason

## Why

Runtime hook failures already honor `required`, but initialization errors did not. A single optional plugin could therefore abort every agent launch. This includes repositories rooted at the user home directory, where the safe plugin data-directory boundary rejects project plugin storage.

The storage boundary is unchanged; only the optional extension is disabled so the core gateway can start.

## Focused verification

- `cargo test -p pentect-runtime environment_loading_ -- --nocapture`
- `cargo test -p pentect-runtime plugin_runtime_storage_uses_project_root_across_nested_working_directories -- --nocapture`
- `cargo test -p pentect-runtime command_plugin_ -- --nocapture`
- `cargo clippy -p pentect-runtime --tests -- -D warnings`
- `cargo fmt --all -- --check`

Closes #1334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Optional plugins that fail during startup are now skipped, allowing the application to continue running.
  - Required plugin failures still stop startup to preserve expected behavior.
  - Improved handling of plugin configuration when the required status is specified in the manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->