### PR TITLE
fix: mask credential fields with key components

### DIFF
--- a/crates/pentect-core/src/detect/structural.rs
+++ b/crates/pentect-core/src/detect/structural.rs
@@ -289,7 +289,7 @@ pub(crate) fn is_sensitive_key_name(key: &str) -> bool {
     if is_explicitly_non_sensitive_key(&name) || is_non_credential_sensitive_word_name(&name) {
         return false;
     }
-    name == "key"
+    name.split('_').any(|part| part == "key")
         || name == "auth"
         || name == "authorization"
         || name.contains("auth_")
@@ -1032,10 +1032,17 @@ mod tests {
             "export MAILGUN_API_KEY='mail gun value'; npx server\n",
             "PUBLIC_MODE=development app\n",
             "FOO=bar SQUARE_ACCESS_TOKEN=SquareValue node app.js\n",
+            "SIGNING_KEY=signing-material service\n",
+            "PUBLIC_KEY=visible-material service\n",
         );
         assert_eq!(
             shell_env_values(raw),
-            ["SyntheticValue", "mail gun value", "SquareValue"]
+            [
+                "SyntheticValue",
+                "mail gun value",
+                "SquareValue",
+                "signing-material",
+            ]
         );
     }
 
@@ -1365,6 +1372,39 @@ mod tests {
             sensitive_key_fires(Some("password"), "correct horse battery staple"),
             Some("PASSWORD".to_string())
         );
+    }
+
+    #[test]
+    fn key_components_are_sensitive_unless_explicitly_non_secret() {
+        for key in [
+            "signing_key",
+            "masterKey",
+            "encryption-key",
+            "deploy_key",
+            "key_material",
+        ] {
+            assert!(is_sensitive_key_name(key), "{key}");
+            assert!(
+                sensitive_key_fires(Some(key), "opaque-material-1341").is_some(),
+                "{key}"
+            );
+        }
+        for key in [
+            "public_key",
+            "correlation_key",
+            "foreign_key",
+            "routing_key",
+            "topology_key",
+            "api_key_name",
+            "monkey_value",
+        ] {
+            assert!(!is_sensitive_key_name(key), "{key}");
+            assert_eq!(
+                sensitive_key_fires(Some(key), "visible-material"),
+                None,
+                "{key}"
+            );
+        }
     }
 
     #[test]

--- a/crates/pentect-core/src/pipeline/mod.rs
+++ b/crates/pentect-core/src/pipeline/mod.rs
@@ -1300,6 +1300,22 @@ mod tests {
     }
 
     #[test]
+    fn json_key_component_values_are_masked_and_recoverable() {
+        let input = r#"{"signing_key":"signing-material","masterKey":"master-material","encryption-key":"encryption-material","deploy_key":"deploy-material","public_key":"visible","correlation_key":"request-id","monkey_value":"banana"}"#;
+        let result = mj(input);
+        let value: serde_json::Value =
+            serde_json::from_str(&result.masked).expect("masked output is valid JSON");
+        let object = value.as_object().unwrap();
+        for key in ["signing_key", "masterKey", "encryption-key", "deploy_key"] {
+            assert!(object[key].as_str().unwrap().starts_with("<<"), "{key}");
+        }
+        assert_eq!(object["public_key"].as_str().unwrap(), "visible");
+        assert_eq!(object["correlation_key"].as_str().unwrap(), "request-id");
+        assert_eq!(object["monkey_value"].as_str().unwrap(), "banana");
+        assert_eq!(restore(&result.masked, &result.recovery).unwrap(), input);
+    }
+
+    #[test]
     fn low_entropy_credential_classes_are_covered_across_text_env_and_logs() {
         let cases = [
             (Kind::Text, "my password is letmein", vec!["letmein"]),


### PR DESCRIPTION
Closes #1341.

## Root cause

The shared structural key-name classifier treated `auth` as an identifier fragment, but recognized `key` only as an exact name or through a short fixed list. As a result, ordinary credential slots such as `signing_key`, `masterKey`, `encryption-key`, and `deploy_key` could reach the canonical masking pipeline without sensitive key context.

## Fix

- recognize an independent normalized `key` identifier component
- keep the existing data-driven public/non-secret exclusions ahead of this check
- avoid raw substring matching, so `monkey_value` remains benign
- add structural tests for snake_case, camelCase, kebab-case, prefix forms, shell assignments, and explicit exclusions
- add canonical JSON pipeline masking and restoration coverage

## Verification

- demonstrated the new structural test fails on `origin/main` at `signing_key`
- `cargo test -p pentect-core key_components_are_sensitive_unless_explicitly_non_secret --locked`
- `cargo test -p pentect-core json_key_component_values_are_masked_and_recoverable --locked`
- `cargo test -p pentect-core shell_environment_assignments_mask_unquoted_and_quoted_values --locked`
- `cargo test -p pentect-core --lib --locked` (473 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
