### PR TITLE
Fix duplicate prompt plugin stage execution

### DIFF
--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -187,15 +187,6 @@ impl OutputMasker {
         let (protected, unmasked_values) =
             protect_prompt_unmask_markers(text, &self.store.session.identity_key);
         let remasked = self.remask_all(&protected)?;
-        let remasked = if run_plugins {
-            self.run_text_plugins(
-                crate::plugin_middleware::MiddlewareStage::Prepare,
-                remasked,
-                &Kind::Text,
-            )?
-        } else {
-            remasked
-        };
         // Prompt scalars are text. Only opt into dotenv parsing when the
         // payload actually contains assignment syntax; treating every
         // `Label: prose` sentence as Env turns ordinary messages into secrets.
@@ -240,20 +231,10 @@ impl OutputMasker {
                 .masked_count
                 .saturating_add(env_result.summary.masked_count);
         }
-        let initially_masked = std::mem::take(&mut result.masked);
-        let masked = if run_plugins {
-            self.run_text_plugins(
-                crate::plugin_middleware::MiddlewareStage::Finalize,
-                initially_masked,
-                &Kind::Text,
-            )?
-        } else {
-            initially_masked
-        };
         let final_result = self.prompt_engine.mask(
             Input {
                 kind: Kind::Text,
-                data: masked,
+                data: std::mem::take(&mut result.masked),
             },
             &Config {
                 disclose_length: false,

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -318,6 +318,32 @@ pub struct PluginMiddleware {
 }
 
 impl PluginMiddleware {
+    #[cfg(test)]
+    pub(crate) fn from_test_command(
+        argv: Vec<String>,
+        hooks: impl IntoIterator<Item = MiddlewareStage>,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            plugins: vec![PluginBinary {
+                name: "test-command".to_string(),
+                program: PluginProgram::Command(CommandProgram::new(
+                    argv,
+                    std::env::current_dir().map_err(|error| error.to_string())?,
+                    DEFAULT_MAX_OUTPUT_BYTES,
+                )?),
+                hooks: hooks.into_iter().collect(),
+                required: true,
+                prewarm: false,
+                command_config: Some(json!({})),
+                timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+                startup_timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+                max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
+                max_output_bytes: DEFAULT_MAX_OUTPUT_BYTES,
+                max_spans: DEFAULT_MAX_SPANS,
+            }],
+        })
+    }
+
     pub fn from_env() -> Result<Self, String> {
         let mut plugins = Vec::new();
         if let Some(value) = std::env::var_os(GLOBAL_BINARIES_ENV) {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1119,6 +1119,67 @@ fn prompt_masking_uses_strict_input_detection_for_env_lines_in_prose() {
 }
 
 #[test]
+fn prompt_masking_runs_prepare_and_finalize_once() {
+    let Some(python) = ["python3", "python"].into_iter().find(|candidate| {
+        std::process::Command::new(candidate)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }) else {
+        return;
+    };
+    let root = temp_root("prompt-plugin-stage-count");
+    std::fs::create_dir_all(&root).unwrap();
+    let calls = root.join("calls.txt");
+    let script = r#"import json,sys
+path=sys.argv[1]
+for line in sys.stdin:
+    request=json.loads(line)
+    with open(path, 'a', encoding='utf-8') as output:
+        output.write(request['hook'] + '\t' + request['payload']['text'] + '\n')
+    print(json.dumps({
+        'schema':'pentect.plugin.v1',
+        'id':request['id'],
+        'type':'result',
+        'action':'next',
+        'payload':request['payload'],
+    }), flush=True)
+"#;
+    let plugins = plugin_middleware::PluginMiddleware::from_test_command(
+        vec![
+            python.to_string(),
+            "-u".to_string(),
+            "-c".to_string(),
+            script.to_string(),
+            calls.display().to_string(),
+        ],
+        [
+            plugin_middleware::MiddlewareStage::Prepare,
+            plugin_middleware::MiddlewareStage::Finalize,
+        ],
+    )
+    .unwrap();
+    let session = Session::open_capability_at(&root, "stage-count").unwrap();
+    let store = MemoryStore::for_session(&session);
+    let mut masker = masking::OutputMasker::new_shared_with_plugins(store, plugins).unwrap();
+
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    masker
+        .mask_prompt_text(&format!("OPENAI_API_KEY={raw}"))
+        .unwrap();
+
+    let calls = std::fs::read_to_string(&calls).unwrap();
+    let calls = calls.lines().collect::<Vec<_>>();
+    assert_eq!(calls.len(), 2, "{calls:?}");
+    assert!(calls[0].starts_with("prepare\tOPENAI_API_KEY=<<"));
+    assert!(calls[1].starts_with("finalize\tOPENAI_API_KEY=<<"));
+    assert!(calls.iter().all(|call| !call.contains(raw)), "{calls:?}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn active_prompt_masker_reuses_bounded_cached_result() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (_active_store, _, _) = ActiveMemoryStoreEnv::start("prompt-cache");


### PR DESCRIPTION
Closes #1346.

## Root cause

`mask_prompt_text_with_plugins` ran Prepare/Finalize around a call to the shared masking helper, while that helper already ran the same stages. The outer Prepare also ran before deterministic masking, allowing a newly entered secret to reach third-party middleware in plaintext.

## Fix

- remove the duplicate prompt-level Prepare/Finalize calls;
- retain the shared engine's secure ordering and plugin Inspect support;
- add a command-plugin regression test that records hook calls and payloads.

## Verification

- regression test fails before the fix with `prepare, prepare, finalize, finalize`;
- regression test passes with exactly `prepare, finalize` and no plaintext key in either payload;
- all 9 prompt-related runtime tests pass;
- `cargo clippy -p pentect-runtime --all-targets -- -D warnings` passes.
