### PR TITLE
release: v0.0.71

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.70"
+version = "0.0.71"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.70"
+version = "0.0.71"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release Pentect v0.0.71, including the Codex 0.152.1 web-search routing fix from #1376 and the changes merged since v0.0.70.

## Version synchronization

- `pentect-cli`: 0.0.71
- npm package: 0.0.71
- lockfile: 0.0.71

## Verification

- main CI for merge commit `b918663b` passed
- real Codex 0.152.1 web-search E2E passed through the locally built Pentect
- `cargo metadata --no-deps --format-version 1 --locked`
- `npm test` (9 passed)
- `npm pack --dry-run`
- `git diff --check`

After merge, tag `v0.0.71` will trigger the release workflow. AUR remains intentionally disabled.