### PR TITLE
perf: reduce Privacy Filter CPU latency and memory

### DIFF
--- a/plugins/openai-privacy-filter/README.md
+++ b/plugins/openai-privacy-filter/README.md
@@ -19,6 +19,12 @@ pentect plugins add github:@EdamAme-x/pentect/plugins/openai-privacy-filter --pr
 To change the profile later, run
 `pentect plugins setup openai-privacy-filter --profile cuda`.
 
+On CPU, Pentect bounds the Privacy Filter model's internal MoE working set to
+avoid excessive temporary memory traffic. Set
+`PENTECT_OPF_CPU_MOE_BATCH_SIZE` to a positive integer to tune this for a
+specific machine, or to `0` to use the upstream checkpoint setting unchanged.
+This setting does not apply to CUDA.
+
 The server returns byte ranges and labels. It does not return the matched text.
 Pentect turns those ranges into normal handles such as
 `<<PRIVATE_EMAIL_...>>`.
@@ -43,6 +49,23 @@ python3 plugins/openai-privacy-filter/tests/live_e2e.py \
 
 Use `--skip-codex` only when validating the model integration without an
 installed Codex CLI.
+
+## Performance benchmark
+
+The benchmark keeps one real plugin process alive, records model startup and
+warm request latency, and rejects runs that fail to detect the synthetic PII.
+It does not contact OpenAI.
+
+```sh
+python3 plugins/openai-privacy-filter/tests/benchmark.py \
+  --iterations 5 --sizes 64 256 1024
+```
+
+Pass `--batch-size 0` to measure the pinned upstream model configuration as a
+baseline. The command prints a versioned JSON report with all samples, p50,
+p95, and maximum latency. Add `--compare-unchunked` to start a second baseline
+process after the optimized run and require byte ranges and labels to match
+exactly for every requested input size.
 
 OpenAI Privacy Filter is an OpenAI project released under Apache-2.0. This
 plugin is maintained by Pentect and released under MIT. OpenAI does not

--- a/plugins/openai-privacy-filter/server.py
+++ b/plugins/openai-privacy-filter/server.py
@@ -12,6 +12,7 @@ from typing import Any
 
 MAX_REQUEST_BYTES = 1024 * 1024
 PROTOCOL_SCHEMA = "pentect.plugin.v1"
+DEFAULT_CPU_MOE_BATCH_SIZE = 2
 
 
 def _use_managed_python() -> None:
@@ -103,6 +104,41 @@ def _label(value: object) -> tuple[str, str]:
     return (label or "PII", "secret" if raw.lower() == "secret" else "pii")
 
 
+def _cpu_moe_batch_size() -> int:
+    """Resolve the CPU MoE chunk size; zero explicitly disables chunking."""
+    raw = os.environ.get("PENTECT_OPF_CPU_MOE_BATCH_SIZE")
+    if raw is None:
+        return DEFAULT_CPU_MOE_BATCH_SIZE
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise ValueError(
+            "PENTECT_OPF_CPU_MOE_BATCH_SIZE must be a non-negative integer"
+        ) from error
+    if value < 0:
+        raise ValueError(
+            "PENTECT_OPF_CPU_MOE_BATCH_SIZE must be a non-negative integer"
+        )
+    return value
+
+
+def configure_runtime(redactor: Any, device: str) -> Any:
+    """Load OPF and bound its CPU MoE working set without changing predictions."""
+    runtime = redactor.get_runtime()
+    if device != "cpu":
+        return runtime
+
+    batch_size = _cpu_moe_batch_size()
+    if batch_size == 0:
+        return runtime
+    blocks = getattr(getattr(runtime, "model", None), "block", ())
+    for block in blocks:
+        mlp = getattr(block, "mlp", None)
+        if mlp is not None and hasattr(mlp, "torch_ops_batch"):
+            mlp.torch_ops_batch = batch_size
+    return runtime
+
+
 def inspect_text(redactor: Any, text: str) -> list[dict[str, object]]:
     result = redactor.redact(text)
     if isinstance(result, str):
@@ -180,13 +216,14 @@ def main() -> None:
 
     from opf import OPF
 
+    device = _selected_device(args.device)
     redactor = OPF(
         model=_managed_checkpoint(args.checkpoint),
-        device=_selected_device(args.device),
+        device=device,
         output_mode="typed",
         output_text_only=False,
     )
-    redactor.get_runtime()
+    configure_runtime(redactor, device)
     serve(redactor)
 
 

--- a/plugins/openai-privacy-filter/tests/benchmark.py
+++ b/plugins/openai-privacy-filter/tests/benchmark.py
@@ -102,16 +102,38 @@ def main() -> None:
     args = parser.parse_args()
     if args.iterations < 1 or any(size < 1 for size in args.sizes):
         parser.error("iterations and sizes must be positive")
+    if args.batch_size is not None and args.batch_size < 0:
+        parser.error("--batch-size must be non-negative")
+    if args.device != "cpu" and args.batch_size is not None:
+        parser.error("--batch-size requires --device cpu")
+    if args.compare_unchunked and args.device != "cpu":
+        parser.error("--compare-unchunked requires --device cpu")
 
     plugin = Path(__file__).parents[1] / "server.py"
     environment = os.environ.copy()
-    if args.batch_size is not None:
-        environment["PENTECT_OPF_CPU_MOE_BATCH_SIZE"] = str(args.batch_size)
+    effective_batch_size: int | None = None
+    if args.device == "cpu":
+        raw_batch_size = (
+            str(args.batch_size)
+            if args.batch_size is not None
+            else environment.get("PENTECT_OPF_CPU_MOE_BATCH_SIZE", "2")
+        )
+        try:
+            effective_batch_size = int(raw_batch_size)
+        except ValueError:
+            parser.error(
+                "PENTECT_OPF_CPU_MOE_BATCH_SIZE must be a non-negative integer"
+            )
+        if effective_batch_size < 0:
+            parser.error(
+                "PENTECT_OPF_CPU_MOE_BATCH_SIZE must be a non-negative integer"
+            )
+        environment["PENTECT_OPF_CPU_MOE_BATCH_SIZE"] = str(effective_batch_size)
     process = start_plugin(plugin, args.device, environment)
     report: dict[str, object] = {
         "schema": "pentect.opf-benchmark.v1",
         "device": args.device,
-        "batch_size": args.batch_size,
+        "batch_size": effective_batch_size,
         "iterations": args.iterations,
         "measurements": [],
     }

--- a/plugins/openai-privacy-filter/tests/benchmark.py
+++ b/plugins/openai-privacy-filter/tests/benchmark.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Benchmark the real persistent OpenAI Privacy Filter plugin process."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import statistics
+import subprocess
+import sys
+import time
+
+
+BASE_TEXT = (
+    "Alice Example can be reached at alice@example.com or +1 415-555-0100. "
+    "Her office is 1 Market Street, San Francisco. "
+)
+
+
+def sample(size: int) -> str:
+    repetitions = size // len(BASE_TEXT) + 2
+    return (BASE_TEXT * repetitions)[:size]
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    position = max(0, min(len(ordered) - 1, int(len(ordered) * fraction + 0.999) - 1))
+    return ordered[position]
+
+
+def linux_memory_kib(process_id: int) -> dict[str, int]:
+    """Read optional Linux process memory counters without extra dependencies."""
+    wanted = {"VmHWM": "peak_rss_kib", "VmRSS": "rss_kib"}
+    result: dict[str, int] = {}
+    try:
+        lines = Path(f"/proc/{process_id}/status").read_text(
+            encoding="utf-8"
+        ).splitlines()
+    except OSError:
+        return result
+    for line in lines:
+        name, separator, value = line.partition(":")
+        if separator and name in wanted:
+            result[wanted[name]] = int(value.strip().split()[0])
+    return result
+
+
+def request(
+    process: subprocess.Popen[str], request_id: int, text: str
+) -> tuple[float, dict[str, object]]:
+    assert process.stdin is not None and process.stdout is not None
+    payload = {
+        "schema": "pentect.plugin.v1",
+        "id": request_id,
+        "hook": "inspect",
+        "payload": {"text": text},
+    }
+    started = time.perf_counter()
+    process.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    process.stdin.flush()
+    line = process.stdout.readline()
+    elapsed = time.perf_counter() - started
+    if not line:
+        raise RuntimeError("OpenAI Privacy Filter exited without a response")
+    response = json.loads(line)
+    if response.get("error"):
+        raise RuntimeError(f"OpenAI Privacy Filter failed: {response['error']!r}")
+    return elapsed, response
+
+
+def start_plugin(
+    plugin: Path, device: str, environment: dict[str, str]
+) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [sys.executable, str(plugin), "--device", device],
+        text=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=None,
+        env=environment,
+    )
+
+
+def stop_plugin(process: subprocess.Popen[str]) -> None:
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--sizes", type=int, nargs="+", default=(64, 256, 1024))
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cpu")
+    parser.add_argument("--batch-size", type=int)
+    parser.add_argument("--compare-unchunked", action="store_true")
+    args = parser.parse_args()
+    if args.iterations < 1 or any(size < 1 for size in args.sizes):
+        parser.error("iterations and sizes must be positive")
+
+    plugin = Path(__file__).parents[1] / "server.py"
+    environment = os.environ.copy()
+    if args.batch_size is not None:
+        environment["PENTECT_OPF_CPU_MOE_BATCH_SIZE"] = str(args.batch_size)
+    process = start_plugin(plugin, args.device, environment)
+    report: dict[str, object] = {
+        "schema": "pentect.opf-benchmark.v1",
+        "device": args.device,
+        "batch_size": args.batch_size,
+        "iterations": args.iterations,
+        "measurements": [],
+    }
+    spans_by_size: dict[int, object] = {}
+    try:
+        request_id = 1
+        startup_s, startup_response = request(process, request_id, sample(64))
+        if not startup_response.get("spans"):
+            raise RuntimeError("startup probe did not detect synthetic PII")
+        report["startup_s"] = startup_s
+        measurements = report["measurements"]
+        assert isinstance(measurements, list)
+        for size in args.sizes:
+            text = sample(size)
+            times: list[float] = []
+            for _ in range(args.iterations):
+                request_id += 1
+                elapsed, response = request(process, request_id, text)
+                if not response.get("spans"):
+                    raise RuntimeError(f"{size}-byte probe did not detect synthetic PII")
+                spans_by_size[size] = response["spans"]
+                times.append(elapsed)
+            measurements.append(
+                {
+                    "bytes": len(text.encode("utf-8")),
+                    "samples_s": times,
+                    "p50_s": statistics.median(times),
+                    "p95_s": percentile(times, 0.95),
+                    "max_s": max(times),
+                }
+            )
+        report.update(linux_memory_kib(process.pid))
+    finally:
+        stop_plugin(process)
+
+    if args.compare_unchunked:
+        baseline_environment = environment.copy()
+        baseline_environment["PENTECT_OPF_CPU_MOE_BATCH_SIZE"] = "0"
+        baseline = start_plugin(plugin, args.device, baseline_environment)
+        try:
+            baseline_startup_s, response = request(baseline, 1, sample(64))
+            if not response.get("spans"):
+                raise RuntimeError("unchunked startup probe did not detect synthetic PII")
+            for request_id, size in enumerate(args.sizes, start=2):
+                _, response = request(baseline, request_id, sample(size))
+                if response.get("spans") != spans_by_size[size]:
+                    raise RuntimeError(
+                        f"optimized and unchunked spans differ for {size} bytes"
+                    )
+            report["unchunked_comparison"] = {
+                "equivalent": True,
+                "startup_s": baseline_startup_s,
+                **linux_memory_kib(baseline.pid),
+            }
+        finally:
+            stop_plugin(baseline)
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/openai-privacy-filter/tests/test_server.py
+++ b/plugins/openai-privacy-filter/tests/test_server.py
@@ -123,6 +123,59 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(result["action"], "next")
         self.assertEqual(len(result["spans"]), 1)
 
+    def test_cpu_runtime_uses_bounded_moe_batches(self) -> None:
+        mlps = [SimpleNamespace(torch_ops_batch=None) for _ in range(2)]
+        runtime = SimpleNamespace(
+            model=SimpleNamespace(
+                block=[SimpleNamespace(mlp=mlp) for mlp in mlps]
+            )
+        )
+        redactor = mock.Mock()
+        redactor.get_runtime.return_value = runtime
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = SERVER.configure_runtime(redactor, "cpu")
+
+        self.assertIs(result, runtime)
+        self.assertEqual(
+            [mlp.torch_ops_batch for mlp in mlps],
+            [SERVER.DEFAULT_CPU_MOE_BATCH_SIZE] * 2,
+        )
+
+    def test_cpu_batch_override_can_disable_chunking(self) -> None:
+        mlp = SimpleNamespace(torch_ops_batch=32)
+        runtime = SimpleNamespace(
+            model=SimpleNamespace(block=[SimpleNamespace(mlp=mlp)])
+        )
+        redactor = mock.Mock()
+        redactor.get_runtime.return_value = runtime
+
+        with mock.patch.dict(
+            os.environ, {"PENTECT_OPF_CPU_MOE_BATCH_SIZE": "0"}, clear=True
+        ):
+            SERVER.configure_runtime(redactor, "cpu")
+
+        self.assertEqual(mlp.torch_ops_batch, 32)
+
+    def test_gpu_runtime_is_not_modified(self) -> None:
+        mlp = SimpleNamespace(torch_ops_batch=32)
+        runtime = SimpleNamespace(
+            model=SimpleNamespace(block=[SimpleNamespace(mlp=mlp)])
+        )
+        redactor = mock.Mock()
+        redactor.get_runtime.return_value = runtime
+
+        SERVER.configure_runtime(redactor, "cuda")
+
+        self.assertEqual(mlp.torch_ops_batch, 32)
+
+    def test_invalid_cpu_batch_override_is_rejected(self) -> None:
+        with mock.patch.dict(
+            os.environ, {"PENTECT_OPF_CPU_MOE_BATCH_SIZE": "many"}, clear=True
+        ):
+            with self.assertRaisesRegex(ValueError, "non-negative integer"):
+                SERVER._cpu_moe_batch_size()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #1357.

## What changed

- bound the pinned OpenAI Privacy Filter CPU MoE working set to two tokens per chunk
- leave CUDA untouched and allow `PENTECT_OPF_CPU_MOE_BATCH_SIZE=0` to preserve the upstream checkpoint setting
- add unit coverage for defaults, override, disable, invalid input, and CUDA isolation
- add a persistent real-model benchmark with cold/warm latency, Linux memory counters, and exact optimized-vs-unchunked span comparison
- document tuning and benchmark commands

## Why

The pinned checkpoint sets `torch_ops_batch` to null. On CPU this gathers and converts expert weights for the entire request at once, causing multi-GiB temporary allocations and poor cache behavior. This is a working-set problem, not a detection shortcut: decoding and model weights are unchanged.

## Real CPU evidence

Intel Core Ultra 5 134U, pinned real OPF model, persistent plugin process:

| Input | Upstream p50 | Optimized p50 | Speedup |
| --- | ---: | ---: | ---: |
| 64 bytes | 1.55 s | 0.37 s | 4.2x |
| 256 bytes | 5.12 s | 1.41 s | 3.6x |
| 1024 bytes | 15.38 s | 5.99 s | 2.6x |

A separate 1024-byte run improved from 17.89 s / 9,234,120 KiB peak RSS to 6.38 s / 3,621,408 KiB peak RSS. `--compare-unchunked` confirmed exact label and byte-range equality at 64, 256, and 1024 bytes.

## Verification

- `python3 -m unittest discover plugins/openai-privacy-filter/tests` (21 tests)
- `python3 plugins/openai-privacy-filter/tests/benchmark.py --iterations 1 --sizes 64 256 1024 --compare-unchunked`
- real plugin + `pentect mask` twice + installed Codex 0.151.0 with `gpt-5.6-luna` against a local recorder: status ok; 9.308 s direct, 11.370 s cold mask, 11.702 s restart, 21.595 s Codex; recorder saw a handle and no plaintext PII

Long-input CPU inference remains linear and is not claimed to be sub-second.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CPU performance tuning through the `PENTECT_OPF_CPU_MOE_BATCH_SIZE` setting.
  * Added a benchmark tool reporting startup time, request latency percentiles, memory usage, and PII detection validation.
  * Added support for comparing chunked and unchunked processing results.

* **Documentation**
  * Documented CPU batch-size configuration, benchmark usage, output, and CUDA behavior.

* **Tests**
  * Added coverage for CPU configuration, environment overrides, GPU behavior, and invalid settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->