### PR TITLE
Report actual proxy coverage and diagnostics

### DIFF
--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -275,6 +275,7 @@ async fn proxy_request_inner(
         );
     }
     let is_stream = endpoint == CloudCodeEndpoint::StreamGenerateContent;
+    let mut request_coverage = None;
     let upstream_url =
         crate::upstream::join_url(&state.upstream, path_and_query, "Google Cloud Code")?;
     let request_headers = request.headers().clone();
@@ -301,6 +302,7 @@ async fn proxy_request_inner(
             &state.plugins,
             state.block_unknown_formats,
         )?;
+        request_coverage = Some(protected.coverage);
         if let Some(response) = protected.local_response {
             if is_stream {
                 return Ok(text_response(
@@ -371,7 +373,9 @@ async fn proxy_request_inner(
     }
     builder = builder.header(
         "x-pentect-coverage",
-        if protected { "full" } else { "none" },
+        request_coverage
+            .unwrap_or(crate::http_files::Coverage::None)
+            .as_header(),
     );
     if event_stream && endpoint == CloudCodeEndpoint::StreamGenerateContent && status.is_success() {
         return builder
@@ -561,6 +565,7 @@ fn enforce_known_endpoint(
 #[derive(Debug)]
 struct ProtectedRequest {
     body: Bytes,
+    coverage: crate::http_files::Coverage,
     local_response: Option<Bytes>,
 }
 
@@ -582,6 +587,7 @@ fn protect_request_body(
             proxy_diagnostic("request-invalid-json");
             return Ok(ProtectedRequest {
                 body: body.clone(),
+                coverage: crate::http_files::Coverage::Partial,
                 local_response: None,
             });
         }
@@ -594,6 +600,7 @@ fn protect_request_body(
             value,
             Some(serde_json::json!({"provider": "google-cloud-code", "transport": "http"})),
         )?;
+    let mut plugin_partial = run.coverage == pentect_agent::MiddlewareCoverage::Partial;
     if run.stopped == Some(pentect_agent::StopOutcome::Block) {
         return Err(format!(
             "plugin blocked: {}",
@@ -607,6 +614,7 @@ fn protect_request_body(
             .map_err(|error| format!("could not encode plugin response: {error}"))?;
         return Ok(ProtectedRequest {
             body: Bytes::new(),
+            coverage: crate::http_files::Coverage::Full,
             local_response: Some(body),
         });
     }
@@ -627,6 +635,7 @@ fn protect_request_body(
             "http_json",
         )
     }?;
+    plugin_partial |= inline_file_partial;
     if block_unknown_formats && inline_file_partial {
         return Err(
             "unknown format blocked: a file plugin reported partial Google Cloud Code inline-file coverage"
@@ -646,6 +655,7 @@ fn protect_request_body(
             proxy_diagnostic("request-protection-skipped");
             return Ok(ProtectedRequest {
                 body: body.clone(),
+                coverage: crate::http_files::Coverage::Partial,
                 local_response: None,
             });
         }
@@ -664,6 +674,11 @@ fn protect_request_body(
         })?;
     Ok(ProtectedRequest {
         body,
+        coverage: if plugin_partial {
+            crate::http_files::Coverage::Partial
+        } else {
+            crate::http_files::Coverage::Full
+        },
         local_response: None,
     })
 }
@@ -1492,6 +1507,24 @@ mod tests {
         let start = text.find("<<")?;
         let end = start + text[start..].find(">>")? + 2;
         Some(text[start..end].to_string())
+    }
+
+    #[test]
+    fn compatible_unprotected_request_reports_partial_coverage() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        let masker = Mutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let protected = protect_request_body(
+            &Bytes::from_static(b"not-json"),
+            CloudCodeEndpoint::GenerateContent,
+            &masker,
+            &plugins,
+            false,
+        )
+        .unwrap();
+        assert_eq!(protected.coverage, crate::http_files::Coverage::Partial);
     }
 
     fn mock_cloud_code_upstream() -> (

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -268,6 +268,7 @@ async fn proxy_request_inner(
     let protected = endpoint.is_protected() && method == hyper::Method::POST;
     let is_stream = endpoint == GeminiEndpoint::StreamGenerateContent;
     let body_forbidden = endpoint == GeminiEndpoint::Models;
+    let mut request_coverage = None;
     if endpoint.is_protected() && method != hyper::Method::POST {
         return Err("unknown format blocked: Gemini model endpoints must use POST".to_string());
     }
@@ -307,6 +308,7 @@ async fn proxy_request_inner(
                 &state.plugins,
                 state.block_unknown_formats,
             )?;
+            request_coverage = Some(protected.coverage);
             if let Some(response) = protected.local_response {
                 if endpoint == GeminiEndpoint::StreamGenerateContent {
                     return Ok(text_response(
@@ -381,7 +383,9 @@ async fn proxy_request_inner(
     }
     builder = builder.header(
         "x-pentect-coverage",
-        if protected { "full" } else { "none" },
+        request_coverage
+            .unwrap_or(crate::http_files::Coverage::None)
+            .as_header(),
     );
     if event_stream && status.is_success() && endpoint == GeminiEndpoint::StreamGenerateContent {
         return builder
@@ -509,6 +513,7 @@ fn diagnostic_endpoint_name(request_path: &str, auth: &str) -> &'static str {
 
 struct ProtectedRequest {
     body: Bytes,
+    coverage: crate::http_files::Coverage,
     local_response: Option<Bytes>,
 }
 
@@ -530,6 +535,7 @@ fn protect_request_body(
             diagnostic("request-invalid-json");
             return Ok(ProtectedRequest {
                 body: body.clone(),
+                coverage: crate::http_files::Coverage::Partial,
                 local_response: None,
             });
         }
@@ -542,6 +548,7 @@ fn protect_request_body(
             value,
             Some(serde_json::json!({"provider": "gemini", "transport": "http"})),
         )?;
+    let mut plugin_partial = run.coverage == pentect_agent::MiddlewareCoverage::Partial;
     if run.stopped == Some(pentect_agent::StopOutcome::Block) {
         return Err(format!(
             "plugin blocked: {}",
@@ -553,6 +560,7 @@ fn protect_request_body(
             .map(Bytes::from)
             .map(|local_response| ProtectedRequest {
                 body: Bytes::new(),
+                coverage: crate::http_files::Coverage::Full,
                 local_response: Some(local_response),
             })
             .map_err(|error| format!("could not encode plugin response: {error}"));
@@ -569,6 +577,7 @@ fn protect_request_body(
             .map_err(|_| "Gemini plugin lock was poisoned".to_string())?;
         crate::http_files::run_google_inline_file_stages(&value, &plugins, "gemini", "http_json")
     }?;
+    plugin_partial |= inline_file_partial;
     if block_unknown_formats && inline_file_partial {
         return Err(
             "unknown format blocked: a file plugin reported partial Gemini inline-file coverage"
@@ -585,6 +594,7 @@ fn protect_request_body(
             diagnostic("request-protection-skipped");
             return Ok(ProtectedRequest {
                 body: body.clone(),
+                coverage: crate::http_files::Coverage::Partial,
                 local_response: None,
             });
         }
@@ -597,6 +607,11 @@ fn protect_request_body(
         .map(Bytes::from)
         .map(|body| ProtectedRequest {
             body,
+            coverage: if plugin_partial {
+                crate::http_files::Coverage::Partial
+            } else {
+                crate::http_files::Coverage::Full
+            },
             local_response: None,
         })
         .map_err(|error| format!("could not encode protected Gemini request: {error}"))
@@ -1301,6 +1316,24 @@ mod tests {
             socket.flush().unwrap();
         });
         (format!("http://{address}"), body_rx, thread)
+    }
+
+    #[test]
+    fn compatible_unprotected_request_reports_partial_coverage() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        let masker = Mutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let protected = protect_request_body(
+            &Bytes::from_static(b"not-json"),
+            GeminiEndpoint::GenerateContent,
+            &masker,
+            &plugins,
+            false,
+        )
+        .unwrap();
+        assert_eq!(protected.coverage, crate::http_files::Coverage::Partial);
     }
 
     fn mock_raw_response(response: String) -> (String, std::thread::JoinHandle<()>) {

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -1264,6 +1264,7 @@ fn diagnostic_surface(value: &str) -> String {
         value,
         &[
             "claude",
+            "claude-app",
             "cloud-code",
             "decode",
             "gemini",
@@ -1289,6 +1290,7 @@ fn diagnostic_event(value: &str) -> String {
             "file-registry-unavailable",
             "gateway-busy",
             "gateway-stopped",
+            "no-protected-connection",
             "provider-mcp-credential-forwarded",
             "request-content-encoding-skipped",
             "request-encode-skipped",
@@ -1334,6 +1336,7 @@ fn diagnostic_kind(value: &str) -> String {
             "internal",
             "limit",
             "model-load",
+            "plugin",
             "policy",
             "preprocess",
             "protection",
@@ -1363,23 +1366,34 @@ fn diagnostic_endpoint(value: &str) -> String {
     allowed_diagnostic_identifier(
         value,
         &[
+            "audio-speech",
+            "audio-transcription",
+            "audio-translation",
+            "batch-embed-contents",
             "bundled",
             "chat-completions",
+            "complete",
+            "completions",
             "control",
             "count-tokens",
             "disabled",
+            "embed-content",
+            "embeddings",
             "files",
             "files-collection",
             "gateway",
             "generate-content",
             "health",
             "image",
+            "image-generation",
             "input-tokens",
             "macos",
             "messages",
+            "message-batches",
             "models",
             "responses",
             "responses-resource",
+            "standalone-search",
             "stream-generate-content",
             "telemetry",
             "tool-input",
@@ -1972,5 +1986,31 @@ mod tests {
         assert_eq!(event.endpoint.as_deref(), Some("unknown"));
         assert_eq!(event.method.as_deref(), Some("unknown"));
         assert_eq!(event.version, None);
+    }
+
+    #[test]
+    fn emitted_http_diagnostic_identifiers_are_preserved() {
+        assert_eq!(diagnostic_surface("claude-app"), "claude-app");
+        assert_eq!(
+            diagnostic_event("no-protected-connection"),
+            "no-protected-connection"
+        );
+        assert_eq!(diagnostic_kind("plugin"), "plugin");
+        for endpoint in [
+            "audio-speech",
+            "audio-transcription",
+            "audio-translation",
+            "batch-embed-contents",
+            "complete",
+            "completions",
+            "embed-content",
+            "embeddings",
+            "image-generation",
+            "message-batches",
+            "standalone-search",
+        ] {
+            assert_eq!(diagnostic_endpoint(endpoint), endpoint);
+        }
+        assert_eq!(diagnostic_kind("response"), "unknown");
     }
 }


### PR DESCRIPTION
Closes #1342

## What changed
- carry actual request coverage through Google Cloud Code and Gemini instead of inferring it from the route
- report `partial` for compatibility-mode pass-through and partial plugin/file coverage
- preserve 14 confirmed fixed diagnostic identifiers
- keep the falsely reported `response` kind rejected

## Verification
- focused Cloud Code and Gemini partial-coverage tests
- focused activity-log identifier allowlist test
- `cargo clippy -p pentect-cli -p pentect-runtime --all-targets -- -D warnings`
- formatting and diff checks