### PR TITLE
fix(metrics): count completed HTTP tool restorations (v0.0.79)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.78"
+version = "0.0.79"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/claude_app_proxy.rs
+++ b/crates/pentect-cli/src/claude_app_proxy.rs
@@ -3091,11 +3091,18 @@ where
             .clone();
         run_chat_tool_plugins(&mut value, &plugins)?;
     }
-    resolve_chat_tool_calls(&mut value, resolve)?;
-    crate::claude_http_proxy::restore_anthropic_json_value(&mut value, restore_output, resolve)?;
-    serde_json::to_vec(&value)
+    let mut restored_tools = resolve_chat_tool_calls(&mut value, resolve)?;
+    restored_tools =
+        restored_tools.saturating_add(crate::claude_http_proxy::restore_anthropic_json_value(
+            &mut value,
+            restore_output,
+            resolve,
+        )?);
+    let encoded = serde_json::to_vec(&value)
         .map(Bytes::from)
-        .map_err(|error| format!("could not encode Claude App Chat response: {error}"))
+        .map_err(|error| format!("could not encode Claude App Chat response: {error}"))?;
+    crate::claude_http_proxy::record_completed_tool_restorations(restored_tools);
+    Ok(encoded)
 }
 
 fn chat_sse_body<S>(
@@ -3280,14 +3287,16 @@ fn run_chat_tool_plugins(
     Ok(())
 }
 
-fn resolve_chat_tool_calls<R>(value: &mut serde_json::Value, resolve: &mut R) -> Result<(), String>
+fn resolve_chat_tool_calls<R>(value: &mut serde_json::Value, resolve: &mut R) -> Result<u64, String>
 where
     R: FnMut(&str) -> Result<String, String>,
 {
+    let mut restored_tools = 0u64;
     match value {
         serde_json::Value::Array(values) => {
             for value in values {
-                resolve_chat_tool_calls(value, resolve)?;
+                restored_tools =
+                    restored_tools.saturating_add(resolve_chat_tool_calls(value, resolve)?);
             }
         }
         serde_json::Value::Object(object) => {
@@ -3300,6 +3309,7 @@ where
                 || kind.contains("tool_call")
                 || kind.contains("function_call");
             if tool_call {
+                let mut call_changed = false;
                 let name = object
                     .get("name")
                     .and_then(serde_json::Value::as_str)
@@ -3315,11 +3325,12 @@ where
                                 false,
                             ),
                         };
-                        let resolved = crate::claude_http_proxy::resolve_tool_input_json(
-                            &encoded,
-                            name.as_deref(),
-                            resolve,
-                        )?;
+                        let (resolved, changed) =
+                            crate::claude_http_proxy::resolve_tool_input_json_with_change(
+                                &encoded,
+                                name.as_deref(),
+                                resolve,
+                            )?;
                         *arguments = if was_string {
                             serde_json::Value::String(resolved)
                         } else {
@@ -3327,16 +3338,19 @@ where
                                 format!("could not decode Claude App tool input: {error}")
                             })?
                         };
+                        call_changed |= changed;
                     }
                 }
+                restored_tools = restored_tools.saturating_add(u64::from(call_changed));
             }
             for nested in object.values_mut() {
-                resolve_chat_tool_calls(nested, resolve)?;
+                restored_tools =
+                    restored_tools.saturating_add(resolve_chat_tool_calls(nested, resolve)?);
             }
         }
         _ => {}
     }
-    Ok(())
+    Ok(restored_tools)
 }
 
 fn metadata_path(path: &str) -> String {

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1589,10 +1589,10 @@ where
             tools.bytes.extend_from_slice(&block);
             if tools.active.is_empty() {
                 let tools = self.tool_buffer.take().expect("tool buffer exists");
-                let rewritten = std::str::from_utf8(&tools.bytes)
+                let (rewritten, restored_tools) = std::str::from_utf8(&tools.bytes)
                     .map_err(|error| format!("Claude tool SSE was not UTF-8: {error}"))
                     .and_then(|text| {
-                        rewrite_anthropic_sse_with_tool_context(
+                        rewrite_anthropic_sse_with_tool_context_tracked(
                             text,
                             None,
                             &mut self.resolve,
@@ -1601,6 +1601,7 @@ where
                         )
                     })?;
                 output.push(Bytes::from(rewritten));
+                record_completed_tool_restorations(restored_tools);
             }
             return Ok(());
         }
@@ -2528,25 +2529,30 @@ where
 {
     let mut value: Value = serde_json::from_slice(body)
         .map_err(|error| format!("Claude response was not valid JSON: {error}"))?;
-    restore_anthropic_json_value(&mut value, restore_output, resolve)?;
-    serde_json::to_vec(&value)
-        .map_err(|error| format!("could not encode restored Claude response: {error}"))
+    let restored_tools = restore_anthropic_json_value(&mut value, restore_output, resolve)?;
+    let encoded = serde_json::to_vec(&value)
+        .map_err(|error| format!("could not encode restored Claude response: {error}"))?;
+    record_completed_tool_restorations(restored_tools);
+    Ok(encoded)
 }
 
 pub(crate) fn restore_anthropic_json_value<R>(
     value: &mut Value,
     restore_output: bool,
     resolve: &mut R,
-) -> Result<(), String>
+) -> Result<u64, String>
 where
     R: FnMut(&str) -> Result<String, String>,
 {
+    let mut restored_tools = 0u64;
     if let Some(content) = value.get_mut("content").and_then(Value::as_array_mut) {
         for block in content {
             if block.get("type").and_then(Value::as_str) == Some("tool_use") {
                 let tool_name = block.get("name").and_then(Value::as_str).map(str::to_owned);
                 if let Some(input) = block.get_mut("input") {
-                    resolve_tool_input_value(input, tool_name.as_deref(), resolve)?;
+                    let changed =
+                        resolve_tool_input_value_with_change(input, tool_name.as_deref(), resolve)?;
+                    restored_tools = restored_tools.saturating_add(u64::from(changed));
                 }
             } else if restore_output {
                 let field = match block.get("type").and_then(Value::as_str) {
@@ -2560,7 +2566,7 @@ where
             }
         }
     }
-    Ok(())
+    Ok(restored_tools)
 }
 
 #[derive(Default)]
@@ -2608,6 +2614,7 @@ where
     )
 }
 
+#[cfg(test)]
 fn rewrite_anthropic_sse_with_tool_context<R>(
     input: &str,
     forced_tool_name: Option<&str>,
@@ -2618,9 +2625,30 @@ fn rewrite_anthropic_sse_with_tool_context<R>(
 where
     R: FnMut(&str) -> Result<String, String>,
 {
+    rewrite_anthropic_sse_with_tool_context_tracked(
+        input,
+        forced_tool_name,
+        resolve,
+        plugins,
+        plugin_context,
+    )
+    .map(|(rewritten, _)| rewritten)
+}
+
+fn rewrite_anthropic_sse_with_tool_context_tracked<R>(
+    input: &str,
+    forced_tool_name: Option<&str>,
+    resolve: &mut R,
+    plugins: Option<&StdMutex<pentect_agent::PluginMiddleware>>,
+    plugin_context: PluginContext,
+) -> Result<(String, u64), String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
     let mut blocks = parse_sse(input);
     let mut tool_indices = HashSet::new();
     let mut pending: HashMap<u64, PendingToolInput> = HashMap::new();
+    let mut restored_tools = 0u64;
 
     for block_index in 0..blocks.len() {
         let Some(data) = blocks[block_index].data.as_ref() else {
@@ -2717,7 +2745,8 @@ where
                 joined = serde_json::to_string(input)
                     .map_err(|error| format!("plugin middleware: encode failed: {error}"))?;
             }
-            let resolved = resolve_tool_input_json(&joined, tool.name.as_deref(), resolve)?;
+            let (resolved, changed) =
+                resolve_tool_input_json_with_change(&joined, tool.name.as_deref(), resolve)?;
             for (position, (chunk_index, _)) in tool.chunks.iter().enumerate() {
                 if let Some(partial_json) = blocks[*chunk_index]
                     .data
@@ -2732,9 +2761,10 @@ where
                     });
                 }
             }
+            restored_tools = restored_tools.saturating_add(u64::from(changed));
         }
     }
-    Ok(render_sse(&blocks))
+    Ok((render_sse(&blocks), restored_tools))
 }
 
 fn parse_sse(input: &str) -> Vec<SseBlock> {
@@ -2828,6 +2858,7 @@ where
     }
 }
 
+#[cfg(test)]
 pub(crate) fn resolve_tool_input_json<R>(
     input: &str,
     tool_name: Option<&str>,
@@ -2836,14 +2867,66 @@ pub(crate) fn resolve_tool_input_json<R>(
 where
     R: FnMut(&str) -> Result<String, String>,
 {
+    resolve_tool_input_json_with_change(input, tool_name, resolve).map(|(resolved, _)| resolved)
+}
+
+pub(crate) fn resolve_tool_input_json_with_change<R>(
+    input: &str,
+    tool_name: Option<&str>,
+    resolve: &mut R,
+) -> Result<(String, bool), String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
     let Ok(mut value) = serde_json::from_str::<Value>(input) else {
         // Fine-grained tool streaming can end with invalid JSON. Keep handles
         // inert rather than resolving into a malformed or injectable payload.
-        return Ok(input.to_string());
+        return Ok((input.to_string(), false));
     };
-    resolve_tool_input_value(&mut value, tool_name, resolve)?;
-    serde_json::to_string(&value)
-        .map_err(|error| format!("could not encode restored Claude tool input: {error}"))
+    let changed = resolve_tool_input_value_with_change(&mut value, tool_name, resolve)?;
+    let encoded = serde_json::to_string(&value)
+        .map_err(|error| format!("could not encode restored Claude tool input: {error}"))?;
+    Ok((encoded, changed))
+}
+
+fn resolve_tool_input_value_with_change<R>(
+    value: &mut Value,
+    tool_name: Option<&str>,
+    resolve: &mut R,
+) -> Result<bool, String>
+where
+    R: FnMut(&str) -> Result<String, String>,
+{
+    let mut changed = false;
+    let mut tracked_resolve = |text: &str| {
+        let resolved = resolve(text)?;
+        changed |= resolved != text;
+        Ok(resolved)
+    };
+    resolve_tool_input_value(value, tool_name, &mut tracked_resolve)?;
+    Ok(changed)
+}
+
+pub(crate) fn record_completed_tool_restorations(count: u64) {
+    if count == 0 {
+        return;
+    }
+    #[cfg(not(test))]
+    pentect_agent::record_completed_tool_restorations(count);
+    #[cfg(test)]
+    TEST_COMPLETED_TOOL_RESTORATIONS.with(|counts| counts.borrow_mut().push(count));
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_COMPLETED_TOOL_RESTORATIONS: std::cell::RefCell<Vec<u64>> = const {
+        std::cell::RefCell::new(Vec::new())
+    };
+}
+
+#[cfg(test)]
+pub(crate) fn take_test_completed_tool_restorations() -> Vec<u64> {
+    TEST_COMPLETED_TOOL_RESTORATIONS.with(|counts| std::mem::take(&mut *counts.borrow_mut()))
 }
 
 fn resolve_tool_input_value<R>(
@@ -3139,11 +3222,35 @@ mod tests {
             ]
         });
         let mut resolve = |text: &str| Ok(text.replace(handle, "local-value"));
-        restore_anthropic_json_value(&mut value, false, &mut resolve).unwrap();
+        assert_eq!(
+            restore_anthropic_json_value(&mut value, false, &mut resolve).unwrap(),
+            1
+        );
 
         assert_eq!(value["content"][0]["text"], handle);
         assert_eq!(value["content"][1]["thinking"], handle);
         assert_eq!(value["content"][2]["input"]["token"], "local-value");
+    }
+
+    #[test]
+    fn completed_anthropic_response_emits_only_after_successful_tool_restore() {
+        take_test_completed_tool_restorations();
+        let handle = "<<SECRET_0011223344556677>>";
+        let body = serde_json::to_vec(&serde_json::json!({
+            "content": [{
+                "type": "tool_use",
+                "name": "shell",
+                "input": {"first": handle, "second": handle}
+            }]
+        }))
+        .unwrap();
+        let mut resolve = |text: &str| Ok(text.replace(handle, "local-value"));
+        rewrite_anthropic_json_response(&body, false, &mut resolve).unwrap();
+        assert_eq!(take_test_completed_tool_restorations(), [1]);
+
+        let mut fail = |_text: &str| Err("synthetic resolver failure".to_string());
+        assert!(rewrite_anthropic_json_response(&body, false, &mut fail).is_err());
+        assert!(take_test_completed_tool_restorations().is_empty());
     }
 
     #[test]
@@ -4834,6 +4941,30 @@ mod tests {
     }
 
     #[test]
+    fn tracked_tool_input_counts_changed_scalars_as_one_operation() {
+        let handle = "<<SECRET_0123456789abcdef>>";
+        let input =
+            format!("{{ \"first\": \"{handle}\", \"nested\": {{\"second\": \"{handle}\"}} }}");
+        let mut resolve = |text: &str| Ok(text.replace(handle, "local-value"));
+        let (restored, changed) =
+            resolve_tool_input_json_with_change(&input, None, &mut resolve).unwrap();
+        assert!(changed);
+        assert_eq!(restored.matches("local-value").count(), 2);
+
+        let mut unchanged = |text: &str| Ok(text.to_string());
+        let (normalized, changed) =
+            resolve_tool_input_json_with_change("{ \"ordinary\": 1 }", None, &mut unchanged)
+                .unwrap();
+        assert_eq!(normalized, r#"{"ordinary":1}"#);
+        assert!(!changed, "JSON normalization is not restoration");
+
+        let (invalid, changed) =
+            resolve_tool_input_json_with_change("{invalid", None, &mut unchanged).unwrap();
+        assert_eq!(invalid, "{invalid");
+        assert!(!changed);
+    }
+
+    #[test]
     fn sse_tool_input_is_reassembled_and_resolved_without_touching_text() {
         let input = concat!(
             "event: content_block_start\n",
@@ -4849,9 +4980,31 @@ mod tests {
         );
         let mut resolve =
             |text: &str| Ok(text.replace("<<SECRET_deadbeefdeadbeef>>", "actual-secret"));
-        let output = rewrite_anthropic_sse_with(input, &mut resolve).unwrap();
+        let (output, restored_tools) = rewrite_anthropic_sse_with_tool_context_tracked(
+            input,
+            None,
+            &mut resolve,
+            None,
+            ANTHROPIC_HTTP_SSE_CONTEXT,
+        )
+        .unwrap();
+        assert_eq!(restored_tools, 1);
         assert!(output.contains("actual-secret"));
         assert!(output.contains("keep <<SECRET_deadbeefdeadbeef>>"));
+
+        let incomplete = input.replace(
+            "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+            "",
+        );
+        let (_, restored_tools) = rewrite_anthropic_sse_with_tool_context_tracked(
+            &incomplete,
+            None,
+            &mut resolve,
+            None,
+            ANTHROPIC_HTTP_SSE_CONTEXT,
+        )
+        .unwrap();
+        assert_eq!(restored_tools, 0);
     }
 
     #[test]

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -3240,7 +3240,11 @@ mod tests {
             "content": [{
                 "type": "tool_use",
                 "name": "shell",
-                "input": {"first": handle, "second": handle}
+                "input": {
+                    "first": handle,
+                    "second": handle,
+                    "unknown": "<<SECRET_ffeeddccbbaa0099>>"
+                }
             }]
         }))
         .unwrap();
@@ -3250,6 +3254,27 @@ mod tests {
 
         let mut fail = |_text: &str| Err("synthetic resolver failure".to_string());
         assert!(rewrite_anthropic_json_response(&body, false, &mut fail).is_err());
+        assert!(take_test_completed_tool_restorations().is_empty());
+
+        let late_failure_body = serde_json::to_vec(&serde_json::json!({
+            "content": [
+                {"type": "tool_use", "name": "first", "input": {"value": handle}},
+                {"type": "tool_use", "name": "second", "input": {"value": handle}}
+            ]
+        }))
+        .unwrap();
+        let mut calls = 0usize;
+        let mut late_fail = |text: &str| {
+            calls += 1;
+            if calls == 2 {
+                Err("synthetic late resolver failure".to_string())
+            } else {
+                Ok(text.replace(handle, "local-value"))
+            }
+        };
+        assert!(
+            rewrite_anthropic_json_response(&late_failure_body, false, &mut late_fail).is_err()
+        );
         assert!(take_test_completed_tool_restorations().is_empty());
     }
 

--- a/crates/pentect-cli/src/cloud_code_http_proxy.rs
+++ b/crates/pentect-cli/src/cloud_code_http_proxy.rs
@@ -937,16 +937,19 @@ fn rewrite_response_body(
     let mut value: Value = serde_json::from_slice(body).map_err(|error| {
         format!("unknown format blocked: Google Cloud Code response is not valid JSON ({error})")
     })?;
-    rewrite_response_value(&mut value, plugins, block_unknown_formats)?;
-    serde_json::to_vec(&value)
-        .map_err(|error| format!("could not encode restored Google Cloud Code response: {error}"))
+    let restored_tools = rewrite_response_value(&mut value, plugins, block_unknown_formats)?;
+    let encoded = serde_json::to_vec(&value).map_err(|error| {
+        format!("could not encode restored Google Cloud Code response: {error}")
+    })?;
+    crate::claude_http_proxy::record_completed_tool_restorations(restored_tools);
+    Ok(encoded)
 }
 
 fn rewrite_response_value(
     value: &mut Value,
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
     block_unknown_formats: bool,
-) -> Result<(), String> {
+) -> Result<u64, String> {
     validate_response_value(value, block_unknown_formats)?;
     let mut run = plugins
         .lock()
@@ -976,9 +979,9 @@ fn rewrite_response_value(
     run_tool_plugins(&mut payload, &plugins)?;
     drop(plugins);
     let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
-    resolve_function_calls(&mut payload, &mut resolve)?;
+    let restored_tools = resolve_function_calls(&mut payload, &mut resolve)?;
     *value = payload;
-    Ok(())
+    Ok(restored_tools)
 }
 
 fn validate_response_value(value: &Value, block_unknown_formats: bool) -> Result<(), String> {
@@ -1094,14 +1097,16 @@ fn run_tool_plugins(
     Ok(())
 }
 
-pub(crate) fn resolve_function_calls<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
+pub(crate) fn resolve_function_calls<R>(value: &mut Value, resolve: &mut R) -> Result<u64, String>
 where
     R: FnMut(&str) -> Result<String, String>,
 {
+    let mut restored_tools = 0u64;
     match value {
         Value::Array(values) => {
             for value in values {
-                resolve_function_calls(value, resolve)?;
+                restored_tools =
+                    restored_tools.saturating_add(resolve_function_calls(value, resolve)?);
             }
         }
         Value::Object(object) => {
@@ -1111,23 +1116,26 @@ where
                     let encoded = serde_json::to_string(args).map_err(|error| {
                         format!("could not encode Google tool arguments: {error}")
                     })?;
-                    let restored = crate::claude_http_proxy::resolve_tool_input_json(
-                        &encoded,
-                        name.as_deref(),
-                        resolve,
-                    )?;
+                    let (restored, changed) =
+                        crate::claude_http_proxy::resolve_tool_input_json_with_change(
+                            &encoded,
+                            name.as_deref(),
+                            resolve,
+                        )?;
                     *args = serde_json::from_str(&restored).map_err(|error| {
                         format!("restored Google tool arguments are invalid: {error}")
                     })?;
+                    restored_tools = restored_tools.saturating_add(u64::from(changed));
                 }
             }
             for child in object.values_mut() {
-                resolve_function_calls(child, resolve)?;
+                restored_tools =
+                    restored_tools.saturating_add(resolve_function_calls(child, resolve)?);
             }
         }
         _ => {}
     }
-    Ok(())
+    Ok(restored_tools)
 }
 
 struct StreamState {
@@ -1253,7 +1261,7 @@ fn rewrite_sse_block(
             return Ok(Bytes::copy_from_slice(block));
         }
     };
-    rewrite_response_value(&mut value, plugins, block_unknown_formats)?;
+    let restored_tools = rewrite_response_value(&mut value, plugins, block_unknown_formats)?;
     let encoded = serde_json::to_string(&value)
         .map_err(|error| format!("could not encode Google Cloud Code SSE event: {error}"))?;
     let ending = if text.ends_with("\r\n\r\n") {
@@ -1275,6 +1283,7 @@ fn rewrite_sse_block(
     output.push_str("data: ");
     output.push_str(&encoded);
     output.push_str(ending);
+    crate::claude_http_proxy::record_completed_tool_restorations(restored_tools);
     Ok(Bytes::from(output))
 }
 
@@ -1756,7 +1765,7 @@ mod tests {
             ]}}]}
         });
         let mut resolve = |text: &str| Ok(text.replace(handle, "C:/private.txt"));
-        resolve_function_calls(&mut value, &mut resolve).unwrap();
+        assert_eq!(resolve_function_calls(&mut value, &mut resolve).unwrap(), 1);
         assert_eq!(
             value["response"]["candidates"][0]["content"]["parts"][0]["text"],
             handle

--- a/crates/pentect-cli/src/gemini_http_proxy.rs
+++ b/crates/pentect-cli/src/gemini_http_proxy.rs
@@ -778,10 +778,13 @@ fn rewrite_response_body(
     validate_response(&value, block_unknown_formats)?;
     run_tool_plugins(&mut value, &plugins)?;
     let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
-    crate::cloud_code_http_proxy::resolve_function_calls(&mut value, &mut resolve)?;
-    serde_json::to_vec(&value)
+    let restored_tools =
+        crate::cloud_code_http_proxy::resolve_function_calls(&mut value, &mut resolve)?;
+    let encoded = serde_json::to_vec(&value)
         .map(Bytes::from)
-        .map_err(|error| format!("could not encode restored Gemini response: {error}"))
+        .map_err(|error| format!("could not encode restored Gemini response: {error}"))?;
+    crate::claude_http_proxy::record_completed_tool_restorations(restored_tools);
+    Ok(encoded)
 }
 
 fn run_tool_plugins(
@@ -1517,7 +1520,10 @@ mod tests {
             ]}}]
         });
         let mut resolve = |text: &str| Ok(text.replace(handle, "sk_test_synthetic"));
-        crate::cloud_code_http_proxy::resolve_function_calls(&mut value, &mut resolve).unwrap();
+        assert_eq!(
+            crate::cloud_code_http_proxy::resolve_function_calls(&mut value, &mut resolve).unwrap(),
+            1
+        );
         assert_eq!(
             value["candidates"][0]["content"]["parts"][0]["text"],
             handle

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -18,6 +18,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::Infallible;
 use std::error::Error;
 use std::future::Future;
+use std::hash::{Hash, Hasher};
 use std::io::{self, Read};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -2394,12 +2395,15 @@ fn rewrite_openai_json_response(body: &[u8], restore_output: bool) -> Result<Vec
     let mut value: Value = serde_json::from_slice(body)
         .map_err(|error| format!("OpenAI response was not valid JSON: {error}"))?;
     let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
-    rewrite_function_calls(&mut value, &mut resolve)?;
+    let restored_tools = ToolRestorationDedup::default()
+        .commit_nonstream(rewrite_function_calls(&mut value, &mut resolve)?);
     if restore_output {
         restore_openai_output_text(&mut value, &mut resolve)?;
     }
-    serde_json::to_vec(&value)
-        .map_err(|error| format!("could not encode restored OpenAI response: {error}"))
+    let encoded = serde_json::to_vec(&value)
+        .map_err(|error| format!("could not encode restored OpenAI response: {error}"))?;
+    crate::claude_http_proxy::record_completed_tool_restorations(restored_tools);
+    Ok(encoded)
 }
 
 fn rewrite_chat_completions_json_response(
@@ -2409,12 +2413,14 @@ fn rewrite_chat_completions_json_response(
     let mut value: Value = serde_json::from_slice(body)
         .map_err(|error| format!("OpenAI Chat Completions response was not valid JSON: {error}"))?;
     let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
-    rewrite_chat_tool_calls(&mut value, &mut resolve)?;
+    let restored_tools = rewrite_chat_tool_calls(&mut value, &mut resolve)?;
     if restore_output {
         restore_chat_output_text(&mut value, &mut resolve)?;
     }
-    serde_json::to_vec(&value)
-        .map_err(|error| format!("could not encode restored Chat Completions response: {error}"))
+    let encoded = serde_json::to_vec(&value)
+        .map_err(|error| format!("could not encode restored Chat Completions response: {error}"))?;
+    crate::claude_http_proxy::record_completed_tool_restorations(restored_tools);
+    Ok(encoded)
 }
 
 fn rewrite_completions_json_response(body: &[u8], restore_output: bool) -> Result<Vec<u8>, String> {
@@ -2509,12 +2515,13 @@ where
     Ok(())
 }
 
-fn rewrite_chat_tool_calls<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
+fn rewrite_chat_tool_calls<R>(value: &mut Value, resolve: &mut R) -> Result<u64, String>
 where
     R: FnMut(&str) -> Result<String, String>,
 {
+    let mut restored_tools = 0u64;
     let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) else {
-        return Ok(());
+        return Ok(0);
     };
     for choice in choices {
         let Some(message) = choice.get_mut("message").and_then(Value::as_object_mut) else {
@@ -2538,25 +2545,28 @@ where
             else {
                 continue;
             };
-            let restored = crate::claude_http_proxy::resolve_tool_input_json(
-                &arguments,
-                tool_name.as_deref(),
-                resolve,
-            )?;
+            let (restored, changed) =
+                crate::claude_http_proxy::resolve_tool_input_json_with_change(
+                    &arguments,
+                    tool_name.as_deref(),
+                    resolve,
+                )?;
             call["function"]["arguments"] = Value::String(restored);
+            restored_tools = restored_tools.saturating_add(u64::from(changed));
         }
     }
-    Ok(())
+    Ok(restored_tools)
 }
 
-fn rewrite_function_calls<R>(value: &mut Value, resolve: &mut R) -> Result<(), String>
+fn rewrite_function_calls<R>(value: &mut Value, resolve: &mut R) -> Result<Vec<Vec<String>>, String>
 where
     R: FnMut(&str) -> Result<String, String>,
 {
+    let mut restored_tools = Vec::new();
     match value {
         Value::Array(values) => {
             for value in values {
-                rewrite_function_calls(value, resolve)?;
+                restored_tools.extend(rewrite_function_calls(value, resolve)?);
             }
         }
         Value::Object(object) => {
@@ -2573,6 +2583,8 @@ where
                     )
                 });
             if is_function_call {
+                let mut call_changed = false;
+                let call_identities = function_call_identities(object);
                 let is_custom_call =
                     object
                         .get("type")
@@ -2596,31 +2608,57 @@ where
                     });
                 for key in ["arguments", "input"] {
                     if let Some(Value::String(arguments)) = object.get_mut(key) {
-                        *arguments = if is_custom_call && key == "input" {
-                            resolve(arguments)?
+                        let (resolved, changed) = if is_custom_call && key == "input" {
+                            let resolved = resolve(arguments)?;
+                            let changed = resolved != *arguments;
+                            (resolved, changed)
                         } else {
-                            crate::claude_http_proxy::resolve_tool_input_json(
+                            crate::claude_http_proxy::resolve_tool_input_json_with_change(
                                 arguments,
                                 tool_name.as_deref(),
                                 resolve,
                             )?
                         };
+                        *arguments = resolved;
+                        call_changed |= changed;
                     }
+                }
+                if call_changed {
+                    restored_tools.push(call_identities);
                 }
             }
             if let Some(item) = object.get_mut("item") {
-                rewrite_function_calls(item, resolve)?;
+                restored_tools.extend(rewrite_function_calls(item, resolve)?);
             }
             if let Some(response) = object.get_mut("response") {
-                rewrite_function_calls(response, resolve)?;
+                restored_tools.extend(rewrite_function_calls(response, resolve)?);
             }
             if let Some(output) = object.get_mut("output") {
-                rewrite_function_calls(output, resolve)?;
+                restored_tools.extend(rewrite_function_calls(output, resolve)?);
             }
         }
         _ => {}
     }
-    Ok(())
+    Ok(restored_tools)
+}
+
+fn function_call_identities(object: &serde_json::Map<String, Value>) -> Vec<String> {
+    let mut identities = Vec::new();
+    for key in ["item_id", "id", "call_id"] {
+        if let Some(identity) = object.get(key).and_then(Value::as_str) {
+            if identity.len() <= 256 && !identities.iter().any(|known| known == identity) {
+                identities.push(identity.to_string());
+            }
+        }
+    }
+    if let Some(item) = object.get("item").and_then(Value::as_object) {
+        for identity in function_call_identities(item) {
+            if !identities.contains(&identity) {
+                identities.push(identity);
+            }
+        }
+    }
+    identities
 }
 
 async fn read_response_capped(response: reqwest::Response) -> Result<Option<Bytes>, String> {
@@ -2650,6 +2688,66 @@ struct StreamState {
     block_unknown_formats: bool,
     output_text: HashMap<String, crate::claude_http_proxy::OutputTextRestorer>,
     output_resolve: HandleResolver,
+    restored_tools: ToolRestorationDedup,
+}
+
+#[derive(Default)]
+struct ToolRestorationDedup {
+    identities: HashSet<u64>,
+    calls: usize,
+    full: bool,
+}
+
+impl ToolRestorationDedup {
+    fn commit_nonstream(&mut self, restored: Vec<Vec<String>>) -> u64 {
+        let mut count = 0u64;
+        let mut identified = Vec::new();
+        for identities in restored {
+            if identities.is_empty() {
+                count = count.saturating_add(1);
+            } else {
+                identified.push(identities);
+            }
+        }
+        count.saturating_add(self.commit(identified))
+    }
+
+    fn commit(&mut self, restored: Vec<Vec<String>>) -> u64 {
+        let mut count = 0u64;
+        for identities in restored {
+            if self.full {
+                break;
+            }
+            if identities.is_empty() {
+                continue;
+            }
+            let identities = identities
+                .iter()
+                .map(|identity| {
+                    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                    identity.hash(&mut hasher);
+                    hasher.finish()
+                })
+                .collect::<Vec<_>>();
+            if identities
+                .iter()
+                .any(|identity| self.identities.contains(identity))
+            {
+                continue;
+            }
+            if self.calls >= MAX_CHAT_TOOL_CALLS
+                || self.identities.len().saturating_add(identities.len())
+                    > MAX_CHAT_TOOL_CALLS.saturating_mul(3)
+            {
+                self.full = true;
+                break;
+            }
+            self.identities.extend(identities);
+            self.calls = self.calls.saturating_add(1);
+            count = count.saturating_add(1);
+        }
+        count
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2663,12 +2761,13 @@ enum StreamTransform {
 fn process_stream_block(state: &mut StreamState, block: Vec<u8>) -> Result<(), String> {
     let block = run_sse_response_plugins(&block, &state.plugins, state.block_unknown_formats)?;
     let rewritten = match state.transform {
-        StreamTransform::Responses => rewrite_openai_sse_block(
+        StreamTransform::Responses => rewrite_openai_sse_block_tracked(
             &block,
             &state.plugins,
             state.restore_output,
             &mut state.output_text,
             &mut state.output_resolve,
+            &mut state.restored_tools,
         ),
         StreamTransform::ChatCompletions => state.chat.rewrite_block(
             &block,
@@ -2719,6 +2818,7 @@ fn streaming_response_body(
         block_unknown_formats,
         output_text: HashMap::new(),
         output_resolve: Box::new(crate::claude_http_proxy::request_scoped_resolver()),
+        restored_tools: ToolRestorationDedup::default(),
     };
     let stream = stream::unfold(state, |mut state| async move {
         loop {
@@ -3110,6 +3210,7 @@ impl ChatStreamState {
             .lock()
             .map_err(|_| "OpenAI plugin lock was poisoned".to_string())?;
         let mut resolve = crate::claude_http_proxy::request_scoped_resolver();
+        let mut restored_tools = 0u64;
         for index in indexes {
             let call = self
                 .calls
@@ -3130,11 +3231,13 @@ impl ChatStreamState {
                 .get("arguments")
                 .and_then(Value::as_str)
                 .unwrap_or_default();
-            let arguments = crate::claude_http_proxy::resolve_tool_input_json(
-                arguments,
-                Some(name),
-                &mut resolve,
-            )?;
+            let (arguments, changed) =
+                crate::claude_http_proxy::resolve_tool_input_json_with_change(
+                    arguments,
+                    Some(name),
+                    &mut resolve,
+                )?;
+            restored_tools = restored_tools.saturating_add(u64::from(changed));
             calls.push(serde_json::json!({
                 "index": index,
                 "id": call.id,
@@ -3148,7 +3251,9 @@ impl ChatStreamState {
             "delta": {"tool_calls": calls},
             "finish_reason": null
         }]);
-        encode_sse_value(template, &completed)
+        let encoded = encode_sse_value(template, &completed)?;
+        crate::claude_http_proxy::record_completed_tool_restorations(restored_tools);
+        Ok(encoded)
     }
 }
 
@@ -3250,12 +3355,31 @@ fn encode_sse_value_for_event(
     Ok(Bytes::from(output))
 }
 
+#[cfg(test)]
 fn rewrite_openai_sse_block(
     block: &[u8],
     plugins: &Mutex<pentect_agent::PluginMiddleware>,
     restore_output: bool,
     output_text: &mut HashMap<String, crate::claude_http_proxy::OutputTextRestorer>,
     resolve: &mut HandleResolver,
+) -> Result<Vec<Bytes>, String> {
+    rewrite_openai_sse_block_tracked(
+        block,
+        plugins,
+        restore_output,
+        output_text,
+        resolve,
+        &mut ToolRestorationDedup::default(),
+    )
+}
+
+fn rewrite_openai_sse_block_tracked(
+    block: &[u8],
+    plugins: &Mutex<pentect_agent::PluginMiddleware>,
+    restore_output: bool,
+    output_text: &mut HashMap<String, crate::claude_http_proxy::OutputTextRestorer>,
+    resolve: &mut HandleResolver,
+    restored_tool_ids: &mut ToolRestorationDedup,
 ) -> Result<Vec<Bytes>, String> {
     let Ok(text) = std::str::from_utf8(block) else {
         return Ok(vec![Bytes::copy_from_slice(block)]);
@@ -3286,11 +3410,13 @@ fn rewrite_openai_sse_block(
             .map_err(|_| "OpenAI plugin lock was poisoned".to_string())?;
         run_openai_tool_plugins(&mut value, &plugins)?;
     }
-    if let Err(error) = rewrite_function_calls(&mut value, resolve) {
-        let _ = error;
-        proxy_diagnostic("sse-restore-skipped");
-        return Ok(vec![Bytes::copy_from_slice(block)]);
-    }
+    let restored_tools = match rewrite_function_calls(&mut value, resolve) {
+        Ok(restored_tools) => restored_tools,
+        Err(_error) => {
+            proxy_diagnostic("sse-restore-skipped");
+            return Ok(vec![Bytes::copy_from_slice(block)]);
+        }
+    };
     let mut output = Vec::new();
     if let Some(delta) = completed_openai_call_delta(&value) {
         let event = delta.get("type").and_then(Value::as_str);
@@ -3303,6 +3429,8 @@ fn rewrite_openai_sse_block(
         }
     }
     output.push(encode_sse_value(text, &value)?);
+    let count = restored_tool_ids.commit(restored_tools);
+    crate::claude_http_proxy::record_completed_tool_restorations(count);
     Ok(output)
 }
 
@@ -5204,6 +5332,7 @@ mod tests {
             block_unknown_formats: true,
             output_text: HashMap::new(),
             output_resolve: Box::new(|text| Ok(text.to_string())),
+            restored_tools: ToolRestorationDedup::default(),
         };
 
         process_pending_stream_block(&mut state).unwrap();
@@ -5312,6 +5441,162 @@ mod tests {
         rewrite_function_calls(&mut value, &mut resolve).unwrap();
         assert_eq!(value["item"]["input"], "python hash.py safe-secret-token");
         assert_eq!(value["visible_text"], "keep <<SECRET_0123456789abcdef>>");
+    }
+
+    #[test]
+    fn streaming_tool_metrics_deduplicate_mirrored_completion_envelopes() {
+        let handle = "<<SECRET_0123456789abcdef>>";
+        let item = serde_json::json!({
+            "id": "item_1",
+            "type": "custom_tool_call",
+            "call_id": "call_1",
+            "name": "exec",
+            "input": handle,
+        });
+        let mut events = [
+            serde_json::json!({
+                "type": "response.custom_tool_call_input.done",
+                "item_id": "item_1",
+                "name": "exec",
+                "input": handle,
+            }),
+            serde_json::json!({"type": "response.output_item.done", "item": item.clone()}),
+            serde_json::json!({
+                "type": "response.completed",
+                "response": {"output": [item]},
+            }),
+        ];
+        let stream_events = events.clone();
+        let mut dedup = ToolRestorationDedup::default();
+        let mut resolve = |text: &str| Ok(text.replace(handle, "local-value"));
+        let counts = events
+            .iter_mut()
+            .map(|event| {
+                let restored = rewrite_function_calls(event, &mut resolve).unwrap();
+                dedup.commit(restored)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(counts, [1, 0, 0]);
+
+        let mut call_only = serde_json::json!({
+            "type": "response.custom_tool_call_input.done",
+            "call_id": "call_alias",
+            "name": "exec",
+            "input": handle,
+        });
+        let mut nested_alias = serde_json::json!({
+            "type": "response.output_item.done",
+            "item": {
+                "id": "item_alias",
+                "call_id": "call_alias",
+                "type": "custom_tool_call",
+                "name": "exec",
+                "input": handle,
+            }
+        });
+        assert_eq!(
+            dedup.commit(rewrite_function_calls(&mut call_only, &mut resolve).unwrap()),
+            1
+        );
+        assert_eq!(
+            dedup.commit(rewrite_function_calls(&mut nested_alias, &mut resolve).unwrap()),
+            0
+        );
+
+        let mut distinct = serde_json::json!({
+            "type": "custom_tool_call",
+            "call_id": "call_2",
+            "name": "exec",
+            "input": handle,
+        });
+        let restored = rewrite_function_calls(&mut distinct, &mut resolve).unwrap();
+        assert_eq!(dedup.commit(restored), 1);
+
+        let mirrored_item = serde_json::json!({
+            "id": "item_nonstream_1",
+            "type": "custom_tool_call",
+            "input": handle,
+        });
+        let mut mirrored = serde_json::json!({
+            "item": mirrored_item.clone(),
+            "response": {"output": [mirrored_item]},
+        });
+        let restored = rewrite_function_calls(&mut mirrored, &mut resolve).unwrap();
+        assert_eq!(
+            ToolRestorationDedup::default().commit_nonstream(restored),
+            1
+        );
+
+        let mut distinct = serde_json::json!({
+            "output": [
+                {"id": "item_nonstream_2", "type": "custom_tool_call", "input": handle},
+                {"id": "item_nonstream_3", "type": "custom_tool_call", "input": handle}
+            ]
+        });
+        let restored = rewrite_function_calls(&mut distinct, &mut resolve).unwrap();
+        assert_eq!(
+            ToolRestorationDedup::default().commit_nonstream(restored),
+            2
+        );
+
+        let mut identityless = serde_json::json!({
+            "type": "custom_tool_call",
+            "input": handle,
+        });
+        let restored = rewrite_function_calls(&mut identityless, &mut resolve).unwrap();
+        assert_eq!(
+            ToolRestorationDedup::default().commit_nonstream(restored),
+            1
+        );
+
+        crate::claude_http_proxy::take_test_completed_tool_restorations();
+        let plugins = Mutex::new(pentect_agent::PluginMiddleware::default());
+        let mut output_text = HashMap::new();
+        let mut resolve: HandleResolver =
+            Box::new(move |text: &str| Ok(text.replace(handle, "local-value")));
+        let mut dedup = ToolRestorationDedup::default();
+        let delta = format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "type": "response.custom_tool_call_input.delta",
+                "item_id": "item_1",
+                "delta": handle,
+            })
+        );
+        assert!(rewrite_openai_sse_block_tracked(
+            delta.as_bytes(),
+            &plugins,
+            false,
+            &mut output_text,
+            &mut resolve,
+            &mut dedup,
+        )
+        .unwrap()
+        .is_empty());
+        assert!(crate::claude_http_proxy::take_test_completed_tool_restorations().is_empty());
+        for event in stream_events {
+            let block = format!("data: {}\n\n", serde_json::to_string(&event).unwrap());
+            rewrite_openai_sse_block_tracked(
+                block.as_bytes(),
+                &plugins,
+                false,
+                &mut output_text,
+                &mut resolve,
+                &mut dedup,
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            crate::claude_http_proxy::take_test_completed_tool_restorations(),
+            [1]
+        );
+
+        let mut bounded = ToolRestorationDedup::default();
+        for index in 0..MAX_CHAT_TOOL_CALLS {
+            assert_eq!(bounded.commit(vec![vec![format!("call_{index}")]]), 1);
+        }
+        assert_eq!(bounded.commit(vec![vec!["overflow".to_string()]]), 0);
+        assert!(bounded.full);
     }
 
     #[test]

--- a/crates/pentect-cli/src/openai_http_proxy.rs
+++ b/crates/pentect-cli/src/openai_http_proxy.rs
@@ -2646,8 +2646,13 @@ fn function_call_identities(object: &serde_json::Map<String, Value>) -> Vec<Stri
     let mut identities = Vec::new();
     for key in ["item_id", "id", "call_id"] {
         if let Some(identity) = object.get(key).and_then(Value::as_str) {
-            if identity.len() <= 256 && !identities.iter().any(|known| known == identity) {
-                identities.push(identity.to_string());
+            if identity.is_empty() || identity.len() > 256 {
+                continue;
+            }
+            let namespace = if key == "call_id" { "call" } else { "item" };
+            let identity = format!("{namespace}:{identity}");
+            if !identities.contains(&identity) {
+                identities.push(identity);
             }
         }
     }
@@ -2729,20 +2734,31 @@ impl ToolRestorationDedup {
                     hasher.finish()
                 })
                 .collect::<Vec<_>>();
-            if identities
+            let already_known = identities
                 .iter()
-                .any(|identity| self.identities.contains(identity))
-            {
+                .any(|identity| self.identities.contains(identity));
+            let new_identities = identities
+                .into_iter()
+                .filter(|identity| !self.identities.contains(identity))
+                .collect::<Vec<_>>();
+            if already_known {
+                if self.identities.len().saturating_add(new_identities.len())
+                    > MAX_CHAT_TOOL_CALLS.saturating_mul(3)
+                {
+                    self.full = true;
+                    break;
+                }
+                self.identities.extend(new_identities);
                 continue;
             }
             if self.calls >= MAX_CHAT_TOOL_CALLS
-                || self.identities.len().saturating_add(identities.len())
+                || self.identities.len().saturating_add(new_identities.len())
                     > MAX_CHAT_TOOL_CALLS.saturating_mul(3)
             {
                 self.full = true;
                 break;
             }
-            self.identities.extend(identities);
+            self.identities.extend(new_identities);
             self.calls = self.calls.saturating_add(1);
             count = count.saturating_add(1);
         }
@@ -5501,6 +5517,53 @@ mod tests {
         assert_eq!(
             dedup.commit(rewrite_function_calls(&mut nested_alias, &mut resolve).unwrap()),
             0
+        );
+        let mut item_only_replay = serde_json::json!({
+            "type": "response.custom_tool_call_input.done",
+            "item_id": "item_alias",
+            "name": "exec",
+            "input": handle,
+        });
+        assert_eq!(
+            dedup.commit(rewrite_function_calls(&mut item_only_replay, &mut resolve).unwrap()),
+            0,
+            "aliases learned from duplicate envelopes must remain deduplicated"
+        );
+
+        let mut separate_namespaces = ToolRestorationDedup::default();
+        let mut call_identity = serde_json::json!({
+            "type": "custom_tool_call",
+            "call_id": "shared",
+            "input": handle,
+        });
+        let mut item_identity = serde_json::json!({
+            "type": "custom_tool_call",
+            "item_id": "shared",
+            "input": handle,
+        });
+        assert_eq!(
+            separate_namespaces
+                .commit(rewrite_function_calls(&mut call_identity, &mut resolve).unwrap()),
+            1
+        );
+        assert_eq!(
+            separate_namespaces
+                .commit(rewrite_function_calls(&mut item_identity, &mut resolve).unwrap()),
+            1,
+            "call and item identifier namespaces must not collide"
+        );
+
+        let mut empty_identity = serde_json::json!({
+            "type": "custom_tool_call",
+            "item_id": "",
+            "call_id": "",
+            "input": handle,
+        });
+        assert_eq!(
+            ToolRestorationDedup::default()
+                .commit(rewrite_function_calls(&mut empty_identity, &mut resolve).unwrap()),
+            0,
+            "empty identifiers are not stable streaming identities"
         );
 
         let mut distinct = serde_json::json!({

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -4241,6 +4241,69 @@ fn display_path(path: &Path) -> String {
 mod tests {
     use super::*;
 
+    struct OwnedTestRoot(std::path::PathBuf);
+
+    impl Drop for OwnedTestRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    struct PluginRuntimeTest {
+        root: std::path::PathBuf,
+        _env: crate::EnvVarGuard,
+        _root: OwnedTestRoot,
+        _env_lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl PluginRuntimeTest {
+        fn new(prefix: &str) -> Self {
+            let env_lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+            let nonce = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root =
+                std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()));
+            std::fs::create_dir_all(&root).unwrap();
+            let root = std::fs::canonicalize(root).unwrap();
+            let root_guard = OwnedTestRoot(root.clone());
+            let home = root.join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let env = crate::EnvVarGuard::set_optional([
+                ("HOME", Some(home.clone().into_os_string())),
+                ("USERPROFILE", Some(home.into_os_string())),
+                (
+                    "LOCALAPPDATA",
+                    Some(root.join("local-app-data").into_os_string()),
+                ),
+                ("XDG_DATA_HOME", Some(root.join("data").into_os_string())),
+                ("XDG_CACHE_HOME", Some(root.join("cache").into_os_string())),
+                ("XDG_STATE_HOME", Some(root.join("state").into_os_string())),
+                (
+                    "XDG_RUNTIME_DIR",
+                    Some(root.join("runtime").into_os_string()),
+                ),
+            ]);
+            Self {
+                root: root.clone(),
+                _env: env,
+                _root: root_guard,
+                _env_lock: env_lock,
+            }
+        }
+
+        fn project(&self) -> std::path::PathBuf {
+            let project = self.root.join("project");
+            std::fs::create_dir_all(&project).unwrap();
+            project
+        }
+
+        fn assert_owned(&self, path: &Path) {
+            assert!(path.starts_with(&self.root), "{}", path.display());
+        }
+    }
+
     #[test]
     fn windows_command_plugins_accept_batch_shims_only() {
         for extension in [".EXE", "com", ".CMD", "bat"] {
@@ -4710,6 +4773,7 @@ mod tests {
 
     #[test]
     fn approved_command_setup_runs_selected_profile_and_is_locked() {
+        let fixture = PluginRuntimeTest::new("pentect-command-setup");
         let Some(python) = python_test_executable() else {
             return;
         };
@@ -4718,8 +4782,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let name = format!("command-setup-{nonce}");
-        let root = std::env::temp_dir().join(&name);
-        std::fs::create_dir_all(&root).unwrap();
+        let root = fixture.project();
         std::fs::write(root.join("server.py"), "print('unused')\n").unwrap();
         std::fs::write(
             root.join("setup.py"),
@@ -4735,6 +4798,7 @@ mod tests {
         .unwrap();
         let source = plugins::plugin_source(&root.to_string_lossy()).unwrap();
         let runtime = plugin_runtime_dirs_for_source(&name, &source).unwrap();
+        fixture.assert_owned(&runtime.data_dir);
 
         setup_plugin_source(source, true, Some("cpu"), false).unwrap();
 
@@ -4745,8 +4809,6 @@ mod tests {
         let lock =
             std::fs::read_to_string(runtime.data_dir.join(PLUGIN_COMMAND_LOCK_FILE)).unwrap();
         assert!(lock.contains("path = \"setup.py\""), "{lock}");
-        let _ = std::fs::remove_dir_all(runtime.data_dir);
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -4779,6 +4841,7 @@ mod tests {
 
     #[test]
     fn local_command_files_are_hashed_into_the_runtime_lock() {
+        let fixture = PluginRuntimeTest::new("pentect-command-lock");
         let Some(python) = python_test_executable() else {
             return;
         };
@@ -4787,8 +4850,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let name = format!("command-lock-{nonce}");
-        let root = std::env::temp_dir().join(&name);
-        std::fs::create_dir_all(&root).unwrap();
+        let root = fixture.project();
         let manifest_path = root.join(plugins::PLUGIN_MANIFEST_FILE);
         std::fs::write(
             &manifest_path,
@@ -4808,8 +4870,9 @@ mod tests {
             runtime_id: name.clone(),
         };
         let manifest = load_plugin_manifest(&source).unwrap().unwrap();
-        write_command_lock(&name, &source, &manifest).unwrap();
         let dirs = plugin_runtime_dirs_for_source(&name, &source).unwrap();
+        fixture.assert_owned(&dirs.data_dir);
+        write_command_lock(&name, &source, &manifest).unwrap();
         let first = std::fs::read_to_string(dirs.data_dir.join(PLUGIN_COMMAND_LOCK_FILE)).unwrap();
         assert!(first.contains("path = \"server.py\""));
 
@@ -4817,12 +4880,11 @@ mod tests {
         write_command_lock(&name, &source, &manifest).unwrap();
         let second = std::fs::read_to_string(dirs.data_dir.join(PLUGIN_COMMAND_LOCK_FILE)).unwrap();
         assert_ne!(first, second);
-        let _ = std::fs::remove_dir_all(dirs.data_dir);
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
     fn command_runtime_snapshot_restores_only_managed_state() {
+        let fixture = PluginRuntimeTest::new("pentect-command-rollback");
         let Some(python) = python_test_executable() else {
             return;
         };
@@ -4831,8 +4893,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let name = format!("command-rollback-{nonce}");
-        let root = std::env::temp_dir().join(&name);
-        std::fs::create_dir_all(&root).unwrap();
+        let root = fixture.project();
         let manifest_path = root.join(plugins::PLUGIN_MANIFEST_FILE);
         std::fs::write(
             &manifest_path,
@@ -4850,6 +4911,7 @@ mod tests {
             runtime_id: name.clone(),
         };
         let dirs = plugin_runtime_dirs_for_source(&name, &source).unwrap();
+        fixture.assert_owned(&dirs.data_dir);
         std::fs::create_dir_all(dirs.data_dir.join("command")).unwrap();
         std::fs::write(dirs.data_dir.join("command/server.py"), "old").unwrap();
         std::fs::write(dirs.data_dir.join(PLUGIN_COMMAND_LOCK_FILE), "old-lock").unwrap();
@@ -4873,8 +4935,6 @@ mod tests {
             std::fs::read_to_string(dirs.data_dir.join(PLUGIN_APPROVAL_FILE)).unwrap(),
             "old-approval"
         );
-        let _ = std::fs::remove_dir_all(dirs.data_dir);
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -4916,9 +4976,8 @@ mod tests {
 
     #[test]
     fn release_binary_is_portable_wasm_with_optional_override() {
-        let root =
-            std::env::temp_dir().join(format!("pentect-plugin-destination-{}", std::process::id()));
-        std::fs::create_dir_all(&root).unwrap();
+        let fixture = PluginRuntimeTest::new("pentect-plugin-destination");
+        let root = fixture.project();
         let manifest = root.join(plugins::PLUGIN_MANIFEST_FILE);
         std::fs::write(&manifest, "schema = \"pentect.plugin.v1\"\n").unwrap();
         let source = plugins::PluginSource {
@@ -4942,12 +5001,10 @@ mod tests {
             binary_destination("test", "../outside.wasm", PluginRuntime::Wasm, &source).is_err()
         );
         assert!(binary_destination("test", "helper", PluginRuntime::Wasm, &source).is_err());
-        assert!(
-            binary_destination("test", "helper.wasm", PluginRuntime::Wasm, &source)
-                .unwrap()
-                .is_absolute()
-        );
-        let _ = std::fs::remove_dir_all(root);
+        let destination =
+            binary_destination("test", "helper.wasm", PluginRuntime::Wasm, &source).unwrap();
+        assert!(destination.is_absolute());
+        fixture.assert_owned(&destination);
     }
 
     #[test]
@@ -5102,41 +5159,13 @@ pattern = "token-[0-9]+"
 
     #[test]
     fn plugin_update_requires_the_exact_approved_manifest() {
-        let _env_lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let nonce = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
         let name = format!("update-approval-{nonce}");
-        let root = std::env::temp_dir().join(&name);
-        struct OwnedRoot(std::path::PathBuf);
-        impl Drop for OwnedRoot {
-            fn drop(&mut self) {
-                let _ = std::fs::remove_dir_all(&self.0);
-            }
-        }
-        std::fs::create_dir_all(&root).unwrap();
-        let root = std::fs::canonicalize(root).unwrap();
-        let _root = OwnedRoot(root.clone());
-        let project = root.join("project");
-        let home = root.join("home");
-        std::fs::create_dir_all(&project).unwrap();
-        std::fs::create_dir_all(&home).unwrap();
-        let _env = crate::EnvVarGuard::set_optional([
-            ("HOME", Some(home.clone().into_os_string())),
-            ("USERPROFILE", Some(home.into_os_string())),
-            (
-                "LOCALAPPDATA",
-                Some(root.join("local-app-data").into_os_string()),
-            ),
-            ("XDG_DATA_HOME", Some(root.join("data").into_os_string())),
-            ("XDG_CACHE_HOME", Some(root.join("cache").into_os_string())),
-            ("XDG_STATE_HOME", Some(root.join("state").into_os_string())),
-            (
-                "XDG_RUNTIME_DIR",
-                Some(root.join("runtime").into_os_string()),
-            ),
-        ]);
+        let fixture = PluginRuntimeTest::new("pentect-update-approval");
+        let project = fixture.project();
         let manifest_path = project.join(plugins::PLUGIN_MANIFEST_FILE);
         let manifest_source = format!(
             "schema = \"pentect.plugin.v1\"\nname = \"{name}\"\nbinary = \"helper.wasm\"\nrepository = \"owner/repo\"\n[publisher]\nworkflow = \".github/workflows/release.yml\"\n"
@@ -5155,7 +5184,7 @@ pattern = "token-[0-9]+"
         let data_dir = plugin_runtime_dirs_for_source(&name, &source)
             .unwrap()
             .data_dir;
-        assert!(data_dir.starts_with(&root));
+        fixture.assert_owned(&data_dir);
         std::fs::create_dir_all(data_dir.join("bin")).unwrap();
         let wasm = wat::parse_str(
             r#"(module
@@ -5326,8 +5355,8 @@ pattern = "token-[0-9]+"
             .unwrap()
             .as_nanos();
         let name = format!("downgrade-{nonce}");
-        let root = std::env::temp_dir().join(&name);
-        std::fs::create_dir_all(&root).unwrap();
+        let fixture = PluginRuntimeTest::new("pentect-plugin-downgrade");
+        let root = fixture.project();
         let manifest = root.join(plugins::PLUGIN_MANIFEST_FILE);
         std::fs::write(&manifest, "schema = \"pentect.plugin.v1\"\n").unwrap();
         let source = plugins::PluginSource {
@@ -5341,6 +5370,7 @@ pattern = "token-[0-9]+"
         let data_dir = plugin_runtime_dirs_for_source(&name, &source)
             .unwrap()
             .data_dir;
+        fixture.assert_owned(&data_dir);
         std::fs::write(
             data_dir.join(PLUGIN_BINARY_LOCK_FILE),
             "schema = \"pentect.plugin-lock.v1\"\nversion = \"2.0.0\"\n",
@@ -5350,9 +5380,6 @@ pattern = "token-[0-9]+"
         assert!(reject_plugin_downgrade(&name, &source, &semver::Version::new(1, 9, 9)).is_err());
         assert!(reject_plugin_downgrade(&name, &source, &semver::Version::new(2, 0, 0)).is_ok());
         assert!(reject_plugin_downgrade(&name, &source, &semver::Version::new(2, 1, 0)).is_ok());
-
-        let _ = std::fs::remove_dir_all(data_dir);
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -5115,6 +5115,8 @@ pattern = "token-[0-9]+"
                 let _ = std::fs::remove_dir_all(&self.0);
             }
         }
+        std::fs::create_dir_all(&root).unwrap();
+        let root = std::fs::canonicalize(root).unwrap();
         let _root = OwnedRoot(root.clone());
         let project = root.join("project");
         let home = root.join("home");

--- a/crates/pentect-cli/src/plugins_cmd.rs
+++ b/crates/pentect-cli/src/plugins_cmd.rs
@@ -5102,14 +5102,40 @@ pattern = "token-[0-9]+"
 
     #[test]
     fn plugin_update_requires_the_exact_approved_manifest() {
+        let _env_lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
         let nonce = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
         let name = format!("update-approval-{nonce}");
         let root = std::env::temp_dir().join(&name);
-        std::fs::create_dir_all(&root).unwrap();
-        let manifest_path = root.join(plugins::PLUGIN_MANIFEST_FILE);
+        struct OwnedRoot(std::path::PathBuf);
+        impl Drop for OwnedRoot {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let _root = OwnedRoot(root.clone());
+        let project = root.join("project");
+        let home = root.join("home");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+        let _env = crate::EnvVarGuard::set_optional([
+            ("HOME", Some(home.clone().into_os_string())),
+            ("USERPROFILE", Some(home.into_os_string())),
+            (
+                "LOCALAPPDATA",
+                Some(root.join("local-app-data").into_os_string()),
+            ),
+            ("XDG_DATA_HOME", Some(root.join("data").into_os_string())),
+            ("XDG_CACHE_HOME", Some(root.join("cache").into_os_string())),
+            ("XDG_STATE_HOME", Some(root.join("state").into_os_string())),
+            (
+                "XDG_RUNTIME_DIR",
+                Some(root.join("runtime").into_os_string()),
+            ),
+        ]);
+        let manifest_path = project.join(plugins::PLUGIN_MANIFEST_FILE);
         let manifest_source = format!(
             "schema = \"pentect.plugin.v1\"\nname = \"{name}\"\nbinary = \"helper.wasm\"\nrepository = \"owner/repo\"\n[publisher]\nworkflow = \".github/workflows/release.yml\"\n"
         );
@@ -5127,6 +5153,7 @@ pattern = "token-[0-9]+"
         let data_dir = plugin_runtime_dirs_for_source(&name, &source)
             .unwrap()
             .data_dir;
+        assert!(data_dir.starts_with(&root));
         std::fs::create_dir_all(data_dir.join("bin")).unwrap();
         let wasm = wat::parse_str(
             r#"(module
@@ -5147,12 +5174,6 @@ pattern = "token-[0-9]+"
         .unwrap();
         let changed = load_plugin_manifest(&source).unwrap().unwrap();
         assert!(verify_plugin_update_approval(&name, &source, &changed).is_err());
-
-        let data_dir = plugin_runtime_dirs_for_source(&name, &source)
-            .unwrap()
-            .data_dir;
-        let _ = std::fs::remove_dir_all(data_dir);
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -247,6 +247,14 @@ pub fn flush_activity_log() {
     activity_log::flush_persistent();
 }
 
+/// Record completed local restoration of model-authored tool-call objects.
+///
+/// Callers stage this count while rewriting a response and invoke this only
+/// after the rewritten object has been encoded successfully.
+pub fn record_completed_tool_restorations(count: u64) {
+    activity_log::record_summary("resolve", "tool", count, BTreeMap::new(), None);
+}
+
 fn mask_input_into_memory_store_client(
     client: &MemoryStoreClient,
     input: Input,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -80,6 +80,26 @@ def shell_command(arguments: list[str]) -> str:
     return shlex.join(arguments)
 
 
+def has_completed_tool_restoration(logs: str) -> bool:
+    for line in logs.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        count = event.get("count")
+        if (
+            event.get("action") == "resolve"
+            and event.get("surface") == "tool"
+            and isinstance(count, int)
+            and not isinstance(count, bool)
+            and count > 0
+        ):
+            return True
+    return False
+
+
 def pentect_command(pentect: str, arguments: list[str]) -> list[str]:
     command = [pentect, *arguments]
     if os.name == "nt" and pentect.lower().endswith((".cmd", ".bat")):
@@ -2425,6 +2445,10 @@ else:
             logs = log_path.read_text(encoding="utf-8")
             if valid in logs or invalid in logs or PLUGIN_PLAINTEXT in logs:
                 raise RuntimeError("a synthetic plaintext key reached persistent diagnostics")
+            if not has_completed_tool_restoration(logs):
+                raise RuntimeError(
+                    f"{client} did not record a completed HTTP tool-input restoration"
+                )
             remove_detector_plugin(pentect, project, environment)
             print(
                 f"installed {client} E2E passed: project plugin "

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -171,9 +171,15 @@ enabled = true
 `true`. Metrics are calculated on demand from retained diagnostic logs and are
 never sent externally. Setting it to `false` disables the summary; diagnostic
 logging and rotation continue independently so crashes remain diagnosable.
-The summary includes masked and restored occurrence counts, blocked restoration
-attempts, blocked operations, plugin failures and timeouts, and warnings grouped
-by a bounded reason code.
+The summary includes masked occurrence counts, completed local restoration
+operation counts, blocked restoration attempts, blocked operations, plugin
+failures and timeouts, and warnings grouped by a bounded reason code. Restoration
+operations currently cover changed `pentect resolve` inputs/files and completed
+HTTP tool-call inputs; multiple restored values in one completed tool call count
+as one operation. OpenAI streaming events without a bounded stable call identity,
+or after the bounded identity tracker is exhausted, are conservatively omitted
+from metrics without affecting restoration. Other automatic restoration paths
+are not yet included.
 The human-readable summary explains those fixed codes in plain language. The
 `--json` form keeps the stable reason, surface, and detector code values for
 scripts and local analysis.


### PR DESCRIPTION
## Summary

Closes #1428. Advances the HTTP tool-input slice of #250; the umbrella remains open.

- Record value-free resolve/tool counts only for completed, changed logical HTTP tool inputs across existing provider restoration paths.
- Stage non-stream counts until successful response encoding; count completed streaming tools and deduplicate OpenAI mirror events with bounded, namespaced identities.
- Do not count JSON normalization, incomplete tools, or failed rewrites. One tool call with multiple restored values counts once.
- Document local-restoration semantics and remaining coverage limits. No detector, protection boundary, share/export, or telemetry expansion.
- Bump CLI/npm version to 0.0.79 for the normal immutable-tag release pipeline.

## Validation

- All four installed client loopback flows (Codex, Claude, OpenCode, Pi) fail the new persisted-event assertion on 0.0.78, and pass on the implementation candidate. Existing secret-absence and actual restoration assertions also pass.
- Focused no-default and all-features tests, proxy suites, Clippy and formatting pass on the author branch.
- Independent final metrics review approved; final integrated full-workspace checks and four-client rerun are underway before marking ready.

Implementation and tests authored by GPT-5.6 Sol subagents; coordinating agent reviewed and integrated. Synthetic fixtures only; no paid model requests or user credentials used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics now report completed tool-input restoration operations across supported model integrations.
  * Restoration counts are recorded for both streaming and non-streaming responses, including nested tool calls.

* **Bug Fixes**
  * Duplicate restoration events are prevented from inflating metrics.
  * Failed or incomplete response rewrites no longer record misleading restoration counts.

* **Documentation**
  * Expanded metrics documentation to clarify counted operations, blocked attempts, failures, warnings, and applicable restoration paths.

* **Chores**
  * Updated the application and CLI version to 0.0.79.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->