### PR TITLE
fix: support current Codex web search endpoint

### DIFF
--- a/crates/pentect-cli/src/gateway_diagnostics.rs
+++ b/crates/pentect-cli/src/gateway_diagnostics.rs
@@ -98,7 +98,13 @@ pub(crate) fn is_local_rejection(error: &str) -> bool {
 
 fn failure_kind(error: &str) -> (&'static str, bool) {
     let lower = error.to_ascii_lowercase();
-    if lower.contains("timed out") || lower.contains("timeout") {
+    if error.starts_with("unknown format blocked: OpenAI endpoint is not supported")
+        || error.starts_with("unknown format blocked: Anthropic endpoint is not supported")
+        || error.starts_with("unknown format blocked: Gemini endpoint is not supported")
+        || error.starts_with("unknown format blocked: Google Cloud Code endpoint is not supported")
+    {
+        ("unsupported-endpoint", false)
+    } else if lower.contains("timed out") || lower.contains("timeout") {
         ("timeout", true)
     } else if lower.contains("connection failed") || lower.contains("could not reach") {
         ("connect", true)
@@ -158,6 +164,10 @@ mod tests {
         assert_eq!(
             failure_kind("request body blocked: fixture"),
             ("policy", false)
+        );
+        assert_eq!(
+            failure_kind("unknown format blocked: OpenAI endpoint is not supported"),
+            ("unsupported-endpoint", false)
         );
         assert_eq!(
             failure_kind("arbitrary secret-bearing detail"),

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -3498,10 +3498,13 @@ fn classify_openai_endpoint(path_and_query: &str) -> OpenAiEndpoint {
         OpenAiEndpoint::InputTokens
     } else if matches!(
         segments.as_slice(),
-        // Current Codex uses /api/codex for ChatGPT-backed search, while
-        // custom Responses providers use /v1. Keep the older backend-api form
-        // for already released Codex clients.
-        ["v1", "alpha", "search"]
+        // Codex resolves `alpha/search` relative to its configured base URL.
+        // Pentect replaces that base with the authenticated local gateway, so
+        // the gateway receives the bare form even though the final ChatGPT URL
+        // is /backend-api/codex/alpha/search. Keep the fully rooted forms for
+        // custom providers and already released Codex clients.
+        ["alpha", "search"]
+            | ["v1", "alpha", "search"]
             | ["api", "codex", "alpha", "search"]
             | ["backend-api", "codex", "alpha", "search"]
     ) {
@@ -4561,6 +4564,10 @@ mod tests {
             OpenAiEndpoint::InputTokens
         );
         assert_eq!(
+            classify_openai_endpoint("/alpha/search"),
+            OpenAiEndpoint::StandaloneSearch
+        );
+        assert_eq!(
             classify_openai_endpoint("/v1/alpha/search"),
             OpenAiEndpoint::StandaloneSearch
         );
@@ -5417,10 +5424,10 @@ mod tests {
         ]
         .concat();
         let (upstream, captured, thread) = mock_chat_upstream();
-        let proxy = OpenAiHttpProxyGuard::start(upstream).unwrap();
+        let proxy = OpenAiHttpProxyGuard::start(format!("{upstream}/backend-api/codex")).unwrap();
 
         let response = reqwest::blocking::Client::new()
-            .post(format!("{}/api/codex/alpha/search", proxy.base_url()))
+            .post(format!("{}/alpha/search", proxy.base_url()))
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .body(
                 serde_json::to_vec(&serde_json::json!({
@@ -5443,7 +5450,7 @@ mod tests {
             .unwrap();
         thread.join().unwrap();
         assert!(
-            headers.starts_with("POST /api/codex/alpha/search "),
+            headers.starts_with("POST /backend-api/codex/alpha/search "),
             "{headers}"
         );
         assert!(!request.contains(&secret), "{request}");

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -288,15 +288,16 @@ async fn proxy_request(
     request: Request<Incoming>,
     state: Arc<ProxyState>,
 ) -> Result<Response<ProxyBody>, Infallible> {
+    let request_path = request
+        .uri()
+        .path_and_query()
+        .map(|value| value.as_str())
+        .unwrap_or("/");
     let context = crate::gateway_diagnostics::RequestContext {
-        endpoint: classify_openai_endpoint(
-            request
-                .uri()
-                .path_and_query()
-                .map(|value| value.as_str())
-                .unwrap_or("/"),
-        )
-        .diagnostic_name(),
+        endpoint: authenticated_request_path(request_path, &state.auth)
+            .map(classify_openai_endpoint)
+            .unwrap_or(OpenAiEndpoint::Unknown)
+            .diagnostic_name(),
         method: crate::gateway_diagnostics::method_name(request.method()),
     };
     let Ok(_permit) = Arc::clone(&state.requests).try_acquire_owned() else {

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -3498,7 +3498,12 @@ fn classify_openai_endpoint(path_and_query: &str) -> OpenAiEndpoint {
         OpenAiEndpoint::InputTokens
     } else if matches!(
         segments.as_slice(),
-        ["v1", "alpha", "search"] | ["backend-api", "codex", "alpha", "search"]
+        // Current Codex uses /api/codex for ChatGPT-backed search, while
+        // custom Responses providers use /v1. Keep the older backend-api form
+        // for already released Codex clients.
+        ["v1", "alpha", "search"]
+            | ["api", "codex", "alpha", "search"]
+            | ["backend-api", "codex", "alpha", "search"]
     ) {
         OpenAiEndpoint::StandaloneSearch
     } else if path.ends_with("/responses") {
@@ -4560,6 +4565,10 @@ mod tests {
             OpenAiEndpoint::StandaloneSearch
         );
         assert_eq!(
+            classify_openai_endpoint("/api/codex/alpha/search"),
+            OpenAiEndpoint::StandaloneSearch
+        );
+        assert_eq!(
             classify_openai_endpoint("/backend-api/codex/alpha/search?client=codex"),
             OpenAiEndpoint::StandaloneSearch
         );
@@ -4624,6 +4633,7 @@ mod tests {
             "/v1/unknown/files/file_123",
             "/v1/unknown/models/model_123",
             "/v1/unknown/alpha/search",
+            "/api/unknown/alpha/search",
             "/backend-api/unknown/alpha/search",
         ] {
             assert_eq!(
@@ -5410,10 +5420,7 @@ mod tests {
         let proxy = OpenAiHttpProxyGuard::start(upstream).unwrap();
 
         let response = reqwest::blocking::Client::new()
-            .post(format!(
-                "{}/backend-api/codex/alpha/search",
-                proxy.base_url()
-            ))
+            .post(format!("{}/api/codex/alpha/search", proxy.base_url()))
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .body(
                 serde_json::to_vec(&serde_json::json!({
@@ -5436,7 +5443,7 @@ mod tests {
             .unwrap();
         thread.join().unwrap();
         assert!(
-            headers.starts_with("POST /backend-api/codex/alpha/search "),
+            headers.starts_with("POST /api/codex/alpha/search "),
             "{headers}"
         );
         assert!(!request.contains(&secret), "{request}");


### PR DESCRIPTION
Closes #315.

## Root cause
Codex resolves `alpha/search` relative to its configured base URL. Pentect replaces that base URL with its authenticated local gateway, so the gateway receives `POST /alpha/search`; the upstream destination becomes `/backend-api/codex/alpha/search` after Pentect rejoins the original ChatGPT base. Pentect recognized only fully rooted variants, so fail-closed handling returned HTTP 422 before the request reached OpenAI.

A second bug classified the token-prefixed local URL directly for persistent diagnostics, causing even known endpoints to be logged as `endpoint: unknown`.

## What changed
- classify the actual gateway input `/alpha/search` as the protected standalone-search dialect
- retain `/v1/alpha/search`, `/api/codex/alpha/search`, and `/backend-api/codex/alpha/search` compatibility
- test the complete local-relative to ChatGPT-upstream path transformation
- verify a synthetic API key in `search_query` is masked before forwarding
- retain fail-closed behavior for disguised and unknown paths
- strip the local authentication prefix before diagnostic classification
- report unknown endpoint rejection with the fixed safe reason `unsupported-endpoint`, without bodies, headers, URLs, or credentials

## Verification
- reproduced HTTP 422 with Pentect 0.0.70 and Codex 0.152.1
- after the fix, ran the locally built Pentect with logged-in Codex 0.152.1 and completed a real web search successfully
- `cargo test -q -p pentect-cli --bin pentect --locked openai_http_proxy::tests` (56 passed)
- `cargo test -q -p pentect-cli --bin pentect --locked gateway_diagnostics::tests` (2 passed)
- `cargo fmt --all --check`
- `git diff --check`