### PR TITLE
Release v0.0.72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.71"
+version = "0.0.72"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.71"
+version = "0.0.72"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump Pentect CLI and npm package versions to 0.0.72
- update the Cargo lockfile version

## Validation
- `cargo fmt --all --check`
- `cargo check --locked -p pentect-cli`
- release package metadata tests and checks
- Cargo/npm version agreement