### PR TITLE
test: isolate project discovery and lifecycle log fixtures

### DIFF
--- a/crates/pentect-cli/tests/persistent_log.rs
+++ b/crates/pentect-cli/tests/persistent_log.rs
@@ -13,6 +13,24 @@ fn temp_root(label: &str) -> PathBuf {
     ))
 }
 
+struct TestDirectory {
+    path: PathBuf,
+}
+
+impl TestDirectory {
+    fn new(label: &str) -> Self {
+        let path = temp_root(label);
+        std::fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 fn events(path: &std::path::Path) -> Vec<Value> {
     std::fs::read_to_string(path)
         .unwrap()
@@ -23,11 +41,24 @@ fn events(path: &std::path::Path) -> Vec<Value> {
 
 #[test]
 fn process_lifecycle_is_persisted_without_arguments_or_environment() {
-    let root = temp_root("persistent-log");
+    let fixture = TestDirectory::new("persistent-log");
+    let root = fixture.path.join("log");
+    let home = fixture.path.join("home");
+    let project = fixture.path.join("project");
+    std::fs::create_dir_all(home.join(".pentect")).unwrap();
+    std::fs::create_dir_all(project.join(".git")).unwrap();
+    std::fs::write(
+        home.join(".pentect/config.toml"),
+        "[update]\ncheck = false\n",
+    )
+    .unwrap();
     let secret = "sk-pentect-persistent-log-secret";
     let output = Command::new(env!("CARGO_BIN_EXE_pentect"))
         .arg("not-a-command")
         .arg(secret)
+        .current_dir(&project)
+        .env("HOME", &home)
+        .env_remove("USERPROFILE")
         .env("PENTECT_LOG_DIR", &root)
         .env("PENTECT_TEST_SECRET", secret)
         .output()
@@ -44,7 +75,6 @@ fn process_lifecycle_is_persisted_without_arguments_or_environment() {
     assert_eq!(events[1]["exit_code"], 2);
     assert_eq!(events[1]["version"], env!("CARGO_PKG_VERSION"));
     assert!(events.iter().all(|event| event["surface"] == "unknown"));
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]

--- a/crates/pentect-cli/tests/plugin_scope.rs
+++ b/crates/pentect-cli/tests/plugin_scope.rs
@@ -11,6 +11,28 @@ fn temp_dir(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!("pentect-{name}-{}-{nonce}", std::process::id()))
 }
 
+struct TestDirectory {
+    path: PathBuf,
+}
+
+impl TestDirectory {
+    fn new(name: &str) -> Self {
+        let path = temp_dir(name);
+        std::fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 fn command(home: &Path, cwd: &Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
     command
@@ -61,7 +83,9 @@ fn write_manifest(root: &Path, name: &str, label: &str, pattern: &str) {
 
 #[test]
 fn plugins_are_user_global_by_default_and_project_scope_is_explicit() {
-    let root = temp_dir("plugin-scope");
+    let fixture = TestDirectory::new("plugin-scope");
+    std::fs::create_dir_all(fixture.path().join(".git")).unwrap();
+    let root = fixture.path().join("fixture");
     let home = root.join("home");
     let first_project = root.join("first-project");
     let second_project = root.join("second-project");
@@ -70,6 +94,8 @@ fn plugins_are_user_global_by_default_and_project_scope_is_explicit() {
     for path in [&home, &first_project, &second_project] {
         std::fs::create_dir_all(path).unwrap();
     }
+    std::fs::create_dir_all(first_project.join(".git")).unwrap();
+    std::fs::create_dir_all(second_project.join(".git")).unwrap();
     write_manifest(
         &global_plugin,
         "global-test",
@@ -127,8 +153,7 @@ fn plugins_are_user_global_by_default_and_project_scope_is_explicit() {
     assert!(inside_nested.contains("<<GLOBAL_TEST_"), "{inside_nested}");
     assert!(inside_nested.contains("<<PROJECT_TEST_"), "{inside_nested}");
     assert!(!nested.join(".pentect/config.toml").exists());
-
-    std::fs::remove_dir_all(root).unwrap();
+    assert!(!fixture.path().join(".pentect").exists());
 }
 
 #[test]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -3746,8 +3746,12 @@ fn pretool_rewrites_direct_read_tool_to_masked_copy() {
 
 #[test]
 fn pretool_rewrites_secret_read_many_paths_to_masked_copies() {
-    let (root, session) = empty_session("hook-pre-read-many-secret");
-    let project = temp_root("pentect-read-many-secret");
+    let session_fixture = TestDirectory::new("hook-pre-read-many-secret-session");
+    let session = Session::open_at(session_fixture.path(), "t").unwrap();
+    let fixture = TestDirectory::new("pentect-read-many-secret");
+    std::fs::create_dir_all(fixture.path().join(".pentect")).unwrap();
+    let project = fixture.path().join("project");
+    std::fs::create_dir_all(project.join(".git")).unwrap();
     let result = {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _cwd = enter_temp_cwd(&project);
@@ -3785,8 +3789,7 @@ fn pretool_rewrites_secret_read_many_paths_to_masked_copies() {
     };
     assert!(result.contains("<<RUNPOD_API_KEY_"), "{result}");
     assert!(!result.contains("rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef"));
-    let _ = std::fs::remove_dir_all(project);
-    let _ = std::fs::remove_dir_all(root);
+    assert_directory_empty(&fixture.path().join(".pentect"));
 }
 
 #[test]
@@ -3834,10 +3837,12 @@ fn masked_read_copy_path_mirrors_relative_paths() {
 #[test]
 fn masked_read_copy_paths_do_not_collide_for_external_same_basename() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
-    let root = temp_root("masked-read-external-collision");
+    let fixture = TestDirectory::new("masked-read-external-collision");
+    std::fs::create_dir_all(fixture.path().join(".pentect")).unwrap();
+    let root = fixture.path();
     let project = root.join("project");
     let external = root.join("external");
-    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(project.join(".git")).unwrap();
     std::fs::create_dir_all(external.join("one")).unwrap();
     std::fs::create_dir_all(external.join("two")).unwrap();
     let first = external.join("one").join(".env");
@@ -3872,7 +3877,7 @@ fn masked_read_copy_paths_do_not_collide_for_external_same_basename() {
     let second_text = std::fs::read_to_string(&second_masked).unwrap();
     assert!(first_text.contains("<<RUNPOD_API_KEY_"), "{first_text}");
     assert!(second_text.contains("<<OPENAI_API_KEY_"), "{second_text}");
-    let _ = std::fs::remove_dir_all(root);
+    assert_directory_empty(&root.join(".pentect"));
 }
 
 #[test]
@@ -4433,6 +4438,36 @@ fn temp_root(name: &str) -> PathBuf {
         std::process::id(),
         unix_millis()
     ))
+}
+
+struct TestDirectory {
+    path: PathBuf,
+}
+
+impl TestDirectory {
+    fn new(name: &str) -> Self {
+        let path = temp_root(name);
+        std::fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn assert_directory_empty(path: &Path) {
+    assert!(
+        std::fs::read_dir(path).unwrap().next().is_none(),
+        "hostile ancestor was modified: {}",
+        path.display()
+    );
 }
 
 fn write_project_config(root: &Path, config: &str) {


### PR DESCRIPTION
Test fixtures could select an unrelated ancestor project and write masked copies or plugin configuration outside their intended root. Give the affected fixtures explicit project boundaries and owned cleanup guards, and exercise deliberately hostile ancestors inside disposable directories.

Also isolate the lifecycle-log test from startup update checks: an asynchronous update diagnostic made the existing main CI expect two events but observe three. Keep the exact lifecycle assertions.

Fixes #1391.

Validation: focused runtime, plugin-scope and persistent-log tests, formatting, and required CI checks. Production project discovery is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for persistent logs and plugin scoping across user and project contexts.
  * Added validation that project detection works correctly when project markers are present.
  * Strengthened checks for temporary-directory cleanup and protection against modifying unrelated ancestor directories.
  * Updated test isolation to ensure temporary files and directories are removed reliably after test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->