### PR TITLE
fix: align dry-run route validation and Claude support documentation

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -86,9 +86,14 @@ or unsupported attachment formats are blocked by default.
 
 Codex Responses-compatible, OpenAI Chat Completions-compatible, and Anthropic Messages-compatible upstreams can be
 selected with `--upstream URL`. Existing Codex provider configuration and
-Claude's managed/user endpoint configuration are preserved as the upstream
-when Pentect inserts its local gateway. Unsupported wire protocols are rejected
-before launch.
+Claude user endpoint configuration are preserved as the upstream when Pentect
+inserts its local gateway. Claude supports the Anthropic Messages HTTP route
+with normal Anthropic authentication and gateways implementing that contract.
+Claude Code's Bedrock, Vertex AI, Foundry, and Mantle transports are rejected
+before launch; they require separate authenticated transport designs. Managed
+policy/configuration remains compatible only when it does not select one of
+those transports, override the enforced route, or use a policy helper whose
+route cannot be verified.
 
 Bifrost's `/openai/v1` and `/anthropic` integration base paths are covered by
 the URL-routing tests. This verifies Pentect's protocol boundary and path

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -2935,7 +2935,7 @@ fn masker_scoped_resolver(
     })
 }
 
-fn parse_upstream_base(value: &str) -> Result<reqwest::Url, String> {
+pub(crate) fn parse_upstream_base(value: &str) -> Result<reqwest::Url, String> {
     crate::upstream::parse_base(value, "Anthropic Messages")
 }
 

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -1719,18 +1719,17 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
 
 fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
     let args = opts.tool_args.clone();
-    let caller_settings = ClaudeCallerSettings::from_args(&args)?;
+    let plan = ClaudeLaunchPlan::resolve(opts, &args)?;
     if opts.dry_run {
-        let args = caller_settings.gateway_args(&args, "<pentect-settings>");
+        let args = plan
+            .caller_settings
+            .gateway_args(&args, "<pentect-settings>");
         print_dry_run(&opts.command, &args);
+        println!(
+            "[pentect] route provider=anthropic-messages model=client-selected upstream=<pentect-upstream>"
+        );
         return Ok(success_status());
     }
-    reject_unsupported_claude_provider(&caller_settings)?;
-    preflight_managed_claude_routing()?;
-    let upstream = claude_effective_upstream(opts, &caller_settings)?;
-    let enable_tool_search = is_official_anthropic_upstream(&upstream)
-        && caller_settings.env_string("ENABLE_TOOL_SEARCH")?.is_none()
-        && std::env::var_os("ENABLE_TOOL_SEARCH").is_none();
 
     let active_plugins = agent_tool_plugins(opts)?;
     let memory_store = start_memory_store(pentect)?;
@@ -1742,7 +1741,7 @@ fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::Exit
     apply_pentect_env(&mut cmd, pentect, Some(memory_store.token.as_str()))?;
     apply_memory_store_env(&mut cmd, Some(&memory_store));
     let http_proxy = claude_http_proxy::ClaudeHttpProxyGuard::start_with_header_env(
-        upstream,
+        plan.upstream,
         &opts.upstream_header_env,
     )?;
     cmd.env("ANTHROPIC_BASE_URL", http_proxy.base_url());
@@ -1751,7 +1750,8 @@ fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::Exit
     // existing --settings payload. The provider-managed-host switch is not
     // used here because it also disables normal Claude subscription auth.
     let gateway_settings =
-        caller_settings.with_gateway(&args, http_proxy.base_url(), enable_tool_search)?;
+        plan.caller_settings
+            .with_gateway(&args, http_proxy.base_url(), plan.enable_tool_search)?;
     cmd.args(gateway_settings.args());
     run_native_command_with_guards(cmd, &opts.command, (http_proxy, gateway_settings))
 }
@@ -1845,6 +1845,35 @@ const CLAUDE_CLOUD_PROVIDER_FLAGS: &[&str] = &[
     "CLAUDE_CODE_USE_FOUNDRY",
     "CLAUDE_CODE_USE_MANTLE",
 ];
+
+#[derive(Debug)]
+struct ClaudeLaunchPlan {
+    caller_settings: ClaudeCallerSettings,
+    upstream: String,
+    enable_tool_search: bool,
+}
+
+impl ClaudeLaunchPlan {
+    /// Resolve every route input without starting listeners, writing generated
+    /// settings, or contacting a provider. Dry-run and launch share this exact
+    /// validation boundary.
+    fn resolve(opts: &AgentToolOpts, args: &[String]) -> Result<Self, String> {
+        let caller_settings = ClaudeCallerSettings::from_args(args)?;
+        reject_unsupported_claude_provider(&caller_settings)?;
+        preflight_managed_claude_routing()?;
+        let upstream = claude_effective_upstream(opts, &caller_settings)?;
+        claude_http_proxy::parse_upstream_base(&upstream)?;
+        upstream::header_overrides(&opts.upstream_header_env)?;
+        let enable_tool_search = is_official_anthropic_upstream(&upstream)
+            && caller_settings.env_string("ENABLE_TOOL_SEARCH")?.is_none()
+            && std::env::var_os("ENABLE_TOOL_SEARCH").is_none();
+        Ok(Self {
+            caller_settings,
+            upstream,
+            enable_tool_search,
+        })
+    }
+}
 
 #[derive(Debug)]
 struct ClaudeCallerSettings {
@@ -4351,6 +4380,37 @@ mod tests {
                 "--model=claude-test".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn claude_managed_policy_route_rejections_match_documentation() {
+        for name in CLAUDE_CLOUD_PROVIDER_FLAGS {
+            let mut settings = serde_json::json!({"env": {}});
+            settings["env"][*name] = serde_json::Value::String("1".to_string());
+            assert!(reject_managed_routing_value(&settings)
+                .unwrap_err()
+                .contains(name));
+        }
+        assert!(reject_managed_routing_value(&serde_json::json!({
+            "env": {"ANTHROPIC_BASE_URL": "https://managed.invalid"}
+        }))
+        .is_err());
+        assert!(
+            reject_managed_routing_value(&serde_json::json!({"policyHelper": "helper"})).is_err()
+        );
+
+        let client_docs = include_str!("../../../website/src/content/docs/clients/claude.md");
+        let compatibility = include_str!("../../../COMPATIBILITY.md");
+        for transport in ["Bedrock", "Vertex", "Foundry", "Mantle"] {
+            assert!(
+                client_docs.contains(transport),
+                "missing {transport} client docs"
+            );
+            assert!(
+                compatibility.contains(transport),
+                "missing {transport} compatibility docs"
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -287,8 +287,15 @@ fn run_opencode(
     }
 
     let api = ClientApi::parse(opts.api.as_deref())?;
+    let route = OpenCodeRoute::resolve(opts)?;
+    validate_opencode_route(&route, &opts.upstream_header_env)?;
     if opts.dry_run {
         crate::print_dry_run(&opts.command, &opts.tool_args);
+        println!(
+            "[pentect] route provider={} model={} upstream=<pentect-upstream>",
+            route.provider,
+            route.model.as_deref().unwrap_or("<picker>")
+        );
         return Ok(crate::success_status());
     }
 
@@ -299,7 +306,6 @@ fn run_opencode(
         return run_opencode_picker(opts, pentect, &active_plugins, memory_store);
     }
 
-    let route = OpenCodeRoute::resolve(opts)?;
     let (proxy, header_env, child_key_env) =
         start_opencode_proxy(&route, &opts.upstream_header_env)?;
     let package = opts.upstream.as_ref().map(|_| api.opencode_package());
@@ -316,6 +322,26 @@ fn run_opencode(
     command.env("OPENCODE_CONFIG_CONTENT", config);
     command.args(&opts.tool_args);
     crate::run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
+}
+
+fn validate_opencode_route(
+    route: &OpenCodeRoute,
+    base_header_env: &[String],
+) -> Result<(), String> {
+    match route.protocol {
+        OpenCodeProtocol::OpenAi => {
+            crate::openai_http_proxy::parse_upstream_base(&route.upstream)?;
+        }
+        OpenCodeProtocol::Anthropic => {
+            crate::claude_http_proxy::parse_upstream_base(&route.upstream)?;
+        }
+        OpenCodeProtocol::Gemini => {
+            crate::upstream::parse_base(&route.upstream, "Gemini")?;
+        }
+    }
+    let (header_env, bearer_env, _) = opencode_proxy_auth(route, base_header_env);
+    crate::upstream::header_overrides_with_bearer_env(&header_env, bearer_env)?;
+    Ok(())
 }
 
 fn start_opencode_proxy(

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -3609,7 +3609,7 @@ fn authenticated_request_path<'a>(path_and_query: &'a str, token: &str) -> Optio
     }
 }
 
-fn parse_upstream_base(value: &str) -> Result<reqwest::Url, String> {
+pub(crate) fn parse_upstream_base(value: &str) -> Result<reqwest::Url, String> {
     crate::upstream::parse_base(value, "OpenAI Responses")
 }
 

--- a/crates/pentect-cli/tests/process_host.rs
+++ b/crates/pentect-cli/tests/process_host.rs
@@ -99,6 +99,140 @@ fn claude_dry_run_shows_the_generated_gateway_settings() {
 }
 
 #[test]
+fn claude_dry_run_rejects_every_managed_cloud_transport() {
+    for name in [
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_USE_MANTLE",
+    ] {
+        let root = test_root();
+        std::fs::create_dir_all(&root).unwrap();
+        let _cleanup = Cleanup {
+            root: root.clone(),
+            host_pid: None,
+            command_pids: Vec::new(),
+        };
+        let mut command = isolated_command(&root, &["claude", "--dry-run", "--version"]);
+        for other in [
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_CODE_USE_VERTEX",
+            "CLAUDE_CODE_USE_FOUNDRY",
+            "CLAUDE_CODE_USE_MANTLE",
+        ] {
+            command.env_remove(other);
+        }
+        let output = command.env(name, "1").output().unwrap();
+        assert_eq!(output.status.code(), Some(2), "{name}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(name),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn opencode_dry_run_validates_and_displays_split_and_assignment_models() {
+    for model_args in [
+        vec!["--model", "unsupported/model"],
+        vec!["--model=unsupported/model"],
+    ] {
+        let root = test_root();
+        let mut args = vec!["opencode", "--dry-run"];
+        args.extend(model_args);
+        args.push("--version");
+        let output = isolated_command(&root, &args).output().unwrap();
+        let _ = std::fs::remove_dir_all(&root);
+        assert_eq!(output.status.code(), Some(2));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("not routed yet"));
+    }
+
+    let root = test_root();
+    let output = isolated_command(
+        &root,
+        &[
+            "opencode",
+            "--dry-run",
+            "--model=openrouter/anthropic/claude-sonnet",
+            "--version",
+        ],
+    )
+    .output()
+    .unwrap();
+    let _ = std::fs::remove_dir_all(&root);
+    assert!(output.status.success());
+    let rendered = String::from_utf8_lossy(&output.stdout);
+    assert!(rendered.contains("provider=openrouter"), "{rendered}");
+    assert!(
+        rendered.contains("model=openrouter/anthropic/claude-sonnet"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("upstream=<pentect-upstream>"),
+        "{rendered}"
+    );
+    assert!(!rendered.contains("https://openrouter.ai"), "{rendered}");
+}
+
+#[test]
+fn claude_and_opencode_dry_run_reject_invalid_upstreams_in_both_argument_forms() {
+    for (client, upstream_args) in [
+        ("claude", vec!["--upstream", "file:///tmp/not-http"]),
+        ("claude", vec!["--upstream=file:///tmp/not-http"]),
+        ("opencode", vec!["--upstream", "https://"]),
+        ("opencode", vec!["--upstream=https://"]),
+    ] {
+        let root = test_root();
+        let mut args = vec![client, "--dry-run"];
+        args.extend(upstream_args);
+        args.push("--version");
+        let output = isolated_command(&root, &args).output().unwrap();
+        let _ = std::fs::remove_dir_all(&root);
+        assert_eq!(output.status.code(), Some(2), "{client}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("upstream"),
+            "{client}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+fn isolated_command(root: &Path, args: &[&str]) -> Command {
+    std::fs::create_dir_all(root.join(".git")).unwrap();
+    std::fs::create_dir_all(root.join(".pentect")).unwrap();
+    std::fs::write(
+        root.join(".pentect/config.toml"),
+        "[update]\ncheck = false\n",
+    )
+    .unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+    command
+        .args(args)
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("HOME", root)
+        .env("USERPROFILE", root)
+        .env("APPDATA", root)
+        .env("PROGRAMDATA", root)
+        .env("CLAUDE_CONFIG_DIR", root.join("claude"));
+    for name in PRIVATE_ENV.iter().chain(
+        [
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_CODE_USE_VERTEX",
+            "CLAUDE_CODE_USE_FOUNDRY",
+            "CLAUDE_CODE_USE_MANTLE",
+        ]
+        .iter(),
+    ) {
+        command.env_remove(name);
+    }
+    command
+}
+
+#[test]
 fn log_hosts_while_running_but_help_does_not() {
     let root = test_root();
     std::fs::create_dir_all(&root).unwrap();

--- a/website/src/content/docs/clients/claude.md
+++ b/website/src/content/docs/clients/claude.md
@@ -21,8 +21,17 @@ pass through, and `app` opens Claude Desktop without changing the official app.
 Prerequisites:
 
 - Claude Code or Claude Desktop is already installed and starts normally.
-- The selected Anthropic or managed-provider login already works.
+- An Anthropic login/API key, or credentials for an Anthropic
+  Messages-compatible custom gateway, already works.
 - Run `pentect doctor` after installing or updating Claude.
+
+`pentect claude` does not currently route Claude Code's Bedrock, Vertex AI,
+Foundry, or Mantle transports. Pentect rejects those switches before launch.
+A centrally managed policy is supported when it leaves the Anthropic Messages
+route available; "managed policy" does not mean that managed cloud-provider
+transports are supported. If your organization requires one of those
+transports, use Claude Code without `pentect claude` and do not assume that the
+remote session passes through Pentect's local gateway.
 
 | Launch | Scope |
 | --- | --- |
@@ -94,6 +103,13 @@ pentect claude --upstream http://127.0.0.1:8080/anthropic
 The selected provider manages login and model routing. Pentect keeps the
 Anthropic Messages API format and protects supported requests, response events,
 and completed tool calls.
+
+Supported combinations are Anthropic's Messages endpoint with normal Claude
+login/API-key authentication, or a custom upstream that implements the same
+Messages and streaming contract with credentials supplied as described in the
+custom-upstream guide. Native Bedrock, Vertex AI, Foundry, and Mantle protocols
+are different transports and are rejected even when Claude Code can authenticate
+to them directly.
 
 An endpoint that accepts similar JSON but does not implement Anthropic Messages
 and its streaming events is not supported. Put a compatible adapter in front of


### PR DESCRIPTION
Claude and OpenCode dry-run now validate the same route inputs as real launch before creating gateway resources. Unsupported providers, invalid upstream URLs and header configuration fail during preflight; valid previews show sanitized route/model information.

Clarify that Claude's protected route supports Anthropic Messages and compatible gateways, while Bedrock, Vertex, Foundry and Mantle transports remain unsupported. Managed policy is distinct from managed-provider transport.

Fixes #1390. Fixes #1392.

Validation: 428 CLI unit tests, five isolated dry-run process regressions, documentation drift coverage, formatting and locked CLI compilation.
