### PR TITLE
feat: count blocked restoration attempts

### DIFF
--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -83,6 +83,7 @@ struct PrivacyMetrics {
     redacted_image_occurrences: u64,
     blocked_image_occurrences: u64,
     restoration_operations: u64,
+    blocked_restoration_occurrences: u64,
     blocked_occurrences: u64,
     warning_occurrences: u64,
     plugin_failure_occurrences: u64,
@@ -397,6 +398,10 @@ pub(crate) fn print_metrics(json: bool) -> Result<(), String> {
         "Local restoration operations: {}",
         metrics.restoration_operations
     );
+    println!(
+        "Blocked restoration attempts: {}",
+        metrics.blocked_restoration_occurrences
+    );
     println!("Blocked operations: {}", metrics.blocked_occurrences);
     println!("Warnings: {}", metrics.warning_occurrences);
     println!(
@@ -507,6 +512,11 @@ fn aggregate_metric_event(event: &ActivityEvent, metrics: &mut PrivacyMetrics) {
         "resolve" => {
             metrics.restoration_operations =
                 metrics.restoration_operations.saturating_add(event.count);
+        }
+        "restoration-blocked" => {
+            metrics.blocked_restoration_occurrences = metrics
+                .blocked_restoration_occurrences
+                .saturating_add(event.count);
         }
         "block" => {
             metrics.blocked_occurrences = metrics.blocked_occurrences.saturating_add(event.count);
@@ -640,6 +650,23 @@ pub(crate) fn record_summary(
         labels,
         target.map(safe_target),
     ));
+}
+
+pub(crate) fn record_restoration_blocked(surface: &str) {
+    record_summary(
+        "restoration-blocked",
+        restoration_block_surface(surface),
+        1,
+        BTreeMap::new(),
+        None,
+    );
+}
+
+fn restoration_block_surface(surface: &str) -> &str {
+    match surface {
+        "argv" | "command" | "exec-server" | "file-repair" => surface,
+        _ => "other",
+    }
 }
 
 pub(crate) fn record_image(secret_images: usize, detected_labels: &BTreeMap<String, u64>) {
@@ -1597,6 +1624,13 @@ mod tests {
             None,
         );
         let restored = ActivityEvent::new("resolve", "tool", 2, BTreeMap::new(), None);
+        let restoration_blocked = ActivityEvent::new(
+            "restoration-blocked",
+            "command",
+            4,
+            BTreeMap::new(),
+            Some("private-restoration-target".to_string()),
+        );
         let warning = ActivityEvent::diagnostic(
             "openai",
             "request-failed",
@@ -1633,6 +1667,7 @@ mod tests {
             [
                 redacted,
                 restored,
+                restoration_blocked,
                 warning,
                 untrusted_warning,
                 plugin_failure,
@@ -1651,6 +1686,7 @@ mod tests {
         assert_eq!(metrics.masked_text_occurrences, 3);
         assert_eq!(metrics.redacted_image_occurrences, 1);
         assert_eq!(metrics.restoration_operations, 2);
+        assert_eq!(metrics.blocked_restoration_occurrences, 4);
         assert_eq!(metrics.warning_occurrences, 2);
         assert_eq!(metrics.plugin_failure_occurrences, 5);
         assert_eq!(metrics.plugin_timeout_occurrences, 3);
@@ -1666,8 +1702,15 @@ mod tests {
         assert!(!output.contains("private-project"));
         assert!(!output.contains("private-account"));
         assert!(!output.contains("private-plugin"));
+        assert!(!output.contains("private-restoration"));
         assert!(!output.contains(".env"));
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn restoration_block_surfaces_are_bounded() {
+        assert_eq!(restoration_block_surface("argv"), "argv");
+        assert_eq!(restoration_block_surface("private-project-name"), "other");
     }
 
     #[test]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -417,6 +417,7 @@ pub fn resolve_text_from_active_memory_store(text: &str) -> Result<Option<String
     let store = MemoryStore::for_session(&session);
     let resolved = store.resolve_all(text).map_err(|e| e.to_string())?;
     if contains_unresolved_masked_handle(&resolved) {
+        activity_log::record_restoration_blocked("exec-server");
         return Err("unknown masked handle in exec-server request".to_string());
     }
     Ok(Some(resolved))
@@ -1604,6 +1605,7 @@ fn resolve_command_args(
         let mut resolved = resolve_command_text(store, arg)?;
         if resolved != *arg && !allow_secret_argv {
             resolved.zeroize();
+            activity_log::record_restoration_blocked("argv");
             return Err(
                 "refusing to place a restored secret in process arguments; prefer target-specific stdin, file-descriptor, or configuration support, or pass --allow-secret-argv after reviewing same-user process visibility (a shell protects the model-facing command only, not child-process arguments)"
                     .to_string(),
@@ -1617,6 +1619,7 @@ fn resolve_command_args(
 fn resolve_command_text(store: &MemoryStore, text: &str) -> Result<String, String> {
     let resolved = store.resolve_all(text).map_err(|e| e.to_string())?;
     if contains_unresolved_masked_handle(&resolved) {
+        activity_log::record_restoration_blocked("command");
         return Err(
             "unknown masked handle; use it inside the same running Pentect-launched agent session or re-register it with `pentect exec`"
                 .to_string(),
@@ -3353,12 +3356,14 @@ fn repair_masked_edit_after_tool(session: &Session, tool_input: &Value) -> Resul
 fn resolve_masked_text(store: &MemoryStore, content: &str) -> Result<String, String> {
     let resolved = store.resolve_all(content).map_err(|e| e.to_string())?;
     if contains_pentect_masked_handle(&resolved) {
+        activity_log::record_restoration_blocked("file-repair");
         return Err(
             "masked handle is unavailable in this running Pentect session; re-read the source and retry."
                 .to_string(),
         );
     }
     if resolved == content {
+        activity_log::record_restoration_blocked("file-repair");
         return Err("masked handle is unavailable in this running Pentect session.".to_string());
     }
     Ok(resolved)

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -171,8 +171,9 @@ enabled = true
 `true`. Metrics are calculated on demand from retained diagnostic logs and are
 never sent externally. Setting it to `false` disables the summary; diagnostic
 logging and rotation continue independently so crashes remain diagnosable.
-The summary includes masked and restored occurrence counts, blocked operations,
-plugin failures and timeouts, and warnings grouped by a bounded reason code.
+The summary includes masked and restored occurrence counts, blocked restoration
+attempts, blocked operations, plugin failures and timeouts, and warnings grouped
+by a bounded reason code.
 Plugin names, error text, values, handles, paths, URLs, and account identifiers
 are not metric dimensions. Plugin timeout counts are a subset of plugin failure
 counts, not an additional failure total.

--- a/website/src/content/docs/start/commands.md
+++ b/website/src/content/docs/start/commands.md
@@ -109,7 +109,7 @@ when a command can consume a handle without creating a plaintext file.
 | View persistent diagnostics | `pentect log` | Values, bodies, headers, and URLs are not logged |
 | Locate the log file | `pentect log --path` | Prints the local path |
 | Machine-readable diagnostics | `pentect log --json` | Suitable for support tooling |
-| View local protection statistics | `pentect metrics` | Counts occurrences, bounded warning reasons, and plugin failures/timeouts; never shows values, handles, paths, URLs, plugin names, error text, or account identifiers |
+| View local protection statistics | `pentect metrics` | Counts occurrences, blocked restorations, bounded warning reasons, and plugin failures/timeouts; never shows values, handles, paths, URLs, plugin names, error text, or account identifiers |
 | Machine-readable statistics | `pentect metrics --json` | Local JSON; no telemetry is sent |
 | Check readiness | `pentect doctor` | Does not change configuration |
 | Offer safe repairs | `pentect doctor --fix` | Confirms changes interactively |


### PR DESCRIPTION
Part of #250.

## What changed
- add a dedicated `blocked_restoration_occurrences` metric instead of inferring restoration denials from the broader blocked-operation total
- record explicit denials at the exec-server, command, argv-policy, and masked-file-repair boundaries
- keep model-gateway unknown handles inert without counting them as denials
- keep malformed-response restore skips separate from policy/unknown-handle denials
- bound persistent event surfaces to four fixed categories plus `other`
- document the new local-only count

No values, handles, paths, command text, error text, or dynamic reason labels are written to the metric event.

## Verification
- `cargo test -q -p pentect-runtime --lib --locked` (334 passed)
- `cargo test -q -p pentect-runtime --lib --locked activity_log::tests` (20 passed after the final bounded-surface change)
- focused command, argv-policy, file-repair, and aggregation tests
- `cargo fmt --all --check`
- `git diff --check`
- `cd website && npm run build` (42 pages, 114 internal links)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics now separately report attempts to restore protected content that were blocked.
  * Blocked restoration activity is recorded with privacy-preserving, normalized details.

* **Documentation**
  * Updated metrics documentation to include blocked restoration counts in configuration and command references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->