### PR TITLE
Clean up plugin setup after hard termination

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,17 +6,38 @@ through the release binary:
 
 | Client | Release gate | Protected mode |
 | --- | --- | --- |
-| Codex CLI `0.147.0` | automated on Linux | `pentect codex` |
-| Claude Code `2.1.227` | automated on Linux | `pentect claude` |
-| OpenCode `1.18.16` | automated on Linux | `pentect opencode` |
-| Pi `0.84.1` | launcher and published extension discovery | `pentect pi` or `@pentect/pi` |
+| Codex CLI `0.149.0` | real launch on Linux and all installer platforms | `pentect codex` |
+| Claude Code `2.1.238` | real launch on Linux and all installer platforms | `pentect claude` |
+| OpenCode `1.18.20` | real launch on Linux and all installer platforms | `pentect opencode` |
+| Pi `0.84.2` | real launch, npm extension, and provider discovery | `pentect pi` or `@pentect/pi` |
 | ChatGPT desktop app (Codex mode) | launcher and Responses protocol tests | `pentect codex app` |
 | Claude Desktop | protocol tests; signed app `1.24012.9` was manually launch-tested, while `1.34493.1` is known incompatible | `pentect claude app` only on an explicitly compatible build |
+
+Release pins are intentionally separate from the scheduled current-client
+monitor. The latest successful monitor on 2026-09-03 exercised the published
+Pentect binary and the then-current downloadable clients on Windows, macOS,
+and Linux:
+
+| Client | Current-client evidence | Installed handle path |
+| --- | --- | --- |
+| Codex CLI `0.153.0` | passed on Windows, macOS, and Linux | OpenAI Responses request, local shell tool arguments, cancellation recovery, and image redaction |
+| Claude Code `2.1.259` | passed on Windows, macOS, and Linux | Anthropic Messages request and local Bash tool arguments |
+| OpenCode `1.18.27` | passed on Windows, macOS, and Linux | configured OpenAI Chat request and local tool arguments |
+| Pi `0.84.4` | passed on Windows, macOS, and Linux | configured OpenAI Chat request and local Bash tool arguments |
+
+These current-client results are compatibility observations, not retroactive
+changes to a release's pinned gate. A client name alone also does not imply
+coverage of every provider, transport, hosted tool, or execution location.
 
 The CLI gate proves that the vendor executable still starts under Pentect.
 Mock protocol tests cover text, streaming responses, completed tool calls,
 structured content, file references, malformed content, and custom upstream
 path preservation without sending repository secrets to a model provider.
+The installed handle-flow test goes further: a real client reads two synthetic
+local keys, receives only distinct handles from a localhost provider fixture,
+uses those handles in local tool calls, and reaches the fixture service with
+the exact originals. The provider requests and persistent diagnostics must not
+contain either plaintext value. It does not make a paid provider request.
 
 Desktop vendor apps are not installed on ephemeral release runners, so their
 full signed-GUI flow is not yet a release gate. Pentect does not claim an App

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -13,7 +13,7 @@ through the release binary:
 | ChatGPT desktop app (Codex mode) | launcher and Responses protocol tests | `pentect codex app` |
 | Claude Desktop | protocol tests; signed app `1.24012.9` was manually launch-tested, while `1.34493.1` is known incompatible | `pentect claude app` only on an explicitly compatible build |
 
-Release pins are intentionally separate from the scheduled current-client
+Release pins are intentionally separate from the daily current-client
 monitor. The latest successful monitor on 2026-09-03 exercised the published
 Pentect binary and the then-current downloadable clients on Windows, macOS,
 and Linux:

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -240,6 +240,9 @@ const COMMANDS: &[CommandSpec] = &[
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
+    if args.get(1).map(String::as_str) == Some("__plugin-setup-supervisor") {
+        std::process::exit(plugins_cmd::cmd_setup_supervisor(&args));
+    }
     let surface = diagnostic_surface(&args);
     install_panic_logger(surface.clone());
     pentect_agent::record_process_activity(

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -2410,9 +2410,21 @@ fn setup_plugin_source_inner(
         if !approved && !confirm_setup()? {
             return Err("plugin setup was not approved".to_string());
         }
-        write_command_lock(&name, &source, &manifest)?;
+        let remote_command = !plugins::remote_command_files(&source)
+            .map_err(|error| error.to_string())?
+            .is_empty();
+        // A local setup does not need runtime metadata. Commit it only after
+        // the external setup succeeds, so SIGKILL cannot leave a new lock.
+        // Remote setup executes from the managed command directory and must
+        // still stage that directory first.
+        if remote_command {
+            write_command_lock(&name, &source, &manifest)?;
+        }
         if let Some(setup) = manifest.setup.as_ref() {
             run_command_environment_setup(&name, &source, setup, profile)?;
+        }
+        if !remote_command {
+            write_command_lock(&name, &source, &manifest)?;
         }
         manifest.hooks.clone()
     };
@@ -2478,10 +2490,8 @@ fn run_command_environment_setup(
     install_setup_interrupt_handler()?;
     SETUP_INTERRUPTED.store(false, Ordering::SeqCst);
     println!("environment setup: starting");
-    let mut command = Command::new(executable);
+    let mut command = setup_supervisor_command(&root, &executable, &argv[1..])?;
     command
-        .args(&argv[1..])
-        .current_dir(&root)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
@@ -2489,6 +2499,11 @@ fn run_command_environment_setup(
     let mut child = command
         .spawn()
         .map_err(|error| format!("could not start plugin environment setup: {error}"))?;
+    let _tree = SetupProcessTree::attach(&child).map_err(|error| {
+        let _ = child.kill();
+        let _ = child.wait();
+        format!("could not isolate plugin environment setup: {error}")
+    })?;
     let status = wait_for_setup_child(&mut child)?;
     let interrupted = SETUP_INTERRUPTED.swap(false, Ordering::SeqCst);
     if interrupted {
@@ -2505,6 +2520,119 @@ fn run_command_environment_setup(
     }
     println!("environment setup: complete");
     Ok(())
+}
+
+#[cfg(not(test))]
+fn setup_supervisor_command(
+    root: &Path,
+    executable: &Path,
+    args: &[String],
+) -> Result<Command, String> {
+    let parent_pid = std::process::id();
+    let parent_started = process_start_time(parent_pid)
+        .ok_or_else(|| "could not identify the plugin setup owner process".to_string())?;
+    let pentect = std::env::current_exe()
+        .map_err(|error| format!("could not locate Pentect for plugin setup: {error}"))?;
+    let mut command = Command::new(pentect);
+    command
+        .arg("__plugin-setup-supervisor")
+        .arg(parent_pid.to_string())
+        .arg(parent_started.to_string())
+        .arg(root)
+        .arg(executable)
+        .args(args);
+    Ok(command)
+}
+
+#[cfg(test)]
+fn setup_supervisor_command(
+    root: &Path,
+    executable: &Path,
+    args: &[String],
+) -> Result<Command, String> {
+    let mut command = Command::new(executable);
+    command.args(args).current_dir(root);
+    Ok(command)
+}
+
+pub(crate) fn cmd_setup_supervisor(args: &[String]) -> i32 {
+    match run_setup_supervisor(args) {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("[pentect] {error}");
+            1
+        }
+    }
+}
+
+fn run_setup_supervisor(args: &[String]) -> Result<i32, String> {
+    let parent_pid = args
+        .get(2)
+        .ok_or_else(|| "plugin setup supervisor is missing its owner PID".to_string())?
+        .parse::<u32>()
+        .map_err(|_| "plugin setup supervisor owner PID is invalid".to_string())?;
+    let parent_started = args
+        .get(3)
+        .ok_or_else(|| "plugin setup supervisor is missing its owner identity".to_string())?
+        .parse::<u64>()
+        .map_err(|_| "plugin setup supervisor owner identity is invalid".to_string())?;
+    let cwd = args
+        .get(4)
+        .ok_or_else(|| "plugin setup supervisor is missing its working directory".to_string())?;
+    let executable = args
+        .get(5)
+        .ok_or_else(|| "plugin setup supervisor is missing its executable".to_string())?;
+    if !process_identity_matches(parent_pid, parent_started) {
+        return Err("plugin setup owner exited before setup could start".to_string());
+    }
+    let mut child = Command::new(executable)
+        .args(&args[6..])
+        .current_dir(cwd)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|error| format!("could not start plugin environment setup command: {error}"))?;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Ok(status.code().unwrap_or(1));
+            }
+            Ok(None) if process_identity_matches(parent_pid, parent_started) => {
+                thread::sleep(SETUP_CHILD_POLL);
+            }
+            Ok(None) => {
+                terminate_setup_process_tree(std::process::id(), true);
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err("plugin setup owner exited".to_string());
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "could not wait for plugin environment setup command: {error}"
+                ));
+            }
+        }
+    }
+}
+
+fn process_start_time(pid: u32) -> Option<u64> {
+    let pid = sysinfo::Pid::from_u32(pid);
+    let mut system = sysinfo::System::new();
+    system.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[pid]),
+        true,
+        sysinfo::ProcessRefreshKind::nothing(),
+    );
+    system.process(pid).and_then(|process| {
+        (process.status() != sysinfo::ProcessStatus::Zombie).then(|| process.start_time())
+    })
+}
+
+fn process_identity_matches(pid: u32, started: u64) -> bool {
+    process_start_time(pid).is_some_and(|observed| observed == started)
 }
 
 fn install_setup_interrupt_handler() -> Result<(), String> {
@@ -2556,6 +2684,72 @@ fn configure_setup_process_tree(command: &mut Command) {
 
 #[cfg(not(any(unix, windows)))]
 fn configure_setup_process_tree(_command: &mut Command) {}
+
+#[cfg(unix)]
+struct SetupProcessTree;
+
+#[cfg(unix)]
+impl SetupProcessTree {
+    fn attach(_child: &Child) -> Result<Self, String> {
+        Ok(Self)
+    }
+}
+
+#[cfg(windows)]
+struct SetupProcessTree {
+    job: usize,
+}
+
+#[cfg(windows)]
+impl SetupProcessTree {
+    fn attach(child: &Child) -> Result<Self, String> {
+        use std::os::windows::io::AsRawHandle as _;
+        use windows_sys::Win32::System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+
+        let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if job.is_null() {
+            return Err("could not create a Windows Job Object".to_string());
+        }
+        let mut information = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        information.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                std::ptr::addr_of!(information).cast(),
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        } != 0;
+        let assigned = configured
+            && unsafe { AssignProcessToJobObject(job, child.as_raw_handle().cast()) } != 0;
+        if !assigned {
+            unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+            return Err("could not assign plugin setup to a Windows Job Object".to_string());
+        }
+        Ok(Self { job: job as usize })
+    }
+}
+
+#[cfg(windows)]
+impl Drop for SetupProcessTree {
+    fn drop(&mut self) {
+        unsafe { windows_sys::Win32::Foundation::CloseHandle(self.job as *mut _) };
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+struct SetupProcessTree;
+
+#[cfg(not(any(unix, windows)))]
+impl SetupProcessTree {
+    fn attach(_child: &Child) -> Result<Self, String> {
+        Ok(Self)
+    }
+}
 
 #[cfg(unix)]
 fn terminate_setup_process_tree(pid: u32, force: bool) {

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -1094,8 +1094,8 @@ command = ["python", "{plugin}/setup.py"]
     if len(markers) != 2:
         raise RuntimeError(f"serialized setup started {len(markers)} setup children, expected 2")
     supervisor_pids = {data["parent"] for data in markers.values()}
-    if len(supervisor_pids) != 2 or supervisor_pids & {process.pid for process in processes}:
-        raise RuntimeError("setup child markers did not identify distinct setup supervisors")
+    if supervisor_pids & {process.pid for process in processes}:
+        raise RuntimeError("setup children did not run below a distinct setup supervisor")
     if {data["role"] for data in markers.values()} != {"slow", "fast"}:
         raise RuntimeError("serialized setup did not run one slow and one fast setup child")
     for process in processes:
@@ -1112,14 +1112,6 @@ command = ["python", "{plugin}/setup.py"]
         raise RuntimeError("exactly one concurrent setup did not wait for the mutation lock")
     if elapsed < 5.5:
         raise RuntimeError("long-running setup fixture did not exercise its six-second operation")
-    for setup_pid in markers:
-        if not wait_for_process_exit(setup_pid, timeout=2.0):
-            raise RuntimeError(f"serialized setup child {setup_pid} survived completion")
-    for supervisor_pid in supervisor_pids:
-        if not wait_for_process_exit(supervisor_pid, timeout=2.0):
-            raise RuntimeError(
-                f"serialized setup supervisor {supervisor_pid} survived completion"
-            )
 
     ordinary = "ordinary long-running setup fixture"
     recovered = run_pentect(

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -591,6 +591,116 @@ command = ["python", "{plugin}/setup.py"]
     )
 
 
+def verify_forced_setup_termination_is_clean(
+    pentect: str,
+    root: Path,
+    home: Path,
+    project: Path,
+    environment: dict[str, str],
+) -> None:
+    plugin = root / "forced-setup-plugin"
+    plugin.mkdir()
+    setup = plugin / "setup.py"
+    setup.write_text(
+        '''import json
+import os
+import time
+
+with open("setup-pid.txt", "w", encoding="utf-8") as marker:
+    json.dump({"setup": os.getpid(), "supervisor": os.getppid()}, marker)
+while True:
+    time.sleep(1)
+''',
+        encoding="utf-8",
+    )
+    (plugin / "server.py").write_text(
+        '''import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    print(json.dumps({
+        "schema": "pentect.plugin.v1",
+        "id": request["id"],
+        "type": "result",
+        "action": "next",
+        "spans": [],
+    }, separators=(",", ":")), flush=True)
+''',
+        encoding="utf-8",
+    )
+    (plugin / "plugin.toml").write_text(
+        '''schema = "pentect.plugin.v1"
+name = "forced-setup-e2e"
+command = ["python", "{plugin}/server.py"]
+hooks = ["inspect"]
+
+[setup]
+command = ["python", "{plugin}/setup.py"]
+''',
+        encoding="utf-8",
+    )
+    before = snapshot_regular_files(home, project)
+    process = subprocess.Popen(
+        pentect_command(
+            pentect,
+            ["plugins", "add", str(plugin), "--project", "--yes"],
+        ),
+        cwd=project,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    marker = plugin / "setup-pid.txt"
+    deadline = time.monotonic() + 10
+    while not marker.exists() and process.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if not marker.exists():
+        process.kill()
+        output, _ = process.communicate(timeout=5)
+        raise RuntimeError("plugin setup did not reach its forced-termination fixture:\n" + output)
+    setup_processes = json.loads(marker.read_text(encoding="utf-8"))
+    setup_pid = int(setup_processes["setup"])
+    supervisor_pid = int(setup_processes["supervisor"])
+    if supervisor_pid == process.pid:
+        process.kill()
+        process.communicate(timeout=5)
+        raise RuntimeError("plugin setup did not run below a distinct supervisor")
+    process.kill()
+    process.communicate(timeout=5)
+    if not wait_for_process_exit(setup_pid, timeout=3.0):
+        raise RuntimeError(f"forced plugin setup process {setup_pid} survived its Pentect owner")
+    if not wait_for_process_exit(supervisor_pid, timeout=3.0):
+        raise RuntimeError(
+            f"forced plugin setup supervisor {supervisor_pid} survived its Pentect owner"
+        )
+    if snapshot_regular_files(home, project) != before:
+        raise RuntimeError("forced plugin setup termination left partial persistent state")
+    listed = run_pentect(
+        pentect,
+        ["plugins", "list"],
+        cwd=project,
+        environment=environment,
+    )
+    if "forced-setup-e2e:" in listed.stdout:
+        raise RuntimeError("forced plugin setup termination left the plugin enabled")
+
+    setup.write_text("raise SystemExit(0)\n", encoding="utf-8")
+    run_pentect(
+        pentect,
+        ["plugins", "add", str(plugin), "--project", "--yes"],
+        cwd=project,
+        environment=environment,
+    )
+    run_pentect(
+        pentect,
+        ["plugins", "remove", "forced-setup-e2e", "--project"],
+        cwd=project,
+        environment=environment,
+    )
+
+
 def verify_failed_update_preserves_command_runtime(
     pentect: str,
     root: Path,
@@ -983,8 +1093,9 @@ command = ["python", "{plugin}/setup.py"]
     }
     if len(markers) != 2:
         raise RuntimeError(f"serialized setup started {len(markers)} setup children, expected 2")
-    if {data["parent"] for data in markers.values()} != {process.pid for process in processes}:
-        raise RuntimeError("setup child markers did not identify their Pentect parents")
+    supervisor_pids = {data["parent"] for data in markers.values()}
+    if len(supervisor_pids) != 2 or supervisor_pids & {process.pid for process in processes}:
+        raise RuntimeError("setup child markers did not identify distinct setup supervisors")
     if {data["role"] for data in markers.values()} != {"slow", "fast"}:
         raise RuntimeError("serialized setup did not run one slow and one fast setup child")
     for process in processes:
@@ -1004,6 +1115,11 @@ command = ["python", "{plugin}/setup.py"]
     for setup_pid in markers:
         if not wait_for_process_exit(setup_pid, timeout=2.0):
             raise RuntimeError(f"serialized setup child {setup_pid} survived completion")
+    for supervisor_pid in supervisor_pids:
+        if not wait_for_process_exit(supervisor_pid, timeout=2.0):
+            raise RuntimeError(
+                f"serialized setup supervisor {supervisor_pid} survived completion"
+            )
 
     ordinary = "ordinary long-running setup fixture"
     recovered = run_pentect(
@@ -1056,6 +1172,9 @@ def run_plugin_lifecycle(pentect: str) -> None:
         verify_interrupted_setup_rolls_back(
             pentect, root, home, project, environment
         )
+        verify_forced_setup_termination_is_clean(
+            pentect, root, home, project, environment
+        )
         verify_failed_update_preserves_command_runtime(
             pentect, root, home, project, environment
         )
@@ -1070,7 +1189,7 @@ def run_plugin_lifecycle(pentect: str) -> None:
         verify_home_rooted_project_storage_boundary(pentect)
         print(
             "installed plugin lifecycle E2E passed: inspect, test, project/user "
-            "add/setup/update/reinstall/remove, failed/interrupted-setup and failed-update rollback, "
+            "add/setup/update/reinstall/remove, failed/interrupted/forced-setup and failed-update rollback, "
             "Command runtime concurrency/restart, long-running serialized setup completion, "
             "Command fail-closed boundaries and process cleanup, installed Wasm trap/timeout/"
             "malformed/oversized required/optional boundaries, HOME-rooted optional/required "

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -17,6 +17,21 @@ drift is visible before the next release.
 | ChatGPT desktop app, Codex mode | Executable launch contract and Responses protocol tests, including computer-use screenshots | `pentect codex app` |
 | Claude Desktop | Protocol tests; Windows current-user trust-store launch path awaiting real-account release verification | `pentect claude app` with explicit certificate confirmation |
 
+Release pins are separate from the daily current-client monitor. The latest
+successful monitor on 2026-09-03 exercised the published Pentect binary on
+Windows, macOS, and Linux:
+
+| Client | Current-client evidence | Installed handle path |
+| --- | --- | --- |
+| Codex CLI `0.153.0` | Passed on all three platforms | OpenAI Responses, local shell tool arguments, cancellation recovery, and image redaction |
+| Claude Code `2.1.259` | Passed on all three platforms | Anthropic Messages and local Bash tool arguments |
+| OpenCode `1.18.27` | Passed on all three platforms | Configured OpenAI Chat and local tool arguments |
+| Pi `0.84.4` | Passed on all three platforms | Configured OpenAI Chat and local Bash tool arguments |
+
+These are compatibility observations, not retroactive changes to a release's
+pinned gate. The installed test uses real client binaries and a localhost
+provider fixture; it does not make a paid provider request.
+
 ## Not implemented
 
 These clients have status pages, but no public launcher in the current
@@ -45,6 +60,8 @@ links, broken data, custom gateway paths, and Codex zstd-compressed requests.
 | --- | --- | --- |
 | `pentect codex` | OpenAI Responses | Includes streaming events and completed tool calls |
 | `pentect claude` | Anthropic Messages | Includes streaming content blocks and tool use |
+| `pentect opencode` | Selected OpenAI Responses, OpenAI Chat, or Anthropic Messages adapter | The current installed-client E2E uses OpenAI Chat; unrelated OpenCode providers are not implied |
+| `pentect pi` | Selected OpenAI Responses, OpenAI Chat, or Anthropic Messages adapter | The current installed-client E2E uses OpenAI Chat; other Pi API adapters are not implied |
 | `pentect codex app` | Responses routes used by supported Codex mode, including documented `computer_call_output` screenshots | Other ChatGPT modes are outside this claim |
 | `pentect claude app` | Supported Claude Chat and attachment routes on a compatible app build | Claude Code should use `pentect claude`; Cowork and Voice are outside this claim |
 
@@ -110,9 +127,14 @@ not acceptable.
 ## Not covered
 
 - ChatGPT Chat, Work, and Voice routes outside supported Codex mode
+- Codex cloud tasks and the Codex Remote control channel; a Remote task is
+  covered only if its connected-computer worker actually uses a separately
+  verified local Pentect path
 - Remote Claude Cowork execution; Claude Voice content is not inspected (the
   exact Voice WebSocket can only be relayed after the user enables unknown
   format pass-through)
+- Independent web-search, hosted-tool, browser, and MCP connections that do
+  not pass through a listed provider contract
 - Copilot, VS Code inline suggestions, and private traffic from other extensions
 - Test binary formats
 - Unknown future routes


### PR DESCRIPTION
## Summary
- supervise plugin setup processes so child trees exit when the owning Pentect process is killed
- defer local command lock persistence until setup succeeds
- cover SIGKILL rollback, supervisor cleanup, immediate reinstall, and Wasm failure boundaries in installed E2E
- refresh release-pin and current-client compatibility documentation

## Validation
- `cargo fmt --all --check`
- `cargo test -p pentect-cli plugins_cmd` (36 passed)
- full installed plugin lifecycle E2E including forced termination and Wasm boundaries
- `python3 -m py_compile tools/installed_agent_e2e.py`
- `npm --prefix website run check` (42 pages, 114 links)
- `git diff --check`

Closes #1339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin setup cleanup when the main process is interrupted or exits unexpectedly.
  - Prevented incomplete plugin setup from leaving behind persistent state or enabling the plugin.
  - Improved cleanup of setup processes across supported platforms.

- **Documentation**
  - Updated compatibility information with current client monitoring results and expanded provider coverage details.
  - Clarified compatibility observations and documented additional integrations outside listed provider contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->