### PR TITLE
ci: align OPF live runtime with isolated home

### DIFF
--- a/.github/workflows/openai-privacy-filter-live.yml
+++ b/.github/workflows/openai-privacy-filter-live.yml
@@ -38,7 +38,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          root="$RUNNER_TEMP/pentect-opf-$OPF_PROFILE"
+          home="$RUNNER_TEMP/pentect-opf-home-$OPF_PROFILE"
+          root="$home/.pentect/openai-privacy-filter"
           logs="$RUNNER_TEMP/pentect-opf-live-logs"
           report="$RUNNER_TEMP/pentect-opf-live-e2e.json"
           {
@@ -47,6 +48,7 @@ jobs:
             echo "PENTECT_OPF_REPORT=$report"
           } >> "$GITHUB_ENV"
           {
+            echo "home=$home"
             echo "root=$root"
             echo "logs=$logs"
             echo "report=$report"
@@ -80,6 +82,7 @@ jobs:
         shell: bash
         env:
           CACHE_HIT: ${{ steps.opf-cache.outputs.cache-hit }}
+          HOME: ${{ steps.live-paths.outputs.home }}
         run: |
           set -euo pipefail
           mkdir -p "$PENTECT_LOG_DIR"
@@ -135,7 +138,7 @@ jobs:
       - name: Clean live-smoke state from the runner
         if: always()
         env:
-          OPF_ROOT_TO_CLEAN: ${{ steps.live-paths.outputs.root }}
+          OPF_HOME_TO_CLEAN: ${{ steps.live-paths.outputs.home }}
           OPF_LOGS_TO_CLEAN: ${{ steps.live-paths.outputs.logs }}
           OPF_REPORT_TO_CLEAN: ${{ steps.live-paths.outputs.report }}
         shell: bash
@@ -147,7 +150,7 @@ jobs:
 
           temporary = Path(os.environ["RUNNER_TEMP"]).resolve()
           for name in (
-              "OPF_ROOT_TO_CLEAN",
+              "OPF_HOME_TO_CLEAN",
               "OPF_LOGS_TO_CLEAN",
               "OPF_REPORT_TO_CLEAN",
           ):


### PR DESCRIPTION
## Root cause

The first real-model run exposed a false local pass. Setup and the direct probe honored `PENTECT_OPF_ROOT`, but Pentect intentionally clears plugin-specific environment variables before starting a Command plugin. The OPF server therefore used its default HOME-relative environment. Existing local state hid this mismatch; a fresh hosted runner had no fallback and the plugin exited during startup.

## Fix

- create a dedicated temporary HOME whose default OPF path is the cached setup path
- apply that HOME only to the live E2E step, after toolchain setup
- clean the entire isolated HOME after explicit cache save and artifact upload

## Verification

- reproduced the fresh-root mismatch from run 33703745380 artifacts
- complete isolated-HOME CPU E2E passed locally through setup, two direct requests, Pentect cold/restart, Codex localhost upstream, and removal
- actionlint passed
- zizmor 1.29.0 reported no findings

Progresses #1339