### PR TITLE
fix: supervise native client lifetimes (v0.0.76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,8 @@ jobs:
               - 'crates/pentect-cli/src/claude_unix_supervisor.rs'
               - 'crates/pentect-cli/src/claude_windows_supervisor.rs'
               - 'crates/pentect-cli/tests/native_interrupt.rs'
+              - 'crates/pentect-cli/tests/native_unix_supervisor.rs'
+              - 'crates/pentect-cli/tests/native_windows_supervisor.rs'
               - 'crates/pentect-cli/tests/*claude*.rs'
             runtime_log:
               - 'crates/pentect-runtime/src/activity_log.rs'
@@ -379,10 +381,13 @@ jobs:
       - name: Test Windows Claude supervisor
         if: needs.changes.outputs.claude_supervisor == 'true' && runner.os == 'Windows'
         run: cargo test -p pentect-cli --no-default-features --bin pentect claude_windows_supervisor::tests --locked
+      - name: Test Windows native supervisor
+        if: needs.changes.outputs.claude_supervisor == 'true' && runner.os == 'Windows'
+        run: cargo test -p pentect-cli --no-default-features --test native_windows_supervisor --locked
       - name: Test macOS Claude supervisor boundaries
         if: needs.changes.outputs.claude_supervisor == 'true' && runner.os == 'macOS'
         timeout-minutes: 5
-        run: cargo test -p pentect-cli --no-default-features --locked --test claude_guardian_boundary --test claude_unix_supervisor --test native_interrupt
+        run: cargo test -p pentect-cli --no-default-features --locked --test claude_guardian_boundary --test claude_unix_supervisor --test native_interrupt --test native_unix_supervisor
       - name: No app changes
         if: needs.changes.outputs.codex_app != 'true' && needs.changes.outputs.claude_app != 'true' && needs.changes.outputs.openai_proxy != 'true' && needs.changes.outputs.command_shims != 'true' && needs.changes.outputs.claude_supervisor != 'true'
         run: echo "No app changes"

--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -45,6 +45,7 @@ jobs:
               - 'crates/pentect-cli/src/*supervisor*.rs'
               - 'crates/pentect-cli/tests/client_store_isolation.rs'
               - 'crates/pentect-cli/tests/native_interrupt.rs'
+              - 'crates/pentect-cli/tests/native_linux_fallback.rs'
               - 'crates/pentect-cli/tests/native_unix_supervisor.rs'
               - 'crates/pentect-cli/tests/native_windows_supervisor.rs'
               - 'crates/pentect-cli/tests/*claude*.rs'
@@ -176,6 +177,10 @@ jobs:
           --test claude_unix_supervisor
           --test claude_guardian_boundary
           --test claude_guardian_loss
+      - name: Test Linux native supervisor compatibility fallback (PR)
+        if: github.event_name == 'pull_request' && runner.os == 'Linux'
+        timeout-minutes: 2
+        run: cargo test -p pentect-cli --locked --test native_linux_fallback
       - name: Install current portable clients
         run: python tools/install_portable_client_smoke.py --mode latest
       - name: Start all current portable clients

--- a/.github/workflows/current-clients.yml
+++ b/.github/workflows/current-clients.yml
@@ -45,6 +45,8 @@ jobs:
               - 'crates/pentect-cli/src/*supervisor*.rs'
               - 'crates/pentect-cli/tests/client_store_isolation.rs'
               - 'crates/pentect-cli/tests/native_interrupt.rs'
+              - 'crates/pentect-cli/tests/native_unix_supervisor.rs'
+              - 'crates/pentect-cli/tests/native_windows_supervisor.rs'
               - 'crates/pentect-cli/tests/*claude*.rs'
               - 'crates/pentect-runtime/src/masking.rs'
               - 'crates/pentect-runtime/src/plugin_middleware.rs'
@@ -170,6 +172,7 @@ jobs:
         run: >-
           cargo test -p pentect-cli --locked
           --test native_interrupt
+          --test native_unix_supervisor
           --test claude_unix_supervisor
           --test claude_guardian_boundary
           --test claude_guardian_loss
@@ -189,6 +192,12 @@ jobs:
           python tools/installed_agent_e2e.py
           --pentect "${{ env.PENTECT_AGENT_E2E_BINARY }}"
           --claude-parent-kill
+      - name: Verify installed Codex descendants stop after parent exit (Linux PR)
+        if: github.event_name == 'pull_request' && runner.os == 'Linux'
+        run: >-
+          python tools/installed_agent_e2e.py
+          --pentect "${{ env.PENTECT_AGENT_E2E_BINARY }}"
+          --codex-parent-kill
       - name: Start both protected desktop app contracts (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.75"
+version = "0.0.76"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.75"
+version = "0.0.76"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/claude_unix_supervisor.rs
+++ b/crates/pentect-cli/src/claude_unix_supervisor.rs
@@ -1362,6 +1362,22 @@ mod tests {
         assert_eq!(payload.args_with_settings_path(None).unwrap(), payload.args);
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn pidfd_verification_accepts_only_owned_live_children() {
+        assert!(open_verified_child_pidfd(std::process::id() as i32)
+            .unwrap()
+            .is_none());
+        assert!(open_verified_child_pidfd(i32::MAX).unwrap().is_none());
+
+        let mut child = Command::new("sh").args(["-c", "sleep 15"]).spawn().unwrap();
+        let pid = child.id() as i32;
+        assert!(open_verified_child_pidfd(pid).unwrap().is_some());
+        child.kill().unwrap();
+        child.wait().unwrap();
+        assert!(open_verified_child_pidfd(pid).unwrap().is_none());
+    }
+
     #[test]
     fn settings_location_is_replaced_exactly() {
         let path = std::path::Path::new("/private/generated.json");

--- a/crates/pentect-cli/src/claude_unix_supervisor.rs
+++ b/crates/pentect-cli/src/claude_unix_supervisor.rs
@@ -31,11 +31,16 @@ pub(crate) fn hidden_main(args: &[String]) -> Option<i32> {
     }
 }
 
-pub(crate) fn spawn_claude(
+pub(crate) enum NativeSetup<'a> {
+    None,
+    Claude(&'a crate::PreparedClaudeGateway),
+}
+
+pub(crate) fn spawn_native(
     command: &Command,
-    prepared: &crate::PreparedClaudeGateway,
+    setup: NativeSetup<'_>,
 ) -> Result<Supervised, String> {
-    let payload = encode_payload(command, prepared)?;
+    let payload = encode_payload(command, setup)?;
     let (mut owner, inherited) = UnixStream::pair()
         .map_err(|error| format!("could not create Claude guardian socket: {error}"))?;
     let timeout = Some(std::time::Duration::from_secs(5));
@@ -256,34 +261,33 @@ fn validate_guardian_status(status: ExitStatus) -> Result<(), String> {
     }
 }
 
-fn encode_payload(
-    command: &Command,
-    prepared: &crate::PreparedClaudeGateway,
-) -> Result<Vec<u8>, String> {
-    if command.get_program().to_str().is_none()
-        || command
-            .get_args()
-            .any(|argument| argument.to_str().is_none())
-    {
-        return Err("Claude program and arguments must be valid UTF-8 on Unix".to_string());
-    }
+fn encode_payload(command: &Command, setup: NativeSetup<'_>) -> Result<Vec<u8>, String> {
     let mut out = Vec::new();
-    put(&mut out, &prepared.encoded)?;
-    let (kind, index) = match prepared.settings_arg {
-        crate::ClaudeSettingsArg::Inline { index } => (1_u8, index),
-        crate::ClaudeSettingsArg::Separate { value_index } => (2, value_index),
-        crate::ClaudeSettingsArg::InsertFront => (3, 0),
+    let args: Vec<OsString> = match setup {
+        NativeSetup::None => {
+            out.push(0);
+            command.get_args().map(OsString::from).collect()
+        }
+        NativeSetup::Claude(prepared) => {
+            out.push(1);
+            put(&mut out, &prepared.encoded)?;
+            let (kind, index) = match prepared.settings_arg {
+                crate::ClaudeSettingsArg::Inline { index } => (1_u8, index),
+                crate::ClaudeSettingsArg::Separate { value_index } => (2, value_index),
+                crate::ClaudeSettingsArg::InsertFront => (3, 0),
+            };
+            out.push(kind);
+            out.extend_from_slice(
+                &u32::try_from(index)
+                    .map_err(|_| "Claude settings index is too large")?
+                    .to_ne_bytes(),
+            );
+            prepared.args.iter().map(OsString::from).collect()
+        }
     };
-    out.push(kind);
-    out.extend_from_slice(
-        &u32::try_from(index)
-            .map_err(|_| "Claude settings index is too large")?
-            .to_ne_bytes(),
-    );
     put(&mut out, command.get_program().as_bytes())?;
-    let args = &prepared.args;
     out.extend_from_slice(&(args.len() as u32).to_ne_bytes());
-    for arg in args {
+    for arg in &args {
         put(&mut out, arg.as_bytes())?;
     }
     if out.len() > MAX_PAYLOAD {
@@ -297,6 +301,24 @@ fn put(out: &mut Vec<u8>, value: &[u8]) -> Result<(), String> {
     out.extend_from_slice(&length.to_ne_bytes());
     out.extend_from_slice(value);
     Ok(())
+}
+
+fn encode_exec_payload(program: &std::ffi::OsStr, args: &[OsString]) -> Result<Vec<u8>, String> {
+    let mut out = Vec::new();
+    put(&mut out, program.as_bytes())?;
+    out.extend_from_slice(
+        &u32::try_from(args.len())
+            .map_err(|_| "native client has too many arguments")?
+            .to_ne_bytes(),
+    );
+    for arg in args {
+        put(&mut out, arg.as_bytes())?;
+    }
+    if out.len() > MAX_PAYLOAD {
+        Err("native client exec payload is too large".to_string())
+    } else {
+        Ok(out)
+    }
 }
 
 fn guardian_main(args: &[String]) -> i32 {
@@ -335,9 +357,9 @@ fn guardian_run(args: &[String]) -> Result<i32, String> {
             }
         }
     });
-    let session = crate::claude_settings_session::Session::create(&payload.settings)?;
-    let path = session.settings_path();
-    let client_args = match payload.args_with_settings_path(&path) {
+    let session = ManagedSession::create(payload.setup.as_ref())?;
+    let settings_path = session.settings_path();
+    let client_args = match payload.args_with_settings_path(settings_path.as_deref()) {
         Ok(args) => args,
         Err(error) => {
             session.abort();
@@ -363,9 +385,6 @@ fn guardian_run(args: &[String]) -> Result<i32, String> {
     client
         .arg("__claude-unix-bootstrap")
         .arg(barrier_fd.to_string())
-        .arg(&payload.program)
-        .arg("--")
-        .args(&client_args)
         .process_group(0)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -450,7 +469,26 @@ fn guardian_run(args: &[String]) -> Result<i32, String> {
         .unwrap_or(None)
     {
         Some(ACK) => {
-            if let Err(error) = (&barrier_writer).write_all(&[GO]) {
+            if let Err(error) =
+                barrier_writer.set_write_timeout(Some(std::time::Duration::from_secs(5)))
+            {
+                terminate_managed(&mut client, &mut relay)?;
+                session.abort();
+                return Err(error.to_string());
+            }
+            let exec_payload = match encode_exec_payload(&payload.program, &client_args) {
+                Ok(payload) => payload,
+                Err(error) => {
+                    terminate_managed(&mut client, &mut relay)?;
+                    session.abort();
+                    return Err(error);
+                }
+            };
+            if let Err(error) = (&barrier_writer)
+                .write_all(&(exec_payload.len() as u32).to_ne_bytes())
+                .and_then(|_| (&barrier_writer).write_all(&exec_payload))
+                .and_then(|_| (&barrier_writer).write_all(&[GO]))
+            {
                 terminate_managed(&mut client, &mut relay)?;
                 session.abort();
                 return Err(error.to_string());
@@ -583,10 +621,14 @@ fn await_status_ack(rx: &mpsc::Receiver<Option<u8>>) -> bool {
     }
 }
 
-struct Payload {
+struct ClaudeSetup {
     settings: Vec<u8>,
     settings_kind: u8,
     settings_index: usize,
+}
+
+struct Payload {
+    setup: Option<ClaudeSetup>,
     program: OsString,
     args: Vec<OsString>,
 }
@@ -601,12 +643,27 @@ fn read_payload(owner: &mut UnixStream) -> Result<Payload, String> {
     let mut bytes = vec![0; length];
     owner.read_exact(&mut bytes).map_err(|e| e.to_string())?;
     let mut at = 0;
-    let settings = take(&bytes, &mut at)?;
-    let settings_kind = *bytes
-        .get(at)
-        .ok_or("Claude guardian payload is truncated")?;
-    at += 1;
-    let settings_index = take_u32(&bytes, &mut at)? as usize;
+    let setup = match bytes.get(at).copied() {
+        Some(0) => {
+            at += 1;
+            None
+        }
+        Some(1) => {
+            at += 1;
+            let settings = take(&bytes, &mut at)?;
+            let settings_kind = *bytes
+                .get(at)
+                .ok_or("Claude guardian payload is truncated")?;
+            at += 1;
+            let settings_index = take_u32(&bytes, &mut at)? as usize;
+            Some(ClaudeSetup {
+                settings,
+                settings_kind,
+                settings_index,
+            })
+        }
+        _ => return Err("native guardian setup is invalid".to_string()),
+    };
     let program = OsString::from_vec(take(&bytes, &mut at)?);
     let count = take_u32(&bytes, &mut at)? as usize;
     if count > 4096 {
@@ -620,34 +677,39 @@ fn read_payload(owner: &mut UnixStream) -> Result<Payload, String> {
         return Err("Claude guardian payload is invalid".to_string());
     }
     Ok(Payload {
-        settings,
-        settings_kind,
-        settings_index,
+        setup,
         program,
         args,
     })
 }
 
 impl Payload {
-    fn args_with_settings_path(&self, path: &std::path::Path) -> Result<Vec<OsString>, String> {
+    fn args_with_settings_path(
+        &self,
+        path: Option<&std::path::Path>,
+    ) -> Result<Vec<OsString>, String> {
+        let Some(setup) = &self.setup else {
+            return Ok(self.args.clone());
+        };
+        let path = path.ok_or("Claude guardian settings session is missing")?;
         let path = path.as_os_str().to_owned();
         let mut args = self.args.clone();
-        match self.settings_kind {
+        match setup.settings_kind {
             1 if args
-                .get(self.settings_index)
+                .get(setup.settings_index)
                 .and_then(|v| v.to_str())
                 .is_some_and(|v| v.starts_with("--settings=")) =>
             {
                 let mut value = OsString::from("--settings=");
                 value.push(path);
-                args[self.settings_index] = value;
+                args[setup.settings_index] = value;
             }
-            2 if self.settings_index > 0
-                && args.get(self.settings_index - 1).and_then(|v| v.to_str())
+            2 if setup.settings_index > 0
+                && args.get(setup.settings_index - 1).and_then(|v| v.to_str())
                     == Some("--settings")
-                && args.get(self.settings_index).is_some() =>
+                && args.get(setup.settings_index).is_some() =>
             {
-                args[self.settings_index] = path
+                args[setup.settings_index] = path
             }
             3 => {
                 args.insert(0, path);
@@ -656,6 +718,33 @@ impl Payload {
             _ => return Err("Claude guardian settings location is invalid".to_string()),
         }
         Ok(args)
+    }
+}
+
+struct ManagedSession(Option<crate::claude_settings_session::Session>);
+
+impl ManagedSession {
+    fn create(setup: Option<&ClaudeSetup>) -> Result<Self, String> {
+        setup
+            .map(|setup| crate::claude_settings_session::Session::create(&setup.settings))
+            .transpose()
+            .map(Self)
+    }
+
+    fn settings_path(&self) -> Option<std::path::PathBuf> {
+        self.0.as_ref().map(|session| session.settings_path())
+    }
+
+    fn abort(self) {
+        if let Some(session) = self.0 {
+            session.abort();
+        }
+    }
+
+    fn release(self) {
+        if let Some(session) = self.0 {
+            session.release();
+        }
     }
 }
 
@@ -701,6 +790,9 @@ fn parse_socket(args: &[String]) -> Result<i32, String> {
 
 fn bootstrap_main(args: &[String]) -> i32 {
     let result = (|| -> Result<(), String> {
+        if args.len() != 3 {
+            return Err("invalid bootstrap arguments".to_string());
+        }
         let fd = args
             .get(2)
             .ok_or("missing bootstrap barrier")?
@@ -714,19 +806,38 @@ fn bootstrap_main(args: &[String]) -> i32 {
         {
             return Err("invalid Claude bootstrap barrier".to_string());
         }
-        let program = args.get(3).ok_or("missing Claude program")?;
-        if args.get(4).map(String::as_str) != Some("--") {
-            return Err("invalid bootstrap arguments".to_string());
-        }
         let mut barrier = unsafe { UnixStream::from_raw_fd(fd) };
+        let mut length = [0; 4];
+        barrier.read_exact(&mut length).map_err(|e| e.to_string())?;
+        let length = u32::from_ne_bytes(length) as usize;
+        if length > MAX_PAYLOAD {
+            return Err("native client exec payload is too large".to_string());
+        }
+        let mut encoded = vec![0; length];
+        barrier
+            .read_exact(&mut encoded)
+            .map_err(|e| e.to_string())?;
+        let mut at = 0;
+        let program = OsString::from_vec(take(&encoded, &mut at)?);
+        let count = take_u32(&encoded, &mut at)? as usize;
+        if count > 4096 {
+            return Err("native client has too many arguments".to_string());
+        }
+        let mut client_args = Vec::with_capacity(count);
+        for _ in 0..count {
+            client_args.push(OsString::from_vec(take(&encoded, &mut at)?));
+        }
+        if at != encoded.len() || program.is_empty() {
+            return Err("native client exec payload is invalid".to_string());
+        }
         let mut byte = [0];
         barrier.read_exact(&mut byte).map_err(|e| e.to_string())?;
         if byte[0] != GO {
             return Err("Claude bootstrap was not released".to_string());
         }
         drop(barrier);
-        let error = Command::new(program).args(&args[5..]).exec();
-        Err(format!("could not exec Claude: {error}"))
+        let error = Command::new(program).args(client_args).exec();
+        Err(format!("could not exec native client: {error}"))
     })();
     result.map(|_| 0).unwrap_or_else(|error| {
         eprintln!("[pentect] {error}");
@@ -926,6 +1037,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn generic_payload_preserves_raw_program_and_arguments() {
+        let program = OsString::from_vec(vec![b'/', b't', b'm', b'p', b'/', 0xff]);
+        let argument = OsString::from_vec(vec![b'a', 0xfe, b'b']);
+        let mut command = Command::new(&program);
+        command.arg(&argument);
+        let encoded = encode_payload(&command, NativeSetup::None).unwrap();
+        let (mut writer, mut reader) = UnixStream::pair().unwrap();
+        writer
+            .write_all(&(encoded.len() as u32).to_ne_bytes())
+            .unwrap();
+        writer.write_all(&encoded).unwrap();
+        let payload = read_payload(&mut reader).unwrap();
+        assert!(payload.setup.is_none());
+        assert_eq!(payload.program, program);
+        assert_eq!(payload.args, [argument]);
+        assert_eq!(payload.args_with_settings_path(None).unwrap(), payload.args);
+    }
+
+    #[test]
     fn settings_location_is_replaced_exactly() {
         let path = std::path::Path::new("/private/generated.json");
         for (kind, index, args, expected) in [
@@ -949,14 +1079,16 @@ mod tests {
             ),
         ] {
             let payload = Payload {
-                settings: vec![],
-                settings_kind: kind,
-                settings_index: index,
+                setup: Some(ClaudeSetup {
+                    settings: vec![],
+                    settings_kind: kind,
+                    settings_index: index,
+                }),
                 program: OsString::from("client"),
                 args: args.into_iter().map(OsString::from).collect(),
             };
             assert_eq!(
-                payload.args_with_settings_path(path).unwrap(),
+                payload.args_with_settings_path(Some(path)).unwrap(),
                 expected.into_iter().map(OsString::from).collect::<Vec<_>>()
             );
         }

--- a/crates/pentect-cli/src/claude_unix_supervisor.rs
+++ b/crates/pentect-cli/src/claude_unix_supervisor.rs
@@ -1079,10 +1079,12 @@ fn reap_linux_adopted_zombies(client: i32, relay: i32, cursor: &mut usize) -> Re
     }
     let start = *cursor % children.len();
     let count = children.len().min(256);
+    let mut visited = 0;
     for offset in 0..count {
         if std::time::Instant::now() >= deadline {
             break;
         }
+        visited += 1;
         let pid = children[(start + offset) % children.len()];
         if pid == client || pid == relay {
             continue;
@@ -1120,8 +1122,13 @@ fn reap_linux_adopted_zombies(client: i32, relay: i32, cursor: &mut usize) -> Re
             }
         }
     }
-    *cursor = (start + count) % children.len();
+    *cursor = advance_reap_cursor(start, visited, children.len());
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn advance_reap_cursor(start: usize, visited: usize, length: usize) -> usize {
+    (start + visited) % length
 }
 
 #[cfg(target_os = "linux")]
@@ -1376,6 +1383,14 @@ mod tests {
         child.kill().unwrap();
         child.wait().unwrap();
         assert!(open_verified_child_pidfd(pid).unwrap().is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn adopted_zombie_cursor_advances_only_past_visited_children() {
+        assert_eq!(advance_reap_cursor(0, 3, 10), 3);
+        assert_eq!(advance_reap_cursor(8, 3, 10), 1);
+        assert_eq!(advance_reap_cursor(4, 0, 10), 4);
     }
 
     #[test]

--- a/crates/pentect-cli/src/claude_unix_supervisor.rs
+++ b/crates/pentect-cli/src/claude_unix_supervisor.rs
@@ -9,6 +9,12 @@ use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::mpsc;
 
 const MAX_PAYLOAD: usize = 1024 * 1024;
+const STARTUP_IO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(target_os = "linux")]
+const DESCENDANT_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+// Startup can spend one bounded interval writing the bootstrap frame and a
+// second draining descendants after EOF. Leave scheduling slack for both.
+const GUARDIAN_CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(12);
 const HELLO: u8 = 1;
 const READY: u8 = 2;
 const ACK: u8 = 3;
@@ -21,6 +27,8 @@ const CONTINUE: u8 = 9;
 const CANCEL: u8 = 10;
 const STATUS_ACK: u8 = 11;
 static RELAY_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+#[cfg(target_os = "linux")]
+static LINUX_TREE_DRAIN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 pub(crate) fn hidden_main(args: &[String]) -> Option<i32> {
     match args.get(1).map(String::as_str) {
@@ -43,7 +51,7 @@ pub(crate) fn spawn_native(
     let payload = encode_payload(command, setup)?;
     let (mut owner, inherited) = UnixStream::pair()
         .map_err(|error| format!("could not create Claude guardian socket: {error}"))?;
-    let timeout = Some(std::time::Duration::from_secs(5));
+    let timeout = Some(STARTUP_IO_TIMEOUT);
     owner.set_read_timeout(timeout).map_err(|e| e.to_string())?;
     owner
         .set_write_timeout(timeout)
@@ -148,7 +156,7 @@ impl Drop for Supervised {
     fn drop(&mut self) {
         drop(self.foreground.take());
         let _ = self.owner.shutdown(std::net::Shutdown::Both);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + GUARDIAN_CLEANUP_TIMEOUT;
         loop {
             match self.guardian.try_wait() {
                 Ok(Some(_)) => break,
@@ -165,7 +173,7 @@ impl Drop for Supervised {
 
 fn cleanup_startup_guardian(child: &mut Child, owner: &UnixStream) {
     let _ = owner.shutdown(std::net::Shutdown::Both);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + GUARDIAN_CLEANUP_TIMEOUT;
     loop {
         match child.try_wait() {
             Ok(Some(_)) => return,
@@ -331,6 +339,12 @@ fn guardian_main(args: &[String]) -> i32 {
 fn guardian_run(args: &[String]) -> Result<i32, String> {
     let fd = parse_socket(args)?;
     let mut owner = unsafe { UnixStream::from_raw_fd(fd) };
+    #[cfg(target_os = "linux")]
+    if let Err(error) = enable_linux_tree_drain() {
+        eprintln!(
+            "[pentect] warning: descendant cleanup is limited to the managed process group: {error}"
+        );
+    }
     owner
         .write_all(&[HELLO])
         .map_err(|error| error.to_string())?;
@@ -464,14 +478,9 @@ fn guardian_run(args: &[String]) -> Result<i32, String> {
         session.abort();
         return Err(error.to_string());
     }
-    match rx
-        .recv_timeout(std::time::Duration::from_secs(5))
-        .unwrap_or(None)
-    {
+    match rx.recv_timeout(STARTUP_IO_TIMEOUT).unwrap_or(None) {
         Some(ACK) => {
-            if let Err(error) =
-                barrier_writer.set_write_timeout(Some(std::time::Duration::from_secs(5)))
-            {
+            if let Err(error) = barrier_writer.set_write_timeout(Some(STARTUP_IO_TIMEOUT)) {
                 terminate_managed(&mut client, &mut relay)?;
                 session.abort();
                 return Err(error.to_string());
@@ -503,6 +512,10 @@ fn guardian_run(args: &[String]) -> Result<i32, String> {
     let mut first_interrupt = None;
     let mut shutdown = None;
     let mut forced = false;
+    #[cfg(target_os = "linux")]
+    let mut last_orphan_reap = std::time::Instant::now();
+    #[cfg(target_os = "linux")]
+    let mut orphan_reap_cursor = 0;
     loop {
         match rx.try_recv() {
             Ok(None) | Err(mpsc::TryRecvError::Disconnected) => {
@@ -559,6 +572,21 @@ fn guardian_run(args: &[String]) -> Result<i32, String> {
             }
             forced = true;
         }
+        #[cfg(target_os = "linux")]
+        if LINUX_TREE_DRAIN.load(std::sync::atomic::Ordering::Acquire)
+            && last_orphan_reap.elapsed() >= std::time::Duration::from_millis(500)
+        {
+            if let Err(error) = reap_linux_adopted_zombies(
+                client.id() as i32,
+                relay.id() as i32,
+                &mut orphan_reap_cursor,
+            ) {
+                terminate_managed(&mut client, &mut relay)?;
+                session.release();
+                return Err(error);
+            }
+            last_orphan_reap = std::time::Instant::now();
+        }
         let stopped = match stopped_without_reaping(client.id()) {
             Ok(stopped) => stopped,
             Err(error) => {
@@ -602,8 +630,7 @@ fn guardian_run(args: &[String]) -> Result<i32, String> {
                 session.release();
                 return Ok(1);
             }
-            client.wait().map_err(|error| error.to_string())?;
-            relay.wait().map_err(|error| error.to_string())?;
+            terminate_managed(&mut client, &mut relay)?;
             session.release();
             return Ok(0);
         }
@@ -943,6 +970,10 @@ fn stopped_without_reaping(pid: u32) -> Result<bool, String> {
 }
 
 fn terminate_anchored(child: &mut Child) -> Result<ExitStatus, String> {
+    #[cfg(target_os = "linux")]
+    if LINUX_TREE_DRAIN.load(std::sync::atomic::Ordering::Acquire) {
+        return terminate_linux_descendants(child.id() as i32);
+    }
     unsafe {
         libc::kill(-(child.id() as i32), libc::SIGKILL);
     }
@@ -952,6 +983,10 @@ fn terminate_anchored(child: &mut Child) -> Result<ExitStatus, String> {
 }
 
 fn terminate_managed(client: &mut Child, relay: &mut Child) -> Result<ExitStatus, String> {
+    #[cfg(target_os = "linux")]
+    if LINUX_TREE_DRAIN.load(std::sync::atomic::Ordering::Acquire) {
+        return terminate_linux_descendants(client.id() as i32);
+    }
     unsafe {
         libc::kill(-(client.id() as i32), libc::SIGKILL);
     }
@@ -964,6 +999,278 @@ fn terminate_managed(client: &mut Child, relay: &mut Child) -> Result<ExitStatus
     match (client_result, relay_result) {
         (Ok(status), Ok(_)) => Ok(status),
         (Err(error), _) | (_, Err(error)) => Err(error),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn enable_linux_tree_drain() -> Result<(), String> {
+    use std::os::fd::FromRawFd as _;
+
+    std::fs::read_to_string("/proc/thread-self/children")
+        .map_err(|error| format!("procfs child discovery unavailable: {error}"))?;
+    let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, libc::getpid(), 0) as i32 };
+    if raw == -1 {
+        return Err(format!(
+            "pidfd unavailable: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    let pidfd = unsafe { std::os::fd::OwnedFd::from_raw_fd(raw) };
+    if unsafe {
+        libc::syscall(
+            libc::SYS_pidfd_send_signal,
+            pidfd.as_raw_fd(),
+            0,
+            std::ptr::null::<libc::siginfo_t>(),
+            0,
+        )
+    } == -1
+    {
+        return Err(format!(
+            "pidfd signaling unavailable: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    let mut info = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
+    if unsafe {
+        libc::waitid(
+            libc::P_PIDFD,
+            pidfd.as_raw_fd() as libc::id_t,
+            &mut info,
+            libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+        )
+    } != -1
+        || std::io::Error::last_os_error().raw_os_error() != Some(libc::ECHILD)
+    {
+        return Err("pidfd child verification unavailable".to_string());
+    }
+    let mut action = unsafe { std::mem::zeroed::<libc::sigaction>() };
+    action.sa_sigaction = libc::SIG_DFL;
+    unsafe {
+        libc::sigemptyset(&mut action.sa_mask);
+    }
+    if unsafe { libc::sigaction(libc::SIGCHLD, &action, std::ptr::null_mut()) } == -1 {
+        return Err(format!(
+            "could not reset child status handling: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    if unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) } == -1 {
+        return Err(format!(
+            "subreaper unavailable: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    LINUX_TREE_DRAIN.store(true, std::sync::atomic::Ordering::Release);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn reap_linux_adopted_zombies(client: i32, relay: i32, cursor: &mut usize) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(100);
+    let children = match linux_direct_children(deadline) {
+        Ok(children) => children,
+        Err(error) if error.starts_with("timed out discovering") => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if children.is_empty() {
+        *cursor = 0;
+        return Ok(());
+    }
+    let start = *cursor % children.len();
+    let count = children.len().min(256);
+    for offset in 0..count {
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        let pid = children[(start + offset) % children.len()];
+        if pid == client || pid == relay {
+            continue;
+        }
+        let Some(pidfd) = open_verified_child_pidfd(pid)? else {
+            continue;
+        };
+        let mut info = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PIDFD,
+                pidfd.as_raw_fd() as libc::id_t,
+                &mut info,
+                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+            )
+        };
+        if result == -1 {
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::ECHILD) {
+                continue;
+            }
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        if unsafe { info.si_pid() } != 0 {
+            let result = unsafe {
+                libc::waitid(
+                    libc::P_PIDFD,
+                    pidfd.as_raw_fd() as libc::id_t,
+                    &mut info,
+                    libc::WEXITED | libc::WNOHANG,
+                )
+            };
+            if result == -1 && std::io::Error::last_os_error().raw_os_error() != Some(libc::ECHILD)
+            {
+                return Err(std::io::Error::last_os_error().to_string());
+            }
+        }
+    }
+    *cursor = (start + count) % children.len();
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn terminate_linux_descendants(leader: i32) -> Result<ExitStatus, String> {
+    use std::os::unix::process::ExitStatusExt as _;
+
+    unsafe {
+        libc::kill(-leader, libc::SIGKILL);
+    }
+    let deadline = std::time::Instant::now() + DESCENDANT_DRAIN_TIMEOUT;
+    let mut leader_status = None;
+    loop {
+        for pid in linux_direct_children(deadline)? {
+            if std::time::Instant::now() >= deadline {
+                return Err("timed out terminating native client descendants".to_string());
+            }
+            let Some(pidfd) = open_verified_child_pidfd(pid)? else {
+                continue;
+            };
+            let mut info = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
+            let result = unsafe {
+                libc::waitid(
+                    libc::P_PIDFD,
+                    pidfd.as_raw_fd() as libc::id_t,
+                    &mut info,
+                    libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+                )
+            };
+            if result == -1 {
+                if std::io::Error::last_os_error().raw_os_error() == Some(libc::ECHILD) {
+                    continue;
+                }
+                return Err(std::io::Error::last_os_error().to_string());
+            }
+            if unsafe { info.si_pid() } == 0
+                && unsafe {
+                    libc::syscall(
+                        libc::SYS_pidfd_send_signal,
+                        pidfd.as_raw_fd(),
+                        libc::SIGKILL,
+                        std::ptr::null::<libc::siginfo_t>(),
+                        0,
+                    )
+                } == -1
+            {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    return Err(error.to_string());
+                }
+            }
+        }
+
+        loop {
+            if std::time::Instant::now() >= deadline {
+                return Err("timed out terminating native client descendants".to_string());
+            }
+            let mut info = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
+            let result =
+                unsafe { libc::waitid(libc::P_ALL, 0, &mut info, libc::WEXITED | libc::WNOHANG) };
+            if result == -1 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::ECHILD) {
+                    return leader_status
+                        .map(ExitStatus::from_raw)
+                        .ok_or_else(|| "native client status was not observed".to_string());
+                }
+                return Err(error.to_string());
+            }
+            let pid = unsafe { info.si_pid() };
+            if pid == 0 {
+                break;
+            }
+            if pid == leader {
+                leader_status = Some(raw_status_from_siginfo(&info));
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err("timed out terminating native client descendants".to_string());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_direct_children(deadline: std::time::Instant) -> Result<Vec<i32>, String> {
+    let mut children = std::collections::BTreeSet::new();
+    for entry in std::fs::read_dir("/proc/self/task").map_err(|error| error.to_string())? {
+        if std::time::Instant::now() >= deadline {
+            return Err("timed out discovering native client descendants".to_string());
+        }
+        let entry = entry.map_err(|error| error.to_string())?;
+        let path = entry.path().join("children");
+        let contents = match std::fs::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.to_string()),
+        };
+        for value in contents.split_whitespace() {
+            if std::time::Instant::now() >= deadline {
+                return Err("timed out discovering native client descendants".to_string());
+            }
+            let pid = value
+                .parse::<i32>()
+                .map_err(|_| "procfs returned an invalid child PID".to_string())?;
+            children.insert(pid);
+        }
+    }
+    Ok(children.into_iter().collect())
+}
+
+#[cfg(target_os = "linux")]
+fn open_verified_child_pidfd(pid: i32) -> Result<Option<std::os::fd::OwnedFd>, String> {
+    use std::os::fd::FromRawFd as _;
+
+    let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) as i32 };
+    if raw == -1 {
+        let error = std::io::Error::last_os_error();
+        return if error.raw_os_error() == Some(libc::ESRCH) {
+            Ok(None)
+        } else {
+            Err(error.to_string())
+        };
+    }
+    let pidfd = unsafe { std::os::fd::OwnedFd::from_raw_fd(raw) };
+    let mut info = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
+    let result = unsafe {
+        libc::waitid(
+            libc::P_PIDFD,
+            pidfd.as_raw_fd() as libc::id_t,
+            &mut info,
+            libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+        )
+    };
+    if result == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ECHILD) {
+        Ok(None)
+    } else if result == -1 {
+        Err(std::io::Error::last_os_error().to_string())
+    } else {
+        Ok(Some(pidfd))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn raw_status_from_siginfo(info: &libc::siginfo_t) -> i32 {
+    let status = unsafe { info.si_status() };
+    match info.si_code {
+        libc::CLD_EXITED => status << 8,
+        libc::CLD_DUMPED => status | 0x80,
+        _ => status,
     }
 }
 

--- a/crates/pentect-cli/src/claude_unix_supervisor.rs
+++ b/crates/pentect-cli/src/claude_unix_supervisor.rs
@@ -1372,16 +1372,21 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn pidfd_verification_accepts_only_owned_live_children() {
-        assert!(open_verified_child_pidfd(std::process::id() as i32)
-            .unwrap()
-            .is_none());
+        let self_result = open_verified_child_pidfd(std::process::id() as i32);
+        if self_result.is_err() {
+            // Runtime fallback intentionally supports kernels and sandboxes
+            // without pidfds.
+            return;
+        }
+        assert!(self_result.unwrap().is_none());
         assert!(open_verified_child_pidfd(i32::MAX).unwrap().is_none());
 
-        let mut child = Command::new("sh").args(["-c", "sleep 15"]).spawn().unwrap();
+        let mut child = Command::new("sleep").arg("15").spawn().unwrap();
         let pid = child.id() as i32;
-        assert!(open_verified_child_pidfd(pid).unwrap().is_some());
+        let verified = open_verified_child_pidfd(pid);
         child.kill().unwrap();
         child.wait().unwrap();
+        assert!(verified.unwrap().is_some());
         assert!(open_verified_child_pidfd(pid).unwrap().is_none());
     }
 

--- a/crates/pentect-cli/src/claude_windows_supervisor.rs
+++ b/crates/pentect-cli/src/claude_windows_supervisor.rs
@@ -373,6 +373,146 @@ pub(crate) fn run_helper(argv: &[String]) -> i32 {
     })
 }
 
+/// Dispatches the Windows-only supervisor verbs before normal CLI parsing.
+///
+/// The hidden native verb carries only the private pipe name. The client
+/// program and arguments are sent after the helper is assigned to the job.
+pub(crate) fn hidden_main(argv: &[String]) -> Option<i32> {
+    match argv.get(1).map(String::as_str) {
+        Some("__claude-windows-supervisor") => Some(run_helper(argv)),
+        Some("__native-windows-supervisor") => Some(run_native_helper(argv)),
+        _ => None,
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct NativeLaunchPayload {
+    version: u8,
+    wrapper_pid: u32,
+    program: Vec<u16>,
+    cwd: Option<Vec<u16>>,
+    args: Vec<Vec<u16>>,
+}
+
+fn native_command(payload: &NativeLaunchPayload) -> Result<Command, String> {
+    if payload.program.is_empty() || payload.program.contains(&0) {
+        return Err("native supervisor program is invalid".to_string());
+    }
+    if payload.args.iter().any(|arg| arg.contains(&0))
+        || payload.cwd.as_ref().is_some_and(|cwd| cwd.contains(&0))
+    {
+        return Err("native supervisor argument is invalid".to_string());
+    }
+    let mut command = Command::new(from_wide(&payload.program));
+    command.args(payload.args.iter().map(|arg| from_wide(arg)));
+    if let Some(cwd) = payload.cwd.as_deref() {
+        command.current_dir(from_wide(cwd));
+    }
+    command
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    Ok(command)
+}
+
+fn native_helper_command(client: &Command, executable: &Path, pipe_name: &str) -> Command {
+    let mut helper = Command::new(executable);
+    helper.arg("__native-windows-supervisor").arg(pipe_name);
+    if let Some(cwd) = client.get_current_dir() {
+        helper.current_dir(cwd);
+    }
+    for (name, value) in client.get_envs() {
+        match value {
+            Some(value) => helper.env(name, value),
+            None => helper.env_remove(name),
+        };
+    }
+    helper
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    helper
+}
+
+fn native_exit_code(status: ExitStatus) -> i32 {
+    status.code().unwrap_or(1)
+}
+
+fn run_native_helper(argv: &[String]) -> i32 {
+    let Some(pipe_name) = argv.get(2).filter(|_| argv.len() == 3) else {
+        return 2;
+    };
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(_) => return 2,
+    };
+    runtime.block_on(async {
+        let deadline = tokio::time::Instant::now() + STARTUP_TIMEOUT;
+        let mut pipe = loop {
+            match tokio::net::windows::named_pipe::ClientOptions::new().open(pipe_name) {
+                Ok(pipe) => break pipe,
+                Err(_) if tokio::time::Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await
+                }
+                Err(_) => return 2,
+            }
+        };
+        let frame = match tokio::time::timeout(STARTUP_TIMEOUT, read_frame(&mut pipe)).await {
+            Ok(Ok(frame)) => frame,
+            _ => return 2,
+        };
+        let payload = match serde_json::from_slice::<NativeLaunchPayload>(&frame) {
+            Ok(payload) if payload.version == PROTOCOL_VERSION => payload,
+            _ => return 2,
+        };
+        let mut contained = 0;
+        let mut server_pid = 0;
+        if unsafe { IsProcessInJob(GetCurrentProcess(), std::ptr::null_mut(), &mut contained) } == 0
+            || contained == 0
+            || unsafe { GetNamedPipeServerProcessId(pipe.as_raw_handle().cast(), &mut server_pid) }
+                == 0
+            || server_pid != payload.wrapper_pid
+        {
+            return 2;
+        }
+        let mut command = match native_command(&payload) {
+            Ok(command) => command,
+            Err(_) => return 2,
+        };
+        if crate::install_native_interrupt_handler().is_err() {
+            return 2;
+        }
+        crate::NATIVE_COMMAND_INTERRUPTS.store(0, std::sync::atomic::Ordering::SeqCst);
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(_) => return 2,
+        };
+        if pipe.write_u8(1).await.is_err() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return 2;
+        }
+        match crate::wait_for_native_child(
+            &mut child,
+            &crate::NATIVE_COMMAND_INTERRUPTS,
+            std::io::stdin().is_terminal(),
+            crate::NATIVE_REPEAT_INTERRUPT_WINDOW,
+            crate::NATIVE_INTERRUPT_GRACE,
+        ) {
+            Ok(status) => native_exit_code(status),
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                2
+            }
+        }
+    })
+}
+
 pub(crate) fn verify_pipe_client(pipe: HANDLE, child: &Child) -> Result<(), String> {
     let mut pid = 0;
     if unsafe { GetNamedPipeClientProcessId(pipe, &mut pid) } == 0 || pid != child.id() {
@@ -535,6 +675,81 @@ pub(crate) fn launch(
     Ok(status)
 }
 
+/// Runs an ordinary native client through the Windows kill-on-close job.
+///
+/// Environment changes are applied to the blocked helper, so its eventual
+/// child inherits the same effective environment without sending environment
+/// values through the protocol. Callers must not use `Command::env_clear`,
+/// which the stable `Command` inspection API cannot distinguish here.
+pub(crate) fn launch_native(client: &Command, display: &Path) -> Result<ExitStatus, String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .map_err(|_| "could not initialize native supervisor".to_string())?;
+    let (pipe_name, mut pipe) = runtime.block_on(async { create_private_pipe() })?;
+    let job = ClaudeJob::new()?;
+    let executable =
+        std::env::current_exe().map_err(|_| "could not locate native supervisor".to_string())?;
+    let mut helper = native_helper_command(client, &executable, &pipe_name);
+    let child = helper
+        .spawn()
+        .map_err(|_| "could not start native supervisor".to_string())?;
+    let mut guard = StartupGuard {
+        child: Some(child),
+        job: Some(job),
+    };
+    let child = guard.child.as_mut().expect("helper retained");
+    guard
+        .job
+        .as_ref()
+        .expect("job retained")
+        .assign_live(child)?;
+    runtime
+        .block_on(async { tokio::time::timeout(STARTUP_TIMEOUT, pipe.connect()).await })
+        .map_err(|_| "native supervisor startup timed out".to_string())?
+        .map_err(|_| "could not connect native supervisor".to_string())?;
+    verify_pipe_client(pipe.as_raw_handle().cast(), child)?;
+    guard
+        .job
+        .as_ref()
+        .expect("job retained")
+        .assign_live_check(child)?;
+    let payload = NativeLaunchPayload {
+        version: PROTOCOL_VERSION,
+        wrapper_pid: std::process::id(),
+        program: wide(client.get_program()),
+        cwd: client.get_current_dir().map(|path| wide(path.as_os_str())),
+        args: client.get_args().map(wide).collect(),
+    };
+    // Validate before sending anything that could cause a client launch.
+    native_command(&payload)?;
+    let encoded = serde_json::to_vec(&payload)
+        .map_err(|_| "could not encode native supervisor payload".to_string())?;
+    runtime
+        .block_on(async {
+            tokio::time::timeout(STARTUP_TIMEOUT, write_frame(&mut pipe, &encoded)).await
+        })
+        .map_err(|_| "native supervisor payload timed out".to_string())??;
+    let acknowledged =
+        runtime.block_on(async { tokio::time::timeout(STARTUP_TIMEOUT, pipe.read_u8()).await });
+    if !matches!(acknowledged, Ok(Ok(1))) {
+        return Err("native supervisor did not confirm client startup".to_string());
+    }
+    drop(pipe);
+    let status = crate::wait_for_native_child(
+        guard.child.as_mut().expect("helper retained"),
+        &crate::NATIVE_COMMAND_INTERRUPTS,
+        std::io::stdin().is_terminal(),
+        crate::NATIVE_REPEAT_INTERRUPT_WINDOW,
+        crate::NATIVE_INTERRUPT_GRACE,
+    )
+    .map_err(|error| format!("could not wait for '{}': {error}", display.display()))?;
+    drop(guard.child.take());
+    drop(guard.job.take());
+    Ok(status)
+}
+
 struct StartupGuard {
     child: Option<Child>,
     job: Option<ClaudeJob>,
@@ -564,7 +779,9 @@ impl ClaudeJob {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::windows::ffi::OsStrExt;
+    use std::ffi::{OsStr, OsString};
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use std::os::windows::process::ExitStatusExt;
     use windows_sys::Win32::Foundation::{
         GetHandleInformation, HANDLE_FLAG_INHERIT, WAIT_OBJECT_0,
     };
@@ -643,6 +860,102 @@ mod tests {
         assert!(runtime
             .block_on(write_frame(&mut sink, &oversized))
             .is_err());
+    }
+
+    #[test]
+    fn native_payload_preserves_windows_arguments_and_cwd_losslessly() {
+        let program = OsString::from_wide(&[b'C' as u16, b':' as u16, b'\\' as u16, 0xd800]);
+        let argument = OsString::from_wide(&[
+            b'q' as u16,
+            b'"' as u16,
+            b'\\' as u16,
+            b'\\' as u16,
+            b' ' as u16,
+            0xdfff,
+        ]);
+        let cwd = OsString::from_wide(&[b'C' as u16, b':' as u16, b'\\' as u16, 0xd801]);
+        let payload = NativeLaunchPayload {
+            version: PROTOCOL_VERSION,
+            wrapper_pid: 7,
+            program: wide(&program),
+            cwd: Some(wide(&cwd)),
+            args: vec![wide(&argument)],
+        };
+        let encoded = serde_json::to_vec(&payload).unwrap();
+        let decoded: NativeLaunchPayload = serde_json::from_slice(&encoded).unwrap();
+        let command = native_command(&decoded).unwrap();
+        assert_eq!(command.get_program(), program);
+        assert_eq!(command.get_current_dir(), Some(Path::new(&cwd)));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            [argument.as_os_str()]
+        );
+    }
+
+    #[test]
+    fn native_payload_rejects_empty_program_and_embedded_nuls() {
+        let valid = NativeLaunchPayload {
+            version: PROTOCOL_VERSION,
+            wrapper_pid: 7,
+            program: wide(OsStr::new("client.exe")),
+            cwd: None,
+            args: vec![wide(OsStr::new("argument"))],
+        };
+        let mut invalid = NativeLaunchPayload {
+            program: vec![],
+            ..valid
+        };
+        assert!(native_command(&invalid).is_err());
+        invalid.program = wide(OsStr::new("client.exe"));
+        invalid.args = vec![vec![b'x' as u16, 0, b'y' as u16]];
+        assert!(native_command(&invalid).is_err());
+        invalid.args = vec![];
+        invalid.cwd = Some(vec![b'C' as u16, b':' as u16, 0]);
+        assert!(native_command(&invalid).is_err());
+    }
+
+    #[test]
+    fn native_helper_receives_only_control_args_and_command_environment_deltas() {
+        let mut client = Command::new("client.exe");
+        client
+            .args(["ordinary", "--literal=secret-looking"])
+            .current_dir(r"C:\fixture")
+            .env("PENTECT_NATIVE_SET", "fixture-value")
+            .env_remove("PENTECT_NATIVE_REMOVE");
+        let helper =
+            native_helper_command(&client, Path::new(r"C:\pentect.exe"), r"\\.\pipe\fixture");
+        assert_eq!(helper.get_program(), r"C:\pentect.exe");
+        assert_eq!(
+            helper.get_args().collect::<Vec<_>>(),
+            [
+                OsStr::new("__native-windows-supervisor"),
+                OsStr::new(r"\\.\pipe\fixture")
+            ]
+        );
+        assert_eq!(helper.get_current_dir(), Some(Path::new(r"C:\fixture")));
+        let env = helper
+            .get_envs()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_eq!(
+            env.get(OsStr::new("PENTECT_NATIVE_SET")),
+            Some(&Some(OsStr::new("fixture-value")))
+        );
+        assert_eq!(env.get(OsStr::new("PENTECT_NATIVE_REMOVE")), Some(&None));
+    }
+
+    #[test]
+    fn native_exit_code_preserves_windows_status_bits() {
+        let raw = 0xc000_013a_u32;
+        assert_eq!(native_exit_code(ExitStatus::from_raw(raw)) as u32, raw);
+        assert_eq!(native_exit_code(ExitStatus::from_raw(37)), 37);
+    }
+
+    #[test]
+    fn hidden_dispatch_ignores_normal_cli_arguments() {
+        assert_eq!(
+            hidden_main(&["pentect".to_string(), "codex".to_string()]),
+            None
+        );
     }
 
     #[test]

--- a/crates/pentect-cli/src/claude_windows_supervisor.rs
+++ b/crates/pentect-cli/src/claude_windows_supervisor.rs
@@ -418,9 +418,6 @@ fn native_command(payload: &NativeLaunchPayload) -> Result<Command, String> {
 fn native_helper_command(client: &Command, executable: &Path, pipe_name: &str) -> Command {
     let mut helper = Command::new(executable);
     helper.arg("__native-windows-supervisor").arg(pipe_name);
-    if let Some(cwd) = client.get_current_dir() {
-        helper.current_dir(cwd);
-    }
     for (name, value) in client.get_envs() {
         match value {
             Some(value) => helper.env(name, value),
@@ -436,6 +433,19 @@ fn native_helper_command(client: &Command, executable: &Path, pipe_name: &str) -
 
 fn native_exit_code(status: ExitStatus) -> i32 {
     status.code().unwrap_or(1)
+}
+
+fn native_payload(client: &Command) -> Result<NativeLaunchPayload, String> {
+    let payload = NativeLaunchPayload {
+        version: PROTOCOL_VERSION,
+        wrapper_pid: std::process::id(),
+        program: wide(client.get_program()),
+        cwd: client.get_current_dir().map(|path| wide(path.as_os_str())),
+        args: client.get_args().map(wide).collect(),
+    };
+    // Validate before a contained helper receives anything that could launch.
+    native_command(&payload)?;
+    Ok(payload)
 }
 
 fn run_native_helper(argv: &[String]) -> i32 {
@@ -715,15 +725,7 @@ pub(crate) fn launch_native(client: &Command, display: &Path) -> Result<ExitStat
         .as_ref()
         .expect("job retained")
         .assign_live_check(child)?;
-    let payload = NativeLaunchPayload {
-        version: PROTOCOL_VERSION,
-        wrapper_pid: std::process::id(),
-        program: wide(client.get_program()),
-        cwd: client.get_current_dir().map(|path| wide(path.as_os_str())),
-        args: client.get_args().map(wide).collect(),
-    };
-    // Validate before sending anything that could cause a client launch.
-    native_command(&payload)?;
+    let payload = native_payload(client)?;
     let encoded = serde_json::to_vec(&payload)
         .map_err(|_| "could not encode native supervisor payload".to_string())?;
     runtime
@@ -915,11 +917,11 @@ mod tests {
     }
 
     #[test]
-    fn native_helper_receives_only_control_args_and_command_environment_deltas() {
+    fn native_transport_applies_relative_cwd_once_and_keeps_client_args_off_helper_argv() {
         let mut client = Command::new("client.exe");
         client
             .args(["ordinary", "--literal=secret-looking"])
-            .current_dir(r"C:\fixture")
+            .current_dir("relative-project")
             .env("PENTECT_NATIVE_SET", "fixture-value")
             .env_remove("PENTECT_NATIVE_REMOVE");
         let helper =
@@ -932,7 +934,22 @@ mod tests {
                 OsStr::new(r"\\.\pipe\fixture")
             ]
         );
-        assert_eq!(helper.get_current_dir(), Some(Path::new(r"C:\fixture")));
+        // Relative client working directories are resolved exactly once by the
+        // eventual client, never first by the blocked helper.
+        assert_eq!(helper.get_current_dir(), None);
+        let payload = native_payload(&client).unwrap();
+        assert_eq!(
+            from_wide(payload.cwd.as_deref().unwrap()),
+            "relative-project"
+        );
+        assert_eq!(
+            payload
+                .args
+                .iter()
+                .map(|arg| from_wide(arg))
+                .collect::<Vec<_>>(),
+            ["ordinary", "--literal=secret-looking"]
+        );
         let env = helper
             .get_envs()
             .collect::<std::collections::BTreeMap<_, _>>();

--- a/crates/pentect-cli/src/main.rs
+++ b/crates/pentect-cli/src/main.rs
@@ -250,8 +250,8 @@ const COMMANDS: &[CommandSpec] = &[
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     #[cfg(windows)]
-    if args.get(1).map(String::as_str) == Some("__claude-windows-supervisor") {
-        std::process::exit(claude_windows_supervisor::run_helper(&args));
+    if let Some(code) = claude_windows_supervisor::hidden_main(&args) {
+        std::process::exit(code);
     }
     #[cfg(unix)]
     if let Some(code) = claude_unix_supervisor::hidden_main(&args) {
@@ -1791,7 +1791,7 @@ fn run_codex(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitS
     apply_plugin_env(&mut cmd, &active_plugins)?;
     apply_untrusted_client_env(&mut cmd, pentect)?;
     cmd.args(args);
-    run_native_command_with_guards(cmd, &opts.command, (http_proxy, memory_store))
+    run_managed_native_command_with_guards(cmd, &opts.command, (http_proxy, memory_store))
 }
 
 fn run_claude(opts: &AgentToolOpts, pentect: &Path) -> Result<std::process::ExitStatus, String> {
@@ -1857,12 +1857,15 @@ fn run_supervised_claude_with_guards<G>(
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
-    let result = claude_unix_supervisor::spawn_claude(&command, &prepared)
-        .map_err(|error| format!("could not run '{}': {error}", display.display()))
-        .and_then(|managed| {
-            claude_unix_supervisor::wait(managed)
-                .map_err(|error| format!("could not wait for '{}': {error}", display.display()))
-        });
+    let result = claude_unix_supervisor::spawn_native(
+        &command,
+        claude_unix_supervisor::NativeSetup::Claude(&prepared),
+    )
+    .map_err(|error| format!("could not run '{}': {error}", display.display()))
+    .and_then(|managed| {
+        claude_unix_supervisor::wait(managed)
+            .map_err(|error| format!("could not wait for '{}': {error}", display.display()))
+    });
     NATIVE_COMMAND_INTERRUPTS.store(0, Ordering::SeqCst);
     result
 }
@@ -2553,6 +2556,53 @@ fn run_native_command_with_guards<G>(
     .map_err(|error| format!("could not wait for '{}': {error}", display.display()))?;
     NATIVE_COMMAND_INTERRUPTS.store(0, Ordering::SeqCst);
     Ok(status)
+}
+
+#[cfg(unix)]
+pub(crate) fn run_managed_native_command_with_guards<G>(
+    mut cmd: Command,
+    display: &Path,
+    _guards: G,
+) -> Result<std::process::ExitStatus, String> {
+    install_native_interrupt_handler()?;
+    NATIVE_COMMAND_INTERRUPTS.store(0, Ordering::SeqCst);
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    let result =
+        claude_unix_supervisor::spawn_native(&cmd, claude_unix_supervisor::NativeSetup::None)
+            .map_err(|error| format!("could not run '{}': {error}", display.display()))
+            .and_then(|managed| {
+                claude_unix_supervisor::wait(managed)
+                    .map_err(|error| format!("could not wait for '{}': {error}", display.display()))
+            });
+    NATIVE_COMMAND_INTERRUPTS.store(0, Ordering::SeqCst);
+    result
+}
+
+#[cfg(windows)]
+pub(crate) fn run_managed_native_command_with_guards<G>(
+    mut cmd: Command,
+    display: &Path,
+    _guards: G,
+) -> Result<std::process::ExitStatus, String> {
+    install_native_interrupt_handler()?;
+    NATIVE_COMMAND_INTERRUPTS.store(0, Ordering::SeqCst);
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    let result = claude_windows_supervisor::launch_native(&cmd, display);
+    NATIVE_COMMAND_INTERRUPTS.store(0, Ordering::SeqCst);
+    result
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn run_managed_native_command_with_guards<G>(
+    cmd: Command,
+    display: &Path,
+    guards: G,
+) -> Result<std::process::ExitStatus, String> {
+    run_native_command_with_guards(cmd, display, guards)
 }
 
 fn install_native_interrupt_handler() -> Result<(), String> {

--- a/crates/pentect-cli/src/openai_clients.rs
+++ b/crates/pentect-cli/src/openai_clients.rs
@@ -105,7 +105,7 @@ pub(crate) fn run(
                 OsString::from("--model"),
                 OsString::from(format!("pentect/{model}")),
             ]);
-            crate::run_native_command_with_guards(
+            crate::run_managed_native_command_with_guards(
                 command,
                 &opts.command,
                 (proxy, memory_store, extension),
@@ -298,7 +298,7 @@ fn run_opencode(
         let mut command = Command::new(&opts.command);
         crate::clear_pentect_control_env(&mut command);
         command.args(&tool_args);
-        return crate::run_native_command_with_guards(command, &opts.command, ());
+        return crate::run_managed_native_command_with_guards(command, &opts.command, ());
     }
 
     let api = ClientApi::parse(opts.api.as_deref())?;
@@ -338,7 +338,7 @@ fn run_opencode(
         command.env(name, "pentect-local");
     }
     apply_opencode_protection(&mut command, config, &opts.tool_args);
-    crate::run_native_command_with_guards(command, &opts.command, (proxy, memory_store))
+    crate::run_managed_native_command_with_guards(command, &opts.command, (proxy, memory_store))
 }
 
 fn apply_opencode_protection(command: &mut Command, config: String, args: &[String]) {
@@ -604,7 +604,7 @@ fn run_opencode_picker(
         command.env(name, "pentect-local");
     }
     apply_opencode_protection(&mut command, config, &opts.tool_args);
-    crate::run_native_command_with_guards(command, &opts.command, (proxies, memory_store))
+    crate::run_managed_native_command_with_guards(command, &opts.command, (proxies, memory_store))
 }
 
 fn is_opencode_auth_command(args: &[String]) -> bool {

--- a/crates/pentect-cli/tests/native_linux_fallback.rs
+++ b/crates/pentect-cli/tests/native_linux_fallback.rs
@@ -1,0 +1,228 @@
+#![cfg(target_os = "linux")]
+
+use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+use std::os::unix::fs::PermissionsExt as _;
+use std::os::unix::process::CommandExt as _;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const SECCOMP_SET_MODE_FILTER: libc::c_ulong = 2;
+const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
+const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
+
+struct Fixture {
+    root: std::path::PathBuf,
+    wrapper: Option<Child>,
+    tracked: Vec<OwnedFd>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-native-linux-fallback-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir(&root).unwrap();
+        Self {
+            root,
+            wrapper: None,
+            tracked: Vec::new(),
+        }
+    }
+
+    fn track(&mut self, pid: i32) {
+        let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) as i32 };
+        assert_ne!(raw, -1, "could not capture fixture process identity");
+        self.tracked.push(unsafe { OwnedFd::from_raw_fd(raw) });
+    }
+
+    fn stop_wrapper(&mut self) {
+        if let Some(mut wrapper) = self.wrapper.take() {
+            unsafe {
+                libc::kill(wrapper.id() as i32, libc::SIGKILL);
+            }
+            let _ = wrapper.wait();
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.stop_wrapper();
+        for pidfd in &self.tracked {
+            unsafe {
+                libc::syscall(
+                    libc::SYS_pidfd_send_signal,
+                    pidfd.as_raw_fd(),
+                    libc::SIGKILL,
+                    std::ptr::null::<libc::siginfo_t>(),
+                    0,
+                );
+            }
+        }
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn deny_pidfd_open() -> std::io::Result<()> {
+    let mut filter = [
+        libc::sock_filter {
+            code: (libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16,
+            jt: 0,
+            jf: 0,
+            k: 0,
+        },
+        libc::sock_filter {
+            code: (libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K) as u16,
+            jt: 0,
+            jf: 1,
+            k: libc::SYS_pidfd_open as u32,
+        },
+        libc::sock_filter {
+            code: (libc::BPF_RET | libc::BPF_K) as u16,
+            jt: 0,
+            jf: 0,
+            k: SECCOMP_RET_ERRNO | libc::ENOSYS as u32,
+        },
+        libc::sock_filter {
+            code: (libc::BPF_RET | libc::BPF_K) as u16,
+            jt: 0,
+            jf: 0,
+            k: SECCOMP_RET_ALLOW,
+        },
+    ];
+    let program = libc::sock_fprog {
+        len: filter.len() as u16,
+        filter: filter.as_mut_ptr(),
+    };
+    if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } == -1
+        || unsafe {
+            libc::prctl(
+                libc::PR_SET_SECCOMP,
+                SECCOMP_SET_MODE_FILTER,
+                &program as *const libc::sock_fprog,
+            )
+        } == -1
+    {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+fn wait_ready(path: &std::path::Path) -> (i32, i32) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                let mut lines = contents.lines();
+                return (
+                    lines.next().unwrap().parse().unwrap(),
+                    lines.next().unwrap().parse().unwrap(),
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => panic!("could not read fixture readiness: {error}"),
+        }
+        assert!(Instant::now() < deadline, "fixture client did not start");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_pidfd_dead(pidfd: &OwnedFd) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let mut pollfd = libc::pollfd {
+            fd: pidfd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        if unsafe { libc::poll(&mut pollfd, 1, 0) } == 1 && pollfd.revents & libc::POLLIN != 0 {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn unavailable_pidfd_keeps_group_lifecycle_compatible() {
+    let mut fixture = Fixture::new();
+    let home = fixture.root.join("home");
+    let project = fixture.root.join("project");
+    let runtime = fixture.root.join("runtime");
+    for directory in [&home, &project, &runtime] {
+        std::fs::create_dir(directory).unwrap();
+        std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    std::fs::create_dir(home.join(".pentect")).unwrap();
+    std::fs::create_dir(project.join(".git")).unwrap();
+    std::fs::write(
+        home.join(".pentect/config.toml"),
+        "[update]\ncheck = false\n",
+    )
+    .unwrap();
+    let ready = fixture.root.join("ready");
+    let stderr = fixture.root.join("stderr");
+    let script = fixture.root.join("client.sh");
+    std::fs::write(
+        &script,
+        r##"#!/bin/sh
+sleep 30 &
+child=$!
+temporary="$READY.tmp.$$"
+printf '%s\n%s\n' "$$" "$child" > "$temporary"
+mv "$temporary" "$READY"
+wait "$child"
+"##,
+    )
+    .unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    let stderr_file = std::fs::File::create(&stderr).unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+    command
+        .arg("opencode")
+        .arg("--opencode")
+        .arg(&script)
+        .arg("auth")
+        .current_dir(&project)
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("XDG_RUNTIME_DIR", &runtime)
+        .env("XDG_CACHE_HOME", fixture.root.join("cache"))
+        .env("XDG_STATE_HOME", fixture.root.join("state"))
+        .env("XDG_CONFIG_HOME", fixture.root.join("config"))
+        .env("PENTECT_LOG_DIR", fixture.root.join("log"))
+        .env("READY", &ready)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(stderr_file);
+    unsafe {
+        command.pre_exec(deny_pidfd_open);
+    }
+    fixture.wrapper = Some(command.spawn().unwrap());
+    let (client, child) = wait_ready(&ready);
+    fixture.track(client);
+    fixture.track(child);
+
+    fixture.stop_wrapper();
+    assert!(
+        wait_pidfd_dead(&fixture.tracked[0]),
+        "client survived wrapper kill"
+    );
+    assert!(
+        wait_pidfd_dead(&fixture.tracked[1]),
+        "same-group child survived wrapper kill"
+    );
+    let diagnostics = std::fs::read_to_string(&stderr).unwrap();
+    assert!(diagnostics.contains(
+        "warning: descendant cleanup is limited to the managed process group: pidfd unavailable"
+    ));
+}

--- a/crates/pentect-cli/tests/native_unix_supervisor.rs
+++ b/crates/pentect-cli/tests/native_unix_supervisor.rs
@@ -39,6 +39,7 @@ impl Fixture {
         }
     }
 
+    #[cfg(target_os = "linux")]
     fn wait_wrapper(&mut self) -> std::process::ExitStatus {
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {

--- a/crates/pentect-cli/tests/native_unix_supervisor.rs
+++ b/crates/pentect-cli/tests/native_unix_supervisor.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, Instant};
 struct Fixture {
     root: std::path::PathBuf,
     wrapper: Option<Child>,
-    group: Option<i32>,
 }
 
 impl Fixture {
@@ -24,7 +23,6 @@ impl Fixture {
         Self {
             root,
             wrapper: None,
-            group: None,
         }
     }
 
@@ -41,15 +39,6 @@ impl Fixture {
 impl Drop for Fixture {
     fn drop(&mut self) {
         self.stop_wrapper();
-        if let Some(group) = self.group {
-            // The managed client is the group leader. Only clean this exact
-            // fixture group while that leader identity still exists.
-            if unsafe { libc::getpgid(group) } == group {
-                unsafe {
-                    libc::kill(-group, libc::SIGKILL);
-                }
-            }
-        }
         let _ = std::fs::remove_dir_all(&self.root);
     }
 }
@@ -115,7 +104,7 @@ fn typed_native_clients_terminate_their_ordinary_process_groups() {
         std::fs::write(
             &script,
             r##"#!/bin/sh
-(while :; do sleep 1; done) &
+(sleep 15) &
 child=$!
 settings=no
 for arg in "$@"; do case "$arg" in --settings|--settings=*) settings=yes;; esac; done
@@ -149,7 +138,6 @@ wait "$child"
             .stderr(Stdio::piped());
         fixture.wrapper = Some(command.spawn().unwrap());
         let (client_pid, child_pid, state) = wait_ready(&ready);
-        fixture.group = Some(client_pid);
         assert_eq!(state, format!("{}:unset:no", project.display()));
 
         fixture.stop_wrapper();
@@ -161,6 +149,5 @@ wait "$child"
             wait_dead(child_pid),
             "{client} descendant survived wrapper kill"
         );
-        fixture.group = None;
     }
 }

--- a/crates/pentect-cli/tests/native_unix_supervisor.rs
+++ b/crates/pentect-cli/tests/native_unix_supervisor.rs
@@ -43,13 +43,14 @@ impl Drop for Fixture {
     }
 }
 
-fn wait_ready(path: &std::path::Path) -> (i32, i32, String) {
+fn wait_ready(path: &std::path::Path) -> (i32, i32, i32, String) {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         match std::fs::read_to_string(path) {
             Ok(contents) => {
                 let mut lines = contents.lines();
                 return (
+                    lines.next().unwrap().parse().unwrap(),
                     lines.next().unwrap().parse().unwrap(),
                     lines.next().unwrap().parse().unwrap(),
                     lines.next().unwrap_or_default().to_string(),
@@ -75,7 +76,7 @@ fn wait_dead(pid: i32) -> bool {
 }
 
 #[test]
-fn typed_native_clients_terminate_their_ordinary_process_groups() {
+fn typed_native_clients_terminate_separate_group_descendant_trees() {
     for (client, flag, tail) in [
         ("codex", "--codex", Vec::<&str>::new()),
         ("opencode", "--opencode", vec!["auth"]),
@@ -103,15 +104,24 @@ fn typed_native_clients_terminate_their_ordinary_process_groups() {
         let script = fixture.root.join("client.sh");
         std::fs::write(
             &script,
-            r##"#!/bin/sh
-(sleep 15) &
-child=$!
-settings=no
-for arg in "$@"; do case "$arg" in --settings|--settings=*) settings=yes;; esac; done
-temporary="$READY.tmp.$$"
-printf '%s\n%s\n%s:%s:%s' "$$" "$child" "$PWD" "${PENTECT_MEMORY_STORE_TOKEN-unset}" "$settings" > "$temporary"
-mv "$temporary" "$READY"
-wait "$child"
+            r##"#!/usr/bin/env python3
+import os, sys, time
+
+middle = os.fork()
+if middle == 0:
+    os.setpgid(0, 0)
+    leaf = os.fork()
+    if leaf == 0:
+        time.sleep(15)
+        os._exit(0)
+    temporary = os.environ["READY"] + ".tmp." + str(os.getpid())
+    settings = "yes" if any(arg == "--settings" or arg.startswith("--settings=") for arg in sys.argv[1:]) else "no"
+    state = os.getcwd() + ":" + os.environ.get("PENTECT_MEMORY_STORE_TOKEN", "unset") + ":" + settings
+    with open(temporary, "w", encoding="utf-8") as marker:
+        marker.write(f"{os.getppid()}\n{os.getpid()}\n{leaf}\n{state}")
+    os.replace(temporary, os.environ["READY"])
+    time.sleep(15)
+time.sleep(15)
 "##,
         )
         .unwrap();
@@ -137,13 +147,17 @@ wait "$child"
             .stdout(Stdio::null())
             .stderr(Stdio::piped());
         fixture.wrapper = Some(command.spawn().unwrap());
-        let (client_pid, child_pid, state) = wait_ready(&ready);
+        let (client_pid, middle_pid, child_pid, state) = wait_ready(&ready);
         assert_eq!(state, format!("{}:unset:no", project.display()));
 
         fixture.stop_wrapper();
         assert!(
             wait_dead(client_pid),
             "{client} client survived wrapper kill"
+        );
+        assert!(
+            wait_dead(middle_pid),
+            "{client} child survived wrapper kill"
         );
         assert!(
             wait_dead(child_pid),

--- a/crates/pentect-cli/tests/native_unix_supervisor.rs
+++ b/crates/pentect-cli/tests/native_unix_supervisor.rs
@@ -1,0 +1,166 @@
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt as _;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+struct Fixture {
+    root: std::path::PathBuf,
+    wrapper: Option<Child>,
+    group: Option<i32>,
+}
+
+impl Fixture {
+    fn new(name: &str) -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-native-supervisor-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir(&root).unwrap();
+        Self {
+            root,
+            wrapper: None,
+            group: None,
+        }
+    }
+
+    fn stop_wrapper(&mut self) {
+        if let Some(mut wrapper) = self.wrapper.take() {
+            unsafe {
+                libc::kill(wrapper.id() as i32, libc::SIGKILL);
+            }
+            let _ = wrapper.wait();
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.stop_wrapper();
+        if let Some(group) = self.group {
+            // The managed client is the group leader. Only clean this exact
+            // fixture group while that leader identity still exists.
+            if unsafe { libc::getpgid(group) } == group {
+                unsafe {
+                    libc::kill(-group, libc::SIGKILL);
+                }
+            }
+        }
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn wait_ready(path: &std::path::Path) -> (i32, i32, String) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                let mut lines = contents.lines();
+                return (
+                    lines.next().unwrap().parse().unwrap(),
+                    lines.next().unwrap().parse().unwrap(),
+                    lines.next().unwrap_or_default().to_string(),
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => panic!("could not read readiness marker: {error}"),
+        }
+        assert!(Instant::now() < deadline, "client did not become ready");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_dead(pid: i32) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while unsafe { libc::kill(pid, 0) } == 0 {
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    true
+}
+
+#[test]
+fn typed_native_clients_terminate_their_ordinary_process_groups() {
+    for (client, flag, tail) in [
+        ("codex", "--codex", Vec::<&str>::new()),
+        ("opencode", "--opencode", vec!["auth"]),
+        ("pi", "--pi", vec!["-p", "offline"]),
+    ] {
+        let mut fixture = Fixture::new(client);
+        let home = fixture.root.join("home");
+        let project = fixture.root.join("project");
+        let runtime = fixture.root.join("runtime");
+        let cache = fixture.root.join("cache");
+        let state = fixture.root.join("state");
+        let config = fixture.root.join("config");
+        for directory in [&home, &project, &runtime, &cache, &state, &config] {
+            std::fs::create_dir(directory).unwrap();
+            std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        std::fs::create_dir(home.join(".pentect")).unwrap();
+        std::fs::create_dir(project.join(".git")).unwrap();
+        std::fs::write(
+            home.join(".pentect/config.toml"),
+            "[update]\ncheck = false\n",
+        )
+        .unwrap();
+        let ready = fixture.root.join("ready");
+        let script = fixture.root.join("client.sh");
+        std::fs::write(
+            &script,
+            r##"#!/bin/sh
+(while :; do sleep 1; done) &
+child=$!
+settings=no
+for arg in "$@"; do case "$arg" in --settings|--settings=*) settings=yes;; esac; done
+temporary="$READY.tmp.$$"
+printf '%s\n%s\n%s:%s:%s' "$$" "$child" "$PWD" "${PENTECT_MEMORY_STORE_TOKEN-unset}" "$settings" > "$temporary"
+mv "$temporary" "$READY"
+wait "$child"
+"##,
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+        command
+            .arg(client)
+            .arg(flag)
+            .arg(&script)
+            .args(tail)
+            .current_dir(&project)
+            .env("HOME", &home)
+            .env("USERPROFILE", &home)
+            .env("XDG_RUNTIME_DIR", &runtime)
+            .env("XDG_CACHE_HOME", cache)
+            .env("XDG_STATE_HOME", state)
+            .env("XDG_CONFIG_HOME", config)
+            .env("PENTECT_LOG_DIR", fixture.root.join("log"))
+            .env("PENTECT_MEMORY_STORE_TOKEN", "hostile-parent-token")
+            .env("READY", &ready)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+        fixture.wrapper = Some(command.spawn().unwrap());
+        let (client_pid, child_pid, state) = wait_ready(&ready);
+        fixture.group = Some(client_pid);
+        assert_eq!(state, format!("{}:unset:no", project.display()));
+
+        fixture.stop_wrapper();
+        assert!(
+            wait_dead(client_pid),
+            "{client} client survived wrapper kill"
+        );
+        assert!(
+            wait_dead(child_pid),
+            "{client} descendant survived wrapper kill"
+        );
+        fixture.group = None;
+    }
+}

--- a/crates/pentect-cli/tests/native_unix_supervisor.rs
+++ b/crates/pentect-cli/tests/native_unix_supervisor.rs
@@ -40,11 +40,21 @@ impl Fixture {
     }
 
     fn wait_wrapper(&mut self) -> std::process::ExitStatus {
-        self.wrapper
-            .take()
-            .expect("wrapper was not started")
-            .wait()
-            .unwrap()
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let status = self
+                .wrapper
+                .as_mut()
+                .expect("wrapper was not started")
+                .try_wait()
+                .unwrap();
+            if let Some(status) = status {
+                self.wrapper.take();
+                return status;
+            }
+            assert!(Instant::now() < deadline, "wrapper did not exit");
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -97,7 +107,10 @@ if middle == 0:
         marker.write(f"{os.getppid()}\n{os.getpid()}\n{leaf}\nready")
     os.replace(temporary, os.environ["READY"])
     time.sleep(15)
-while not os.path.exists(os.environ["READY"]):
+deadline = time.monotonic() + 15
+while not os.path.exists(os.environ["GO"]):
+    if time.monotonic() >= deadline:
+        raise SystemExit(2)
     time.sleep(0.01)
 raise SystemExit(37)
 "##,
@@ -117,6 +130,7 @@ raise SystemExit(37)
             .env("XDG_CONFIG_HOME", config)
             .env("PENTECT_LOG_DIR", fixture.root.join("log"))
             .env("READY", &ready)
+            .env("GO", fixture.root.join("go"))
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
@@ -129,6 +143,7 @@ raise SystemExit(37)
         fixture.track(middle),
         fixture.track(leaf),
     ];
+    std::fs::write(fixture.root.join("go"), b"go").unwrap();
     assert_eq!(fixture.wait_wrapper().code(), Some(37));
     for identity in identities {
         assert!(wait_pidfd_dead(&fixture.observed[identity]));

--- a/crates/pentect-cli/tests/native_unix_supervisor.rs
+++ b/crates/pentect-cli/tests/native_unix_supervisor.rs
@@ -291,7 +291,8 @@ time.sleep(15)
             .stderr(Stdio::piped());
         fixture.wrapper = Some(command.spawn().unwrap());
         let (client_pid, middle_pid, child_pid, state) = wait_ready(&ready);
-        assert_eq!(state, format!("{}:unset:no", project.display()));
+        let canonical_project = project.canonicalize().unwrap();
+        assert_eq!(state, format!("{}:unset:no", canonical_project.display()));
 
         #[cfg(target_os = "linux")]
         let identities = [

--- a/crates/pentect-cli/tests/native_unix_supervisor.rs
+++ b/crates/pentect-cli/tests/native_unix_supervisor.rs
@@ -7,6 +7,8 @@ use std::time::{Duration, Instant};
 struct Fixture {
     root: std::path::PathBuf,
     wrapper: Option<Child>,
+    #[cfg(target_os = "linux")]
+    observed: Vec<std::os::fd::OwnedFd>,
 }
 
 impl Fixture {
@@ -23,6 +25,8 @@ impl Fixture {
         Self {
             root,
             wrapper: None,
+            #[cfg(target_os = "linux")]
+            observed: Vec::new(),
         }
     }
 
@@ -34,11 +38,118 @@ impl Fixture {
             let _ = wrapper.wait();
         }
     }
+
+    fn wait_wrapper(&mut self) -> std::process::ExitStatus {
+        self.wrapper
+            .take()
+            .expect("wrapper was not started")
+            .wait()
+            .unwrap()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn track(&mut self, pid: i32) -> usize {
+        use std::os::fd::FromRawFd as _;
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) as i32 };
+        assert_ne!(fd, -1, "could not retain fixture process identity");
+        self.observed
+            .push(unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) });
+        self.observed.len() - 1
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn normal_status_waits_for_cross_group_descendant_drain() {
+    let mut fixture = Fixture::new("normal-exit");
+    let home = fixture.root.join("home");
+    let project = fixture.root.join("project");
+    let runtime = fixture.root.join("runtime");
+    let cache = fixture.root.join("cache");
+    let state = fixture.root.join("state");
+    let config = fixture.root.join("config");
+    for directory in [&home, &project, &runtime, &cache, &state, &config] {
+        std::fs::create_dir(directory).unwrap();
+        std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    std::fs::create_dir(home.join(".pentect")).unwrap();
+    std::fs::create_dir(project.join(".git")).unwrap();
+    std::fs::write(
+        home.join(".pentect/config.toml"),
+        "[update]\ncheck = false\n",
+    )
+    .unwrap();
+    let ready = fixture.root.join("ready");
+    let script = fixture.root.join("client.py");
+    std::fs::write(
+        &script,
+        r##"#!/usr/bin/env python3
+import os, time
+middle = os.fork()
+if middle == 0:
+    os.setpgid(0, 0)
+    leaf = os.fork()
+    if leaf == 0:
+        time.sleep(15)
+        os._exit(0)
+    temporary = os.environ["READY"] + ".tmp." + str(os.getpid())
+    with open(temporary, "w", encoding="utf-8") as marker:
+        marker.write(f"{os.getppid()}\n{os.getpid()}\n{leaf}\nready")
+    os.replace(temporary, os.environ["READY"])
+    time.sleep(15)
+while not os.path.exists(os.environ["READY"]):
+    time.sleep(0.01)
+raise SystemExit(37)
+"##,
+    )
+    .unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+    fixture.wrapper = Some(
+        Command::new(env!("CARGO_BIN_EXE_pentect"))
+            .args(["codex", "--codex"])
+            .arg(&script)
+            .current_dir(&project)
+            .env("HOME", &home)
+            .env("USERPROFILE", &home)
+            .env("XDG_RUNTIME_DIR", &runtime)
+            .env("XDG_CACHE_HOME", cache)
+            .env("XDG_STATE_HOME", state)
+            .env("XDG_CONFIG_HOME", config)
+            .env("PENTECT_LOG_DIR", fixture.root.join("log"))
+            .env("READY", &ready)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap(),
+    );
+    let (client, middle, leaf, _) = wait_ready(&ready);
+    let identities = [
+        fixture.track(client),
+        fixture.track(middle),
+        fixture.track(leaf),
+    ];
+    assert_eq!(fixture.wait_wrapper().code(), Some(37));
+    for identity in identities {
+        assert!(wait_pidfd_dead(&fixture.observed[identity]));
+    }
 }
 
 impl Drop for Fixture {
     fn drop(&mut self) {
         self.stop_wrapper();
+        #[cfg(target_os = "linux")]
+        for pidfd in &self.observed {
+            unsafe {
+                libc::syscall(
+                    libc::SYS_pidfd_send_signal,
+                    std::os::fd::AsRawFd::as_raw_fd(pidfd),
+                    libc::SIGKILL,
+                    std::ptr::null::<libc::siginfo_t>(),
+                    0,
+                );
+            }
+        }
         let _ = std::fs::remove_dir_all(&self.root);
     }
 }
@@ -64,6 +175,7 @@ fn wait_ready(path: &std::path::Path) -> (i32, i32, i32, String) {
     }
 }
 
+#[cfg(not(target_os = "linux"))]
 fn wait_dead(pid: i32) -> bool {
     let deadline = Instant::now() + Duration::from_secs(10);
     while unsafe { libc::kill(pid, 0) } == 0 {
@@ -75,8 +187,18 @@ fn wait_dead(pid: i32) -> bool {
     true
 }
 
+#[cfg(target_os = "linux")]
+fn wait_pidfd_dead(pidfd: &std::os::fd::OwnedFd) -> bool {
+    let mut pollfd = libc::pollfd {
+        fd: std::os::fd::AsRawFd::as_raw_fd(pidfd),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    (unsafe { libc::poll(&mut pollfd, 1, 10_000) }) == 1 && pollfd.revents & libc::POLLIN != 0
+}
+
 #[test]
-fn typed_native_clients_terminate_separate_group_descendant_trees() {
+fn typed_native_clients_terminate_descendant_trees() {
     for (client, flag, tail) in [
         ("codex", "--codex", Vec::<&str>::new()),
         ("opencode", "--opencode", vec!["auth"]),
@@ -109,7 +231,8 @@ import os, sys, time
 
 middle = os.fork()
 if middle == 0:
-    os.setpgid(0, 0)
+    if os.environ["SEPARATE_PG"] == "1":
+        os.setpgid(0, 0)
     leaf = os.fork()
     if leaf == 0:
         time.sleep(15)
@@ -143,6 +266,10 @@ time.sleep(15)
             .env("PENTECT_LOG_DIR", fixture.root.join("log"))
             .env("PENTECT_MEMORY_STORE_TOKEN", "hostile-parent-token")
             .env("READY", &ready)
+            .env(
+                "SEPARATE_PG",
+                if cfg!(target_os = "linux") { "1" } else { "0" },
+            )
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::piped());
@@ -150,18 +277,38 @@ time.sleep(15)
         let (client_pid, middle_pid, child_pid, state) = wait_ready(&ready);
         assert_eq!(state, format!("{}:unset:no", project.display()));
 
+        #[cfg(target_os = "linux")]
+        let identities = [
+            fixture.track(client_pid),
+            fixture.track(middle_pid),
+            fixture.track(child_pid),
+        ];
+
         fixture.stop_wrapper();
-        assert!(
-            wait_dead(client_pid),
-            "{client} client survived wrapper kill"
-        );
-        assert!(
-            wait_dead(middle_pid),
-            "{client} child survived wrapper kill"
-        );
-        assert!(
-            wait_dead(child_pid),
-            "{client} descendant survived wrapper kill"
-        );
+        #[cfg(target_os = "linux")]
+        for (identity, role) in identities
+            .into_iter()
+            .zip(["client", "child", "descendant"])
+        {
+            assert!(
+                wait_pidfd_dead(&fixture.observed[identity]),
+                "{client} {role} survived wrapper kill"
+            );
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert!(
+                wait_dead(client_pid),
+                "{client} client survived wrapper kill"
+            );
+            assert!(
+                wait_dead(middle_pid),
+                "{client} child survived wrapper kill"
+            );
+            assert!(
+                wait_dead(child_pid),
+                "{client} descendant survived wrapper kill"
+            );
+        }
     }
 }

--- a/crates/pentect-cli/tests/native_windows_supervisor.rs
+++ b/crates/pentect-cli/tests/native_windows_supervisor.rs
@@ -1,11 +1,11 @@
 #![cfg(windows)]
 
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0};
 use windows_sys::Win32::System::Threading::{
-    OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
+    OpenProcess, TerminateProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
 };
 
 struct TestDirectory(PathBuf);
@@ -46,7 +46,7 @@ struct ProcessHandle(HANDLE);
 
 impl ProcessHandle {
     fn open(pid: u32) -> Self {
-        let handle = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, 0, pid) };
+        let handle = unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_TERMINATE, 0, pid) };
         assert!(!handle.is_null(), "could not retain fixture process {pid}");
         Self(handle)
     }
@@ -54,7 +54,25 @@ impl ProcessHandle {
 
 impl Drop for ProcessHandle {
     fn drop(&mut self) {
+        if unsafe { WaitForSingleObject(self.0, 0) } == windows_sys::Win32::Foundation::WAIT_TIMEOUT
+        {
+            unsafe { TerminateProcess(self.0, 1) };
+            let _ = unsafe { WaitForSingleObject(self.0, 5_000) };
+        }
         unsafe { CloseHandle(self.0) };
+    }
+}
+
+fn output_bounded(mut command: Command, timeout: Duration) -> Output {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = ChildGuard(Some(command.spawn().unwrap()));
+    let deadline = Instant::now() + timeout;
+    loop {
+        if child.0.as_mut().unwrap().try_wait().unwrap().is_some() {
+            return child.0.take().unwrap().wait_with_output().unwrap();
+        }
+        assert!(Instant::now() < deadline, "supervised command did not exit");
+        std::thread::sleep(Duration::from_millis(20));
     }
 }
 
@@ -140,8 +158,17 @@ fn native_supervisor_preserves_normal_nonzero_and_still_active_exit_codes() {
         let fixture = TestDirectory::new("native-windows-exit");
         let client = fixture.0.join("opencode.cmd");
         write_cmd(&client, &format!("exit /b {expected}"));
-        let status = isolated_command(&fixture.0, &client).status().unwrap();
-        assert_eq!(status.code().map(|code| code as u32), Some(expected));
+        let output = output_bounded(
+            isolated_command(&fixture.0, &client),
+            Duration::from_secs(20),
+        );
+        assert_eq!(
+            output.status.code().map(|code| code as u32),
+            Some(expected),
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }
 
@@ -150,11 +177,18 @@ fn bad_native_executable_fails_without_waiting_for_startup_timeout() {
     let fixture = TestDirectory::new("native-windows-bad-executable");
     let client = fixture.0.join("invalid.exe");
     std::fs::write(&client, b"not a Windows executable").unwrap();
-    let started = Instant::now();
-    let status = isolated_command(&fixture.0, &client).status().unwrap();
-    assert!(!status.success());
+    let output = output_bounded(
+        isolated_command(&fixture.0, &client),
+        Duration::from_secs(20),
+    );
+    assert!(!output.status.success());
+    let diagnostic = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     assert!(
-        started.elapsed() < Duration::from_secs(5),
-        "bad executable waited for the supervisor startup deadline"
+        !diagnostic.contains("startup timed out") && !diagnostic.contains("payload timed out"),
+        "bad executable reached a supervisor timeout instead of failing startup: {diagnostic}"
     );
 }

--- a/crates/pentect-cli/tests/native_windows_supervisor.rs
+++ b/crates/pentect-cli/tests/native_windows_supervisor.rs
@@ -63,13 +63,25 @@ impl Drop for ProcessHandle {
     }
 }
 
-fn output_bounded(mut command: Command, timeout: Duration) -> Output {
-    command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let mut child = ChildGuard(Some(command.spawn().unwrap()));
+fn output_bounded(mut command: Command, root: &Path, timeout: Duration) -> Output {
+    let stdout_path = root.join("wrapper.stdout");
+    let stderr_path = root.join("wrapper.stderr");
+    command
+        .stdout(Stdio::from(std::fs::File::create(&stdout_path).unwrap()))
+        .stderr(Stdio::from(std::fs::File::create(&stderr_path).unwrap()));
+    let spawned = command.spawn().unwrap();
+    // Do not retain the parent's copies of the fixture output handles.
+    drop(command);
+    let mut child = ChildGuard(Some(spawned));
     let deadline = Instant::now() + timeout;
     loop {
-        if child.0.as_mut().unwrap().try_wait().unwrap().is_some() {
-            return child.0.take().unwrap().wait_with_output().unwrap();
+        if let Some(status) = child.0.as_mut().unwrap().try_wait().unwrap() {
+            drop(child.0.take());
+            return Output {
+                status,
+                stdout: std::fs::read(&stdout_path).unwrap(),
+                stderr: std::fs::read(&stderr_path).unwrap(),
+            };
         }
         assert!(Instant::now() < deadline, "supervised command did not exit");
         std::thread::sleep(Duration::from_millis(20));
@@ -160,6 +172,7 @@ fn native_supervisor_preserves_normal_nonzero_and_still_active_exit_codes() {
         write_cmd(&client, &format!("exit /b {expected}"));
         let output = output_bounded(
             isolated_command(&fixture.0, &client),
+            &fixture.0,
             Duration::from_secs(20),
         );
         assert_eq!(
@@ -179,6 +192,7 @@ fn bad_native_executable_fails_without_waiting_for_startup_timeout() {
     std::fs::write(&client, b"not a Windows executable").unwrap();
     let output = output_bounded(
         isolated_command(&fixture.0, &client),
+        &fixture.0,
         Duration::from_secs(20),
     );
     assert!(!output.status.success());

--- a/crates/pentect-cli/tests/native_windows_supervisor.rs
+++ b/crates/pentect-cli/tests/native_windows_supervisor.rs
@@ -1,0 +1,160 @@
+#![cfg(windows)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0};
+use windows_sys::Win32::System::Threading::{
+    OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
+};
+
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+    fn new(label: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "pentect-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct ChildGuard(Option<Child>);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+struct ProcessHandle(HANDLE);
+
+impl ProcessHandle {
+    fn open(pid: u32) -> Self {
+        let handle = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, 0, pid) };
+        assert!(!handle.is_null(), "could not retain fixture process {pid}");
+        Self(handle)
+    }
+}
+
+impl Drop for ProcessHandle {
+    fn drop(&mut self) {
+        unsafe { CloseHandle(self.0) };
+    }
+}
+
+fn isolated_command(root: &Path, client: &Path) -> Command {
+    let home = root.join("home");
+    let project = root.join("project");
+    for directory in [&home, &project, &root.join("logs")] {
+        std::fs::create_dir_all(directory).unwrap();
+    }
+    std::fs::create_dir_all(home.join(".pentect")).unwrap();
+    std::fs::create_dir_all(project.join(".git")).unwrap();
+    std::fs::write(
+        home.join(".pentect/config.toml"),
+        "[update]\ncheck = false\n",
+    )
+    .unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+    command
+        .current_dir(project)
+        .args(["opencode", "--opencode"])
+        .arg(client)
+        .arg("auth")
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("PENTECT_LOG_DIR", root.join("logs"))
+        .env_remove("PENTECT_HOME");
+    command
+}
+
+fn write_cmd(path: &Path, body: &str) {
+    std::fs::write(path, format!("@echo off\r\n{body}\r\n")).unwrap();
+}
+
+fn wait_for_pid(marker: &Path) -> u32 {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(value) = std::fs::read_to_string(marker) {
+            if let Ok(pid) = value.trim().parse() {
+                return pid;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "native fixture did not become ready"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn wrapper_hard_kill_terminates_the_exact_native_client_descendant() {
+    let fixture = TestDirectory::new("native-windows-parent-kill");
+    let marker = fixture.0.join("client.pid");
+    let client = fixture.0.join("opencode.cmd");
+    write_cmd(
+        &client,
+        r#"powershell.exe -NoLogo -NoProfile -NonInteractive -Command "[IO.File]::WriteAllText($env:PENTECT_NATIVE_MARKER, [string]$PID); Start-Sleep -Seconds 30""#,
+    );
+    let mut wrapper = isolated_command(&fixture.0, &client);
+    wrapper
+        .env("PENTECT_NATIVE_MARKER", &marker)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut wrapper = ChildGuard(Some(wrapper.spawn().unwrap()));
+    let client_pid = wait_for_pid(&marker);
+    let client = ProcessHandle::open(client_pid);
+
+    // Child::kill targets only the retained wrapper process handle. Closing
+    // its sole job handle must terminate the separately retained client.
+    wrapper.0.as_mut().unwrap().kill().unwrap();
+    wrapper.0.as_mut().unwrap().wait().unwrap();
+    wrapper.0.take();
+    assert_eq!(
+        unsafe { WaitForSingleObject(client.0, 5_000) },
+        WAIT_OBJECT_0
+    );
+}
+
+#[test]
+fn native_supervisor_preserves_normal_nonzero_and_still_active_exit_codes() {
+    for expected in [0_u32, 37, 259] {
+        let fixture = TestDirectory::new("native-windows-exit");
+        let client = fixture.0.join("opencode.cmd");
+        write_cmd(&client, &format!("exit /b {expected}"));
+        let status = isolated_command(&fixture.0, &client).status().unwrap();
+        assert_eq!(status.code().map(|code| code as u32), Some(expected));
+    }
+}
+
+#[test]
+fn bad_native_executable_fails_without_waiting_for_startup_timeout() {
+    let fixture = TestDirectory::new("native-windows-bad-executable");
+    let client = fixture.0.join("invalid.exe");
+    std::fs::write(&client, b"not a Windows executable").unwrap();
+    let started = Instant::now();
+    let status = isolated_command(&fixture.0, &client).status().unwrap();
+    assert!(!status.success());
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "bad executable waited for the supervisor startup deadline"
+    );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -2613,6 +2613,223 @@ def capture_descendant_identities(wrapper_pid: int, identities: dict[int, str]) 
             identities.setdefault(pid, identity)
 
 
+def run_codex_parent_kill(pentect: str) -> None:
+    if not sys.platform.startswith("linux"):
+        raise RuntimeError("Codex parent-exit E2E currently requires Linux pidfd cleanup")
+    state = State("unused-valid", "unused-invalid", hold_model=True)
+    server = FixtureServer(state)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    process: subprocess.Popen[str] | None = None
+    recorded_identities: dict[int, str] = {}
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix="pentect-codex-parent-kill-", ignore_cleanup_errors=True
+        ) as raw_root:
+            root = Path(raw_root)
+            home = root / "home"
+            project = root / "project"
+            runtime = root / "runtime"
+            temporary = root / "tmp"
+            for directory in (home, project, runtime, temporary):
+                directory.mkdir()
+            (project / ".git").mkdir()
+            synthetic_input = project / "lifecycle-input.txt"
+            synthetic_input.write_text("ordinary lifecycle fixture\n", encoding="utf-8")
+            input_snapshot = synthetic_input.read_bytes()
+
+            marker = root / "mcp-ready.json"
+            mcp_server = root / "mcp-lifecycle.py"
+            mcp_server.write_text(
+                r'''import json
+import os
+import signal
+import subprocess
+import sys
+
+marker = sys.argv[1]
+if len(sys.argv) == 3 and sys.argv[2] == "--child":
+    while True:
+        signal.pause()
+
+child = subprocess.Popen([sys.executable, __file__, marker, "--child"])
+
+def publish(initialized):
+    temporary = marker + ".tmp"
+    with open(temporary, "x", encoding="utf-8") as output:
+        json.dump({
+            "server_pid": os.getpid(),
+            "child_pid": child.pid,
+            "initialized": initialized,
+        }, output, separators=(",", ":"))
+        output.flush()
+        os.fsync(output.fileno())
+    os.replace(temporary, marker)
+
+publish(False)
+for line in sys.stdin:
+    request = json.loads(line)
+    identifier = request.get("id")
+    method = request.get("method")
+    if identifier is None:
+        continue
+    if method == "initialize":
+        result = {
+            "protocolVersion": request.get("params", {}).get(
+                "protocolVersion", "2025-06-18"
+            ),
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "pentect-lifecycle-fixture", "version": "1"},
+        }
+    elif method == "tools/list":
+        result = {"tools": []}
+    elif method == "ping":
+        result = {}
+    else:
+        result = {}
+    print(json.dumps({"jsonrpc": "2.0", "id": identifier, "result": result},
+                     separators=(",", ":")), flush=True)
+    if method == "initialize":
+        publish(True)
+''',
+                encoding="utf-8",
+            )
+            server_snapshot = mcp_server.read_bytes()
+
+            codex_home = home / ".codex"
+            codex_home.mkdir()
+            config = codex_home / "config.toml"
+            config.write_text(
+                f"[projects.{json.dumps(str(project.resolve()))}]\n"
+                'trust_level = "trusted"\n\n'
+                "[mcp_servers.pentect_lifecycle]\n"
+                f"command = {json.dumps(sys.executable)}\n"
+                f"args = {json.dumps([str(mcp_server), str(marker)])}\n"
+                "startup_timeout_sec = 10\n",
+                encoding="utf-8",
+            )
+            config_snapshot = config.read_bytes()
+            environment = isolated_environment(home, root / "logs")
+            for name in tuple(environment):
+                upper = name.upper()
+                if any(
+                    marker in upper
+                    for marker in ("TOKEN", "SECRET", "API_KEY", "PASSWORD", "CREDENTIAL")
+                ):
+                    environment.pop(name)
+            environment.update({
+                "CODEX_HOME": str(codex_home),
+                "OPENAI_API_KEY": "local-fixture",
+                "TMP": str(temporary),
+                "TEMP": str(temporary),
+                "TMPDIR": str(temporary),
+                "XDG_RUNTIME_DIR": str(runtime),
+                "PENTECT_DISABLE_UPDATE_CHECK": "1",
+            })
+            command = [
+                pentect,
+                "codex",
+                "--upstream",
+                f"http://127.0.0.1:{server.server_port}/v1",
+                "--model",
+                "gpt-5.6-luna",
+                "exec",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--skip-git-repo-check",
+                "Wait for the local lifecycle fixture response.",
+            ]
+            process = subprocess.Popen(
+                command,
+                cwd=project,
+                env=environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            ready: dict[str, object] | None = None
+            deadline = time.monotonic() + 25
+            while time.monotonic() < deadline:
+                capture_descendant_identities(process.pid, recorded_identities)
+                if marker.exists():
+                    try:
+                        candidate = json.loads(marker.read_text(encoding="utf-8"))
+                        if candidate.get("initialized") is True:
+                            ready = candidate
+                    except (FileNotFoundError, json.JSONDecodeError):
+                        pass
+                if ready is not None and state.model_request_seen.is_set():
+                    break
+                if process.poll() is not None:
+                    break
+                state.model_request_seen.wait(timeout=0.05)
+            capture_descendant_identities(process.pid, recorded_identities)
+            if ready is None:
+                raise RuntimeError("installed Codex did not initialize the synthetic MCP server")
+            if not state.model_request_seen.is_set():
+                raise RuntimeError("installed Codex did not reach the local model fixture")
+            mcp_pids = [int(ready["server_pid"]), int(ready["child_pid"])]
+            descendants = descendant_processes(process.pid)
+            if any(pid not in descendants for pid in mcp_pids):
+                raise RuntimeError(
+                    "synthetic MCP server tree was not below the Pentect wrapper: "
+                    + repr({pid: descendants.get(pid) for pid in mcp_pids})
+                )
+            for pid in mcp_pids:
+                identity = process_identity(pid)
+                if identity is None:
+                    raise RuntimeError(f"synthetic MCP process {pid} exited before parent kill")
+                recorded_identities[pid] = identity
+            if config.read_bytes() != config_snapshot:
+                raise RuntimeError("Codex modified the caller-owned lifecycle config")
+            if synthetic_input.read_bytes() != input_snapshot:
+                raise RuntimeError("Codex modified the synthetic lifecycle input")
+
+            process.kill()
+            process.wait(timeout=10)
+            surviving = wait_for_process_identities_exit(recorded_identities, 10)
+            if surviving:
+                raise RuntimeError(
+                    "installed Codex descendants survived wrapper exit: "
+                    + ", ".join(map(str, surviving))
+                )
+            if config.read_bytes() != config_snapshot:
+                raise RuntimeError("Codex changed lifecycle config after wrapper exit")
+            if synthetic_input.read_bytes() != input_snapshot:
+                raise RuntimeError("Codex changed lifecycle input after wrapper exit")
+            runtime_root = home / ".cache" / "pentect" / "runtime"
+            residue = list(runtime_root.glob("process-host-candidate-*.json"))
+            residue.extend(runtime_root.glob("delegated-process-host.json"))
+            if residue:
+                raise RuntimeError(
+                    "Pentect left process-host registration after Codex parent exit: "
+                    + ", ".join(path.name for path in residue)
+                )
+            if mcp_server.read_bytes() != server_snapshot:
+                raise RuntimeError("Codex modified the synthetic MCP fixture")
+            print(
+                "installed Codex parent-exit E2E passed: initialized MCP server, "
+                "ordinary child, and client tree exited"
+            )
+    finally:
+        if process is not None and process.poll() is None:
+            process.kill()
+            process.wait()
+        surviving_cleanup = wait_for_process_identities_exit(recorded_identities, 5)
+        for pid in surviving_cleanup:
+            terminate_process_identity(pid, recorded_identities[pid])
+        surviving_cleanup = wait_for_process_identities_exit(recorded_identities, 5)
+        state.release_model_request.set()
+        server.shutdown()
+        server.server_close()
+        thread.join()
+        if surviving_cleanup:
+            raise RuntimeError(
+                "test cleanup could not reap recorded Codex identities: "
+                + ", ".join(map(str, surviving_cleanup))
+            )
+
+
 def run_claude_parent_kill(pentect: str) -> None:
     if os.name == "nt" and Path(pentect).suffix.lower() != ".exe":
         raise RuntimeError(
@@ -2901,6 +3118,7 @@ def main() -> int:
         dest="clients",
     )
     parser.add_argument("--skip-image", action="store_true")
+    parser.add_argument("--codex-parent-kill", action="store_true")
     parser.add_argument("--claude-parent-kill", action="store_true")
     parser.add_argument("--plugin-lifecycle-only", action="store_true")
     args = parser.parse_args()
@@ -2909,6 +3127,9 @@ def main() -> int:
         args.pentect = str(candidate.resolve())
     if args.plugin_lifecycle_only:
         run_plugin_lifecycle(args.pentect)
+        return 0
+    if args.codex_parent_kill:
+        run_codex_parent_kill(args.pentect)
         return 0
     if args.claude_parent_kill:
         run_claude_parent_kill(args.pentect)

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -1827,6 +1827,33 @@ def descendant_processes(parent_pid: int) -> dict[int, tuple[int, str]]:
     return descendants
 
 
+def linux_process_diagnostics(
+    pids: list[int], identities: dict[int, str]
+) -> list[dict[str, object]]:
+    diagnostics: list[dict[str, object]] = []
+    for pid in pids:
+        try:
+            raw = (Path("/proc") / str(pid) / "stat").read_text(encoding="utf-8")
+            _, separator, suffix = raw.rpartition(") ")
+            fields = suffix.split()
+            if not separator or len(fields) <= 19:
+                raise RuntimeError("malformed stat")
+            executable = os.readlink(Path("/proc") / str(pid) / "exe")
+            diagnostics.append({
+                "pid": pid,
+                "basename": Path(executable).name,
+                "ppid": int(fields[1]),
+                "pgid": int(fields[2]),
+                "sid": int(fields[3]),
+                "state": fields[0],
+                "recorded_identity": identities.get(pid),
+                "current_identity": fields[19],
+            })
+        except (FileNotFoundError, ProcessLookupError):
+            diagnostics.append({"pid": pid, "state": "exited"})
+    return diagnostics
+
+
 def tool_response(sequence: int, source: str) -> bytes:
     response_id = f"resp_e2e_{sequence}"
     item_id = f"ct_e2e_{sequence}"
@@ -2622,6 +2649,7 @@ def run_codex_parent_kill(pentect: str) -> None:
     thread.start()
     process: subprocess.Popen[str] | None = None
     recorded_identities: dict[int, str] = {}
+    before_kill: list[dict[str, object]] = []
     try:
         with tempfile.TemporaryDirectory(
             prefix="pentect-codex-parent-kill-", ignore_cleanup_errors=True
@@ -2785,13 +2813,21 @@ for line in sys.stdin:
             if synthetic_input.read_bytes() != input_snapshot:
                 raise RuntimeError("Codex modified the synthetic lifecycle input")
 
+            before_kill = linux_process_diagnostics(
+                sorted(recorded_identities), recorded_identities
+            )
             process.kill()
             process.wait(timeout=10)
             surviving = wait_for_process_identities_exit(recorded_identities, 10)
             if surviving:
                 raise RuntimeError(
                     "installed Codex descendants survived wrapper exit: "
-                    + ", ".join(map(str, surviving))
+                    + json.dumps(
+                        linux_process_diagnostics(surviving, recorded_identities),
+                        separators=(",", ":"),
+                    )
+                    + "; before wrapper kill: "
+                    + json.dumps(before_kill, separators=(",", ":"))
                 )
             if config.read_bytes() != config_snapshot:
                 raise RuntimeError("Codex changed lifecycle config after wrapper exit")

--- a/tools/test_client_smoke_coverage.py
+++ b/tools/test_client_smoke_coverage.py
@@ -53,6 +53,7 @@ def main() -> None:
         "crates/pentect-cli/src/*supervisor*.rs",
         "crates/pentect-cli/tests/client_store_isolation.rs",
         "crates/pentect-cli/tests/native_interrupt.rs",
+        "crates/pentect-cli/tests/native_linux_fallback.rs",
         "crates/pentect-cli/tests/native_unix_supervisor.rs",
         "crates/pentect-cli/tests/native_windows_supervisor.rs",
         "crates/pentect-cli/tests/*claude*.rs",
@@ -64,6 +65,17 @@ def main() -> None:
     assert "--claude-parent-kill" in workflow
     assert "--codex-parent-kill" in workflow
     assert "--test claude_guardian_loss" in workflow
+    linux_fallback_step = re.search(
+        r"      - name: Test Linux native supervisor compatibility fallback \(PR\)\n"
+        r"        if: github\.event_name == 'pull_request' && runner\.os == 'Linux'\n"
+        r"        timeout-minutes: 2\n"
+        r"        run: (?P<command>.+)\n",
+        workflow,
+    )
+    assert linux_fallback_step is not None
+    assert linux_fallback_step.group("command") == (
+        "cargo test -p pentect-cli --locked --test native_linux_fallback"
+    )
 
     ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     assert "claude_supervisor: ${{ steps.filter.outputs.claude_supervisor }}" in ci

--- a/tools/test_client_smoke_coverage.py
+++ b/tools/test_client_smoke_coverage.py
@@ -53,6 +53,8 @@ def main() -> None:
         "crates/pentect-cli/src/*supervisor*.rs",
         "crates/pentect-cli/tests/client_store_isolation.rs",
         "crates/pentect-cli/tests/native_interrupt.rs",
+        "crates/pentect-cli/tests/native_unix_supervisor.rs",
+        "crates/pentect-cli/tests/native_windows_supervisor.rs",
         "crates/pentect-cli/tests/*claude*.rs",
         "tools/installed_agent_e2e.py",
     ):
@@ -60,6 +62,7 @@ def main() -> None:
             f"current-client workflow does not watch launch boundary {boundary}"
         )
     assert "--claude-parent-kill" in workflow
+    assert "--codex-parent-kill" in workflow
     assert "--test claude_guardian_loss" in workflow
 
     ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
@@ -80,6 +83,8 @@ def main() -> None:
         "crates/pentect-cli/src/claude_unix_supervisor.rs",
         "crates/pentect-cli/src/claude_windows_supervisor.rs",
         "crates/pentect-cli/tests/native_interrupt.rs",
+        "crates/pentect-cli/tests/native_unix_supervisor.rs",
+        "crates/pentect-cli/tests/native_windows_supervisor.rs",
         "crates/pentect-cli/tests/*claude*.rs",
     ):
         assert f"- '{boundary}'" in supervisor_filter.group("body"), (
@@ -99,6 +104,10 @@ def main() -> None:
         "cargo test -p pentect-cli --no-default-features --bin pentect "
         "claude_windows_supervisor::tests --locked"
     ) in ci
+    assert (
+        "cargo test -p pentect-cli --no-default-features "
+        "--test native_windows_supervisor --locked"
+    ) in ci
     macos_step = re.search(
         r"      - name: Test macOS Claude supervisor boundaries\n"
         r"        if: .*claude_supervisor.*runner\.os == 'macOS'\n"
@@ -110,7 +119,7 @@ def main() -> None:
     assert macos_step.group("command") == (
         "cargo test -p pentect-cli --no-default-features --locked "
         "--test claude_guardian_boundary --test claude_unix_supervisor "
-        "--test native_interrupt"
+        "--test native_interrupt --test native_unix_supervisor"
     )
     assert (
         "needs.changes.outputs.command_shims != 'true' && "

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -14,13 +14,23 @@ than on adding more client launchers. Codex App and Claude Desktop entries are
 separate desktop surfaces within those client families, not additional core
 clients.
 
-On Unix, the four protected CLI launchers supervise the native client process
-group. If the shell-facing Pentect process is forcibly killed, a separate
-guardian stops ordinary descendants that remain in that group. Normal exit
-status and terminal job control are preserved. This is a lifecycle boundary,
-not a sandbox: a process that deliberately creates a new session or process
-group is outside the guarantee, and forcibly killing the guardian itself can
-leave the client running. Desktop launchers have separate lifecycle contracts.
+The four protected CLI launchers supervise their native client processes while
+preserving normal exit status and terminal job control. On Linux, the guardian
+uses subreaper support, pidfds, and `/proc` child discovery, when available, to
+stop ordinary descendants even when a client gives them another process group.
+If those facilities are unavailable, Pentect warns and falls back to managing
+only the original process group; this does not impose a new minimum kernel
+version. On macOS, supervision is process-group based, so a client or ordinary
+child such as an MCP server can create another group outside that boundary.
+
+On Windows, a kill-on-close job contains ordinary descendants of protected
+Codex, Claude Code, OpenCode, and Pi launches; this path must pass its Windows
+CI lifecycle gate before release. These are lifecycle boundaries, not a
+sandbox or a universal cleanup mechanism. Killing the guardian itself, an
+unkillable kernel wait, or an intentional OS-level containment escape can
+remain outside the guarantee, and cleanup of temporary files owned by the
+wrapper or client is not universal. Desktop launchers have separate lifecycle
+contracts.
 
 | Client | Test | Protected launch |
 | --- | --- | --- |

--- a/website/src/content/docs/reference/compatibility.md
+++ b/website/src/content/docs/reference/compatibility.md
@@ -14,6 +14,14 @@ than on adding more client launchers. Codex App and Claude Desktop entries are
 separate desktop surfaces within those client families, not additional core
 clients.
 
+On Unix, the four protected CLI launchers supervise the native client process
+group. If the shell-facing Pentect process is forcibly killed, a separate
+guardian stops ordinary descendants that remain in that group. Normal exit
+status and terminal job control are preserved. This is a lifecycle boundary,
+not a sandbox: a process that deliberately creates a new session or process
+group is outside the guarantee, and forcibly killing the guardian itself can
+leave the client running. Desktop launchers have separate lifecycle contracts.
+
 | Client | Test | Protected launch |
 | --- | --- | --- |
 | Codex CLI `0.149.0` | Real launch on Linux and all installer platforms | `pentect codex` |


### PR DESCRIPTION
## What

Prepare v0.0.76: supervise the four typed native CLI launchers (Codex, Claude Code, OpenCode, Pi) through the existing Unix guardian / Windows kill-on-close job machinery. Generic clients do not create Claude settings sessions.

Linux additionally adopts orphaned descendants and drains verified child identities across process groups. This fixes the reproduced case where Codex creates a separate process group for an ordinary MCP server and leaves its child running after the Pentect parent is killed.

## Why

Refs #1389. Keep the issue open: macOS remains process-group scoped, including when an ordinary client/MCP process creates another group. This PR does not claim identical whole-tree containment on all operating systems.

No client fork, sandbox/capability framework, or share/export protection is introduced. Other launcher families retain their existing paths.

## Safety and compatibility

- Preserve terminal handoff, Ctrl-C / repeated interrupt behavior, stop/foreground handling, native exit statuses, raw arguments, cwd, environment removals, and guard lifetime.
- Keep the Unix leader unreaped through terminal STATUS_ACK; never signal a cached descendant PID/PGID after its identity anchor is gone.
- Linux verifies child relation through pidfds, repeatedly drains newly adopted generations, and requires ECHILD before successful cleanup. Incomplete cleanup retains unreleased Claude settings and reports failure.
- If required Linux facilities are unavailable, explicitly warn and retain the narrower managed-process-group behavior; no unconditional kernel-version increase.
- Windows keeps one non-inherited kill-on-close job owner and authenticates the blocked helper before releasing native execution. Relative cwd is applied exactly once.
- Document the Unix guardian-loss boundary, macOS cross-group limitation, and non-universal cleanup of wrapper/client-owned temporary files.

## Validation

- [x] Focused Unix guardian, settings boundary/loss, native status, and terminal regression suites pass locally.
- [x] Actual installed Codex parent-kill test changed from surviving ordinary MCP descendants to all recorded client/MCP identities exited.
- [x] Actual installed Codex, Claude, OpenCode, and Pi plugin/handle workflows pass with synthetic local fixture providers.
- [x] Actual Codex cancellation and image-mask workflows pass.
- [x] Whole-workspace default-feature tests pass on the final production code (623119e4); the subsequent macOS canonical-path fixture correction also passes its focused tests. Earlier no-default-features workspace tests passed as well.
- [x] User-facing platform guarantees are documented.
- [x] No real credentials, user conversations, personal data, or private URLs are included in fixtures/evidence.

Windows compilation/runtime and macOS regression validation are required from CI before merge/release. Release assets are created only by the existing immutable tag workflow after all required gates pass.
