### PR TITLE
test: preserve approved runtime after failed plugin update

### DIFF
--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -580,6 +580,110 @@ command = ["python", "{plugin}/setup.py"]
     )
 
 
+def verify_failed_update_preserves_command_runtime(
+    pentect: str,
+    root: Path,
+    home: Path,
+    project: Path,
+    environment: dict[str, str],
+) -> None:
+    plugin = root / "failed-update-plugin"
+    plugin.mkdir()
+    manifest = plugin / "plugin.toml"
+    server = plugin / "server.py"
+    manifest_source = '''schema = "pentect.plugin.v1"
+name = "failed-update-e2e"
+command = ["python", "{plugin}/server.py"]
+hooks = ["inspect"]
+required = true
+
+[setup]
+command = ["python", "-c", "raise SystemExit(0)"]
+'''
+    server.write_text(
+        r'''import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    print(json.dumps({
+        "schema": "pentect.plugin.v1",
+        "id": request["id"],
+        "type": "result",
+        "action": "next",
+        "spans": [],
+    }, separators=(",", ":")), flush=True)
+''',
+        encoding="utf-8",
+    )
+    manifest.write_text(manifest_source, encoding="utf-8")
+    run_pentect(
+        pentect,
+        ["plugins", "add", str(plugin), "--project", "--yes"],
+        cwd=project,
+        environment=environment,
+    )
+    ordinary = "ordinary failed update fixture"
+    run_pentect(
+        pentect,
+        ["mask"],
+        cwd=project,
+        environment=environment,
+        stdin=ordinary,
+    )
+    before = snapshot_regular_files(home, project)
+    manifest.write_text(
+        manifest_source.replace(
+            'required = true\n', 'required = true\ndescription = "updated"\n'
+        ).replace("raise SystemExit(0)", "raise SystemExit(17)"),
+        encoding="utf-8",
+    )
+    failed = subprocess.run(
+        pentect_command(
+            pentect,
+            ["plugins", "update", str(plugin), "--project", "--yes"],
+        ),
+        cwd=project,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+    )
+    if (
+        failed.returncode == 0
+        or "plugin environment setup failed with exit 17" not in failed.stdout
+    ):
+        raise RuntimeError(
+            "failed plugin update did not expose its setup failure:\n" + failed.stdout
+        )
+    if snapshot_regular_files(home, project) != before:
+        raise RuntimeError("failed plugin update changed approved persistent state")
+
+    # A local source is owned by the user and is not rewritten by Pentect. Once
+    # that source is restored, the previously approved runtime must work without
+    # another setup. Remote sources restore this side through the cache rollback.
+    manifest.write_text(manifest_source, encoding="utf-8")
+    recovered = run_pentect(
+        pentect,
+        ["mask"],
+        cwd=project,
+        environment=environment,
+        stdin=ordinary,
+    )
+    if ordinary not in recovered.stdout:
+        raise RuntimeError(
+            "previously approved plugin did not recover after failed update:\n"
+            + recovered.stdout
+        )
+    run_pentect(
+        pentect,
+        ["plugins", "remove", "failed-update-e2e", "--project"],
+        cwd=project,
+        environment=environment,
+    )
+
+
 def run_plugin_lifecycle(pentect: str) -> None:
     with tempfile.TemporaryDirectory(
         prefix="pentect-plugin-e2e-project-", ignore_cleanup_errors=True
@@ -613,13 +717,16 @@ def run_plugin_lifecycle(pentect: str) -> None:
         verify_interrupted_setup_rolls_back(
             pentect, root, home, project, environment
         )
+        verify_failed_update_preserves_command_runtime(
+            pentect, root, home, project, environment
+        )
         verify_installed_command_failure_boundaries(pentect, root, project, environment)
         verify_home_rooted_project_storage_boundary(pentect)
         print(
             "installed plugin lifecycle E2E passed: inspect, test, project/user "
-            "add/setup/update/reinstall/remove, failed/interrupted-setup rollback, Command runtime "
-            "fail-closed boundaries and process cleanup, HOME-rooted optional/required storage "
-            "boundaries, no log plaintext"
+            "add/setup/update/reinstall/remove, failed/interrupted-setup and failed-update rollback, "
+            "Command runtime fail-closed boundaries and process cleanup, HOME-rooted "
+            "optional/required storage boundaries, no log plaintext"
         )
 
 


### PR DESCRIPTION
## Why

A Command plugin update can rewrite its command lock before native setup finishes. If failed setup leaves the new lock or approval behind, the update command reports an error but the previously working plugin becomes unusable too.

The individual rollback helpers existed, but the installed cross-platform E2E did not prove that the complete CLI update path preserves the last approved runtime.

## What changed

- install and invoke a real required Command plugin;
- change its manifest so update requires renewed approval and its setup exits with code 17;
- verify `plugins update --project --yes` reports that exact setup failure;
- verify persistent HOME and project files remain byte-for-byte identical to their pre-update state;
- restore the user-owned local source and verify the previously approved plugin works without another setup;
- remove the fixture through the normal CLI.

This fixture proves approval, command-lock, config, and project-lock preservation. A local source remains user-owned and is deliberately not rewritten by Pentect; remote source bytes are covered separately by the existing remote-cache rollback unit test.

No product behavior is changed.

## Focused verification

- `python3 -m py_compile tools/installed_agent_e2e.py`
- `git diff --check`
- `python3 tools/installed_agent_e2e.py --pentect /home/edamame/sub/pentect-1334/target/debug/pentect --plugin-lifecycle-only`

Part of #1339.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin update handling when setup fails.
  * Existing approved plugin runtimes now remain usable after an unsuccessful update.
  * Failed updates preserve the plugin’s prior persistent state and report the setup failure clearly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->