### PR TITLE
Release v0.0.77: readable privacy metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,7 +510,9 @@ jobs:
         run: cargo test -p pentect-runtime --no-default-features activity_log::tests --locked
       - name: Test privacy metrics CLI
         if: needs.changes.outputs.runtime_log == 'true'
-        run: cargo test -p pentect-cli --no-default-features --locked --test metrics
+        run: |
+          cargo test -p pentect-cli --no-default-features --locked --test metrics
+          cargo test -p pentect-cli --all-features --locked --test metrics
       - name: Test general CLI changes
         if: needs.changes.outputs.cli_general == 'true'
         run: cargo test -p pentect-cli --no-default-features --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.76"
+version = "0.0.77"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.76"
+version = "0.0.77"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/tests/metrics.rs
+++ b/crates/pentect-cli/tests/metrics.rs
@@ -54,7 +54,7 @@ fn metrics_human_describes_stable_codes_without_echoing_untrusted_values() {
     std::fs::create_dir(fixture.0.join(".git")).unwrap();
     std::fs::write(
         home.join(".pentect/config.toml"),
-        "[metrics]\nenabled = true\n",
+        "[metrics]\nenabled = true\n\n[update]\ncheck = false\n",
     )
     .unwrap();
 

--- a/crates/pentect-cli/tests/metrics.rs
+++ b/crates/pentect-cli/tests/metrics.rs
@@ -103,6 +103,7 @@ fn metrics_human_describes_stable_codes_without_echoing_untrusted_values() {
             .env("XDG_CACHE_HOME", fixture.0.join("cache"))
             .env("XDG_STATE_HOME", fixture.0.join("state"))
             .env("XDG_RUNTIME_DIR", fixture.0.join("runtime"))
+            .env("LOCALAPPDATA", fixture.0.join("local-app-data"))
             .env("PENTECT_LOG_DIR", &logs)
             .env("TMPDIR", fixture.0.join("tmp"));
         if json {
@@ -161,5 +162,15 @@ fn metrics_human_describes_stable_codes_without_echoing_untrusted_values() {
     assert!(!String::from_utf8(encoded.stdout)
         .unwrap()
         .contains(sentinel));
-    assert!(!fixture.0.join("state/pentect/update-check.json").exists());
+    for cache in [
+        fixture.0.join("state/pentect/update-check.json"),
+        home.join("Library/Application Support/pentect/update-check.json"),
+        fixture.0.join("local-app-data/pentect/update-check.json"),
+    ] {
+        assert!(
+            !cache.exists(),
+            "update check wrote cache {}",
+            cache.display()
+        );
+    }
 }

--- a/crates/pentect-cli/tests/metrics.rs
+++ b/crates/pentect-cli/tests/metrics.rs
@@ -161,4 +161,5 @@ fn metrics_human_describes_stable_codes_without_echoing_untrusted_values() {
     assert!(!String::from_utf8(encoded.stdout)
         .unwrap()
         .contains(sentinel));
+    assert!(!fixture.0.join("state/pentect/update-check.json").exists());
 }

--- a/crates/pentect-cli/tests/native_windows_supervisor.rs
+++ b/crates/pentect-cli/tests/native_windows_supervisor.rs
@@ -1,5 +1,6 @@
 #![cfg(windows)]
 
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -118,17 +119,47 @@ fn write_cmd(path: &Path, body: &str) {
     std::fs::write(path, format!("@echo off\r\n{body}\r\n")).unwrap();
 }
 
-fn wait_for_pid(marker: &Path) -> u32 {
-    let deadline = Instant::now() + Duration::from_secs(10);
+fn diagnostic_tail(path: &Path) -> String {
+    const LIMIT: u64 = 4 * 1024;
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return String::new();
+    };
+    let length = file.metadata().map(|value| value.len()).unwrap_or(0);
+    let _ = file.seek(SeekFrom::Start(length.saturating_sub(LIMIT)));
+    let mut bytes = Vec::with_capacity(LIMIT as usize);
+    let _ = file.take(LIMIT).read_to_end(&mut bytes);
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+fn wrapper_diagnostics(stdout: &Path, stderr: &Path) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        diagnostic_tail(stdout),
+        diagnostic_tail(stderr)
+    )
+}
+
+fn wait_for_pid(marker: &Path, wrapper: &mut ChildGuard, stdout: &Path, stderr: &Path) -> u32 {
+    // This fixture deadline includes the synthetic PowerShell startup after
+    // cmd.exe launches; it is separate from each supervisor protocol stage.
+    let deadline = Instant::now() + Duration::from_secs(20);
     loop {
         if let Ok(value) = std::fs::read_to_string(marker) {
             if let Ok(pid) = value.trim().parse() {
                 return pid;
             }
         }
+        if let Some(status) = wrapper.0.as_mut().unwrap().try_wait().unwrap() {
+            drop(wrapper.0.take());
+            panic!(
+                "native fixture exited before readiness with {status}: {}",
+                wrapper_diagnostics(stdout, stderr)
+            );
+        }
         assert!(
             Instant::now() < deadline,
-            "native fixture did not become ready"
+            "native fixture did not become ready: {}",
+            wrapper_diagnostics(stdout, stderr)
         );
         std::thread::sleep(Duration::from_millis(20));
     }
@@ -144,13 +175,18 @@ fn wrapper_hard_kill_terminates_the_exact_native_client_descendant() {
         r#"powershell.exe -NoLogo -NoProfile -NonInteractive -Command "[IO.File]::WriteAllText($env:PENTECT_NATIVE_MARKER, [string]$PID); Start-Sleep -Seconds 30""#,
     );
     let mut wrapper = isolated_command(&fixture.0, &client);
+    let stdout = fixture.0.join("parent-kill.stdout");
+    let stderr = fixture.0.join("parent-kill.stderr");
     wrapper
         .env("PENTECT_NATIVE_MARKER", &marker)
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    let mut wrapper = ChildGuard(Some(wrapper.spawn().unwrap()));
-    let client_pid = wait_for_pid(&marker);
+        .stdout(Stdio::from(std::fs::File::create(&stdout).unwrap()))
+        .stderr(Stdio::from(std::fs::File::create(&stderr).unwrap()));
+    let spawned = wrapper.spawn().unwrap();
+    // Do not retain parent copies of output handles while observing readiness.
+    drop(wrapper);
+    let mut wrapper = ChildGuard(Some(spawned));
+    let client_pid = wait_for_pid(&marker, &mut wrapper, &stdout, &stderr);
     let client = ProcessHandle::open(client_pid);
 
     // Child::kill targets only the retained wrapper process handle. Closing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/tools/test_client_smoke_coverage.py
+++ b/tools/test_client_smoke_coverage.py
@@ -83,6 +83,9 @@ def main() -> None:
         "cargo test -p pentect-cli --no-default-features --locked --test metrics"
         in ci
     )
+    assert (
+        "cargo test -p pentect-cli --all-features --locked --test metrics" in ci
+    )
     assert "claude_supervisor: ${{ steps.filter.outputs.claude_supervisor }}" in ci
     supervisor_filter = re.search(
         r"^            claude_supervisor:\n(?P<body>(?:              - .+\n)+)",


### PR DESCRIPTION
## Release

Ship the human-readable privacy metric warning/surface explanations already merged in #1422 (refs #250). JSON codes, counts, detection, and telemetry behavior are unchanged. Bump the canonical CLI/Cargo/npm versions to 0.0.77; generated package metadata follows the normal release automation.

## Post-merge test fixes

Main CI exposed two fixture gaps after #1422 PR checks passed:
- Metrics invoked the asynchronous updater while reading synthetic logs. Disable update checks using the documented fixture setting, retain exact count assertions, check all platform cache locations, and run both no-default and all-features metrics tests in PR CI.
- Windows parent-kill readiness discarded all diagnostics and only waited 10 seconds. Retain wrapper status/file-backed bounded diagnostics, detect early exit immediately, and use a separate bounded 20-second fixture-readiness budget. The exact process HANDLE and 5-second descendant death assertion are unchanged. The previous log does not establish whether startup was slow or failed, so this is not claimed as a production supervisor fix.

## Verification

- Whole workspace with all features passes: CLI455/core487/runtime341 plus integrations.
- Final metrics all-features fixture passes; format/diff/workflow contract checks pass.
- Windows fixture runtime needs required Windows CI before merge.
- All implementation and test changes authored by GPT-5.6 Sol subagents; coordinating agent reviewed and independently verified.

No tag or release exists yet. After required checks/review and normal merge, the immutable tag will start the standard release and distribution validation pipeline.