### PR TITLE
test: cover installed Command plugin failure boundaries

### DIFF
--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import base64
+import csv
+import io
 import json
 import os
 import re
@@ -417,62 +419,204 @@ def run_plugin_lifecycle(pentect: str) -> None:
         verify_failed_setup_rolls_back(
             pentect, root, home, project, environment
         )
-        verify_plugin_startup_failure_modes(pentect, root, project, environment)
+        verify_installed_command_failure_boundaries(pentect, root, project, environment)
         print(
             "installed plugin lifecycle E2E passed: inspect, test, project/user "
-            "add/setup/update/reinstall/remove, failed-setup rollback, no log plaintext"
+            "add/setup/update/reinstall/remove, failed-setup rollback, Command runtime "
+            "fail-closed boundaries and process cleanup, no log plaintext"
         )
 
 
-def verify_plugin_startup_failure_modes(
+def verify_installed_command_failure_boundaries(
     pentect: str,
     root: Path,
     project: Path,
     environment: dict[str, str],
 ) -> None:
-    for required in (False, True):
-        plugin = root / ("required-broken-plugin" if required else "optional-broken-plugin")
-        plugin.mkdir()
-        (plugin / "plugin.toml").write_text(
-            f'''schema = "pentect.plugin.v1"
-name = "{'required' if required else 'optional'}-broken-plugin"
-command = ["missing-pentect-plugin-command"]
+    plugin = root / "command-failure-plugin"
+    plugin.mkdir()
+    manifest = plugin / "plugin.toml"
+    script = plugin / "server.py"
+    manifest_source = '''schema = "pentect.plugin.v1"
+name = "command-failure-e2e"
+command = ["python", "{plugin}/server.py"]
 hooks = ["inspect"]
-required = {str(required).lower()}
+required = true
 
 [execution]
-timeout_ms = 0
-''',
-            encoding="utf-8",
+timeout_ms = 1000
+startup_timeout_ms = 1000
+max_output_bytes = 1024
+'''
+    script_source = r'''import json
+import os
+import subprocess
+import sys
+import time
+
+for line in sys.stdin:
+    request = json.loads(line)
+    mode = request.get("config", {}).get("mode", "valid")
+    if mode == "invalid-json":
+        print("not-json", flush=True)
+    elif mode == "oversized":
+        print("x" * 2048, flush=True)
+    elif mode == "timeout":
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        with open("timeout-pids.json", "w", encoding="utf-8") as marker:
+            json.dump([os.getpid(), child.pid], marker)
+        time.sleep(30)
+    elif mode == "exit":
+        sys.exit(17)
+    else:
+        print(json.dumps({
+            "schema": "pentect.plugin.v1",
+            "id": request["id"],
+            "type": "result",
+            "action": "next",
+            "spans": [],
+        }, separators=(",", ":")), flush=True)
+'''
+    manifest.write_text(manifest_source, encoding="utf-8")
+    script.write_text(script_source, encoding="utf-8")
+    run_pentect(
+        pentect,
+        ["plugins", "add", str(plugin), "--project", "--yes"],
+        cwd=project,
+        environment=environment,
+    )
+
+    def set_mode(mode: str) -> None:
+        run_pentect(
+            pentect,
+            ["plugins", "config", "command-failure-e2e", f"mode={mode}", "--project"],
+            cwd=project,
+            environment=environment,
         )
+
+    def expect_mask_failure(reason: str) -> None:
         completed = subprocess.run(
-            pentect_command(
-                pentect,
-                ["mask", "--plugins", str(plugin)],
-            ),
+            pentect_command(pentect, ["mask"]),
             cwd=project,
             env=environment,
-            input="ordinary plugin failure fixture",
+            input="ordinary command plugin fixture",
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             timeout=30,
         )
-        if required:
-            if completed.returncode == 0 or "execution limits" not in completed.stdout:
-                raise RuntimeError(
-                    "required broken plugin did not fail closed:\n" + completed.stdout
-                )
-        else:
-            if completed.returncode != 0:
-                raise RuntimeError(
-                    "optional broken plugin aborted Pentect:\n" + completed.stdout
-                )
-            if "optional plugin 'optional-broken-plugin' skipped during startup" not in completed.stdout:
-                raise RuntimeError(
-                    "optional broken plugin did not emit its startup reason:\n"
-                    + completed.stdout
-                )
+        if completed.returncode == 0 or reason not in completed.stdout:
+            raise RuntimeError(
+                f"required command plugin did not fail closed with {reason!r}:\n"
+                + completed.stdout
+            )
+
+    set_mode("valid")
+    run_pentect(
+        pentect,
+        ["mask"],
+        cwd=project,
+        environment=environment,
+        stdin="ordinary command plugin fixture",
+    )
+    for mode, reason in (
+        ("invalid-json", "returned invalid JSON"),
+        ("oversized", "response exceeds its limit"),
+        ("exit", "closed stdout"),
+        ("timeout", "command startup timed out"),
+    ):
+        set_mode(mode)
+        expect_mask_failure(reason)
+
+    timeout_pids = json.loads((plugin / "timeout-pids.json").read_text(encoding="utf-8"))
+    for pid in timeout_pids:
+        if process_exists(pid):
+            raise RuntimeError(f"timed-out command plugin process {pid} was not terminated")
+
+    set_mode("valid")
+    manifest.write_text(
+        manifest_source.replace(
+            'name = "command-failure-e2e"\n',
+            'name = "command-failure-e2e"\ndescription = "changed"\n',
+        ),
+        encoding="utf-8",
+    )
+    expect_mask_failure("changed after approval")
+    manifest.write_text(manifest_source, encoding="utf-8")
+
+    script.write_text(script_source + "\n# changed after setup\n", encoding="utf-8")
+    expect_mask_failure("changed after setup")
+    script.write_text(script_source, encoding="utf-8")
+    script.unlink()
+    expect_mask_failure("is unavailable")
+
+    run_pentect(
+        pentect,
+        ["plugins", "remove", "command-failure-e2e", "--project"],
+        cwd=project,
+        environment=environment,
+    )
+
+    optional = root / "optional-command-failure-plugin"
+    optional.mkdir()
+    optional_manifest = manifest_source.replace(
+        'name = "command-failure-e2e"',
+        'name = "optional-command-failure-e2e"',
+    ).replace("required = true", "required = false")
+    (optional / "plugin.toml").write_text(optional_manifest, encoding="utf-8")
+    optional_script = optional / "server.py"
+    optional_script.write_text(script_source, encoding="utf-8")
+    run_pentect(
+        pentect,
+        ["plugins", "add", str(optional), "--project", "--yes"],
+        cwd=project,
+        environment=environment,
+    )
+    optional_script.unlink()
+    completed = run_pentect(
+        pentect,
+        ["mask"],
+        cwd=project,
+        environment=environment,
+        stdin="ordinary optional command plugin fixture",
+    )
+    if (
+        "optional plugin 'optional-command-failure-e2e' skipped during startup"
+        not in completed.stdout
+        or "is unavailable" not in completed.stdout
+    ):
+        raise RuntimeError(
+            "optional installed command failure did not expose its reason:\n"
+            + completed.stdout
+        )
+    run_pentect(
+        pentect,
+        ["plugins", "remove", "optional-command-failure-e2e", "--project"],
+        cwd=project,
+        environment=environment,
+    )
+
+
+def process_exists(pid: int) -> bool:
+    if os.name != "nt":
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+    completed = subprocess.run(
+        ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        timeout=10,
+    )
+    return any(
+        len(row) > 1 and row[1] == str(pid)
+        for row in csv.reader(io.StringIO(completed.stdout))
+    )
 
 
 def tool_response(sequence: int, source: str) -> bytes:

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -530,7 +530,7 @@ for line in sys.stdin:
 
     timeout_pids = json.loads((plugin / "timeout-pids.json").read_text(encoding="utf-8"))
     for pid in timeout_pids:
-        if process_exists(pid):
+        if not wait_for_process_exit(pid, timeout=2.0):
             raise RuntimeError(f"timed-out command plugin process {pid} was not terminated")
 
     set_mode("valid")
@@ -617,6 +617,15 @@ def process_exists(pid: int) -> bool:
         len(row) > 1 and row[1] == str(pid)
         for row in csv.reader(io.StringIO(completed.stdout))
     )
+
+
+def wait_for_process_exit(pid: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while process_exists(pid):
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.05)
+    return True
 
 
 def tool_response(sequence: int, source: str) -> bytes:


### PR DESCRIPTION
## Why

The installed plugin E2E claimed to cover missing Command startup failures, but its fixture used `timeout_ms = 0`. Manifest validation therefore failed before executable resolution, approval verification, or process startup. Low-level runtime tests cover individual protocol failures, but the installed CLI path from approval and command locking through execution was not covered.

## What changed

- install a real project-scoped Command plugin through `pentect plugins add --yes`
- verify a valid invocation before exercising failures
- verify required plugins fail closed with actionable reasons for invalid JSON, oversized output, unexpected exit, timeout, manifest approval mismatch, locked-file mutation, and a missing locked file
- verify timeout cleanup terminates both the plugin process and a descendant process
- verify an installed optional plugin with a missing locked file is skipped without aborting masking and reports the concrete reason
- remove the old fixture whose invalid execution limit masked the failure it claimed to test

## Local verification

- `python3 -m py_compile tools/installed_agent_e2e.py`
- `git diff --check`
- `python3 tools/installed_agent_e2e.py --pentect /home/edamame/sub/pentect-1334/target/debug/pentect --plugin-lifecycle-only`

Part of #1339.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded installed command validation to cover invalid responses, oversized output, failed execution, and startup timeouts.
  * Added checks confirming timed-out processes are properly cleaned up.
  * Added verification that changes to approved plugin files are detected after approval and setup.
  * Improved process-liveness checks across supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->