### PR TITLE
test: schedule real OpenAI Privacy Filter smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,8 +278,11 @@ jobs:
         if: needs.changes.outputs.detector == 'true'
         run: cargo test -p pentect-runtime --lib --locked canonical_engine_construction_stays_off_the_warm_up_path -- --nocapture
       - name: Test plugin runtime
-        if: needs.changes.outputs.plugins == 'true'
+        if: needs.changes.outputs.plugins == 'true' && runner.os != 'Windows'
         run: cargo test -p pentect-runtime plugin_middleware::tests --locked
+      - name: Test plugin runtime without Windows process-start contention
+        if: needs.changes.outputs.plugins == 'true' && runner.os == 'Windows'
+        run: cargo test -p pentect-runtime plugin_middleware::tests --locked -- --test-threads=1
       - name: Test plugin CLI
         if: needs.changes.outputs.plugins == 'true'
         run: cargo test -p pentect-cli plugins::tests --bin pentect --locked

--- a/.github/workflows/openai-privacy-filter-live.yml
+++ b/.github/workflows/openai-privacy-filter-live.yml
@@ -18,7 +18,7 @@ permissions:
 
 concurrency:
   group: openai-privacy-filter-live-${{ inputs.profile || 'cpu' }}
-  cancel-in-progress: ${{ 1 == 0 }}
+  cancel-in-progress: false
 
 jobs:
   live:
@@ -27,14 +27,30 @@ jobs:
     timeout-minutes: 150
     env:
       OPF_PROFILE: ${{ inputs.profile || 'cpu' }}
-      PENTECT_OPF_ROOT: ${{ runner.temp }}/pentect-opf-${{ inputs.profile || 'cpu' }}
-      PENTECT_LOG_DIR: ${{ runner.temp }}/pentect-opf-live-logs
       OPENAI_API_KEY: not-a-real-openai-key
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
-          persist-credentials: ${{ 1 == 0 }}
+          persist-credentials: false
+      - name: Configure bounded live-smoke paths
+        id: live-paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/pentect-opf-$OPF_PROFILE"
+          logs="$RUNNER_TEMP/pentect-opf-live-logs"
+          report="$RUNNER_TEMP/pentect-opf-live-e2e.json"
+          {
+            echo "PENTECT_OPF_ROOT=$root"
+            echo "PENTECT_LOG_DIR=$logs"
+            echo "PENTECT_OPF_REPORT=$report"
+          } >> "$GITHUB_ENV"
+          {
+            echo "root=$root"
+            echo "logs=$logs"
+            echo "report=$report"
+          } >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/rust-toolchain
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -51,9 +67,9 @@ jobs:
           shared-key: opf-live-${{ inputs.profile || 'cpu' }}
       - name: Restore managed OpenAI Privacy Filter environment
         id: opf-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ env.PENTECT_OPF_ROOT }}
+          path: ${{ steps.live-paths.outputs.root }}
           key: opf-${{ runner.os }}-${{ runner.arch }}-py312-${{ inputs.profile || 'cpu' }}-${{ hashFiles('plugins/openai-privacy-filter/setup.py') }}
       - name: Build Pentect with standard features
         run: cargo build --locked -p pentect-cli
@@ -62,16 +78,17 @@ jobs:
       - name: Run real-model installation-to-Codex smoke
         id: live
         shell: bash
+        env:
+          CACHE_HIT: ${{ steps.opf-cache.outputs.cache-hit }}
         run: |
           set -euo pipefail
           mkdir -p "$PENTECT_LOG_DIR"
-          report="$RUNNER_TEMP/pentect-opf-live-e2e.json"
           python plugins/openai-privacy-filter/tests/live_e2e.py \
             --pentect "$GITHUB_WORKSPACE/target/debug/pentect" \
             --codex "$(command -v codex)" \
             --profile "$OPF_PROFILE" \
             --timeout-seconds 1800 \
-            | tee "$report"
+            | tee "$PENTECT_OPF_REPORT"
           jq -e '
             .schema == "pentect.opf-live-e2e.v2" and
             .status == "ok" and
@@ -82,19 +99,25 @@ jobs:
             (.cold_seconds | numbers) >= 0 and
             (.restart_seconds | numbers) >= 0 and
             (.codex_seconds | numbers) >= 0
-          ' "$report"
+          ' "$PENTECT_OPF_REPORT"
           {
             echo "### OpenAI Privacy Filter live smoke"
             echo
-            echo "- Profile: `$(jq -r .profile "$report")`"
-            echo "- Managed environment cache hit: `${{ steps.opf-cache.outputs.cache-hit }}`"
-            echo "- Setup: `$(jq -r .setup_seconds "$report")s`"
-            echo "- Direct startup: `$(jq -r .plugin_startup_seconds "$report")s`"
-            echo "- Warm request: `$(jq -r .warm_request_seconds "$report")s`"
-            echo "- Pentect cold process: `$(jq -r .cold_seconds "$report")s`"
-            echo "- Pentect restart: `$(jq -r .restart_seconds "$report")s`"
-            echo "- Codex/local upstream: `$(jq -r .codex_seconds "$report")s`"
+            printf -- '- Profile: `%s`\n' "$(jq -r .profile "$PENTECT_OPF_REPORT")"
+            printf -- '- Managed environment cache hit: `%s`\n' "${CACHE_HIT:-miss}"
+            printf -- '- Setup: `%ss`\n' "$(jq -r .setup_seconds "$PENTECT_OPF_REPORT")"
+            printf -- '- Direct startup: `%ss`\n' "$(jq -r .plugin_startup_seconds "$PENTECT_OPF_REPORT")"
+            printf -- '- Warm request: `%ss`\n' "$(jq -r .warm_request_seconds "$PENTECT_OPF_REPORT")"
+            printf -- '- Pentect cold process: `%ss`\n' "$(jq -r .cold_seconds "$PENTECT_OPF_REPORT")"
+            printf -- '- Pentect restart: `%ss`\n' "$(jq -r .restart_seconds "$PENTECT_OPF_REPORT")"
+            printf -- '- Codex/local upstream: `%ss`\n' "$(jq -r .codex_seconds "$PENTECT_OPF_REPORT")"
           } >> "$GITHUB_STEP_SUMMARY"
+      - name: Save managed OpenAI Privacy Filter environment
+        if: steps.live.outcome == 'success' && steps.opf-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.live-paths.outputs.root }}
+          key: ${{ steps.opf-cache.outputs.cache-primary-key }}
       - name: Verify artifacts contain no fixture plaintext
         id: verify-artifacts
         if: always()
@@ -105,7 +128,37 @@ jobs:
         with:
           name: openai-privacy-filter-live-${{ inputs.profile || 'cpu' }}
           path: |
-            ${{ runner.temp }}/pentect-opf-live-e2e.json
-            ${{ env.PENTECT_LOG_DIR }}/pentect.log
+            ${{ steps.live-paths.outputs.report }}
+            ${{ steps.live-paths.outputs.logs }}/
           if-no-files-found: warn
           retention-days: 14
+      - name: Clean live-smoke state from the runner
+        if: always()
+        env:
+          OPF_ROOT_TO_CLEAN: ${{ steps.live-paths.outputs.root }}
+          OPF_LOGS_TO_CLEAN: ${{ steps.live-paths.outputs.logs }}
+          OPF_REPORT_TO_CLEAN: ${{ steps.live-paths.outputs.report }}
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          import shutil
+
+          temporary = Path(os.environ["RUNNER_TEMP"]).resolve()
+          for name in (
+              "OPF_ROOT_TO_CLEAN",
+              "OPF_LOGS_TO_CLEAN",
+              "OPF_REPORT_TO_CLEAN",
+          ):
+              configured = os.environ.get(name)
+              if not configured:
+                  continue
+              path = Path(configured).resolve()
+              if temporary not in path.parents:
+                  raise RuntimeError(f"refusing to clean path outside RUNNER_TEMP: {name}")
+              if path.is_dir():
+                  shutil.rmtree(path)
+              elif path.exists():
+                  path.unlink()
+          PY

--- a/.github/workflows/openai-privacy-filter-live.yml
+++ b/.github/workflows/openai-privacy-filter-live.yml
@@ -1,0 +1,111 @@
+name: OpenAI Privacy Filter live smoke
+
+on:
+  schedule:
+    - cron: "23 5 * * 3"
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: Real-model runtime profile
+        type: choice
+        options:
+          - cpu
+          - cuda
+        default: cpu
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openai-privacy-filter-live-${{ inputs.profile || 'cpu' }}
+  cancel-in-progress: ${{ 1 == 0 }}
+
+jobs:
+  live:
+    if: github.repository == 'EdamAme-x/pentect'
+    runs-on: ${{ inputs.profile == 'cuda' && fromJSON('["self-hosted","linux","x64","gpu","nvidia"]') || 'ubuntu-22.04' }}
+    timeout-minutes: 150
+    env:
+      OPF_PROFILE: ${{ inputs.profile || 'cpu' }}
+      PENTECT_OPF_ROOT: ${{ runner.temp }}/pentect-opf-${{ inputs.profile || 'cpu' }}
+      PENTECT_LOG_DIR: ${{ runner.temp }}/pentect-opf-live-logs
+      OPENAI_API_KEY: not-a-real-openai-key
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          submodules: recursive
+          persist-credentials: ${{ 1 == 0 }}
+      - uses: ./.github/actions/rust-toolchain
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/alcatraz-helper/go.mod
+          cache-dependency-path: tools/alcatraz-helper/go.sum
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: opf-live-${{ inputs.profile || 'cpu' }}
+      - name: Restore managed OpenAI Privacy Filter environment
+        id: opf-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.PENTECT_OPF_ROOT }}
+          key: opf-${{ runner.os }}-${{ runner.arch }}-py312-${{ inputs.profile || 'cpu' }}-${{ hashFiles('plugins/openai-privacy-filter/setup.py') }}
+      - name: Build Pentect with standard features
+        run: cargo build --locked -p pentect-cli
+      - name: Install a current downloadable Codex
+        run: python tools/install_portable_client_smoke.py --mode latest --only codex
+      - name: Run real-model installation-to-Codex smoke
+        id: live
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$PENTECT_LOG_DIR"
+          report="$RUNNER_TEMP/pentect-opf-live-e2e.json"
+          python plugins/openai-privacy-filter/tests/live_e2e.py \
+            --pentect "$GITHUB_WORKSPACE/target/debug/pentect" \
+            --codex "$(command -v codex)" \
+            --profile "$OPF_PROFILE" \
+            --timeout-seconds 1800 \
+            | tee "$report"
+          jq -e '
+            .schema == "pentect.opf-live-e2e.v2" and
+            .status == "ok" and
+            .profile == env.OPF_PROFILE and
+            (.setup_seconds | numbers) >= 0 and
+            (.plugin_startup_seconds | numbers) >= 0 and
+            (.warm_request_seconds | numbers) >= 0 and
+            (.cold_seconds | numbers) >= 0 and
+            (.restart_seconds | numbers) >= 0 and
+            (.codex_seconds | numbers) >= 0
+          ' "$report"
+          {
+            echo "### OpenAI Privacy Filter live smoke"
+            echo
+            echo "- Profile: `$(jq -r .profile "$report")`"
+            echo "- Managed environment cache hit: `${{ steps.opf-cache.outputs.cache-hit }}`"
+            echo "- Setup: `$(jq -r .setup_seconds "$report")s`"
+            echo "- Direct startup: `$(jq -r .plugin_startup_seconds "$report")s`"
+            echo "- Warm request: `$(jq -r .warm_request_seconds "$report")s`"
+            echo "- Pentect cold process: `$(jq -r .cold_seconds "$report")s`"
+            echo "- Pentect restart: `$(jq -r .restart_seconds "$report")s`"
+            echo "- Codex/local upstream: `$(jq -r .codex_seconds "$report")s`"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Verify artifacts contain no fixture plaintext
+        id: verify-artifacts
+        if: always()
+        run: python plugins/openai-privacy-filter/tests/verify_artifacts.py
+      - name: Upload bounded live-smoke evidence
+        if: always() && steps.verify-artifacts.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: openai-privacy-filter-live-${{ inputs.profile || 'cpu' }}
+          path: |
+            ${{ runner.temp }}/pentect-opf-live-e2e.json
+            ${{ env.PENTECT_LOG_DIR }}/pentect.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/plugins/openai-privacy-filter/README.md
+++ b/plugins/openai-privacy-filter/README.md
@@ -40,12 +40,20 @@ plaintext, and returns a complete local response that Codex must consume
 without a plugin timeout. No OpenAI request is made by that step. It may
 download several gigabytes when the managed environment is not ready.
 
-This is currently a manual test. Pull-request CI runs the bridge unit tests and
-Pentect's deterministic installed-plugin fixtures on Linux, macOS, and Windows,
-but it does not install or load the real model, exercise CUDA, or run this
-script. A green pull request does not claim real-model coverage. The planned
-cache-backed scheduled CPU smoke and optional CUDA smoke are not implemented
-yet.
+Pull-request CI runs the bridge unit tests and Pentect's deterministic
+installed-plugin fixtures on Linux, macOS, and Windows, but it does not install
+or load the real model or exercise CUDA. A green pull request therefore does
+not claim real-model coverage.
+
+The `OpenAI Privacy Filter live smoke` workflow runs this script every week on
+a hosted Linux CPU runner and can be started manually with the CPU profile. It
+caches the managed environment and checkpoint by OS, architecture, Python
+version, profile, and setup revision. The smoke installs the plugin, records
+setup, direct startup, warm request, Pentect restart, and Codex/local-upstream
+durations, verifies worker cleanup, removes the plugin, and uploads only
+fixture-plaintext-free logs and timing evidence. The manual CUDA profile
+targets a separately managed self-hosted runner labeled `gpu` and `nvidia`;
+CUDA availability is not a pull-request or scheduled-release gate.
 
 ```sh
 python3 plugins/openai-privacy-filter/tests/live_e2e.py \

--- a/plugins/openai-privacy-filter/tests/live_e2e.py
+++ b/plugins/openai-privacy-filter/tests/live_e2e.py
@@ -14,6 +14,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from queue import Empty, Queue
 from typing import Any
 
 
@@ -24,6 +25,8 @@ EXPECTED_HANDLE_GROUPS = (
 )
 CODEX_SAMPLE = "The synthetic test contact is alice@example.com. Reply exactly OK."
 EMAIL_HANDLE = re.compile(rb"<<(?:PRIVATE_EMAIL|EMAIL_ADDRESS)_[0-9a-f]{16,64}>>")
+FIXTURE_EMAIL = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+FIXTURE_PHONE = re.compile(r"\+?\d[\d ()-]{7,}\d")
 
 
 def live_environment() -> dict[str, str]:
@@ -58,6 +61,14 @@ def run(
     )
 
 
+def require_success(
+    result: subprocess.CompletedProcess[str], operation: str
+) -> None:
+    """Report a bounded phase and exit code without copying child output."""
+    if result.returncode != 0:
+        raise RuntimeError(f"{operation} failed with exit code {result.returncode}")
+
+
 def assert_live_setup(environment: dict[str, str]) -> None:
     root = Path(
         environment.get(
@@ -83,30 +94,23 @@ def assert_live_setup(environment: dict[str, str]) -> None:
 
 def mask_once(
     pentect: Path,
-    plugin: Path,
     project: Path,
     environment: dict[str, str],
     timeout: float,
 ) -> float:
     started = time.monotonic()
     result = run(
-        [str(pentect), "mask", "--plugins", str(plugin)],
+        [str(pentect), "mask"],
         cwd=project,
         environment=environment,
         timeout=timeout,
         input_text=SAMPLE + "\n",
     )
     elapsed = time.monotonic() - started
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"Pentect mask failed ({result.returncode}): {result.stderr.strip()}"
-        )
+    require_success(result, "Pentect mask")
     for labels in EXPECTED_HANDLE_GROUPS:
         if not any(f"<<{label}_" in result.stdout for label in labels):
-            raise RuntimeError(
-                f"Pentect did not produce one of {labels!r}; "
-                f"stdout={result.stdout.strip()!r}; stderr={result.stderr.strip()!r}"
-            )
+            raise RuntimeError(f"Pentect mask missed expected label group {labels!r}")
     if "alice@example.com" in result.stdout or "+1 415-555-0100" in result.stdout:
         raise RuntimeError("real OPF allowed synthetic PII through unchanged")
     if "preparing plugin 'openai-privacy-filter'" not in result.stderr:
@@ -116,41 +120,24 @@ def mask_once(
     return elapsed
 
 
-def inspect_plugin_once(
-    plugin: Path,
-    project: Path,
-    environment: dict[str, str],
-    timeout: float,
-    profile: str,
-) -> float:
-    request = {
-        "schema": "pentect.plugin.v1",
-        "id": 1,
-        "hook": "inspect",
-        "payload": {"text": SAMPLE},
-    }
-    started = time.monotonic()
-    result = run(
-        [
-            shutil.which("python3") or "python3",
-            str(plugin / "server.py"),
-            "--device",
-            "cpu" if profile == "auto" else profile,
-        ],
-        cwd=project,
-        environment=environment,
-        timeout=timeout,
-        input_text=json.dumps(request, separators=(",", ":")) + "\n",
-    )
-    elapsed = time.monotonic() - started
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"real OPF protocol probe failed ({result.returncode}): {result.stderr.strip()}"
-        )
+def _readline_with_timeout(stream: Any, timeout: float, operation: str) -> str:
+    lines: Queue[str] = Queue(maxsize=1)
+    thread = threading.Thread(target=lambda: lines.put(stream.readline()), daemon=True)
+    thread.start()
     try:
-        response = json.loads(result.stdout.strip())
+        line = lines.get(timeout=timeout)
+    except Empty as error:
+        raise RuntimeError(f"{operation} timed out") from error
+    if not line:
+        raise RuntimeError(f"{operation} ended before returning a response")
+    return line
+
+
+def _validate_protocol_response(line: str) -> None:
+    try:
+        response = json.loads(line)
     except json.JSONDecodeError as error:
-        raise RuntimeError(f"real OPF returned invalid protocol JSON: {error}") from error
+        raise RuntimeError("real OPF returned invalid protocol JSON") from error
     labels = {
         span.get("label")
         for span in response.get("spans", [])
@@ -158,10 +145,110 @@ def inspect_plugin_once(
     }
     missing = {"PRIVATE_EMAIL", "PRIVATE_PHONE"} - labels
     if missing:
-        raise RuntimeError(
-            f"real OPF protocol probe missed {sorted(missing)!r}; response={response!r}"
-        )
-    return elapsed
+        raise RuntimeError(f"real OPF protocol probe missed {sorted(missing)!r}")
+
+
+def inspect_plugin_twice(
+    plugin: Path,
+    project: Path,
+    environment: dict[str, str],
+    timeout: float,
+    profile: str,
+) -> tuple[float, float]:
+    process = subprocess.Popen(
+        [
+            shutil.which("python3") or "python3",
+            str(plugin / "server.py"),
+            "--device",
+            "cpu" if profile == "auto" else profile,
+        ],
+        cwd=project,
+        env=environment,
+        text=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        if process.stdin is None or process.stdout is None:
+            raise RuntimeError("real OPF protocol pipes are unavailable")
+        samples: list[float] = []
+        for request_id in (1, 2):
+            request = {
+                "schema": "pentect.plugin.v1",
+                "id": request_id,
+                "hook": "inspect",
+                "payload": {"text": SAMPLE},
+            }
+            started = time.monotonic()
+            process.stdin.write(json.dumps(request, separators=(",", ":")) + "\n")
+            process.stdin.flush()
+            line = _readline_with_timeout(
+                process.stdout, timeout, f"real OPF request {request_id}"
+            )
+            samples.append(time.monotonic() - started)
+            _validate_protocol_response(line)
+        process.stdin.close()
+        return samples[0], samples[1]
+    finally:
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+        if process.stdin is not None and not process.stdin.closed:
+            process.stdin.close()
+        if process.stdout is not None:
+            process.stdout.close()
+
+
+def assert_no_plugin_process(plugin: Path, timeout: float = 10.0) -> None:
+    """On Linux CI, prove that the real plugin worker did not outlive Pentect."""
+    proc = Path("/proc")
+    if not proc.is_dir():
+        return
+    marker = str(plugin / "server.py").encode()
+    deadline = time.monotonic() + timeout
+    while True:
+        alive = 0
+        for entry in proc.iterdir():
+            if not entry.name.isdigit() or int(entry.name) == os.getpid():
+                continue
+            try:
+                command = (entry / "cmdline").read_bytes()
+            except OSError:
+                continue
+            alive += marker in command
+        if alive == 0:
+            return
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"{alive} real OPF worker process(es) remained alive")
+        time.sleep(0.1)
+
+
+def fixture_plaintext() -> tuple[bytes, ...]:
+    text = f"{SAMPLE}\n{CODEX_SAMPLE}"
+    values = {*FIXTURE_EMAIL.findall(text), *FIXTURE_PHONE.findall(text)}
+    return tuple(value.encode() for value in sorted(values))
+
+
+def assert_value_free_logs(environment: dict[str, str]) -> None:
+    configured = environment.get("PENTECT_LOG_DIR")
+    if not configured:
+        return
+    root = Path(configured).expanduser()
+    if not root.is_dir():
+        return
+    needles = fixture_plaintext()
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            contents = path.read_bytes()
+        except OSError:
+            continue
+        if any(needle in contents for needle in needles):
+            raise RuntimeError("persistent OPF smoke logs contain fixture plaintext")
 
 
 class ProtectedUpstream:
@@ -321,7 +408,6 @@ def _completed_response_stream() -> bytes:
 def codex_once(
     pentect: Path,
     codex: Path,
-    plugin: Path,
     project: Path,
     environment: dict[str, str],
     timeout: float,
@@ -339,8 +425,6 @@ def codex_once(
                 "codex",
                 "--upstream",
                 upstream.base_url,
-                "--plugins",
-                str(plugin),
                 "--",
                 "exec",
                 "--ephemeral",
@@ -355,17 +439,13 @@ def codex_once(
             timeout=timeout,
         )
         elapsed = time.monotonic() - started
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"Pentect Codex E2E failed ({result.returncode}): "
-                f"{result.stderr.strip()} {result.stdout.strip()}"
-            )
+        require_success(result, "Pentect Codex E2E")
         if not upstream.request_seen.is_set():
             raise RuntimeError("Pentect Codex E2E never reached the local upstream")
         if upstream.error is not None:
             raise RuntimeError(upstream.error)
         if "timed out" in result.stderr or "plugin 'openai-privacy-filter' skipped" in result.stderr:
-            raise RuntimeError(f"real OPF did not remain active: {result.stderr.strip()}")
+            raise RuntimeError("real OPF did not remain active during Codex E2E")
         if '"text":"OK"' not in result.stdout:
             raise RuntimeError("Codex did not consume the local upstream response")
         return elapsed
@@ -396,11 +476,12 @@ def main() -> None:
     environment = live_environment()
     with tempfile.TemporaryDirectory(prefix="pentect-opf-live-") as directory:
         project = Path(directory)
+        setup_started = time.monotonic()
         setup = run(
             [
                 str(pentect),
                 "plugins",
-                "setup",
+                "add",
                 str(plugin),
                 "--project",
                 "--profile",
@@ -411,20 +492,20 @@ def main() -> None:
             environment=environment,
             timeout=args.timeout_seconds,
         )
-        if setup.returncode != 0:
-            raise RuntimeError(
-                f"real OPF setup failed ({setup.returncode}): {setup.stderr.strip()}"
-            )
+        require_success(setup, "real OPF installation and setup")
+        setup_seconds = time.monotonic() - setup_started
         assert_live_setup(environment)
-        plugin_seconds = inspect_plugin_once(
+        plugin_startup_seconds, warm_request_seconds = inspect_plugin_twice(
             plugin, project, environment, args.timeout_seconds, args.profile
         )
         cold_seconds = mask_once(
-            pentect, plugin, project, environment, args.timeout_seconds
+            pentect, project, environment, args.timeout_seconds
         )
+        assert_no_plugin_process(plugin)
         restart_seconds = mask_once(
-            pentect, plugin, project, environment, args.timeout_seconds
+            pentect, project, environment, args.timeout_seconds
         )
+        assert_no_plugin_process(plugin)
         codex_seconds = None
         if not args.skip_codex:
             if args.codex is None:
@@ -432,19 +513,44 @@ def main() -> None:
             codex_seconds = codex_once(
                 pentect,
                 args.codex.expanduser().absolute(),
-                plugin,
                 project,
                 environment,
                 args.timeout_seconds,
                 args.model,
             )
+            assert_no_plugin_process(plugin)
+        removal = run(
+            [
+                str(pentect),
+                "plugins",
+                "remove",
+                "openai-privacy-filter",
+                "--project",
+            ],
+            cwd=project,
+            environment=environment,
+            timeout=args.timeout_seconds,
+        )
+        require_success(removal, "real OPF removal")
+        listing = run(
+            [str(pentect), "plugins", "list"],
+            cwd=project,
+            environment=environment,
+            timeout=args.timeout_seconds,
+        )
+        require_success(listing, "post-removal plugin listing")
+        if "openai-privacy-filter" in listing.stdout:
+            raise RuntimeError("real OPF remained enabled after removal")
+        assert_value_free_logs(environment)
 
     print(
         json.dumps(
             {
-                "schema": "pentect.opf-live-e2e.v1",
+                "schema": "pentect.opf-live-e2e.v2",
                 "profile": args.profile,
-                "plugin_seconds": round(plugin_seconds, 3),
+                "setup_seconds": round(setup_seconds, 3),
+                "plugin_startup_seconds": round(plugin_startup_seconds, 3),
+                "warm_request_seconds": round(warm_request_seconds, 3),
                 "cold_seconds": round(cold_seconds, 3),
                 "restart_seconds": round(restart_seconds, 3),
                 "codex_seconds": (

--- a/plugins/openai-privacy-filter/tests/live_e2e.py
+++ b/plugins/openai-privacy-filter/tests/live_e2e.py
@@ -133,13 +133,15 @@ def _readline_with_timeout(stream: Any, timeout: float, operation: str) -> str:
     return line
 
 
-def _validate_protocol_response(line: str) -> dict[str, Any]:
+def _validate_protocol_response(line: str, request_id: int) -> dict[str, Any]:
     try:
         response = json.loads(line)
     except json.JSONDecodeError as error:
         raise RuntimeError("real OPF returned invalid protocol JSON") from error
     if not isinstance(response, dict):
         raise RuntimeError("real OPF returned a non-object protocol response")
+    if response.get("id") != request_id:
+        raise RuntimeError("real OPF returned a mismatched protocol response ID")
     labels = {
         span.get("label")
         for span in response.get("spans", [])
@@ -191,7 +193,7 @@ def inspect_plugin_twice(
                 process.stdout, timeout, f"real OPF request {request_id}"
             )
             samples.append(time.monotonic() - started)
-            response = _validate_protocol_response(line)
+            response = _validate_protocol_response(line, request_id)
             if response_observer is not None:
                 response_observer(response)
         process.stdin.close()

--- a/plugins/openai-privacy-filter/tests/live_e2e.py
+++ b/plugins/openai-privacy-filter/tests/live_e2e.py
@@ -15,7 +15,7 @@ import tempfile
 import threading
 import time
 from queue import Empty, Queue
-from typing import Any
+from typing import Any, Callable
 
 
 SAMPLE = "Please contact Alice Example at alice@example.com or +1 415-555-0100."
@@ -133,11 +133,13 @@ def _readline_with_timeout(stream: Any, timeout: float, operation: str) -> str:
     return line
 
 
-def _validate_protocol_response(line: str) -> None:
+def _validate_protocol_response(line: str) -> dict[str, Any]:
     try:
         response = json.loads(line)
     except json.JSONDecodeError as error:
         raise RuntimeError("real OPF returned invalid protocol JSON") from error
+    if not isinstance(response, dict):
+        raise RuntimeError("real OPF returned a non-object protocol response")
     labels = {
         span.get("label")
         for span in response.get("spans", [])
@@ -146,6 +148,7 @@ def _validate_protocol_response(line: str) -> None:
     missing = {"PRIVATE_EMAIL", "PRIVATE_PHONE"} - labels
     if missing:
         raise RuntimeError(f"real OPF protocol probe missed {sorted(missing)!r}")
+    return response
 
 
 def inspect_plugin_twice(
@@ -154,6 +157,7 @@ def inspect_plugin_twice(
     environment: dict[str, str],
     timeout: float,
     profile: str,
+    response_observer: Callable[[dict[str, Any]], None] | None = None,
 ) -> tuple[float, float]:
     process = subprocess.Popen(
         [
@@ -187,17 +191,19 @@ def inspect_plugin_twice(
                 process.stdout, timeout, f"real OPF request {request_id}"
             )
             samples.append(time.monotonic() - started)
-            _validate_protocol_response(line)
+            response = _validate_protocol_response(line)
+            if response_observer is not None:
+                response_observer(response)
         process.stdin.close()
         return samples[0], samples[1]
     finally:
+        if process.stdin is not None and not process.stdin.closed:
+            process.stdin.close()
         try:
             process.wait(timeout=10)
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=10)
-        if process.stdin is not None and not process.stdin.closed:
-            process.stdin.close()
         if process.stdout is not None:
             process.stdout.close()
 
@@ -232,17 +238,24 @@ def fixture_plaintext() -> tuple[bytes, ...]:
     return tuple(value.encode() for value in sorted(values))
 
 
-def assert_value_free_logs(environment: dict[str, str]) -> None:
+def assert_value_free_logs(
+    environment: dict[str, str], *, must_exist: bool = False
+) -> None:
     configured = environment.get("PENTECT_LOG_DIR")
     if not configured:
+        if must_exist:
+            raise RuntimeError("persistent OPF smoke log directory is not configured")
         return
     root = Path(configured).expanduser()
     if not root.is_dir():
+        if must_exist:
+            raise RuntimeError("persistent OPF smoke log directory is missing")
         return
+    files = [path for path in root.rglob("*") if path.is_file()]
+    if must_exist and not files:
+        raise RuntimeError("persistent OPF smoke log directory contains no logs")
     needles = fixture_plaintext()
-    for path in root.rglob("*"):
-        if not path.is_file():
-            continue
+    for path in files:
         try:
             contents = path.read_bytes()
         except OSError:

--- a/plugins/openai-privacy-filter/tests/test_live_e2e.py
+++ b/plugins/openai-privacy-filter/tests/test_live_e2e.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+LIVE_PATH = Path(__file__).with_name("live_e2e.py")
+SPEC = importlib.util.spec_from_file_location("pentect_opf_live_e2e", LIVE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+LIVE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(LIVE)
+
+
+class LiveE2ETests(unittest.TestCase):
+    def test_protocol_probe_reuses_one_worker_for_two_requests(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            plugin = root / "plugin"
+            plugin.mkdir()
+            (plugin / "server.py").write_text(
+                """\
+import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    response = {
+        "schema": "pentect.plugin.v1",
+        "id": request["id"],
+        "spans": [
+            {"start": 0, "end": 1, "label": "PRIVATE_EMAIL"},
+            {"start": 2, "end": 3, "label": "PRIVATE_PHONE"},
+        ],
+    }
+    print(json.dumps(response), flush=True)
+""",
+                encoding="utf-8",
+            )
+            startup, warm = LIVE.inspect_plugin_twice(
+                plugin, root, os.environ.copy(), 5.0, "cpu"
+            )
+            self.assertGreaterEqual(startup, 0)
+            self.assertGreaterEqual(warm, 0)
+
+    def test_child_failure_does_not_copy_captured_output(self) -> None:
+        result = subprocess.CompletedProcess(
+            ["fixture"],
+            17,
+            stdout=LIVE.SAMPLE,
+            stderr=LIVE.CODEX_SAMPLE,
+        )
+        with self.assertRaisesRegex(RuntimeError, "exit code 17") as caught:
+            LIVE.require_success(result, "fixture operation")
+        message = str(caught.exception)
+        for value in LIVE.fixture_plaintext():
+            self.assertNotIn(value.decode(), message)
+
+    def test_log_scan_rejects_fixture_plaintext_without_repeating_it(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            value = LIVE.fixture_plaintext()[0]
+            (root / "pentect.log").write_bytes(b"prefix " + value + b" suffix")
+            with self.assertRaisesRegex(RuntimeError, "contain fixture plaintext") as caught:
+                LIVE.assert_value_free_logs({"PENTECT_LOG_DIR": directory})
+            self.assertNotIn(value.decode(), str(caught.exception))
+
+    def test_log_scan_accepts_handles(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "pentect.log").write_text(
+                "<<PRIVATE_EMAIL_0123456789abcdef>>\n", encoding="utf-8"
+            )
+            LIVE.assert_value_free_logs({"PENTECT_LOG_DIR": directory})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/openai-privacy-filter/tests/test_live_e2e.py
+++ b/plugins/openai-privacy-filter/tests/test_live_e2e.py
@@ -24,13 +24,18 @@ class LiveE2ETests(unittest.TestCase):
             (plugin / "server.py").write_text(
                 """\
 import json
+import os
 import sys
 
+served = 0
 for line in sys.stdin:
     request = json.loads(line)
+    served += 1
     response = {
         "schema": "pentect.plugin.v1",
         "id": request["id"],
+        "pid": os.getpid(),
+        "served": served,
         "spans": [
             {"start": 0, "end": 1, "label": "PRIVATE_EMAIL"},
             {"start": 2, "end": 3, "label": "PRIVATE_PHONE"},
@@ -40,11 +45,19 @@ for line in sys.stdin:
 """,
                 encoding="utf-8",
             )
+            responses = []
             startup, warm = LIVE.inspect_plugin_twice(
-                plugin, root, os.environ.copy(), 5.0, "cpu"
+                plugin,
+                root,
+                os.environ.copy(),
+                5.0,
+                "cpu",
+                responses.append,
             )
             self.assertGreaterEqual(startup, 0)
             self.assertGreaterEqual(warm, 0)
+            self.assertEqual([response["served"] for response in responses], [1, 2])
+            self.assertEqual(len({response["pid"] for response in responses}), 1)
 
     def test_child_failure_does_not_copy_captured_output(self) -> None:
         result = subprocess.CompletedProcess(
@@ -75,6 +88,20 @@ for line in sys.stdin:
                 "<<PRIVATE_EMAIL_0123456789abcdef>>\n", encoding="utf-8"
             )
             LIVE.assert_value_free_logs({"PENTECT_LOG_DIR": directory})
+
+    def test_log_scan_can_require_the_configured_directory(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "not configured"):
+            LIVE.assert_value_free_logs({}, must_exist=True)
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "missing"
+            with self.assertRaisesRegex(RuntimeError, "is missing"):
+                LIVE.assert_value_free_logs(
+                    {"PENTECT_LOG_DIR": str(missing)}, must_exist=True
+                )
+            with self.assertRaisesRegex(RuntimeError, "contains no logs"):
+                LIVE.assert_value_free_logs(
+                    {"PENTECT_LOG_DIR": directory}, must_exist=True
+                )
 
 
 if __name__ == "__main__":

--- a/plugins/openai-privacy-filter/tests/test_live_e2e.py
+++ b/plugins/openai-privacy-filter/tests/test_live_e2e.py
@@ -16,6 +16,11 @@ SPEC.loader.exec_module(LIVE)
 
 
 class LiveE2ETests(unittest.TestCase):
+    def test_protocol_probe_rejects_a_mismatched_response_id(self) -> None:
+        response = '{"id":2,"spans":[]}'
+        with self.assertRaisesRegex(RuntimeError, "mismatched protocol response ID"):
+            LIVE._validate_protocol_response(response, 1)
+
     def test_protocol_probe_reuses_one_worker_for_two_requests(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/plugins/openai-privacy-filter/tests/verify_artifacts.py
+++ b/plugins/openai-privacy-filter/tests/verify_artifacts.py
@@ -11,4 +11,4 @@ SPEC = importlib.util.spec_from_file_location("pentect_opf_live_e2e", LIVE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 LIVE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(LIVE)
-LIVE.assert_value_free_logs(os.environ)
+LIVE.assert_value_free_logs(os.environ, must_exist=True)

--- a/plugins/openai-privacy-filter/tests/verify_artifacts.py
+++ b/plugins/openai-privacy-filter/tests/verify_artifacts.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Refuse to publish OPF live-smoke logs containing fixture plaintext."""
+
+import importlib.util
+from pathlib import Path
+import os
+
+
+LIVE_PATH = Path(__file__).with_name("live_e2e.py")
+SPEC = importlib.util.spec_from_file_location("pentect_opf_live_e2e", LIVE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+LIVE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(LIVE)
+LIVE.assert_value_free_logs(os.environ)

--- a/website/src/content/docs/plugins/official.md
+++ b/website/src/content/docs/plugins/official.md
@@ -102,10 +102,17 @@ not claim that those heavyweight boundaries were exercised.
 The repository includes a separate
 [`live_e2e.py`](https://github.com/EdamAme-x/pentect/blob/main/plugins/openai-privacy-filter/tests/live_e2e.py)
 for the real model. It verifies real setup and checkpoint state, the direct
-plugin protocol, cold and restarted Pentect masking, and an installed Codex
-flow against a localhost recorder without sending a request to OpenAI. This
-test is currently manual, not a required or scheduled GitHub Actions job. A
-cache-backed scheduled CPU smoke and an optional CUDA smoke remain planned.
+plugin protocol including a warm second request, cold and restarted Pentect
+masking, worker cleanup, removal, and an installed Codex flow against a
+localhost recorder without sending a request to OpenAI.
+
+The `OpenAI Privacy Filter live smoke` workflow runs this test weekly with the
+CPU profile and also supports manual CPU runs. The managed Python environment
+and checkpoint are cached by the setup revision and runtime identity. Its
+bounded artifact contains timing evidence and persistent logs only after a
+fixture-plaintext scan succeeds. A manually selected CUDA profile targets a
+separately managed self-hosted Linux runner labeled `gpu` and `nvidia`; CUDA is
+not a pull-request or scheduled-release gate.
 
 ### How it connects
 


### PR DESCRIPTION
## Summary
- run the official OpenAI Privacy Filter against its real checkpoint weekly on hosted Linux CPU runners
- cache the managed model environment and expose manual CPU/CUDA profiles
- exercise install, persistent protocol reuse, Pentect restart, Codex with a localhost upstream, worker cleanup, and removal
- reject artifact upload when synthetic fixture plaintext appears in persistent logs
- document the exact boundary between pull-request CI and heavyweight live smoke coverage

## Local verification
- 25 OpenAI Privacy Filter Python tests passed with ResourceWarning treated as an error
- website build generated 42 pages and checked 114 internal links
- real CPU checkpoint E2E passed twice, including the Codex/local-upstream path and post-removal listing

Progresses #1339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scheduled and manually triggered live smoke testing for the OpenAI Privacy Filter, supporting CPU and optional CUDA profiles.
  - Added timing reports and privacy-safe evidence artifacts covering setup, startup, requests, restarts, and integration flows.

- **Bug Fixes**
  - Strengthened validation for persistent responses, worker cleanup, plugin removal, and sensitive fixture data in logs and artifacts.
  - Improved test reliability on Windows environments.

- **Documentation**
  - Updated plugin documentation with workflow details, supported profiles, caching, timing reports, and artifact safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->