### PR TITLE
feat: add safe failure reasons to privacy metrics

### DIFF
--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -85,8 +85,11 @@ struct PrivacyMetrics {
     restoration_operations: u64,
     blocked_occurrences: u64,
     warning_occurrences: u64,
+    plugin_failure_occurrences: u64,
+    plugin_timeout_occurrences: u64,
     by_secret_type: BTreeMap<String, u64>,
     by_surface: BTreeMap<String, u64>,
+    by_warning_reason: BTreeMap<String, u64>,
     records_read: u64,
     records_skipped: u64,
 }
@@ -396,11 +399,17 @@ pub(crate) fn print_metrics(json: bool) -> Result<(), String> {
     );
     println!("Blocked operations: {}", metrics.blocked_occurrences);
     println!("Warnings: {}", metrics.warning_occurrences);
+    println!(
+        "Plugin failures (including timeouts): {}",
+        metrics.plugin_failure_occurrences
+    );
+    println!("Plugin timeouts: {}", metrics.plugin_timeout_occurrences);
     print_metric_group(
         "Secret types (text masks and image redactions)",
         &metrics.by_secret_type,
     );
     print_metric_group("Protection surfaces", &metrics.by_surface);
+    print_metric_group("Warning reasons", &metrics.by_warning_reason);
     if metrics.records_skipped > 0 {
         println!(
             "Skipped unreadable records: {} (counts may be incomplete)",
@@ -509,6 +518,11 @@ fn aggregate_metric_event(event: &ActivityEvent, metrics: &mut PrivacyMetrics) {
         }
         "warning" => {
             metrics.warning_occurrences = metrics.warning_occurrences.saturating_add(event.count);
+            increment_metric(
+                &mut metrics.by_warning_reason,
+                diagnostic_event(event.event.as_deref().unwrap_or("unknown")),
+                event.count,
+            );
             if is_block_event(event.event.as_deref()) {
                 metrics.blocked_occurrences =
                     metrics.blocked_occurrences.saturating_add(event.count);
@@ -516,6 +530,16 @@ fn aggregate_metric_event(event: &ActivityEvent, metrics: &mut PrivacyMetrics) {
         }
         "diagnostic" if is_block_event(event.event.as_deref()) => {
             metrics.blocked_occurrences = metrics.blocked_occurrences.saturating_add(event.count);
+        }
+        "plugin-failure" => {
+            metrics.plugin_failure_occurrences = metrics
+                .plugin_failure_occurrences
+                .saturating_add(event.count);
+            if event.labels.iter().any(|label| label.name == "timeout") {
+                metrics.plugin_timeout_occurrences = metrics
+                    .plugin_timeout_occurrences
+                    .saturating_add(event.count);
+            }
         }
         _ => {}
     }
@@ -1583,6 +1607,22 @@ mod tests {
             Some(true),
             None,
         );
+        let mut untrusted_warning = warning.clone();
+        untrusted_warning.event = Some("private-account-warning".to_string());
+        let plugin_failure = ActivityEvent::new(
+            "plugin-failure",
+            "plugin",
+            2,
+            BTreeMap::from([("failure".to_string(), 2)]),
+            Some("private-plugin-name".to_string()),
+        );
+        let plugin_timeout = ActivityEvent::new(
+            "plugin-failure",
+            "plugin",
+            3,
+            BTreeMap::from([("timeout".to_string(), 3)]),
+            None,
+        );
         std::fs::write(
             rotated_log_path(&path, 1),
             format!("{}\n", serde_json::to_string(&masked).unwrap()),
@@ -1590,11 +1630,18 @@ mod tests {
         .unwrap();
         std::fs::write(
             &path,
-            [redacted, restored, warning]
-                .iter()
-                .map(|event| serde_json::to_string(event).unwrap())
-                .collect::<Vec<_>>()
-                .join("\n")
+            [
+                redacted,
+                restored,
+                warning,
+                untrusted_warning,
+                plugin_failure,
+                plugin_timeout,
+            ]
+            .iter()
+            .map(|event| serde_json::to_string(event).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
                 + "\nnot-json\n",
         )
         .unwrap();
@@ -1604,15 +1651,21 @@ mod tests {
         assert_eq!(metrics.masked_text_occurrences, 3);
         assert_eq!(metrics.redacted_image_occurrences, 1);
         assert_eq!(metrics.restoration_operations, 2);
-        assert_eq!(metrics.warning_occurrences, 1);
+        assert_eq!(metrics.warning_occurrences, 2);
+        assert_eq!(metrics.plugin_failure_occurrences, 5);
+        assert_eq!(metrics.plugin_timeout_occurrences, 3);
         assert_eq!(metrics.by_secret_type["AWS_AKID"], 3);
         assert_eq!(metrics.by_secret_type["EMAIL_ADDRESS"], 1);
         assert_eq!(metrics.by_surface["prompt"], 3);
         assert_eq!(metrics.by_surface["image"], 1);
+        assert_eq!(metrics.by_warning_reason["request-failed"], 1);
+        assert_eq!(metrics.by_warning_reason["unknown"], 1);
         assert_eq!(metrics.records_skipped, 1);
 
         let output = serde_json::to_string(&metrics).unwrap();
         assert!(!output.contains("private-project"));
+        assert!(!output.contains("private-account"));
+        assert!(!output.contains("private-plugin"));
         assert!(!output.contains(".env"));
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -966,6 +966,20 @@ impl PluginBinary {
         context: Option<&Value>,
         budget: &mut PluginChainBudget,
     ) -> Result<PluginResponse, String> {
+        let result = self.invoke_bounded_inner(hook, payload, context, budget);
+        if let Err(error) = &result {
+            record_plugin_failure(error);
+        }
+        result
+    }
+
+    fn invoke_bounded_inner(
+        &self,
+        hook: MiddlewareStage,
+        payload: &Value,
+        context: Option<&Value>,
+        budget: &mut PluginChainBudget,
+    ) -> Result<PluginResponse, String> {
         let request_id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
         let request = json!({
             "schema": PROTOCOL_SCHEMA,
@@ -2741,6 +2755,25 @@ fn record_plugin_access(name: &str, operation: &str) {
     );
 }
 
+fn record_plugin_failure(error: &str) {
+    let reason = plugin_failure_reason(error);
+    activity_log::record_summary(
+        "plugin-failure",
+        "plugin",
+        1,
+        BTreeMap::from([(reason.to_string(), 1)]),
+        None,
+    );
+}
+
+fn plugin_failure_reason(error: &str) -> &'static str {
+    if error.contains("timed out") || error.contains("deadline exceeded") {
+        "timeout"
+    } else {
+        "failure"
+    }
+}
+
 fn replace_host_file(staged: &Path, destination: &Path) -> Result<(), String> {
     if !destination.exists() {
         return std::fs::rename(staged, destination).map_err(|error| error.to_string());
@@ -4296,6 +4329,22 @@ mod tests {
         .invoke(b"{}", Duration::from_secs(15), "fixture")
         .unwrap_err();
         assert!(oversized.contains("exceeds its limit"), "{oversized}");
+    }
+
+    #[test]
+    fn plugin_failure_metrics_distinguish_timeouts_without_exposing_errors() {
+        assert_eq!(
+            plugin_failure_reason("plugin 'private-name' timed out"),
+            "timeout"
+        );
+        assert_eq!(
+            plugin_failure_reason("plugin 'private-name' command chain deadline exceeded"),
+            "timeout"
+        );
+        assert_eq!(
+            plugin_failure_reason("plugin 'private-name' returned invalid JSON"),
+            "failure"
+        );
     }
 
     #[test]

--- a/crates/pentect-runtime/src/plugin_middleware.rs
+++ b/crates/pentect-runtime/src/plugin_middleware.rs
@@ -968,7 +968,7 @@ impl PluginBinary {
     ) -> Result<PluginResponse, String> {
         let result = self.invoke_bounded_inner(hook, payload, context, budget);
         if let Err(error) = &result {
-            record_plugin_failure(error);
+            record_plugin_failure(&self.name, error);
         }
         result
     }
@@ -2755,8 +2755,8 @@ fn record_plugin_access(name: &str, operation: &str) {
     );
 }
 
-fn record_plugin_failure(error: &str) {
-    let reason = plugin_failure_reason(error);
+fn record_plugin_failure(plugin_name: &str, error: &str) {
+    let reason = plugin_failure_reason(plugin_name, error);
     activity_log::record_summary(
         "plugin-failure",
         "plugin",
@@ -2766,8 +2766,11 @@ fn record_plugin_failure(error: &str) {
     );
 }
 
-fn plugin_failure_reason(error: &str) -> &'static str {
-    if error.contains("timed out") || error.contains("deadline exceeded") {
+fn plugin_failure_reason(plugin_name: &str, error: &str) -> &'static str {
+    let plugin_prefix = format!("plugin '{plugin_name}'");
+    let error_without_name = error.strip_prefix(&plugin_prefix).unwrap_or(error);
+    if error_without_name.contains("timed out") || error_without_name.contains("deadline exceeded")
+    {
         "timeout"
     } else {
         "failure"
@@ -4334,15 +4337,25 @@ mod tests {
     #[test]
     fn plugin_failure_metrics_distinguish_timeouts_without_exposing_errors() {
         assert_eq!(
-            plugin_failure_reason("plugin 'private-name' timed out"),
+            plugin_failure_reason("private-name", "plugin 'private-name' timed out"),
             "timeout"
         );
         assert_eq!(
-            plugin_failure_reason("plugin 'private-name' command chain deadline exceeded"),
+            plugin_failure_reason(
+                "private-name",
+                "plugin 'private-name' command chain deadline exceeded"
+            ),
             "timeout"
         );
         assert_eq!(
-            plugin_failure_reason("plugin 'private-name' returned invalid JSON"),
+            plugin_failure_reason(
+                "private-name",
+                "plugin 'private-name' returned invalid JSON"
+            ),
+            "failure"
+        );
+        assert_eq!(
+            plugin_failure_reason("timed out", "plugin 'timed out' returned invalid JSON"),
             "failure"
         );
     }

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -171,6 +171,11 @@ enabled = true
 `true`. Metrics are calculated on demand from retained diagnostic logs and are
 never sent externally. Setting it to `false` disables the summary; diagnostic
 logging and rotation continue independently so crashes remain diagnosable.
+The summary includes masked and restored occurrence counts, blocked operations,
+plugin failures and timeouts, and warnings grouped by a bounded reason code.
+Plugin names, error text, values, handles, paths, URLs, and account identifiers
+are not metric dimensions. Plugin timeout counts are a subset of plugin failure
+counts, not an additional failure total.
 
 For `activity.share` and `metrics.enabled`, `false` in either the user config or
 the project config disables the feature. A project cannot re-enable a feature

--- a/website/src/content/docs/start/commands.md
+++ b/website/src/content/docs/start/commands.md
@@ -109,7 +109,7 @@ when a command can consume a handle without creating a plaintext file.
 | View persistent diagnostics | `pentect log` | Values, bodies, headers, and URLs are not logged |
 | Locate the log file | `pentect log --path` | Prints the local path |
 | Machine-readable diagnostics | `pentect log --json` | Suitable for support tooling |
-| View local protection statistics | `pentect metrics` | Counts occurrences; never shows values, handles, paths, URLs, or account identifiers |
+| View local protection statistics | `pentect metrics` | Counts occurrences, bounded warning reasons, and plugin failures/timeouts; never shows values, handles, paths, URLs, plugin names, error text, or account identifiers |
 | Machine-readable statistics | `pentect metrics --json` | Local JSON; no telemetry is sent |
 | Check readiness | `pentect doctor` | Does not change configuration |
 | Offer safe repairs | `pentect doctor --fix` | Confirms changes interactively |


### PR DESCRIPTION
Part of #250.

## What changed
- record plugin invocation failures with only bounded `failure` / `timeout` categories
- expose plugin failure and timeout occurrence counts in `pentect metrics` and JSON output
- group warnings by the existing allowlisted diagnostic reason codes
- collapse unknown or tampered warning event names to `unknown`
- document the local-only, value-free metric dimensions

Plugin names, raw error messages, values, handles, paths, URLs, and account identifiers are not retained as metric dimensions. Timeout occurrences are a subset of total plugin failures.

## Verification
- `cargo test -q -p pentect-runtime --lib --locked activity_log::tests` (19 passed)
- `cargo test -q -p pentect-runtime --lib --locked plugin_middleware::tests` (42 passed)
- `cargo fmt --all --check`
- `git diff --check`
- `cd website && npm run build` (42 pages, 114 internal links)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added metrics for plugin failures and timeouts.
  - Added warning counts grouped by bounded reason codes.
  - Metrics output now includes these statistics while continuing to protect sensitive details such as plugin names, error text, paths, URLs, and account identifiers.

- **Documentation**
  - Updated configuration and command references to describe the expanded `pentect metrics` output and clarify that timeout counts are included within failure counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->