### PR TITLE
Make version reporting side-effect free

### DIFF
--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -243,6 +243,13 @@ fn main() {
     if args.get(1).map(String::as_str) == Some("__plugin-setup-supervisor") {
         std::process::exit(plugins_cmd::cmd_setup_supervisor(&args));
     }
+    if matches!(
+        args.get(1).map(String::as_str),
+        Some("version" | "--version" | "-V")
+    ) {
+        update::cmd_version();
+        return;
+    }
     let surface = diagnostic_surface(&args);
     install_panic_logger(surface.clone());
     pentect_agent::record_process_activity(

--- a/crates/pentect-cli/tests/persistent_log.rs
+++ b/crates/pentect-cli/tests/persistent_log.rs
@@ -26,13 +26,13 @@ fn process_lifecycle_is_persisted_without_arguments_or_environment() {
     let root = temp_root("persistent-log");
     let secret = "sk-pentect-persistent-log-secret";
     let output = Command::new(env!("CARGO_BIN_EXE_pentect"))
-        .arg("version")
+        .arg("not-a-command")
         .arg(secret)
         .env("PENTECT_LOG_DIR", &root)
         .env("PENTECT_TEST_SECRET", secret)
         .output()
         .unwrap();
-    assert!(output.status.success(), "{output:?}");
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
 
     let path = root.join("pentect.log");
     let raw = std::fs::read_to_string(&path).unwrap();
@@ -41,10 +41,32 @@ fn process_lifecycle_is_persisted_without_arguments_or_environment() {
     assert_eq!(events.len(), 2);
     assert_eq!(events[0]["event"], "started");
     assert_eq!(events[1]["event"], "finished");
-    assert_eq!(events[1]["exit_code"], 0);
+    assert_eq!(events[1]["exit_code"], 2);
     assert_eq!(events[1]["version"], env!("CARGO_PKG_VERSION"));
-    assert!(events.iter().all(|event| event["surface"] == "version"));
+    assert!(events.iter().all(|event| event["surface"] == "unknown"));
     let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn version_forms_do_not_initialize_persistent_logging() {
+    for form in ["version", "--version", "-V"] {
+        let root = temp_root("version-fast-path");
+        let output = Command::new(env!("CARGO_BIN_EXE_pentect"))
+            .arg(form)
+            .env("PENTECT_LOG_DIR", &root)
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{form}: {output:?}");
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            format!("pentect {}\n", env!("CARGO_PKG_VERSION"))
+        );
+        assert!(
+            !root.exists(),
+            "{form} initialized persistent logging at {}",
+            root.display()
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- dispatch `version`, `--version`, and `-V` before diagnostics and activity logging initialize
- preserve lifecycle logging coverage with an ordinary failing command
- verify version forms do not create or touch persistent log state

## Performance
- local built binary: 50 `--version` invocations in 0.247 seconds (~4.9 ms each), including with an unwritable `PENTECT_LOG_DIR`

## Validation
- `cargo fmt --all --check`
- `cargo test -p pentect-cli --test persistent_log`
- `cargo test -p pentect-cli --test help`
- `cargo clippy -p pentect-cli --all-targets -- -D warnings`
- `git diff --check`

Closes #1383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying the application version with `version`, `--version`, and `-V`.
  * Version checks now complete successfully without initializing persistent activity logging.

* **Bug Fixes**
  * Improved process lifecycle reporting for unrecognized commands, including the correct exit status and unknown command surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->