### PR TITLE
Explain privacy metric warning and surface codes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
               - 'crates/pentect-runtime/src/activity_log.rs'
               - 'crates/pentect-runtime/src/delegated_process_host.rs'
               - 'crates/pentect-runtime/src/memory_store.rs'
+              - 'crates/pentect-cli/tests/metrics.rs'
             runtime_main:
               - 'crates/pentect-runtime/src/main.rs'
       # Negated globs require AND semantics. With paths-filter's default OR
@@ -507,6 +508,9 @@ jobs:
       - name: Test runtime activity log
         if: needs.changes.outputs.runtime_log == 'true'
         run: cargo test -p pentect-runtime --no-default-features activity_log::tests --locked
+      - name: Test privacy metrics CLI
+        if: needs.changes.outputs.runtime_log == 'true'
+        run: cargo test -p pentect-cli --no-default-features --locked --test metrics
       - name: Test general CLI changes
         if: needs.changes.outputs.cli_general == 'true'
         run: cargo test -p pentect-cli --no-default-features --locked

--- a/crates/pentect-cli/tests/metrics.rs
+++ b/crates/pentect-cli/tests/metrics.rs
@@ -1,0 +1,164 @@
+use serde_json::json;
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+struct Fixture(std::path::PathBuf);
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn event(action: &str, surface: &str, count: u64) -> serde_json::Value {
+    json!({
+        "time": "2026-01-01T00:00:00Z",
+        "action": action,
+        "surface": surface,
+        "count": count
+    })
+}
+
+fn run_metrics(mut command: Command) -> Output {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            return child.wait_with_output().unwrap();
+        }
+        if Instant::now() >= deadline {
+            child.kill().unwrap();
+            let _ = child.wait();
+            panic!("pentect metrics did not exit within five seconds");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn metrics_human_describes_stable_codes_without_echoing_untrusted_values() {
+    let root = std::env::temp_dir().join(format!(
+        "pentect-metrics-cli-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let fixture = Fixture(root);
+    let home = fixture.0.join("home");
+    let logs = fixture.0.join("logs");
+    std::fs::create_dir_all(home.join(".pentect")).unwrap();
+    std::fs::create_dir(&logs).unwrap();
+    std::fs::create_dir(fixture.0.join(".git")).unwrap();
+    std::fs::write(
+        home.join(".pentect/config.toml"),
+        "[metrics]\nenabled = true\n",
+    )
+    .unwrap();
+
+    let sentinel = "SECRET_PATH_\u{1b}[31m_/private/account";
+    let mut records = Vec::new();
+    let mut masked = event("mask", "prompt", 2);
+    masked["labels"] = json!([
+        {"name": "API_KEY", "count": 2},
+        {"name": sentinel, "count": 3}
+    ]);
+    masked["target"] = json!(sentinel);
+    records.push(masked);
+    let mut unknown_surface = event("mask", sentinel, 4);
+    unknown_surface["labels"] = json!([{"name": sentinel, "count": 4}]);
+    records.push(unknown_surface);
+    for (reason, count) in [
+        ("upstream-response", 4),
+        ("scan-unavailable-allowed", 3),
+        ("scan-unavailable-blocked", 1),
+        ("request-rejected", 2),
+        ("no-protected-connection", 2),
+        ("response-restore-skipped", 1),
+        (sentinel, 5),
+    ] {
+        let mut warning = event("warning", "openai", count);
+        warning["event"] = json!(reason);
+        records.push(warning);
+    }
+    let payload = records
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    std::fs::write(logs.join("pentect.log"), payload).unwrap();
+
+    let run = |json: bool| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+        command
+            .arg("metrics")
+            .current_dir(&fixture.0)
+            .env_clear()
+            .env("HOME", &home)
+            .env("USERPROFILE", &home)
+            .env("XDG_CONFIG_HOME", fixture.0.join("config"))
+            .env("XDG_CACHE_HOME", fixture.0.join("cache"))
+            .env("XDG_STATE_HOME", fixture.0.join("state"))
+            .env("XDG_RUNTIME_DIR", fixture.0.join("runtime"))
+            .env("PENTECT_LOG_DIR", &logs)
+            .env("TMPDIR", fixture.0.join("tmp"));
+        if json {
+            command.arg("--json");
+        }
+        run_metrics(command)
+    };
+
+    let human = run(false);
+    assert!(
+        human.status.success(),
+        "{}",
+        String::from_utf8_lossy(&human.stderr)
+    );
+    let human = String::from_utf8(human.stdout).unwrap();
+    for expected in [
+        "prompt (Text sent to a model): 2",
+        "OTHER (Other protected surface): 4",
+        "API_KEY (Api Key): 2",
+        "OTHER (Other): 7",
+        "unknown (Unknown or unclassified warning): 5",
+        "upstream-response (A provider response status was observed): 4",
+        "scan-unavailable-allowed (Policy allowed image content without OCR inspection): 3",
+        "scan-unavailable-blocked (Affected image content was blocked because OCR inspection was unavailable): 1",
+        "request-rejected (A request was rejected to preserve protection): 2",
+        "no-protected-connection (No protected client connection was observed): 2",
+        "response-restore-skipped (Local response-handle restoration was skipped): 1",
+    ] {
+        assert!(human.contains(expected), "missing {expected:?}:\n{human}");
+    }
+    assert!(!human.contains(sentinel));
+    let ordered = [
+        "unknown (",
+        "upstream-response (",
+        "scan-unavailable-allowed (",
+    ];
+    assert!(ordered
+        .windows(2)
+        .all(|pair| human.find(pair[0]) < human.find(pair[1])));
+
+    let encoded = run(true);
+    assert!(
+        encoded.status.success(),
+        "{}",
+        String::from_utf8_lossy(&encoded.stderr)
+    );
+    let metrics: serde_json::Value = serde_json::from_slice(&encoded.stdout).unwrap();
+    assert_eq!(metrics["masked_text_occurrences"], 6);
+    assert_eq!(metrics["warning_occurrences"], 18);
+    assert_eq!(metrics["blocked_occurrences"], 3);
+    assert_eq!(metrics["by_secret_type"], json!({"API_KEY": 2, "OTHER": 7}));
+    assert_eq!(metrics["by_surface"], json!({"OTHER": 4, "prompt": 2}));
+    assert_eq!(metrics["by_warning_reason"]["unknown"], 5);
+    assert_eq!(metrics["by_warning_reason"]["scan-unavailable-allowed"], 3);
+    assert_eq!(metrics["by_warning_reason"]["scan-unavailable-blocked"], 1);
+    assert!(!String::from_utf8(encoded.stdout)
+        .unwrap()
+        .contains(sentinel));
+}

--- a/crates/pentect-cli/tests/metrics.rs
+++ b/crates/pentect-cli/tests/metrics.rs
@@ -121,7 +121,7 @@ fn metrics_human_describes_stable_codes_without_echoing_untrusted_values() {
     for expected in [
         "prompt (Text sent to a model): 2",
         "OTHER (Other protected surface): 4",
-        "API_KEY (Api Key): 2",
+        "API_KEY (API key): 2",
         "OTHER (Other): 7",
         "unknown (Unknown or unclassified warning): 5",
         "upstream-response (A provider response status was observed): 4",

--- a/crates/pentect-runtime/src/activity_log.rs
+++ b/crates/pentect-runtime/src/activity_log.rs
@@ -4,6 +4,7 @@ use pentect_core::{model::labels, MaskResult};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::fmt::Write as FmtWrite;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -390,45 +391,111 @@ pub(crate) fn print_metrics(json: bool) -> Result<(), String> {
         return Ok(());
     }
 
-    println!("Pentect privacy metrics (retained local logs)");
-    println!("Masked occurrences: {}", metrics.masked_text_occurrences);
-    println!("Redacted images: {}", metrics.redacted_image_occurrences);
-    println!("Blocked images: {}", metrics.blocked_image_occurrences);
-    println!(
-        "Local restoration operations: {}",
-        metrics.restoration_operations
-    );
-    println!(
-        "Blocked restoration attempts: {}",
-        metrics.blocked_restoration_occurrences
-    );
-    println!("Blocked operations: {}", metrics.blocked_occurrences);
-    println!("Warnings: {}", metrics.warning_occurrences);
-    println!(
-        "Plugin failures (including timeouts): {}",
-        metrics.plugin_failure_occurrences
-    );
-    println!("Plugin timeouts: {}", metrics.plugin_timeout_occurrences);
-    print_metric_group(
-        "Secret types (text masks and image redactions)",
-        &metrics.by_secret_type,
-    );
-    print_metric_group("Protection surfaces", &metrics.by_surface);
-    print_metric_group("Warning reasons", &metrics.by_warning_reason);
-    if metrics.records_skipped > 0 {
-        println!(
-            "Skipped unreadable records: {} (counts may be incomplete)",
-            metrics.records_skipped
-        );
-    }
-    println!("No secret values, handles, paths, URLs, or account identifiers are included.");
+    print!("{}", format_metrics_human(&metrics));
     Ok(())
 }
 
-fn print_metric_group(title: &str, values: &BTreeMap<String, u64>) {
-    println!("{title}:");
+fn format_metrics_human(metrics: &PrivacyMetrics) -> String {
+    let mut output = String::new();
+    writeln!(output, "Pentect privacy metrics (retained local logs)").unwrap();
+    writeln!(
+        output,
+        "Masked occurrences: {}",
+        metrics.masked_text_occurrences
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "Redacted images: {}",
+        metrics.redacted_image_occurrences
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "Blocked images: {}",
+        metrics.blocked_image_occurrences
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "Local restoration operations: {}",
+        metrics.restoration_operations
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "Blocked restoration attempts: {}",
+        metrics.blocked_restoration_occurrences
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "Blocked operations: {}",
+        metrics.blocked_occurrences
+    )
+    .unwrap();
+    writeln!(output, "Warnings: {}", metrics.warning_occurrences).unwrap();
+    writeln!(
+        output,
+        "Plugin failures (including timeouts): {}",
+        metrics.plugin_failure_occurrences
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "Plugin timeouts: {}",
+        metrics.plugin_timeout_occurrences
+    )
+    .unwrap();
+    format_metric_group(
+        &mut output,
+        "Secret types (text masks and image redactions)",
+        &metrics.by_secret_type,
+        |name| {
+            (safe_metric_secret_type(name) == name).then(|| {
+                labels::description(name)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| readable_metric_name(name))
+            })
+        },
+    );
+    format_metric_group(
+        &mut output,
+        "Protection surfaces",
+        &metrics.by_surface,
+        metric_surface_description,
+    );
+    format_metric_group(
+        &mut output,
+        "Warning reasons",
+        &metrics.by_warning_reason,
+        warning_reason_description,
+    );
+    if metrics.records_skipped > 0 {
+        writeln!(
+            output,
+            "Skipped unreadable records: {} (counts may be incomplete)",
+            metrics.records_skipped
+        )
+        .unwrap();
+    }
+    writeln!(
+        output,
+        "No secret values, handles, paths, URLs, or account identifiers are included."
+    )
+    .unwrap();
+    output
+}
+
+fn format_metric_group(
+    output: &mut String,
+    title: &str,
+    values: &BTreeMap<String, u64>,
+    description: fn(&str) -> Option<String>,
+) {
+    writeln!(output, "{title}:").unwrap();
     if values.is_empty() {
-        println!("  (none)");
+        writeln!(output, "  (none)").unwrap();
         return;
     }
     let mut values = values.iter().collect::<Vec<_>>();
@@ -438,15 +505,26 @@ fn print_metric_group(title: &str, values: &BTreeMap<String, u64>) {
             .then_with(|| left_name.cmp(right_name))
     });
     for (name, count) in values {
-        let readable = labels::description(name)
-            .map(str::to_string)
-            .unwrap_or_else(|| readable_metric_name(name));
-        if readable == *name {
-            println!("  {name}: {count}");
-        } else {
-            println!("  {name} ({readable}): {count}");
-        }
+        let (safe_name, readable) = description(name)
+            .map(|readable| (name.as_str(), readable))
+            .unwrap_or_else(|| ("unknown", "Unknown or unclassified value".to_string()));
+        writeln!(output, "  {safe_name} ({readable}): {count}").unwrap();
     }
+}
+
+fn metric_surface_description(name: &str) -> Option<String> {
+    Some(
+        match name {
+            "prompt" => "Text sent to a model",
+            "output" => "Masked tool or command output",
+            "tool" => "Local tool input or output",
+            "read" => "Content read from a local file",
+            "image" => "Image or OCR content",
+            "OTHER" => "Other protected surface",
+            _ => return None,
+        }
+        .to_string(),
+    )
 }
 
 fn readable_metric_name(name: &str) -> String {
@@ -1510,48 +1588,150 @@ fn diagnostic_surface(value: &str) -> String {
     )
 }
 
+const WARNING_REASON_DESCRIPTIONS: &[(&str, &str)] = &[
+    (
+        "cmd-binding-skipped",
+        "Shell command binding could not be inspected",
+    ),
+    (
+        "connection-failed",
+        "A protected connection could not be established",
+    ),
+    (
+        "candidate-limit",
+        "Inspection reached the configured candidate limit",
+    ),
+    (
+        "decoded-byte-limit",
+        "Inspection reached the decoded-data limit",
+    ),
+    (
+        "diagnostic-queue-overflow",
+        "Some diagnostic records could not be queued",
+    ),
+    ("elapsed-limit", "Inspection reached the time limit"),
+    (
+        "expansion-limit",
+        "Inspection reached the decoded-expansion limit",
+    ),
+    (
+        "file-attestation-unavailable",
+        "Local file identity could not be verified",
+    ),
+    (
+        "file-registry-unavailable",
+        "Protected local file tracking was unavailable",
+    ),
+    (
+        "gateway-busy",
+        "The local protection gateway was at capacity",
+    ),
+    ("gateway-stopped", "The local protection gateway stopped"),
+    (
+        "no-protected-connection",
+        "No protected client connection was observed",
+    ),
+    (
+        "provider-mcp-credential-forwarded",
+        "A configured provider MCP credential was forwarded",
+    ),
+    (
+        "request-content-encoding-skipped",
+        "Request content encoding could not be inspected",
+    ),
+    (
+        "request-encode-skipped",
+        "A protected request could not be encoded",
+    ),
+    ("request-failed", "A protected provider request failed"),
+    ("request-invalid-json", "Request content was not valid JSON"),
+    (
+        "request-protection-skipped",
+        "Request content protection was skipped",
+    ),
+    (
+        "request-rejected",
+        "A request was rejected to preserve protection",
+    ),
+    (
+        "response-protection-skipped",
+        "Response content protection was skipped",
+    ),
+    (
+        "response-restore-skipped",
+        "Local response-handle restoration was skipped",
+    ),
+    ("scan-complete", "Image inspection completed"),
+    ("scan-failed", "Image inspection failed"),
+    (
+        "scan-failure-allowed",
+        "Policy allowed image content after OCR inspection failed",
+    ),
+    (
+        "scan-failure-blocked",
+        "Affected image content was blocked after OCR inspection failed",
+    ),
+    (
+        "scan-unavailable-allowed",
+        "Policy allowed image content without OCR inspection",
+    ),
+    (
+        "scan-unavailable-blocked",
+        "Affected image content was blocked because OCR inspection was unavailable",
+    ),
+    (
+        "shell-secret-unresolved",
+        "A protected value could not be restored for a local shell",
+    ),
+    (
+        "sse-event-limit",
+        "A stream event exceeded the inspection size limit",
+    ),
+    (
+        "sse-restore-skipped",
+        "Local stream-handle restoration was skipped",
+    ),
+    (
+        "sse-tool-limit",
+        "Stream tool input exceeded the inspection size limit",
+    ),
+    (
+        "stream-event-protection-skipped",
+        "Stream event content protection was skipped",
+    ),
+    (
+        "tool-input-restore-skipped",
+        "Local tool-input handle restoration was skipped",
+    ),
+    (
+        "unknown-content-block",
+        "Unrecognized content was blocked because it could not be inspected",
+    ),
+    ("unknown-endpoint", "A provider endpoint was not recognized"),
+    (
+        "upstream-response",
+        "A provider response status was observed",
+    ),
+];
+
 fn diagnostic_event(value: &str) -> String {
-    allowed_diagnostic_identifier(
-        value,
-        &[
-            "cmd-binding-skipped",
-            "connection-failed",
-            "candidate-limit",
-            "decoded-byte-limit",
-            "diagnostic-queue-overflow",
-            "elapsed-limit",
-            "expansion-limit",
-            "file-attestation-unavailable",
-            "file-registry-unavailable",
-            "gateway-busy",
-            "gateway-stopped",
-            "no-protected-connection",
-            "provider-mcp-credential-forwarded",
-            "request-content-encoding-skipped",
-            "request-encode-skipped",
-            "request-failed",
-            "request-invalid-json",
-            "request-protection-skipped",
-            "request-rejected",
-            "response-protection-skipped",
-            "response-restore-skipped",
-            "scan-complete",
-            "scan-failed",
-            "scan-failure-allowed",
-            "scan-failure-blocked",
-            "scan-unavailable-allowed",
-            "scan-unavailable-blocked",
-            "shell-secret-unresolved",
-            "sse-event-limit",
-            "sse-restore-skipped",
-            "sse-tool-limit",
-            "stream-event-protection-skipped",
-            "tool-input-restore-skipped",
-            "unknown-content-block",
-            "unknown-endpoint",
-            "upstream-response",
-        ],
-    )
+    if WARNING_REASON_DESCRIPTIONS
+        .iter()
+        .any(|(code, _)| *code == value)
+    {
+        value.to_string()
+    } else {
+        "unknown".to_string()
+    }
+}
+
+fn warning_reason_description(name: &str) -> Option<String> {
+    if name == "unknown" {
+        return Some("Unknown or unclassified warning".to_string());
+    }
+    WARNING_REASON_DESCRIPTIONS
+        .iter()
+        .find_map(|(code, description)| (*code == name).then(|| (*description).to_string()))
 }
 
 fn diagnostic_kind(value: &str) -> String {
@@ -1888,6 +2068,9 @@ mod tests {
         assert!(!output.contains("private-plugin"));
         assert!(!output.contains("private-restoration"));
         assert!(!output.contains(".env"));
+        assert!(output.contains("\"by_surface\":{\"image\":1,\"prompt\":3}"));
+        assert!(output.contains("\"by_warning_reason\":{\"request-failed\":1,\"unknown\":1}"));
+        assert!(!output.contains("A protected provider request failed"));
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -1904,6 +2087,62 @@ mod tests {
         assert_eq!(readable_metric_name("request-failed"), "Request failed");
         assert_eq!(readable_metric_name("PII"), "PII");
         assert_eq!(readable_metric_name(""), "Unknown");
+    }
+
+    #[test]
+    fn human_metrics_explain_bounded_codes_without_exposing_untrusted_dimensions() {
+        let private = "https://private.example/account/alice";
+        let metrics = PrivacyMetrics {
+            masked_text_occurrences: 2,
+            by_secret_type: BTreeMap::from([("AWS_AKID".to_string(), 1), (private.to_string(), 1)]),
+            by_surface: BTreeMap::from([("tool".to_string(), 1), (private.to_string(), 1)]),
+            by_warning_reason: BTreeMap::from([
+                ("scan-unavailable-allowed".to_string(), 1),
+                ("request-rejected".to_string(), 2),
+                (private.to_string(), 1),
+            ]),
+            ..PrivacyMetrics::default()
+        };
+
+        let output = format_metrics_human(&metrics);
+        assert!(output.contains("AWS_AKID (AWS akid): 1"), "{output}");
+        assert!(
+            output.contains("tool (Local tool input or output): 1"),
+            "{output}"
+        );
+        assert!(
+            output.contains(
+                "scan-unavailable-allowed (Policy allowed image content without OCR inspection): 1"
+            ),
+            "{output}"
+        );
+        assert!(
+            output.contains("request-rejected (A request was rejected to preserve protection): 2"),
+            "{output}"
+        );
+        assert!(!output.contains(private), "{output}");
+        assert_eq!(
+            output.matches("unknown (Unknown or unclassified").count(),
+            3
+        );
+    }
+
+    #[test]
+    fn warning_reason_allowlist_and_descriptions_share_one_complete_source() {
+        for (code, description) in WARNING_REASON_DESCRIPTIONS {
+            assert_eq!(diagnostic_event(code), *code);
+            assert_eq!(
+                warning_reason_description(code).as_deref(),
+                Some(*description)
+            );
+            assert!(!description.is_empty());
+        }
+        assert_eq!(diagnostic_event("private-error-/home/alice"), "unknown");
+        assert_eq!(
+            warning_reason_description("unknown").as_deref(),
+            Some("Unknown or unclassified warning")
+        );
+        assert!(warning_reason_description("private-error-/home/alice").is_none());
     }
 
     #[test]

--- a/tools/test_client_smoke_coverage.py
+++ b/tools/test_client_smoke_coverage.py
@@ -78,6 +78,11 @@ def main() -> None:
     )
 
     ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert "- 'crates/pentect-cli/tests/metrics.rs'" in ci
+    assert (
+        "cargo test -p pentect-cli --no-default-features --locked --test metrics"
+        in ci
+    )
     assert "claude_supervisor: ${{ steps.filter.outputs.claude_supervisor }}" in ci
     supervisor_filter = re.search(
         r"^            claude_supervisor:\n(?P<body>(?:              - .+\n)+)",

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -174,6 +174,9 @@ logging and rotation continue independently so crashes remain diagnosable.
 The summary includes masked and restored occurrence counts, blocked restoration
 attempts, blocked operations, plugin failures and timeouts, and warnings grouped
 by a bounded reason code.
+The human-readable summary explains those fixed codes in plain language. The
+`--json` form keeps the stable reason, surface, and detector code values for
+scripts and local analysis.
 Plugin names, error text, values, handles, paths, URLs, and account identifiers
 are not metric dimensions. Plugin timeout counts are a subset of plugin failure
 counts, not an additional failure total.


### PR DESCRIPTION
## Summary

Advances #250 with fixed, plain-language explanations in human-readable pentect metrics output. Stable diagnostic codes remain visible; JSON fields, codes, aggregation, and persistence remain unchanged. The diagnostic allowlist and explanations share one fixed table. Unknown dimensions stay generic without echoing raw values.

This slice does not add detector rules, telemetry, client health dimensions, feedback capture, or new protection guarantees. Issue #250 remains open for its other work.

## Verification

- New actual CLI regression fails on baseline missing explanation and passes on candidate.
- 23 focused runtime activity-log tests pass with default features; author also verified no-default-features.
- Clippy runtime/CLI all-targets with warnings denied passes.
- Formatting, diff check, and workflow coverage contract pass.
- CLI fixture verifies allowed vs blocked OCR wording, retained counts/codes, unknown reason/label/surface collapse, and absence of synthetic sensitive paths/control text in human and JSON output.
- Added narrow PR CI execution for the metrics CLI test.

Implementation and tests authored by GPT-5.6 Sol subagents; coordinating agent reviewed wording/privacy and independently ran candidate checks. Documentation build and required CI pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `pentect metrics` summary now displays readable descriptions for metric groups and warning reasons.
  * JSON output continues to provide stable reason, surface, and detector codes for scripts and local analysis.

* **Documentation**
  * Expanded the configuration reference with details about human-readable and JSON metrics summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->