### PR TITLE
Focus official support on four coding clients

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,6 +4,12 @@ Pentect validates its HTTP gateways against provider-shaped mock servers in
 the Rust test suite. Every release also launches these exact public CLI builds
 through the release binary:
 
+The current official coding-client scope is four clients: **Codex CLI, Claude
+Code, OpenCode, and Pi**. Pentect is concentrating compatibility work on these
+four rather than adding more client launchers. Desktop rows below are separate
+surfaces within the Codex and Claude client families, not additional core
+clients.
+
 | Client | Release gate | Protected mode |
 | --- | --- | --- |
 | Codex CLI `0.149.0` | real launch on Linux and all installer platforms | `pentect codex` |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@
 Pentect is a local security boundary between supported AI clients and their
 providers. Start with the [documentation](https://pentect.dev/).
 
+Pentect currently focuses official client support on four AI coding clients:
+**Codex CLI, Claude Code, OpenCode, and Pi**. Supported Codex App and Claude
+Desktop routes are documented separately as desktop surfaces of those client
+families; additional client integrations are outside the current support scope.
+
 ## Repository guides
 
 - [Compatibility](COMPATIBILITY.md)

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -23,6 +23,9 @@ aside: false
 
 ## Clients
 
+Pentect currently focuses official support on four AI coding clients: Codex
+CLI, Claude Code, OpenCode, and Pi.
+
 <DocsGrid class="is-compact">
   <a href="/clients/codex/" class="docs-grid__item">
     <small>CLI + Desktop</small><strong>Codex</strong>

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -8,6 +8,12 @@ installs and starts every public client launcher with the release binary. A
 daily workflow installs current upstream client versions so compatibility
 drift is visible before the next release.
 
+Pentect currently supports four core AI coding clients: **Codex CLI, Claude
+Code, OpenCode, and Pi**. Compatibility work is focused on these four rather
+than on adding more client launchers. Codex App and Claude Desktop entries are
+separate desktop surfaces within those client families, not additional core
+clients.
+
 | Client | Test | Protected launch |
 | --- | --- | --- |
 | Codex CLI `0.149.0` | Real launch on Linux and all installer platforms | `pentect codex` |

--- a/website/src/content/docs/start/what-is-pentect.md
+++ b/website/src/content/docs/start/what-is-pentect.md
@@ -59,9 +59,11 @@ process arguments, or debuggers. The protected boundary is provider traffic.
 
 ## Supported surfaces
 
-Pentect supports Codex, Claude, OpenCode, and Pi, plus supported Codex App and
-Claude Desktop routes. It also offers local masking commands, custom gateways,
-and safe plugins.
+Pentect currently supports four core AI coding clients: Codex CLI, Claude Code,
+OpenCode, and Pi. Compatibility work is focused on these four rather than on
+adding more client launchers. Supported Codex App and Claude Desktop routes are
+separate surfaces within the same client families. Pentect also offers local
+masking commands, custom gateways, and safe plugins.
 
 Antigravity, Aider, Continue, Cline, Roo Code, Zed, Goose, Junie, and Gemini
 CLI are documented as [not implemented](/reference/compatibility/#not-implemented).


### PR DESCRIPTION
## Summary
- state that Codex CLI, Claude Code, OpenCode, and Pi are the four core supported clients
- make compatibility depth for those four the current priority over adding launchers
- clarify that Codex App and Claude Desktop are surfaces in existing client families

## Validation
- `npm --prefix website run check`
- `git diff --check`