### PR TITLE
feat: explain privacy metric labels

### DIFF
--- a/crates/pentect-core/src/model.rs
+++ b/crates/pentect-core/src/model.rs
@@ -9,7 +9,7 @@ pub type Label = String;
 /// retyped (and drifting) across detectors.
 pub mod labels {
     macro_rules! define_canonical_labels {
-        ($( $(#[$meta:meta])* $name:ident = $value:literal; )+) => {
+        ($( $(#[$meta:meta])* $name:ident = $value:literal => $description:literal; )+) => {
             $(
                 $(#[$meta])*
                 pub const $name: &str = $value;
@@ -22,52 +22,60 @@ pub mod labels {
             pub fn is_canonical(value: &str) -> bool {
                 ALL.contains(&value)
             }
+
+            /// A short user-facing explanation for a canonical detector label.
+            pub fn description(value: &str) -> Option<&'static str> {
+                match value {
+                    $($value => Some($description),)+
+                    _ => None,
+                }
+            }
         };
     }
 
     define_canonical_labels! {
         /// High-entropy run with no anchoring context (entropy detector).
-        LIKELY_SECRET = "LIKELY_SECRET";
+        LIKELY_SECRET = "LIKELY_SECRET" => "high-entropy value that may be a secret";
         /// Decodes to binary-looking bytes ("looks encrypted") with no inner secret.
-        OPAQUE_BLOB = "OPAQUE_BLOB";
+        OPAQUE_BLOB = "OPAQUE_BLOB" => "encoded or encrypted-looking data";
         /// Value masked because its key name looks sensitive.
-        SECRET = "SECRET";
+        SECRET = "SECRET" => "value associated with a sensitive name";
         /// Ambiguous personally identifying information.
-        PII = "PII";
+        PII = "PII" => "personally identifying information";
         /// Ambiguous identifier.
-        IDENTIFIER = "IDENTIFIER";
+        IDENTIFIER = "IDENTIFIER" => "potentially sensitive identifier";
         /// Ambiguous endpoint.
-        ENDPOINT = "ENDPOINT";
+        ENDPOINT = "ENDPOINT" => "potentially sensitive service endpoint";
         /// Sensitive value whose category could not be narrowed further.
-        SENSITIVE = "SENSITIVE";
+        SENSITIVE = "SENSITIVE" => "sensitive value of an unspecified type";
         /// Value masked because a plaintext key/value structure carries a sensitive key.
-        KEYED_SECRET = "KEYED_SECRET";
+        KEYED_SECRET = "KEYED_SECRET" => "value associated with a sensitive key";
         /// One-time password or verification code.
-        OTP = "OTP";
+        OTP = "OTP" => "one-time password or verification code";
         /// BIP-39 wallet recovery phrase.
-        BIP39_MNEMONIC = "BIP39_MNEMONIC";
+        BIP39_MNEMONIC = "BIP39_MNEMONIC" => "cryptocurrency wallet recovery phrase";
         /// Body of a PEM private-key block.
-        PRIVATE_KEY = "PRIVATE_KEY";
+        PRIVATE_KEY = "PRIVATE_KEY" => "private cryptographic key";
         /// Host/authority of an internal service URL.
-        INTERNAL_ENDPOINT = "INTERNAL_ENDPOINT";
+        INTERNAL_ENDPOINT = "INTERNAL_ENDPOINT" => "internal service host or authority";
         /// Resource identifier inside an internal URL path.
-        RESOURCE_ID = "RESOURCE_ID";
+        RESOURCE_ID = "RESOURCE_ID" => "internal resource identifier";
         /// User-info credential portion of a URL authority.
-        URL_CREDENTIAL = "URL_CREDENTIAL";
+        URL_CREDENTIAL = "URL_CREDENTIAL" => "credential embedded in a URL";
         /// Password-like value passed through a shell or PowerShell command option.
-        CMD_PASSWORD = "CMD_PASSWORD";
+        CMD_PASSWORD = "CMD_PASSWORD" => "password supplied to a command";
         /// UUID/GUID value in an identifier-bearing slot.
-        UUID = "UUID";
+        UUID = "UUID" => "UUID or GUID in an identifier field";
         /// Bucket name in an Amazon S3 hostname.
-        AWS_S3_BUCKET = "AWS_S3_BUCKET";
+        AWS_S3_BUCKET = "AWS_S3_BUCKET" => "Amazon S3 bucket name";
         /// Firebase project/database prefix in a Realtime Database hostname.
-        FIREBASE_PROJECT_ID = "FIREBASE_PROJECT_ID";
+        FIREBASE_PROJECT_ID = "FIREBASE_PROJECT_ID" => "Firebase project or database identifier";
         /// Query parameter value in an internal URL.
-        URL_QUERY_VALUE = "URL_QUERY_VALUE";
+        URL_QUERY_VALUE = "URL_QUERY_VALUE" => "sensitive URL query value";
         /// Fragment value in an internal URL.
-        URL_FRAGMENT = "URL_FRAGMENT";
+        URL_FRAGMENT = "URL_FRAGMENT" => "sensitive URL fragment";
         /// Location metadata embedded in image EXIF GPS tags.
-        IMAGE_GPS_METADATA = "IMAGE_GPS_METADATA";
+        IMAGE_GPS_METADATA = "IMAGE_GPS_METADATA" => "GPS location stored in image metadata";
     }
 }
 

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -438,8 +438,73 @@ fn print_metric_group(title: &str, values: &BTreeMap<String, u64>) {
             .then_with(|| left_name.cmp(right_name))
     });
     for (name, count) in values {
-        println!("  {name}: {count}");
+        let readable = labels::description(name)
+            .map(str::to_string)
+            .unwrap_or_else(|| readable_metric_name(name));
+        if readable == *name {
+            println!("  {name}: {count}");
+        } else {
+            println!("  {name} ({readable}): {count}");
+        }
     }
+}
+
+fn readable_metric_name(name: &str) -> String {
+    let mut output = String::new();
+    for (index, word) in name
+        .split(['_', '-'])
+        .filter(|word| !word.is_empty())
+        .enumerate()
+    {
+        if index > 0 {
+            output.push(' ');
+        }
+        if is_metric_acronym(word) {
+            output.push_str(&word.to_ascii_uppercase());
+            continue;
+        }
+        let normalized = word.to_ascii_lowercase();
+        if index == 0 {
+            let mut chars = normalized.chars();
+            if let Some(first) = chars.next() {
+                output.extend(first.to_uppercase());
+                output.push_str(chars.as_str());
+            }
+        } else {
+            output.push_str(&normalized);
+        }
+    }
+    if output.is_empty() {
+        "Unknown".to_string()
+    } else {
+        output
+    }
+}
+
+fn is_metric_acronym(word: &str) -> bool {
+    matches!(
+        word.to_ascii_uppercase().as_str(),
+        "API"
+            | "AWS"
+            | "CLI"
+            | "CMD"
+            | "GPS"
+            | "HTTP"
+            | "IBAN"
+            | "JSON"
+            | "JWT"
+            | "MCP"
+            | "NINO"
+            | "OCR"
+            | "OPENAI"
+            | "OTP"
+            | "PII"
+            | "S3"
+            | "SSE"
+            | "UK"
+            | "URL"
+            | "UUID"
+    )
 }
 
 fn read_metrics(path: &Path) -> Result<PrivacyMetrics, String> {
@@ -1711,6 +1776,15 @@ mod tests {
     fn restoration_block_surfaces_are_bounded() {
         assert_eq!(restoration_block_surface("argv"), "argv");
         assert_eq!(restoration_block_surface("private-project-name"), "other");
+    }
+
+    #[test]
+    fn metric_names_are_readable_without_changing_the_stable_key() {
+        assert_eq!(readable_metric_name("AWS_S3_BUCKET"), "AWS S3 bucket");
+        assert_eq!(readable_metric_name("OPENAI_API_KEY"), "OPENAI API key");
+        assert_eq!(readable_metric_name("request-failed"), "Request failed");
+        assert_eq!(readable_metric_name("PII"), "PII");
+        assert_eq!(readable_metric_name(""), "Unknown");
     }
 
     #[test]

--- a/website/src/content/docs/start/commands.md
+++ b/website/src/content/docs/start/commands.md
@@ -109,7 +109,7 @@ when a command can consume a handle without creating a plaintext file.
 | View persistent diagnostics | `pentect log` | Values, bodies, headers, and URLs are not logged |
 | Locate the log file | `pentect log --path` | Prints the local path |
 | Machine-readable diagnostics | `pentect log --json` | Suitable for support tooling |
-| View local protection statistics | `pentect metrics` | Counts occurrences, blocked restorations, bounded warning reasons, and plugin failures/timeouts; never shows values, handles, paths, URLs, plugin names, error text, or account identifiers |
+| View local protection statistics | `pentect metrics` | Shows stable metric keys with readable names, occurrence counts, blocked restorations, bounded warning reasons, and plugin failures/timeouts; never shows values, handles, paths, URLs, plugin names, error text, or account identifiers |
 | Machine-readable statistics | `pentect metrics --json` | Local JSON; no telemetry is sent |
 | Check readiness | `pentect doctor` | Does not change configuration |
 | Offer safe repairs | `pentect doctor --fix` | Confirms changes interactively |


### PR DESCRIPTION
Part of #250.

## What changed
- require every canonical core detector label to define a short user-facing explanation alongside its stable key
- show `STABLE_KEY (plain-language explanation): count` in interactive `pentect metrics` output
- render bounded warning reason codes and vendor labels as readable words with common acronyms preserved
- leave `pentect metrics --json` keys and values unchanged for tooling compatibility
- document the stable-key plus readable-name presentation

No metric dimensions or retained data were added. This is a presentation-only change over the existing bounded aggregates.

## Verification
- `cargo test -q -p pentect-core --lib --locked` (473 passed)
- `cargo test -q -p pentect-runtime --lib --locked` (336 passed)
- `cargo fmt --all --check`
- `git diff --check`
- `cd website && npm run build` (42 pages, 114 internal links)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metric reports now include clear, human-readable descriptions alongside stable metric keys.
  * Unrecognized metric names are automatically formatted into readable labels.

* **Documentation**
  * Updated the metrics command documentation to describe the improved readable names and reported diagnostic details.

* **Bug Fixes**
  * Improved metric output formatting while preserving recognizable acronyms and technical terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->