### PR TITLE
docs: distinguish plugin CI from live OPF smoke

### DIFF
--- a/plugins/openai-privacy-filter/README.md
+++ b/plugins/openai-privacy-filter/README.md
@@ -40,6 +40,13 @@ plaintext, and returns a complete local response that Codex must consume
 without a plugin timeout. No OpenAI request is made by that step. It may
 download several gigabytes when the managed environment is not ready.
 
+This is currently a manual test. Pull-request CI runs the bridge unit tests and
+Pentect's deterministic installed-plugin fixtures on Linux, macOS, and Windows,
+but it does not install or load the real model, exercise CUDA, or run this
+script. A green pull request does not claim real-model coverage. The planned
+cache-backed scheduled CPU smoke and optional CUDA smoke are not implemented
+yet.
+
 ```sh
 python3 plugins/openai-privacy-filter/tests/live_e2e.py \
   --pentect ./target/debug/pentect \

--- a/website/src/content/docs/plugins/official.md
+++ b/website/src/content/docs/plugins/official.md
@@ -85,6 +85,28 @@ Test with fake data:
 echo "Email Alice at alice@example.test" | pentect mask
 ```
 
+### What CI verifies
+
+Plugin-sensitive pull requests run the installed plugin lifecycle on Linux,
+macOS, and Windows. That required CI uses deterministic manifest, Command, and
+Wasm fixtures to cover installation, approval, setup, update, removal,
+required and optional failures, process cleanup, scope isolation, and
+value-free diagnostics. It also runs the OpenAI Privacy Filter bridge unit
+tests with fixture setup state.
+
+Pull-request CI does **not** download the multi-gigabyte OpenAI Privacy Filter
+checkpoint, install its real managed Python environment, run model inference,
+test CUDA, or sign in to an AI provider. A green pull request therefore does
+not claim that those heavyweight boundaries were exercised.
+
+The repository includes a separate
+[`live_e2e.py`](https://github.com/EdamAme-x/pentect/blob/main/plugins/openai-privacy-filter/tests/live_e2e.py)
+for the real model. It verifies real setup and checkpoint state, the direct
+plugin protocol, cold and restarted Pentect masking, and an installed Codex
+flow against a localhost recorder without sending a request to OpenAI. This
+test is currently manual, not a required or scheduled GitHub Actions job. A
+cache-backed scheduled CPU smoke and an optional CUDA smoke remain planned.
+
 ### How it connects
 
 ```text


### PR DESCRIPTION
## Summary

- document exactly what the required three-platform plugin CI verifies
- state that pull-request CI does not install or run the real OpenAI Privacy Filter model
- document the existing real-model live E2E and its current manual-only status
- keep the planned scheduled CPU and optional CUDA smoke explicitly marked as unimplemented

## Why

The repository had both deterministic plugin CI and a heavyweight real-model script, but the public documentation did not distinguish their guarantees. A green pull request could therefore be misread as evidence that model download, real inference, CUDA, and the live Codex flow had run.

## Verification

- `npm run build` in `website/`
  - generated 42 pages
  - checked 114 internal links
- `git diff --check`

Part of #1339
