### PR TITLE
Release v0.0.78: count dotenv prompt masks once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.77"
+version = "0.0.78"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.77"
+version = "0.0.78"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -203,9 +203,6 @@ impl OutputMasker {
                 },
             )
         });
-        if let Some(env_result) = &env_result {
-            self.track_mask_result("prompt", env_result);
-        }
         let no_plugins = PluginMiddleware::default();
         let plugins = if run_plugins {
             &self.plugin_middleware
@@ -225,6 +222,7 @@ impl OutputMasker {
             },
         )?;
         if let Some(env_result) = env_result {
+            result.items.extend(env_result.items);
             result.recovery.extend_same_key(env_result.recovery);
             result.summary.masked_count = result
                 .summary
@@ -576,6 +574,16 @@ impl OutputMasker {
             let count = summary.labels.entry(item.label.clone()).or_default();
             *count = count.saturating_add(1);
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_activity_for(
+        &self,
+        surface: &str,
+    ) -> Option<(u64, BTreeMap<String, u64>)> {
+        self.activity
+            .get(surface)
+            .map(|summary| (summary.count, summary.labels.clone()))
     }
 
     pub(crate) fn flush_activity(&mut self) {

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1256,7 +1256,8 @@ fn prompt_dotenv_activity_counts_each_finding_once() {
         "[activity]\nshare = false\n[update]\ncheck = false\n",
     )
     .unwrap();
-    let output = std::process::Command::new(std::env::current_exe().unwrap())
+    let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+    command
         .arg("--exact")
         .arg("tests::prompt_dotenv_activity_counts_each_finding_once")
         .arg("--nocapture")
@@ -1270,12 +1271,16 @@ fn prompt_dotenv_activity_counts_each_finding_once() {
         .env("TMPDIR", child_root.join("tmp"))
         .env("TMP", child_root.join("tmp"))
         .env("TEMP", child_root.join("tmp"))
-        .current_dir(&child_work)
-        .output()
-        .unwrap();
+        .current_dir(&child_work);
+    #[cfg(windows)]
+    if let Some(system_root) = std::env::var_os("SystemRoot") {
+        command.env("SystemRoot", system_root);
+    }
+    let output = command.output().unwrap();
     assert!(
         output.status.success(),
-        "child failed: {}",
+        "child failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1180,6 +1180,43 @@ for line in sys.stdin:
 }
 
 #[test]
+fn prompt_dotenv_activity_counts_each_finding_once() {
+    let root = temp_root("prompt-dotenv-activity-count");
+    std::fs::create_dir_all(&root).unwrap();
+
+    for (session_name, prompt, expected_count, expected_labels) in [
+        (
+            "dotenv-only",
+            "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX",
+            1,
+            [("OPENAI_API_KEY", 1), ("EMAIL_ADDRESS", 0)],
+        ),
+        (
+            "dotenv-and-text",
+            "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\nContact alice@example.com",
+            2,
+            [("OPENAI_API_KEY", 1), ("EMAIL_ADDRESS", 1)],
+        ),
+    ] {
+        let session = Session::open_capability_at(&root, session_name).unwrap();
+        let store = MemoryStore::for_session(&session);
+        let mut masker = masking::OutputMasker::new_shared(store).unwrap();
+        let masked = masker.mask_prompt_text_without_plugins(prompt).unwrap();
+        assert!(!masked.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"));
+        assert!(!masked.contains("alice@example.com"));
+
+        let (count, labels) = masker.pending_activity_for("prompt").unwrap();
+        assert_eq!(count, expected_count);
+        for (label, expected) in expected_labels {
+            assert_eq!(labels.get(label).copied().unwrap_or_default(), expected);
+        }
+        assert_eq!(labels.values().sum::<u64>(), count);
+    }
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn active_prompt_masker_reuses_bounded_cached_result() {
     let _env_guard = TEST_ENV_LOCK.lock().unwrap();
     let (_active_store, _, _) = ActiveMemoryStoreEnv::start("prompt-cache");

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1202,8 +1202,15 @@ fn prompt_dotenv_activity_counts_each_finding_once() {
         let store = MemoryStore::for_session(&session);
         let mut masker = masking::OutputMasker::new_shared(store).unwrap();
         let masked = masker.mask_prompt_text_without_plugins(prompt).unwrap();
+        assert_ne!(masked, prompt);
         assert!(!masked.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"));
         assert!(!masked.contains("alice@example.com"));
+        assert_eq!(
+            MemoryStore::for_session(&session)
+                .resolve_all(&masked)
+                .unwrap(),
+            prompt
+        );
 
         let (count, labels) = masker.pending_activity_for("prompt").unwrap();
         assert_eq!(count, expected_count);

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1181,6 +1181,29 @@ for line in sys.stdin:
 
 #[test]
 fn prompt_dotenv_activity_counts_each_finding_once() {
+    const CHILD_ROOT_ENV: &str = "PENTECT_TEST_DOTENV_ACTIVITY_CHILD_ROOT";
+    const MIXED_PROMPT: &str =
+        "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\nContact alice@example.com";
+
+    if let Some(child_root) = std::env::var_os(CHILD_ROOT_ENV) {
+        let child_root = PathBuf::from(child_root);
+        let session = Session::open_capability_at(&child_root, "emitted-activity").unwrap();
+        let store = MemoryStore::for_session(&session);
+        let mut masker = masking::OutputMasker::new_shared(store).unwrap();
+        let masked = masker
+            .mask_prompt_text_without_plugins(MIXED_PROMPT)
+            .unwrap();
+        assert_eq!(
+            MemoryStore::for_session(&session)
+                .resolve_all(&masked)
+                .unwrap(),
+            MIXED_PROMPT
+        );
+        masker.flush_activity();
+        activity_log::flush_persistent();
+        return;
+    }
+
     let root = temp_root("prompt-dotenv-activity-count");
     std::fs::create_dir_all(&root).unwrap();
 
@@ -1193,7 +1216,7 @@ fn prompt_dotenv_activity_counts_each_finding_once() {
         ),
         (
             "dotenv-and-text",
-            "OPENAI_API_KEY=sk-ABCDEFGHIJKLMNOPQRSTUVWX\nContact alice@example.com",
+            MIXED_PROMPT,
             2,
             [("OPENAI_API_KEY", 1), ("EMAIL_ADDRESS", 1)],
         ),
@@ -1218,6 +1241,67 @@ fn prompt_dotenv_activity_counts_each_finding_once() {
             assert_eq!(labels.get(label).copied().unwrap_or_default(), expected);
         }
         assert_eq!(labels.values().sum::<u64>(), count);
+    }
+
+    let child_root = root.join("activity-child");
+    let child_home = child_root.join("home");
+    let child_work = child_root.join("work");
+    let child_log = child_root.join("logs");
+    std::fs::create_dir_all(&child_home).unwrap();
+    std::fs::create_dir_all(child_root.join("runtime")).unwrap();
+    std::fs::create_dir_all(child_root.join("tmp")).unwrap();
+    std::fs::create_dir_all(child_work.join(".pentect")).unwrap();
+    std::fs::write(
+        child_work.join(".pentect/config.toml"),
+        "[activity]\nshare = false\n[update]\ncheck = false\n",
+    )
+    .unwrap();
+    let output = std::process::Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("tests::prompt_dotenv_activity_counts_each_finding_once")
+        .arg("--nocapture")
+        .env_clear()
+        .env(CHILD_ROOT_ENV, &child_root)
+        .env("PENTECT_LOG_DIR", &child_log)
+        .env("HOME", &child_home)
+        .env("USERPROFILE", &child_home)
+        .env("XDG_CONFIG_HOME", child_home.join(".config"))
+        .env("XDG_RUNTIME_DIR", child_root.join("runtime"))
+        .env("TMPDIR", child_root.join("tmp"))
+        .env("TMP", child_root.join("tmp"))
+        .env("TEMP", child_root.join("tmp"))
+        .current_dir(&child_work)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "child failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload = std::fs::read_to_string(child_log.join("pentect.log")).unwrap();
+    let events = payload
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(events.len(), 1, "{payload}");
+    assert_eq!(events[0]["action"], "mask");
+    assert_eq!(events[0]["surface"], "prompt");
+    assert_eq!(events[0]["count"], 2);
+    assert_eq!(
+        events[0]["labels"],
+        json!([
+            { "name": "EMAIL_ADDRESS", "count": 1 },
+            { "name": "OPENAI_API_KEY", "count": 1 }
+        ])
+    );
+    for private_value in [
+        MIXED_PROMPT,
+        "sk-ABCDEFGHIJKLMNOPQRSTUVWX",
+        "alice@example.com",
+        "Contact alice",
+    ] {
+        assert!(!payload.contains(private_value), "{payload}");
     }
 
     std::fs::remove_dir_all(root).unwrap();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Fixes #1424.

Count the combined dotenv/text prompt masking result once and include dotenv detector items in that result. This corrects count 2 / label 1 for a single masked dotenv value without changing detection scope, handles, recovery, metric schema, or telemetry.

Regression tests cover dotenv-only and mixed dotenv/email findings, exact detector-label totals, plaintext masking, and exact recovery through a fresh MemoryStore. Restoring the old production behavior while retaining the test fails with count 2 versus expected 1; the fix passes.

Bump the canonical CLI/lock/npm versions to 0.0.78. Generated package metadata stays on the last published release until release automation updates it.

## Validation
- Sol-authored implementation and tests, root review plus independent Sol review approved
- No-default prompt suite: 10 passed
- All-features focused regression: passed
- Runtime all-features suite: 342 passed before version-only bump; final-head rerun underway
- cargo fmt --all --check and git diff --check: passed

Merge only after required CI/current-client checks pass. Then create a fresh immutable v0.0.78 tag; never replace v0.0.77 assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prompt masking activity tracking so environment-variable findings are counted once and retain accurate metadata.
  - Ensured masked prompts containing dotenv-style assignments and email addresses can be restored correctly.

- **Chores**
  - Updated the package and CLI version to 0.0.78.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->