### PR TITLE
feat: add bounded diagnostics and clarify expected fallback logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,6 @@ Values such as `<<API_KEY_ab12...>>` are opaque handles:
   surface and let the user choose a documented compatibility setting.
 - Do not assume that remote or cloud agents use the local Pentect gateway.
 
-Use `pentect doctor` to check the installation and `pentect log` for
-value-free diagnostics. Product support and limits are documented at
+Use `pentect doctor` to check the installation and `pentect log --once --tail
+100` for bounded, value-free diagnostics. Product support and limits are documented at
 https://pentect.dev/reference/compatibility/.

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -154,7 +154,7 @@ const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "log",
-        usage: "pentect log [--json | --path]",
+        usage: "pentect log [--json] [--once [--tail N] | --follow | --path]",
         summary: "Show persistent diagnostics and live protection events",
         audience: CommandAudience::Public,
     },
@@ -252,28 +252,51 @@ fn main() {
     }
     let surface = diagnostic_surface(&args);
     install_panic_logger(surface.clone());
-    pentect_agent::record_process_activity(
-        "started",
-        &surface,
-        env!("CARGO_PKG_VERSION"),
-        None,
-        None,
-        None,
-    );
+    let record_process = should_record_process_activity(&args);
+    if record_process {
+        pentect_agent::record_process_activity(
+            "started",
+            &surface,
+            env!("CARGO_PKG_VERSION"),
+            None,
+            None,
+            None,
+        );
+    }
     let code = catch_cli_exit(|| run(args));
     let exit_code = code.unwrap_or(0);
-    pentect_agent::record_process_activity(
-        "finished",
-        &surface,
-        env!("CARGO_PKG_VERSION"),
-        Some(exit_code),
-        None,
-        None,
-    );
-    pentect_agent::flush_activity_log();
+    if record_process {
+        pentect_agent::record_process_activity(
+            "finished",
+            &surface,
+            env!("CARGO_PKG_VERSION"),
+            Some(exit_code),
+            None,
+            None,
+        );
+        pentect_agent::flush_activity_log();
+    }
     if let Some(code) = code {
         std::process::exit(code);
     }
+}
+
+fn should_record_process_activity(args: &[String]) -> bool {
+    !is_bounded_log_request(args)
+}
+
+fn is_bounded_log_request(args: &[String]) -> bool {
+    let option_start = match (
+        args.get(1).map(String::as_str),
+        args.get(2).map(String::as_str),
+    ) {
+        (Some("log"), _) => 2,
+        (Some("agent"), Some("log")) => 3,
+        _ => return false,
+    };
+    args.iter()
+        .skip(option_start)
+        .any(|arg| arg == "--once" || arg == "--path")
 }
 
 fn diagnostic_surface(args: &[String]) -> String {
@@ -337,7 +360,9 @@ fn run(args: Vec<String>) -> Option<i32> {
     }
     let inherited_env_is_trusted =
         command_uses_agent_runtime(&args) && pentect_agent::active_memory_store_ready();
-    update::start_update_notification(&args);
+    if !is_bounded_log_request(&args) {
+        update::start_update_notification(&args);
+    }
     if is_memory_store_server(&args) || !supports_process_host(&args) {
         return dispatch(args, inherited_env_is_trusted);
     }
@@ -443,13 +468,7 @@ fn is_memory_store_server(args: &[String]) -> bool {
 /// One-shot inspection commands would only add startup cost and disappear
 /// before a useful handoff can occur.
 fn supports_process_host(args: &[String]) -> bool {
-    if matches!(
-        (
-            args.get(1).map(String::as_str),
-            args.get(2).map(String::as_str),
-        ),
-        (Some("log"), Some("--path"))
-    ) {
+    if is_bounded_log_request(args) {
         return false;
     }
     matches!(
@@ -717,7 +736,7 @@ fn cmd_agent_from(start: usize, args: &[String], inherited_env_is_trusted: bool)
             .unwrap_or_else(|| "pentect".to_string()),
     );
     agent_args.extend(forward_args);
-    let log_store = if agent_args.get(1).is_some_and(|arg| arg == "log") {
+    let log_store = if log_needs_memory_store(&agent_args) {
         let pentect = default_pentect_path();
         Some(start_memory_store(&pentect).unwrap_or_else(|e| die_with_issue(e)))
     } else {
@@ -744,6 +763,10 @@ fn cmd_agent_from(start: usize, args: &[String], inherited_env_is_trusted: bool)
     drop(log_store);
     drop(plugin_env);
     code
+}
+
+fn log_needs_memory_store(args: &[String]) -> bool {
+    args.get(1).is_some_and(|arg| arg == "log") && !is_bounded_log_request(args)
 }
 
 fn cmd_agent_tool(tool: &'static client_descriptor::ClientDescriptor, args: &[String]) -> i32 {
@@ -4091,6 +4114,15 @@ mod tests {
             "log".to_string(),
             "--path".to_string(),
         ]));
+        for args in [
+            vec!["pentect", "log", "--json", "--once"],
+            vec!["pentect", "agent", "log", "--once", "--tail", "5"],
+        ] {
+            let args = args.into_iter().map(str::to_string).collect::<Vec<_>>();
+            assert!(is_bounded_log_request(&args));
+            assert!(!supports_process_host(&args));
+            assert!(!should_record_process_activity(&args));
+        }
     }
 
     #[test]

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -155,7 +155,7 @@ const COMMANDS: &[CommandSpec] = &[
     CommandSpec {
         name: "log",
         usage: "pentect log [--json] [--once [--tail N] | --follow | --path]",
-        summary: "Show persistent diagnostics and live protection events",
+        summary: "Follow value-free events, or use --once for the latest 100 records (1-10000)",
         audience: CommandAudience::Public,
     },
     CommandSpec {

--- a/crates/pentect-cli/tests/log_once.rs
+++ b/crates/pentect-cli/tests/log_once.rs
@@ -1,0 +1,178 @@
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct Fixture {
+    root: PathBuf,
+}
+
+impl Fixture {
+    fn new(label: &str) -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-log-once-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let work = root.join("work");
+        std::fs::create_dir_all(work.join(".git")).unwrap();
+        std::fs::create_dir_all(work.join(".pentect")).unwrap();
+        std::fs::write(
+            work.join(".pentect/config.toml"),
+            "[update]\ncheck = false\n",
+        )
+        .unwrap();
+        Self { root }
+    }
+}
+
+impl std::ops::Deref for Fixture {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.root
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn event(index: usize) -> String {
+    json!({
+        "time": format!("2026-01-01T00:00:{index:02}Z"),
+        "action": "diagnostic",
+        "surface": "test",
+        "count": index
+    })
+    .to_string()
+}
+
+fn run(root: &Path, args: &[&str]) -> std::process::Output {
+    configured_command(root)
+        .arg("log")
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn run_agent_alias(root: &Path, args: &[&str]) -> std::process::Output {
+    configured_command(root)
+        .args(["agent", "log"])
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn configured_command(root: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+    command
+        .current_dir(root.join("work"))
+        .env("PENTECT_LOG_DIR", root.join("logs"))
+        .env_remove("PENTECT_HOME")
+        .env("HOME", root.join("home"))
+        .env("USERPROFILE", root.join("home"))
+        .env("LOCALAPPDATA", root.join("local"))
+        .env("XDG_RUNTIME_DIR", root.join("runtime"))
+        .env("XDG_CACHE_HOME", root.join("cache"))
+        .env("XDG_STATE_HOME", root.join("state"));
+    command
+}
+
+fn json_lines(output: &[u8]) -> Vec<Value> {
+    String::from_utf8(output.to_vec())
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+#[test]
+fn once_is_empty_and_does_not_start_a_process_host() {
+    for (label, command) in [
+        ("direct", run as fn(&Path, &[&str]) -> std::process::Output),
+        ("agent", run_agent_alias),
+    ] {
+        let root = Fixture::new(label);
+        let output = command(&root, &["--once", "--json"]);
+        assert!(output.status.success(), "{output:?}");
+        assert!(output.stdout.is_empty());
+        assert!(!root.join("runtime/pentect").exists());
+        assert!(!root.join("local/pentect").exists());
+        assert!(!root.join("logs").exists());
+    }
+}
+
+#[test]
+fn once_tails_large_and_rotated_logs_in_chronological_order() {
+    let root = Fixture::new("rotated");
+    let logs = root.join("logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    let rotated = (0..50_000).map(event).collect::<Vec<_>>().join("\n") + "\n";
+    let current = (50_000..50_005).map(event).collect::<Vec<_>>().join("\n") + "\n";
+    std::fs::write(logs.join("pentect.log.1"), rotated).unwrap();
+    std::fs::write(logs.join("pentect.log"), current).unwrap();
+
+    let output = run(&root, &["--json", "--once", "--tail", "7"]);
+    assert!(output.status.success(), "{output:?}");
+    let events = json_lines(&output.stdout);
+    assert_eq!(events.len(), 7);
+    assert_eq!(events[0]["count"], 49_998);
+    assert_eq!(events[6]["count"], 50_004);
+}
+
+#[test]
+fn once_ignores_an_incomplete_concurrent_append() {
+    let root = Fixture::new("partial");
+    let logs = root.join("logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    std::fs::write(
+        logs.join("pentect.log"),
+        format!("{}\n{}", event(1), r#"{"time":"incomplete""#),
+    )
+    .unwrap();
+
+    let output = run(&root, &["--once", "--json"]);
+    assert!(output.status.success(), "{output:?}");
+    let events = json_lines(&output.stdout);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["count"], 1);
+}
+
+#[test]
+fn log_rejects_invalid_limits_and_path_combinations() {
+    let root = Fixture::new("invalid");
+    for args in [
+        &["--once", "--tail", "0"][..],
+        &["--once", "--tail", "10001"][..],
+        &["--once", "--tail", "nope"][..],
+        &["--tail", "1"][..],
+        &["--path", "--once"][..],
+        &["--once", "--follow"][..],
+    ] {
+        let output = run(&root, args);
+        assert_eq!(output.status.code(), Some(2), "{args:?}: {output:?}");
+    }
+    let path = run(&root, &["--path"]);
+    assert!(path.status.success(), "{path:?}");
+    assert_eq!(
+        String::from_utf8(path.stdout).unwrap().trim(),
+        root.join("logs/pentect.log").display().to_string()
+    );
+}
+
+#[test]
+fn once_rejects_an_unbounded_unterminated_record() {
+    let root = Fixture::new("unterminated");
+    let logs = root.join("logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    std::fs::write(logs.join("pentect.log"), vec![b'x'; 1024 * 1024 + 1]).unwrap();
+
+    let output = run(&root, &["--once", "--json", "--tail", "1"]);
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("line limit"));
+}

--- a/crates/pentect-cli/tests/process_host.rs
+++ b/crates/pentect-cli/tests/process_host.rs
@@ -130,6 +130,47 @@ fn log_hosts_while_running_but_help_does_not() {
     assert!(!host_root(&help_root).join("runtime").exists());
 }
 
+#[test]
+fn human_log_marks_when_it_starts_following_live_events() {
+    let root = test_root();
+    std::fs::create_dir_all(&root).unwrap();
+    let mut cleanup = Cleanup {
+        root: root.clone(),
+        host_pid: None,
+        command_pids: Vec::new(),
+    };
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+    command
+        .arg("log")
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    for name in PRIVATE_ENV {
+        command.env_remove(name);
+    }
+    configure_runtime_root(&mut command, &root);
+    let mut log = command.spawn().unwrap();
+    cleanup.command_pids.push(log.id());
+    let stdout = log.stdout.take().unwrap();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if line.contains("following live events") {
+                let _ = sender.send(line);
+                return;
+            }
+        }
+    });
+
+    let indicator = receiver.recv_timeout(Duration::from_secs(10)).unwrap();
+    assert!(indicator.contains("Ctrl-C"), "{indicator}");
+    log.kill().unwrap();
+    log.wait().unwrap();
+    cleanup.command_pids.clear();
+    reader.join().unwrap();
+}
+
 fn spawn_command(root: &Path, args: &[&str]) -> std::process::Child {
     let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
     command

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -823,6 +823,118 @@ pub(crate) fn follow(json: bool) -> Result<(), String> {
     }
 }
 
+pub(crate) fn print_tail(json: bool, limit: usize) -> Result<(), String> {
+    let path = persistent_log_path();
+    let mut payloads = Vec::with_capacity(limit);
+    for generation in 0..=LOG_ROTATIONS {
+        if payloads.len() == limit {
+            break;
+        }
+        let path = if generation == 0 {
+            path.clone()
+        } else {
+            rotated_log_path(&path, generation)
+        };
+        let remaining = limit - payloads.len();
+        payloads.extend(read_lines_newest_first(&path, remaining)?);
+    }
+    payloads.reverse();
+
+    let stdout = std::io::stdout();
+    let mut output = stdout.lock();
+    for payload in payloads {
+        let event: ActivityEvent = serde_json::from_str(&payload)
+            .map_err(|error| format!("invalid persistent log event: {error}"))?;
+        if json {
+            writeln!(output, "{payload}")
+                .map_err(|error| format!("could not write persistent log: {error}"))?;
+        } else {
+            writeln!(output, "{}", format_event(&event))
+                .map_err(|error| format!("could not write persistent log: {error}"))?;
+        }
+    }
+    output
+        .flush()
+        .map_err(|error| format!("could not flush persistent log: {error}"))
+}
+
+fn read_lines_newest_first(path: &Path, limit: usize) -> Result<Vec<String>, String> {
+    const READ_CHUNK: usize = 16 * 1024;
+    const MAX_LINE_BYTES: usize = 1024 * 1024;
+    const MAX_SCAN_BYTES: u64 = LOG_MAX_BYTES;
+
+    let mut file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(format!("could not open persistent activity log: {error}")),
+    };
+    let mut position = file
+        .metadata()
+        .map_err(|error| format!("could not inspect persistent activity log: {error}"))?
+        .len();
+    if position == 0 || limit == 0 {
+        return Ok(Vec::new());
+    }
+    file.seek(SeekFrom::Start(position - 1))
+        .map_err(|error| format!("could not seek persistent activity log: {error}"))?;
+    let mut last = [0_u8; 1];
+    file.read_exact(&mut last)
+        .map_err(|error| format!("could not read persistent activity log: {error}"))?;
+    let mut skip_incomplete_tail = last[0] != b'\n';
+    let mut pending = Vec::new();
+    let mut lines = Vec::with_capacity(limit);
+    let mut scanned = 0_u64;
+
+    while position > 0 && lines.len() < limit {
+        let start = position.saturating_sub(READ_CHUNK as u64);
+        let length = (position - start) as usize;
+        scanned = scanned.saturating_add(length as u64);
+        if scanned > MAX_SCAN_BYTES {
+            return Err("persistent activity log tail exceeds the read limit".to_string());
+        }
+        file.seek(SeekFrom::Start(start))
+            .map_err(|error| format!("could not seek persistent activity log: {error}"))?;
+        let mut combined = vec![0_u8; length];
+        file.read_exact(&mut combined)
+            .map_err(|error| format!("could not read persistent activity log: {error}"))?;
+        combined.extend_from_slice(&pending);
+
+        let mut segments = combined.split(|byte| *byte == b'\n');
+        pending = segments.next().unwrap_or_default().to_vec();
+        if pending.len() > MAX_LINE_BYTES {
+            return Err("persistent activity log event exceeds the line limit".to_string());
+        }
+        let complete = segments.collect::<Vec<_>>();
+        for segment in complete.into_iter().rev() {
+            if skip_incomplete_tail {
+                skip_incomplete_tail = false;
+                continue;
+            }
+            if segment.is_empty() {
+                continue;
+            }
+            if segment.len() > MAX_LINE_BYTES {
+                return Err("persistent activity log event exceeds the line limit".to_string());
+            }
+            lines.push(
+                String::from_utf8(segment.to_vec())
+                    .map_err(|_| "persistent activity log is not valid UTF-8".to_string())?,
+            );
+            if lines.len() == limit {
+                break;
+            }
+        }
+        position = start;
+    }
+    if position == 0 && lines.len() < limit && !pending.is_empty() && !skip_incomplete_tail {
+        lines.push(
+            String::from_utf8(pending)
+                .map_err(|_| "persistent activity log is not valid UTF-8".to_string())?,
+        );
+    }
+    Ok(lines)
+}
+
 impl LifecycleSource {
     fn open() -> Self {
         Self::open_at(codex_lifecycle_log_path())

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -753,6 +753,7 @@ pub(crate) fn follow(json: bool) -> Result<(), String> {
     let mut lifecycle = LifecycleSource::open();
     let mut persistent = LifecycleSource::open_at(persistent_log_path());
     let mut seen = SeenActivity::default();
+    let mut following_announced = false;
 
     let stdout = std::io::stdout();
     let mut output = stdout.lock();
@@ -813,6 +814,12 @@ pub(crate) fn follow(json: bool) -> Result<(), String> {
                 source = activity_source()?;
                 continue;
             }
+        }
+        if !json && !following_announced {
+            writeln!(output, "-- following live events; press Ctrl-C to stop --")
+                .map_err(|error| format!("could not write activity log: {error}"))?;
+            following_announced = true;
+            wrote = true;
         }
         if wrote {
             output

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -886,7 +886,7 @@ fn usage() {
          pentect exec \"<command>\"\n\
          pentect view <HANDLE>\n\
          pentect resolve [PATH...]\n\
-         pentect log [--json | --path]\n\
+         pentect log [--json] [--once [--tail N] | --follow | --path]\n\
          pentect metrics [--json]\n\
          \n\
          exec: masked output\n\
@@ -898,15 +898,54 @@ fn usage() {
 }
 
 fn cmd_log(args: &[String]) -> i32 {
-    if args.get(2).map(String::as_str) == Some("--path") && args.len() == 3 {
+    const DEFAULT_TAIL: usize = 100;
+    const MAX_TAIL: usize = 10_000;
+
+    let mut json = false;
+    let mut once = false;
+    let mut follow = false;
+    let mut path = false;
+    let mut tail = None;
+    let mut index = 2;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" if !json => json = true,
+            "--once" if !once => once = true,
+            "--follow" if !follow => follow = true,
+            "--path" if !path => path = true,
+            "--tail" if tail.is_none() => {
+                index += 1;
+                let Some(raw) = args.get(index) else {
+                    return die("log --tail requires a record count");
+                };
+                tail = match raw.parse::<usize>() {
+                    Ok(value) if (1..=MAX_TAIL).contains(&value) => Some(value),
+                    _ => return die("log --tail must be between 1 and 10000"),
+                };
+            }
+            _ => return die("log [--json] [--once [--tail N] | --follow | --path]"),
+        }
+        index += 1;
+    }
+    if path {
+        if json || once || follow || tail.is_some() {
+            return die("log --path cannot be combined with other options");
+        }
         println!("{}", activity_log::persistent_log_path().display());
         return 0;
     }
-    let json = match args.get(2).map(String::as_str) {
-        None => false,
-        Some("--json") if args.len() == 3 => true,
-        _ => return die("log [--json | --path]"),
-    };
+    if once && follow {
+        return die("log --once and --follow cannot be combined");
+    }
+    if tail.is_some() && !once {
+        return die("log --tail requires --once");
+    }
+    if once {
+        return match activity_log::print_tail(json, tail.unwrap_or(DEFAULT_TAIL)) {
+            Ok(()) => 0,
+            Err(error) => die(&error),
+        };
+    }
     match activity_log::follow(json) {
         Ok(()) => 0,
         Err(error) => die(&error),

--- a/website/src/content/docs/reference/agents.md
+++ b/website/src/content/docs/reference/agents.md
@@ -15,8 +15,8 @@ the model. A handle looks like `<<API_KEY_ab12...>>`.
   let the user choose a documented compatibility setting.
 - Do not assume that a remote or cloud agent uses the local Pentect gateway.
 
-Use `pentect doctor` to check the installation and `pentect log` for
-diagnostics that do not contain secret values.
+Use `pentect doctor` to check the installation and `pentect log --once --tail
+100` for bounded diagnostics that do not contain secret values.
 
 The same instructions are available in the repository's
 [`AGENTS.md`](https://github.com/EdamAme-x/pentect/blob/main/AGENTS.md).

--- a/website/src/content/docs/reference/capabilities.md
+++ b/website/src/content/docs/reference/capabilities.md
@@ -85,7 +85,7 @@ unknown-handle behavior.
 | `pentect exec --live "COMMAND"` | Stream masked output while the command runs |
 | `pentect view HANDLE` | Show handle details without revealing the real value |
 | `pentect resolve [PATH...]` | Restore known handles from stdin or selected files |
-| `pentect log [--json \| --path]` | Show persistent diagnostics and follow protection events without secret values |
+| `pentect log [--json] [--once [--tail N] \| --follow \| --path]` | Show bounded persistent diagnostics or follow events without secret values |
 | `pentect metrics [--json]` | Show local value-free counts by secret type and protection surface |
 | `pentect doctor [--json]` | Check the installation and supported clients |
 | `pentect doctor --fix` | Offer repairable configuration changes |

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -89,7 +89,7 @@ pentect pi --model gpt-5
 | `pentect read PATH` | Print a masked preview of a file |
 | `pentect exec "COMMAND"` | Restore known handles, run the command, and mask its output |
 | `pentect view HANDLE` | Show handle details without revealing its value |
-| `pentect log [--json \| --path]` | Show persistent diagnostics and follow protection events |
+| `pentect log [--json] [--once [--tail N] \| --follow \| --path]` | Show bounded persistent diagnostics or follow protection events |
 | `pentect metrics [--json]` | Show local counts by secret type and protection surface |
 
 Image statistics distinguish blocked operations from blocked images: one tool

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -200,7 +200,11 @@ diagnostics to `~/.pentect/logs/pentect.log`. `pentect log` reads that history
 before following live events, `--once` prints a bounded snapshot and exits,
 `--tail` selects 1 to 10,000 records (`--once` defaults to 100), `--json` keeps
 the JSONL representation, and `--path` prints the exact file location. Use
-`--follow` to request the existing live-follow behavior explicitly. Panic entries include the Pentect
+`--follow` to request the existing live-follow behavior explicitly. A bounded
+read is best effort during concurrent writes or rotation; it can omit or repeat
+an event across files rather than claiming an atomic multi-file snapshot. Human
+follow output marks the transition to waiting for live events; JSONL contains
+events only. Panic entries include the Pentect
 version, OS, architecture, PID, source location, and a backtrace so a crash can
 be investigated after the process exits.
 

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -190,13 +190,17 @@ attach a request sample.
 ```sh
 pentect log
 pentect log --json
+pentect log --once --tail 100
+pentect log --json --once --tail 100
 pentect log --path
 ```
 
 Pentect persists process starts, exit codes, gateway activity, and panic
 diagnostics to `~/.pentect/logs/pentect.log`. `pentect log` reads that history
-before following live events, `--json` keeps the JSONL representation, and
-`--path` prints the exact file location. Panic entries include the Pentect
+before following live events, `--once` prints a bounded snapshot and exits,
+`--tail` selects 1 to 10,000 records (`--once` defaults to 100), `--json` keeps
+the JSONL representation, and `--path` prints the exact file location. Use
+`--follow` to request the existing live-follow behavior explicitly. Panic entries include the Pentect
 version, OS, architecture, PID, source location, and a backtrace so a crash can
 be investigated after the process exits.
 

--- a/website/src/content/docs/reference/troubleshooting.md
+++ b/website/src/content/docs/reference/troubleshooting.md
@@ -115,6 +115,21 @@ Pentect also uses this error for an unknown nested server-history shape, even in
 unknown-format compatibility mode. Pentect cannot safely rewrite or inspect an
 unrecognized provider-owned block while preserving resumable history.
 
+## Codex logs an initial HTTP 426 error
+
+With Codex CLI 0.153.0, an initial Responses WebSocket attempt can receive HTTP
+426 from Pentect and be logged by Codex as an error before Codex retries the
+same turn through protected HTTP/SSE. This negotiation message is expected when
+the retry succeeds. Pentect keeps Codex's built-in provider identity so saved
+threads remain resumable; that verified client version does not expose a
+working built-in-provider setting to suppress only the initial attempt.
+
+Do not ignore a failed `POST /responses`, a turn that never retries, or a final
+gateway error. Those indicate a genuine request failure and still need the
+normal diagnostics from `pentect doctor` and `pentect log --once --tail 100`.
+Future Codex versions may add a supported HTTP-only control, so check current
+Pentect compatibility guidance after upgrading.
+
 ## A plugin does not run
 
 ```sh

--- a/website/src/content/docs/start/commands.md
+++ b/website/src/content/docs/start/commands.md
@@ -106,9 +106,10 @@ when a command can consume a handle without creating a plaintext file.
 
 | Task | Command | Notes |
 | --- | --- | --- |
-| View persistent diagnostics | `pentect log` | Values, bodies, headers, and URLs are not logged |
+| View recent persistent diagnostics | `pentect log --once --tail 100` | Bounded output; values, bodies, headers, and URLs are not logged |
+| Follow diagnostics | `pentect log --follow` | Reads retained history, then waits for live events |
 | Locate the log file | `pentect log --path` | Prints the local path |
-| Machine-readable diagnostics | `pentect log --json` | Suitable for support tooling |
+| Machine-readable diagnostics | `pentect log --json --once --tail 100` | Bounded JSONL suitable for support tooling |
 | View local protection statistics | `pentect metrics` | Shows stable metric keys with readable names, occurrence counts, blocked restorations, bounded warning reasons, and plugin failures/timeouts; never shows values, handles, paths, URLs, plugin names, error text, or account identifiers |
 | Machine-readable statistics | `pentect metrics --json` | Local JSON; no telemetry is sent |
 | Check readiness | `pentect doctor` | Does not change configuration |
@@ -117,7 +118,7 @@ when a command can consume a handle without creating a plaintext file.
 | Update Pentect | `pentect update` | Uses the recorded package-manager scope when available |
 | Remove Pentect | `pentect uninstall` | Keeps project data |
 
-For failures, include the value-free reason shown by `pentect log --json` and
+For failures, include the value-free reason shown by `pentect log --json --once --tail 100` and
 follow [Troubleshooting](/reference/troubleshooting/). Installation-specific
 commands are documented in [Install](/start/install/), and the complete option
 list is in the [CLI reference](/reference/cli/).


### PR DESCRIPTION
Add `pentect log --once --tail N` for bounded diagnostics. The default one-shot limit is 100 records (accepted range 1–10000); tail reads work backward in chunks across retained rotations and enforce byte/record bounds. One-shot/path reads do not start a process host, perform update checks, or add their own lifecycle events.

Existing follow behavior remains available, with a human-only transition indicator. Agent and troubleshooting examples use the bounded form. JSON output remains JSONL.

Fixes #1393.

Also document the version-specific expected Codex 0.153.0 HTTP 426 fallback discussed in #1394. No speculative WebSocket configuration is added and #1394 remains open for an upstream-compatible transport control.

Validation: empty direct/agent-alias reads, rotated/large histories, incomplete append, malformed limits, --path interactions, oversized records, follow compatibility, formatting and CLI compilation.
