### PR TITLE
fix: roll back interrupted plugin setup

### DIFF
--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -6,7 +6,11 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use std::thread;
+use std::time::{Duration, Instant};
 
 const PLUGIN_BINARY_LOCK_FILE: &str = "binary.lock";
 const PLUGIN_COMMAND_LOCK_FILE: &str = "command.lock";
@@ -15,6 +19,11 @@ const MAX_PLUGIN_MANIFEST_BYTES: u64 = 256 * 1024;
 const MAX_PLUGIN_METADATA_BYTES: u64 = 64 * 1024;
 const MAX_PLUGIN_CONFIG_BYTES: u64 = 1024 * 1024;
 const MAX_PLUGIN_WASM_BYTES: u64 = 32 * 1024 * 1024;
+const SETUP_CHILD_POLL: Duration = Duration::from_millis(25);
+const SETUP_INTERRUPT_GRACE: Duration = Duration::from_secs(2);
+
+static SETUP_INTERRUPTED: AtomicBool = AtomicBool::new(false);
+static SETUP_INTERRUPT_HANDLER: OnceLock<Result<(), String>> = OnceLock::new();
 
 pub(crate) fn cmd_plugins(args: &[String]) {
     let opts = match PluginCmd::parse(args) {
@@ -2450,15 +2459,25 @@ fn run_command_environment_setup(
         argv.push(profile.to_string());
     }
     let executable = resolve_command_executable(&argv[0])?;
+    install_setup_interrupt_handler()?;
+    SETUP_INTERRUPTED.store(false, Ordering::SeqCst);
     println!("environment setup: starting");
-    let status = Command::new(executable)
+    let mut command = Command::new(executable);
+    command
         .args(&argv[1..])
         .current_dir(&root)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
+        .stderr(Stdio::inherit());
+    configure_setup_process_tree(&mut command);
+    let mut child = command
+        .spawn()
         .map_err(|error| format!("could not start plugin environment setup: {error}"))?;
+    let status = wait_for_setup_child(&mut child)?;
+    let interrupted = SETUP_INTERRUPTED.swap(false, Ordering::SeqCst);
+    if interrupted {
+        return Err("plugin environment setup was interrupted".to_string());
+    }
     if !status.success() {
         return Err(format!(
             "plugin environment setup failed with {}",
@@ -2471,6 +2490,77 @@ fn run_command_environment_setup(
     println!("environment setup: complete");
     Ok(())
 }
+
+fn install_setup_interrupt_handler() -> Result<(), String> {
+    SETUP_INTERRUPT_HANDLER
+        .get_or_init(|| {
+            ctrlc::set_handler(|| {
+                SETUP_INTERRUPTED.store(true, Ordering::SeqCst);
+            })
+            .map_err(|error| format!("could not install plugin setup interrupt handler: {error}"))
+        })
+        .clone()
+}
+
+fn wait_for_setup_child(child: &mut Child) -> Result<std::process::ExitStatus, String> {
+    let mut interrupted_at = None;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) => {}
+            Err(error) => {
+                terminate_setup_process_tree(child.id(), true);
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "could not wait for plugin environment setup: {error}"
+                ));
+            }
+        }
+        if SETUP_INTERRUPTED.load(Ordering::SeqCst) {
+            let started = interrupted_at.get_or_insert_with(Instant::now);
+            terminate_setup_process_tree(child.id(), started.elapsed() >= SETUP_INTERRUPT_GRACE);
+        }
+        thread::sleep(SETUP_CHILD_POLL);
+    }
+}
+
+#[cfg(unix)]
+fn configure_setup_process_tree(command: &mut Command) {
+    use std::os::unix::process::CommandExt as _;
+    command.process_group(0);
+}
+
+#[cfg(windows)]
+fn configure_setup_process_tree(command: &mut Command) {
+    use std::os::windows::process::CommandExt as _;
+    use windows_sys::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
+    command.creation_flags(CREATE_NEW_PROCESS_GROUP);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn configure_setup_process_tree(_command: &mut Command) {}
+
+#[cfg(unix)]
+fn terminate_setup_process_tree(pid: u32, force: bool) {
+    let signal = if force { libc::SIGKILL } else { libc::SIGTERM };
+    unsafe {
+        libc::kill(-(pid as i32), signal);
+    }
+}
+
+#[cfg(windows)]
+fn terminate_setup_process_tree(pid: u32, _force: bool) {
+    let _ = Command::new(crate::windows_system_executable("taskkill.exe"))
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+#[cfg(not(any(unix, windows)))]
+fn terminate_setup_process_tree(_pid: u32, _force: bool) {}
 
 struct CommandRuntimeSnapshot {
     data_dir: PathBuf,

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -389,6 +389,128 @@ command = ["python", "-c", "import sys; sys.exit(17)"]
         raise RuntimeError("failed plugin setup remained enabled")
 
 
+def verify_interrupted_setup_rolls_back(
+    pentect: str,
+    root: Path,
+    home: Path,
+    project: Path,
+    environment: dict[str, str],
+) -> None:
+    plugin = root / "interrupted-setup-plugin"
+    plugin.mkdir()
+    setup = plugin / "setup.py"
+    setup.write_text(
+        '''import os
+import time
+
+with open("setup-pid.txt", "w", encoding="utf-8") as marker:
+    marker.write(str(os.getpid()))
+while True:
+    time.sleep(1)
+''',
+        encoding="utf-8",
+    )
+    (plugin / "server.py").write_text(
+        '''import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    print(json.dumps({
+        "schema": "pentect.plugin.v1",
+        "id": request["id"],
+        "type": "result",
+        "action": "next",
+        "spans": [],
+    }, separators=(",", ":")), flush=True)
+''',
+        encoding="utf-8",
+    )
+    (plugin / "plugin.toml").write_text(
+        '''schema = "pentect.plugin.v1"
+name = "interrupted-setup-e2e"
+command = ["python", "{plugin}/server.py"]
+hooks = ["inspect"]
+
+[setup]
+command = ["python", "{plugin}/setup.py"]
+''',
+        encoding="utf-8",
+    )
+    before = snapshot_regular_files(home, project)
+    popen_options: dict[str, object] = {}
+    if os.name == "nt":
+        popen_options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_options["start_new_session"] = True
+    process = subprocess.Popen(
+        pentect_command(
+            pentect,
+            ["plugins", "add", str(plugin), "--project", "--yes"],
+        ),
+        cwd=project,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        **popen_options,
+    )
+    marker = plugin / "setup-pid.txt"
+    deadline = time.monotonic() + 10
+    while not marker.exists() and process.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if not marker.exists():
+        process.kill()
+        output, _ = process.communicate(timeout=5)
+        raise RuntimeError("plugin setup did not reach its interrupt fixture:\n" + output)
+    setup_pid = int(marker.read_text(encoding="utf-8"))
+    if os.name == "nt":
+        process.send_signal(signal.CTRL_BREAK_EVENT)
+    else:
+        os.kill(process.pid, signal.SIGINT)
+    try:
+        output, _ = process.communicate(timeout=8)
+    except subprocess.TimeoutExpired as error:
+        process.kill()
+        process.wait()
+        raise RuntimeError("interrupted plugin setup did not exit within 8 seconds") from error
+    if process.returncode == 0 or "plugin environment setup was interrupted" not in output:
+        raise RuntimeError("interrupted plugin setup did not report interruption:\n" + output)
+    if not wait_for_process_exit(setup_pid, timeout=2.0):
+        raise RuntimeError(f"interrupted plugin setup process {setup_pid} was not terminated")
+    if snapshot_regular_files(home, project) != before:
+        raise RuntimeError("interrupted plugin setup left partial persistent state")
+    listed = run_pentect(
+        pentect,
+        ["plugins", "list"],
+        cwd=project,
+        environment=environment,
+    )
+    if "interrupted-setup-e2e:" in listed.stdout:
+        raise RuntimeError("interrupted plugin setup remained enabled")
+
+    setup.write_text("raise SystemExit(0)\n", encoding="utf-8")
+    run_pentect(
+        pentect,
+        ["plugins", "add", str(plugin), "--project", "--yes"],
+        cwd=project,
+        environment=environment,
+    )
+    run_pentect(
+        pentect,
+        ["mask"],
+        cwd=project,
+        environment=environment,
+        stdin="ordinary recovered setup fixture",
+    )
+    run_pentect(
+        pentect,
+        ["plugins", "remove", "interrupted-setup-e2e", "--project"],
+        cwd=project,
+        environment=environment,
+    )
+
+
 def run_plugin_lifecycle(pentect: str) -> None:
     with tempfile.TemporaryDirectory(
         prefix="pentect-plugin-e2e-project-", ignore_cleanup_errors=True
@@ -419,10 +541,13 @@ def run_plugin_lifecycle(pentect: str) -> None:
         verify_failed_setup_rolls_back(
             pentect, root, home, project, environment
         )
+        verify_interrupted_setup_rolls_back(
+            pentect, root, home, project, environment
+        )
         verify_installed_command_failure_boundaries(pentect, root, project, environment)
         print(
             "installed plugin lifecycle E2E passed: inspect, test, project/user "
-            "add/setup/update/reinstall/remove, failed-setup rollback, Command runtime "
+            "add/setup/update/reinstall/remove, failed/interrupted-setup rollback, Command runtime "
             "fail-closed boundaries and process cleanup, no log plaintext"
         )
 


### PR DESCRIPTION
## Why

Command plugin setup used blocking `Command::status()`. Ctrl-C could terminate Pentect without running `CommandRuntimeSnapshot::restore`, and the native setup child was not placed in a separately managed process tree. That could leave partial approval/lock state and an orphaned setup process.

## What changed

- install a setup-specific Ctrl-C/termination handler before starting native setup
- launch setup in a separate POSIX process group or Windows process group
- poll the child so an interrupt terminates the complete setup tree
- allow two seconds for graceful POSIX termination, then force termination
- on wait errors, force cleanup before returning
- return a specific interruption error so the existing Command runtime snapshot and plugin transaction rollback execute
- add installed lifecycle E2E that interrupts a real setup, verifies the setup PID exits, verifies home/project files are restored byte-for-byte, verifies the plugin is not enabled, then retries installation and runs the plugin successfully

This handles Ctrl-C/CTRL_BREAK and termination signals supported by the existing `ctrlc` dependency. It does not claim recovery after SIGKILL, power loss, or host crash; durable on-disk transaction recovery remains tracked in #1339.

## Local verification

- `cargo fmt --all -- --check`
- `python3 -m py_compile tools/installed_agent_e2e.py`
- `git diff --check`
- `cargo build -p pentect-cli --bin pentect`
- `cargo test -p pentect-cli command_runtime_snapshot_restores_only_managed_state` (1 passed)
- `python3 tools/installed_agent_e2e.py --pentect /home/edamame/sub/pentect-1334/target/debug/pentect --plugin-lifecycle-only`

Part of #1339.