### PR TITLE
fix: count completed exec input restorations (v0.0.80)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.79"
+version = "0.0.80"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.79"
+version = "0.0.80"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/tests/exec_restoration_metrics.rs
+++ b/crates/pentect-cli/tests/exec_restoration_metrics.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -11,6 +11,7 @@ struct Fixture {
     home: PathBuf,
     project: PathBuf,
     source: PathBuf,
+    verifier: PathBuf,
     handle: String,
 }
 
@@ -36,11 +37,24 @@ impl Fixture {
 
         let source = project.join("source.env");
         std::fs::write(&source, format!("OPENAI_API_KEY={SECRET}\n")).unwrap();
+        let verifier = project.join("verify.ps1");
+        std::fs::write(
+            &verifier,
+            concat!(
+                "param([string]$Mode,[string]$ExpectedPath,[string]$Value,[int]$ExitCode=0)\n",
+                "$expected=(Get-Content -Raw -LiteralPath $ExpectedPath).TrimEnd(\"`r\",\"`n\") -replace '^OPENAI_API_KEY=', ''\n",
+                "if ($Mode -eq 'stdin') { $Value=[Console]::In.ReadToEnd() }\n",
+                "if ($Value -cne $expected) { exit 1 }\n",
+                "exit $ExitCode\n",
+            ),
+        )
+        .unwrap();
         let mut fixture = Self {
             root,
             home,
             project,
             source,
+            verifier,
             handle: String::new(),
         };
         let output = fixture.run(
@@ -150,7 +164,7 @@ fn actual_exec_records_completed_input_restoration_once() {
     for (label, live) in [("stdin-buffered", false), ("stdin-live", true)] {
         let output = fixture.run(
             label,
-            secret_stdin_args(&fixture.handle, &fixture.source, live),
+            secret_stdin_args(&fixture.handle, &fixture.source, &fixture.verifier, live),
         );
         assert_success(&output, label);
         fixture.assert_resolve_count(label, 1);
@@ -164,7 +178,16 @@ fn actual_exec_records_completed_input_restoration_once() {
     fixture.assert_resolve_count("referenced-env", 1);
 
     for (label, live) in [("argv-nonzero", false), ("argv-nonzero-live", true)] {
-        let output = fixture.run(label, argv_args(&fixture.handle, &fixture.source, 37, live));
+        let output = fixture.run(
+            label,
+            argv_args(
+                &fixture.handle,
+                &fixture.source,
+                &fixture.verifier,
+                37,
+                live,
+            ),
+        );
         assert_eq!(output.status.code(), Some(37), "{output:?}");
         fixture.assert_resolve_count(label, 1);
     }
@@ -197,7 +220,7 @@ fn actual_exec_does_not_count_noop_or_failed_input_preparation() {
 
     let output = fixture.run(
         "argv-denied",
-        argv_args_without_opt_in(&fixture.handle, &fixture.source),
+        argv_args_without_opt_in(&fixture.handle, &fixture.source, &fixture.verifier),
     );
     assert!(!output.status.success(), "{output:?}");
     fixture.assert_resolve_count("argv-denied", 0);
@@ -281,7 +304,7 @@ fn bounded_output(mut command: Command, context: &str) -> Output {
 }
 
 #[cfg(unix)]
-fn shell_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsString> {
+fn shell_args(handle: &str, source: &Path, live: bool) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
@@ -297,7 +320,7 @@ fn shell_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsStr
 }
 
 #[cfg(unix)]
-fn referenced_env_args(handle: &str, source: &PathBuf) -> Vec<std::ffi::OsString> {
+fn referenced_env_args(handle: &str, source: &Path) -> Vec<std::ffi::OsString> {
     let name = env_name_for_handle(handle);
     vec![
         "exec".into(),
@@ -310,7 +333,7 @@ fn referenced_env_args(handle: &str, source: &PathBuf) -> Vec<std::ffi::OsString
 }
 
 #[cfg(windows)]
-fn shell_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsString> {
+fn shell_args(handle: &str, source: &Path, live: bool) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
@@ -326,7 +349,7 @@ fn shell_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsStr
 }
 
 #[cfg(windows)]
-fn referenced_env_args(handle: &str, source: &PathBuf) -> Vec<std::ffi::OsString> {
+fn referenced_env_args(handle: &str, source: &Path) -> Vec<std::ffi::OsString> {
     let name = env_name_for_handle(handle);
     vec![
         "exec".into(),
@@ -339,7 +362,12 @@ fn referenced_env_args(handle: &str, source: &PathBuf) -> Vec<std::ffi::OsString
 }
 
 #[cfg(unix)]
-fn secret_stdin_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsString> {
+fn secret_stdin_args(
+    handle: &str,
+    source: &Path,
+    _verifier: &Path,
+    live: bool,
+) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
@@ -360,7 +388,12 @@ fn secret_stdin_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi
 }
 
 #[cfg(windows)]
-fn secret_stdin_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsString> {
+fn secret_stdin_args(
+    handle: &str,
+    source: &Path,
+    verifier: &Path,
+    live: bool,
+) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
@@ -373,18 +406,22 @@ fn secret_stdin_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi
         "-NoLogo".into(),
         "-NoProfile".into(),
         "-NonInteractive".into(),
-        "-Command".into(),
-        format!(
-            "$value=[Console]::In.ReadToEnd(); $expected=(Get-Content -LiteralPath '{}') -replace '^OPENAI_API_KEY=', ''; if ($value -ne $expected) {{ exit 1 }}",
-            source.display()
-        )
-        .into(),
+        "-File".into(),
+        verifier.to_path_buf().into_os_string(),
+        "stdin".into(),
+        source.to_path_buf().into_os_string(),
     ]);
     args
 }
 
 #[cfg(unix)]
-fn argv_args(handle: &str, source: &PathBuf, exit: i32, live: bool) -> Vec<std::ffi::OsString> {
+fn argv_args(
+    handle: &str,
+    source: &Path,
+    _verifier: &Path,
+    exit: i32,
+    live: bool,
+) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
@@ -400,13 +437,19 @@ fn argv_args(handle: &str, source: &PathBuf, exit: i32, live: bool) -> Vec<std::
         .into(),
         "pentect-test".into(),
         handle.into(),
-        source.clone().into_os_string(),
+        source.to_path_buf().into_os_string(),
     ]);
     args
 }
 
 #[cfg(windows)]
-fn argv_args(handle: &str, source: &PathBuf, exit: i32, live: bool) -> Vec<std::ffi::OsString> {
+fn argv_args(
+    handle: &str,
+    source: &Path,
+    verifier: &Path,
+    exit: i32,
+    live: bool,
+) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
@@ -418,16 +461,22 @@ fn argv_args(handle: &str, source: &PathBuf, exit: i32, live: bool) -> Vec<std::
         "-NoLogo".into(),
         "-NoProfile".into(),
         "-NonInteractive".into(),
-        "-Command".into(),
-        format!("param($value,$path); $expected=(Get-Content -LiteralPath $path) -replace '^OPENAI_API_KEY=', ''; if ($value -ne $expected) {{ exit 1 }}; exit {exit}").into(),
+        "-File".into(),
+        verifier.to_path_buf().into_os_string(),
+        "argv".into(),
+        source.to_path_buf().into_os_string(),
         handle.into(),
-        source.clone().into_os_string(),
+        exit.to_string().into(),
     ]);
     args
 }
 
-fn argv_args_without_opt_in(handle: &str, source: &PathBuf) -> Vec<std::ffi::OsString> {
-    let mut args = argv_args(handle, source, 0, false);
+fn argv_args_without_opt_in(
+    handle: &str,
+    source: &Path,
+    verifier: &Path,
+) -> Vec<std::ffi::OsString> {
+    let mut args = argv_args(handle, source, verifier, 0, false);
     args.remove(1);
     args
 }

--- a/crates/pentect-cli/tests/exec_restoration_metrics.rs
+++ b/crates/pentect-cli/tests/exec_restoration_metrics.rs
@@ -1,7 +1,8 @@
 use serde_json::Value;
 use std::path::PathBuf;
-use std::process::{Command, Output};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const SECRET: &str = "sk-proj-pentect-synthetic-exec-restoration-1234567890";
 
@@ -9,6 +10,7 @@ struct Fixture {
     root: PathBuf,
     home: PathBuf,
     project: PathBuf,
+    source: PathBuf,
     handle: String,
 }
 
@@ -38,9 +40,13 @@ impl Fixture {
             root,
             home,
             project,
+            source,
             handle: String::new(),
         };
-        let output = fixture.run("seed", ["read".into(), source.into_os_string()]);
+        let output = fixture.run(
+            "seed",
+            ["read".into(), fixture.source.clone().into_os_string()],
+        );
         assert_success(&output, "seed handle");
         let masked = String::from_utf8(output.stdout).unwrap();
         fixture.handle = first_handle(&masked);
@@ -62,6 +68,7 @@ impl Fixture {
         }
         let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
         command
+            .env_clear()
             .args(args)
             .current_dir(&self.project)
             .env("HOME", &self.home)
@@ -76,16 +83,12 @@ impl Fixture {
             .env("TEMP", &temp)
             .env("PENTECT_LOG_DIR", &log_dir)
             .env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
-        for name in [
-            "PENTECT_MEMORY_STORE_ADDR",
-            "PENTECT_MEMORY_STORE_TOKEN",
-            "PENTECT_PROCESS_HOST_READ_TOKEN",
-            "PENTECT_PROCESS_HOST_WRITE_TOKEN",
-            "PENTECT_AGENT_LAUNCHED",
-        ] {
-            command.env_remove(name);
+        for name in ["PATH", "SystemRoot", "WINDIR"] {
+            if let Some(value) = std::env::var_os(name) {
+                command.env(name, value);
+            }
         }
-        command.output().unwrap()
+        bounded_output(command, label)
     }
 
     fn resolve_events(&self, label: &str) -> Vec<Value> {
@@ -97,14 +100,34 @@ impl Fixture {
         );
         raw.lines()
             .map(|line| serde_json::from_str::<Value>(line).unwrap())
-            .filter(|event| event["action"] == "resolve" && event["surface"] == "exec")
+            .filter(|event| event["action"] == "resolve")
             .collect()
     }
 
     fn assert_resolve_count(&self, label: &str, expected: usize) {
         let events = self.resolve_events(label);
         assert_eq!(events.len(), expected, "{label}: {events:?}");
-        assert!(events.iter().all(|event| event["count"] == 1));
+        let env_name = env_name_for_handle(&self.handle);
+        for event in events {
+            assert_eq!(event["surface"], "exec", "{label}: {event:?}");
+            assert_eq!(event["count"], 1, "{label}: {event:?}");
+            assert!(
+                event
+                    .get("labels")
+                    .is_none_or(|labels| labels == &Value::Array(Vec::new())),
+                "{label}: {event:?}"
+            );
+            assert!(event.get("target").is_none(), "{label}: {event:?}");
+            let encoded = serde_json::to_string(&event).unwrap();
+            for private in [
+                SECRET,
+                self.handle.as_str(),
+                self.source.to_str().unwrap(),
+                env_name.as_str(),
+            ] {
+                assert!(!encoded.contains(private), "{label}: {event:?}");
+            }
+        }
     }
 }
 
@@ -119,38 +142,49 @@ fn actual_exec_records_completed_input_restoration_once() {
     let fixture = Fixture::new();
 
     for (label, live) in [("shell-buffered", false), ("shell-live", true)] {
-        let output = fixture.run(label, shell_args(&fixture.handle, live));
+        let output = fixture.run(label, shell_args(&fixture.handle, &fixture.source, live));
         assert_success(&output, label);
         fixture.assert_resolve_count(label, 1);
     }
 
     for (label, live) in [("stdin-buffered", false), ("stdin-live", true)] {
-        let output = fixture.run(label, secret_stdin_args(&fixture.handle, live));
+        let output = fixture.run(
+            label,
+            secret_stdin_args(&fixture.handle, &fixture.source, live),
+        );
         assert_success(&output, label);
         fixture.assert_resolve_count(label, 1);
     }
 
-    let output = fixture.run("referenced-env", referenced_env_args(&fixture.handle));
+    let output = fixture.run(
+        "referenced-env",
+        referenced_env_args(&fixture.handle, &fixture.source),
+    );
     assert_success(&output, "referenced-env");
     fixture.assert_resolve_count("referenced-env", 1);
 
-    let output = fixture.run("argv-nonzero", argv_args(&fixture.handle, 37));
-    assert_eq!(output.status.code(), Some(37), "{output:?}");
-    fixture.assert_resolve_count("argv-nonzero", 1);
+    for (label, live) in [("argv-nonzero", false), ("argv-nonzero-live", true)] {
+        let output = fixture.run(label, argv_args(&fixture.handle, &fixture.source, 37, live));
+        assert_eq!(output.status.code(), Some(37), "{output:?}");
+        fixture.assert_resolve_count(label, 1);
+    }
 
-    let missing = fixture.root.join("program-that-does-not-exist");
-    let output = fixture.run(
-        "spawn-failure",
-        [
-            "exec".into(),
+    for (label, live) in [("spawn-failure", false), ("spawn-failure-live", true)] {
+        let missing = fixture.root.join("program-that-does-not-exist");
+        let mut args = vec!["exec".into()];
+        if live {
+            args.push("--live".into());
+        }
+        args.extend([
             "--allow-secret-argv".into(),
             "--".into(),
             missing.into_os_string(),
             fixture.handle.clone().into(),
-        ],
-    );
-    assert!(!output.status.success(), "{output:?}");
-    fixture.assert_resolve_count("spawn-failure", 1);
+        ]);
+        let output = fixture.run(label, args);
+        assert!(!output.status.success(), "{output:?}");
+        fixture.assert_resolve_count(label, 1);
+    }
 }
 
 #[test]
@@ -161,14 +195,22 @@ fn actual_exec_does_not_count_noop_or_failed_input_preparation() {
     assert_success(&output, "noop");
     fixture.assert_resolve_count("noop", 0);
 
-    let output = fixture.run("argv-denied", argv_args_without_opt_in(&fixture.handle));
+    let output = fixture.run(
+        "argv-denied",
+        argv_args_without_opt_in(&fixture.handle, &fixture.source),
+    );
     assert!(!output.status.success(), "{output:?}");
     fixture.assert_resolve_count("argv-denied", 0);
 
     let unknown = unknown_handle(&fixture.handle);
-    let output = fixture.run("unknown", secret_stdin_args(&unknown, false));
-    assert!(!output.status.success(), "{output:?}");
-    fixture.assert_resolve_count("unknown", 0);
+    for (label, live) in [("late-unknown", false), ("late-unknown-live", true)] {
+        let output = fixture.run(
+            label,
+            argv_with_late_unknown(&fixture.handle, &unknown, live),
+        );
+        assert!(!output.status.success(), "{output:?}");
+        fixture.assert_resolve_count(label, 0);
+    }
 }
 
 fn first_handle(masked: &str) -> String {
@@ -190,11 +232,8 @@ fn unknown_handle(handle: &str) -> String {
         .position(|window| window == prefix)
         .map(|index| index + prefix.len())
         .unwrap();
-    let index = unknown[hash_start..]
-        .iter()
-        .position(|byte| byte.is_ascii_hexdigit() && byte.is_ascii_lowercase())
-        .map(|index| hash_start + index)
-        .unwrap();
+    let index = hash_start;
+    assert!(unknown[index].is_ascii_hexdigit());
     unknown[index] = if unknown[index] == b'a' { b'b' } else { b'a' };
     String::from_utf8(unknown).unwrap()
 }
@@ -221,46 +260,86 @@ fn assert_success(output: &Output, context: &str) {
     );
 }
 
+fn bounded_output(mut command: Command, context: &str) -> Output {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            return child.wait_with_output().unwrap();
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("{context}: pentect command did not exit within 15 seconds");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
 #[cfg(unix)]
-fn shell_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
+fn shell_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
     }
-    args.push(format!(": '{handle}'").into());
+    args.push(
+        format!(
+            "expected=$(cut -d= -f2- '{}'); test '{handle}' = \"$expected\"; test '{handle}' = \"$expected\"",
+            source.display()
+        )
+        .into(),
+    );
     args
 }
 
 #[cfg(unix)]
-fn referenced_env_args(handle: &str) -> Vec<std::ffi::OsString> {
+fn referenced_env_args(handle: &str, source: &PathBuf) -> Vec<std::ffi::OsString> {
     let name = env_name_for_handle(handle);
     vec![
         "exec".into(),
-        format!(": '{handle}'; test -n \"${name}\"").into(),
+        format!(
+            "expected=$(cut -d= -f2- '{}'); : '{handle}'; test \"${name}\" = \"$expected\"",
+            source.display()
+        )
+        .into(),
     ]
 }
 
 #[cfg(windows)]
-fn shell_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
+fn shell_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
     }
-    args.push(format!("'{handle}' | Out-Null").into());
+    args.push(
+        format!(
+            "$expected=(Get-Content -LiteralPath '{}') -replace '^OPENAI_API_KEY=', ''; if ('{handle}' -ne $expected -or '{handle}' -ne $expected) {{ exit 1 }}",
+            source.display()
+        )
+        .into(),
+    );
     args
 }
 
 #[cfg(windows)]
-fn referenced_env_args(handle: &str) -> Vec<std::ffi::OsString> {
+fn referenced_env_args(handle: &str, source: &PathBuf) -> Vec<std::ffi::OsString> {
     let name = env_name_for_handle(handle);
     vec![
         "exec".into(),
-        format!("'{handle}' | Out-Null; if (-not $env:{name}) {{ exit 1 }}").into(),
+        format!(
+            "$expected=(Get-Content -LiteralPath '{}') -replace '^OPENAI_API_KEY=', ''; '{handle}' | Out-Null; if ($env:{name} -ne $expected) {{ exit 1 }}",
+            source.display()
+        )
+        .into(),
     ]
 }
 
 #[cfg(unix)]
-fn secret_stdin_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
+fn secret_stdin_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
@@ -271,13 +350,17 @@ fn secret_stdin_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
         "--".into(),
         "sh".into(),
         "-c".into(),
-        "IFS= read -r value; test -n \"$value\"".into(),
+        format!(
+            "IFS= read -r value; expected=$(cut -d= -f2- '{}'); test \"$value\" = \"$expected\"",
+            source.display()
+        )
+        .into(),
     ]);
     args
 }
 
 #[cfg(windows)]
-fn secret_stdin_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
+fn secret_stdin_args(handle: &str, source: &PathBuf, live: bool) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
     if live {
         args.push("--live".into());
@@ -291,29 +374,44 @@ fn secret_stdin_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
         "-NoProfile".into(),
         "-NonInteractive".into(),
         "-Command".into(),
-        "$value=[Console]::In.ReadToEnd(); if ($value.Length -eq 0) { exit 1 }".into(),
+        format!(
+            "$value=[Console]::In.ReadToEnd(); $expected=(Get-Content -LiteralPath '{}') -replace '^OPENAI_API_KEY=', ''; if ($value -ne $expected) {{ exit 1 }}",
+            source.display()
+        )
+        .into(),
     ]);
     args
 }
 
 #[cfg(unix)]
-fn argv_args(handle: &str, exit: i32) -> Vec<std::ffi::OsString> {
-    vec![
-        "exec".into(),
+fn argv_args(handle: &str, source: &PathBuf, exit: i32, live: bool) -> Vec<std::ffi::OsString> {
+    let mut args = vec!["exec".into()];
+    if live {
+        args.push("--live".into());
+    }
+    args.extend([
         "--allow-secret-argv".into(),
         "--".into(),
         "sh".into(),
         "-c".into(),
-        format!("exit {exit}").into(),
+        format!(
+            "expected=$(cut -d= -f2- \"$2\"); test \"$1\" = \"$expected\" || exit 1; exit {exit}"
+        )
+        .into(),
         "pentect-test".into(),
         handle.into(),
-    ]
+        source.clone().into_os_string(),
+    ]);
+    args
 }
 
 #[cfg(windows)]
-fn argv_args(handle: &str, exit: i32) -> Vec<std::ffi::OsString> {
-    vec![
-        "exec".into(),
+fn argv_args(handle: &str, source: &PathBuf, exit: i32, live: bool) -> Vec<std::ffi::OsString> {
+    let mut args = vec!["exec".into()];
+    if live {
+        args.push("--live".into());
+    }
+    args.extend([
         "--allow-secret-argv".into(),
         "--".into(),
         "powershell.exe".into(),
@@ -321,14 +419,31 @@ fn argv_args(handle: &str, exit: i32) -> Vec<std::ffi::OsString> {
         "-NoProfile".into(),
         "-NonInteractive".into(),
         "-Command".into(),
-        format!("exit {exit}").into(),
+        format!("param($value,$path); $expected=(Get-Content -LiteralPath $path) -replace '^OPENAI_API_KEY=', ''; if ($value -ne $expected) {{ exit 1 }}; exit {exit}").into(),
         handle.into(),
-    ]
+        source.clone().into_os_string(),
+    ]);
+    args
 }
 
-fn argv_args_without_opt_in(handle: &str) -> Vec<std::ffi::OsString> {
-    let mut args = argv_args(handle, 0);
+fn argv_args_without_opt_in(handle: &str, source: &PathBuf) -> Vec<std::ffi::OsString> {
+    let mut args = argv_args(handle, source, 0, false);
     args.remove(1);
+    args
+}
+
+fn argv_with_late_unknown(known: &str, unknown: &str, live: bool) -> Vec<std::ffi::OsString> {
+    let mut args = vec!["exec".into()];
+    if live {
+        args.push("--live".into());
+    }
+    args.extend([
+        "--allow-secret-argv".into(),
+        "--".into(),
+        "program-is-never-spawned".into(),
+        known.into(),
+        unknown.into(),
+    ]);
     args
 }
 

--- a/crates/pentect-cli/tests/exec_restoration_metrics.rs
+++ b/crates/pentect-cli/tests/exec_restoration_metrics.rs
@@ -29,11 +29,11 @@ impl Fixture {
         let project = root.join("project");
         std::fs::create_dir_all(home.join(".pentect")).unwrap();
         std::fs::create_dir_all(project.join(".git")).unwrap();
-        std::fs::write(
-            home.join(".pentect/config.toml"),
-            "[activity]\nshare = false\n[files]\nremember = true\n[update]\ncheck = false\n",
-        )
-        .unwrap();
+        std::fs::create_dir_all(project.join(".pentect")).unwrap();
+        let config =
+            "[activity]\nshare = false\n[files]\nremember = true\n[update]\ncheck = false\n";
+        std::fs::write(home.join(".pentect/config.toml"), config).unwrap();
+        std::fs::write(project.join(".pentect/config.toml"), config).unwrap();
 
         let source = project.join("source.env");
         std::fs::write(&source, format!("OPENAI_API_KEY={SECRET}\n")).unwrap();
@@ -57,11 +57,21 @@ impl Fixture {
             verifier,
             handle: String::new(),
         };
-        let output = fixture.run(
-            "seed",
-            ["read".into(), fixture.source.clone().into_os_string()],
-        );
+        // Use the runtime's test setup route. Public standalone `read`
+        // intentionally creates transient handles when no store is active.
+        let output = fixture.run("seed", seed_args(&fixture.source));
         assert_success(&output, "seed handle");
+        for name in ["key.bin", "index.bin"] {
+            let path = fixture
+                .project
+                .join(".pentect/file-pointer-manager")
+                .join(name);
+            assert!(
+                std::fs::metadata(&path).is_ok_and(|metadata| metadata.len() > 0),
+                "runtime read did not register {}",
+                path.display()
+            );
+        }
         let masked = String::from_utf8(output.stdout).unwrap();
         fixture.handle = first_handle(&masked);
         assert!(!fixture.handle.contains(SECRET));
@@ -281,6 +291,14 @@ fn assert_success(output: &Output, context: &str) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn seed_args(source: &Path) -> Vec<std::ffi::OsString> {
+    vec![
+        "agent".into(),
+        "read".into(),
+        source.to_path_buf().into_os_string(),
+    ]
 }
 
 fn bounded_output(mut command: Command, context: &str) -> Output {

--- a/crates/pentect-cli/tests/exec_restoration_metrics.rs
+++ b/crates/pentect-cli/tests/exec_restoration_metrics.rs
@@ -31,7 +31,7 @@ impl Fixture {
         std::fs::create_dir_all(project.join(".git")).unwrap();
         std::fs::write(
             home.join(".pentect/config.toml"),
-            "[activity]\nshare = false\n[update]\ncheck = false\n",
+            "[activity]\nshare = false\n[files]\nremember = true\n[update]\ncheck = false\n",
         )
         .unwrap();
 

--- a/crates/pentect-cli/tests/exec_restoration_metrics.rs
+++ b/crates/pentect-cli/tests/exec_restoration_metrics.rs
@@ -1,0 +1,358 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SECRET: &str = "sk-proj-pentect-synthetic-exec-restoration-1234567890";
+
+struct Fixture {
+    root: PathBuf,
+    home: PathBuf,
+    project: PathBuf,
+    handle: String,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "pentect-exec-restoration-metrics-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let home = root.join("home");
+        let project = root.join("project");
+        std::fs::create_dir_all(home.join(".pentect")).unwrap();
+        std::fs::create_dir_all(project.join(".git")).unwrap();
+        std::fs::write(
+            home.join(".pentect/config.toml"),
+            "[activity]\nshare = false\n[update]\ncheck = false\n",
+        )
+        .unwrap();
+
+        let source = project.join("source.env");
+        std::fs::write(&source, format!("OPENAI_API_KEY={SECRET}\n")).unwrap();
+        let mut fixture = Self {
+            root,
+            home,
+            project,
+            handle: String::new(),
+        };
+        let output = fixture.run("seed", ["read".into(), source.into_os_string()]);
+        assert_success(&output, "seed handle");
+        let masked = String::from_utf8(output.stdout).unwrap();
+        fixture.handle = first_handle(&masked);
+        assert!(!fixture.handle.contains(SECRET));
+        fixture
+    }
+
+    fn run<I>(&self, label: &str, args: I) -> Output
+    where
+        I: IntoIterator<Item = std::ffi::OsString>,
+    {
+        let log_dir = self.root.join("logs").join(label);
+        let runtime = self.root.join("runtime");
+        let cache = self.root.join("cache");
+        let state = self.root.join("state");
+        let temp = self.root.join("tmp");
+        for path in [&log_dir, &runtime, &cache, &state, &temp] {
+            std::fs::create_dir_all(path).unwrap();
+        }
+        let mut command = Command::new(env!("CARGO_BIN_EXE_pentect"));
+        command
+            .args(args)
+            .current_dir(&self.project)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .env("LOCALAPPDATA", &self.home)
+            .env("XDG_CONFIG_HOME", self.home.join(".config"))
+            .env("XDG_RUNTIME_DIR", &runtime)
+            .env("XDG_CACHE_HOME", &cache)
+            .env("XDG_STATE_HOME", &state)
+            .env("TMPDIR", &temp)
+            .env("TMP", &temp)
+            .env("TEMP", &temp)
+            .env("PENTECT_LOG_DIR", &log_dir)
+            .env("PENTECT_BIN", env!("CARGO_BIN_EXE_pentect"));
+        for name in [
+            "PENTECT_MEMORY_STORE_ADDR",
+            "PENTECT_MEMORY_STORE_TOKEN",
+            "PENTECT_PROCESS_HOST_READ_TOKEN",
+            "PENTECT_PROCESS_HOST_WRITE_TOKEN",
+            "PENTECT_AGENT_LAUNCHED",
+        ] {
+            command.env_remove(name);
+        }
+        command.output().unwrap()
+    }
+
+    fn resolve_events(&self, label: &str) -> Vec<Value> {
+        let path = self.root.join("logs").join(label).join("pentect.log");
+        let raw = std::fs::read_to_string(path).unwrap_or_default();
+        assert!(
+            !raw.contains(SECRET),
+            "activity log contained fixture value"
+        );
+        raw.lines()
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+            .filter(|event| event["action"] == "resolve" && event["surface"] == "exec")
+            .collect()
+    }
+
+    fn assert_resolve_count(&self, label: &str, expected: usize) {
+        let events = self.resolve_events(label);
+        assert_eq!(events.len(), expected, "{label}: {events:?}");
+        assert!(events.iter().all(|event| event["count"] == 1));
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+#[test]
+fn actual_exec_records_completed_input_restoration_once() {
+    let fixture = Fixture::new();
+
+    for (label, live) in [("shell-buffered", false), ("shell-live", true)] {
+        let output = fixture.run(label, shell_args(&fixture.handle, live));
+        assert_success(&output, label);
+        fixture.assert_resolve_count(label, 1);
+    }
+
+    for (label, live) in [("stdin-buffered", false), ("stdin-live", true)] {
+        let output = fixture.run(label, secret_stdin_args(&fixture.handle, live));
+        assert_success(&output, label);
+        fixture.assert_resolve_count(label, 1);
+    }
+
+    let output = fixture.run("referenced-env", referenced_env_args(&fixture.handle));
+    assert_success(&output, "referenced-env");
+    fixture.assert_resolve_count("referenced-env", 1);
+
+    let output = fixture.run("argv-nonzero", argv_args(&fixture.handle, 37));
+    assert_eq!(output.status.code(), Some(37), "{output:?}");
+    fixture.assert_resolve_count("argv-nonzero", 1);
+
+    let missing = fixture.root.join("program-that-does-not-exist");
+    let output = fixture.run(
+        "spawn-failure",
+        [
+            "exec".into(),
+            "--allow-secret-argv".into(),
+            "--".into(),
+            missing.into_os_string(),
+            fixture.handle.clone().into(),
+        ],
+    );
+    assert!(!output.status.success(), "{output:?}");
+    fixture.assert_resolve_count("spawn-failure", 1);
+}
+
+#[test]
+fn actual_exec_does_not_count_noop_or_failed_input_preparation() {
+    let fixture = Fixture::new();
+
+    let output = fixture.run("noop", noop_args());
+    assert_success(&output, "noop");
+    fixture.assert_resolve_count("noop", 0);
+
+    let output = fixture.run("argv-denied", argv_args_without_opt_in(&fixture.handle));
+    assert!(!output.status.success(), "{output:?}");
+    fixture.assert_resolve_count("argv-denied", 0);
+
+    let unknown = unknown_handle(&fixture.handle);
+    let output = fixture.run("unknown", secret_stdin_args(&unknown, false));
+    assert!(!output.status.success(), "{output:?}");
+    fixture.assert_resolve_count("unknown", 0);
+}
+
+fn first_handle(masked: &str) -> String {
+    let start = masked
+        .find("<<")
+        .unwrap_or_else(|| panic!("missing handle"));
+    let end = masked[start..]
+        .find(">>")
+        .map(|offset| start + offset + 2)
+        .unwrap_or_else(|| panic!("unterminated handle"));
+    masked[start..end].to_string()
+}
+
+fn unknown_handle(handle: &str) -> String {
+    let mut unknown = handle.as_bytes().to_vec();
+    let prefix = b"OPENAI_API_KEY_";
+    let hash_start = unknown
+        .windows(prefix.len())
+        .position(|window| window == prefix)
+        .map(|index| index + prefix.len())
+        .unwrap();
+    let index = unknown[hash_start..]
+        .iter()
+        .position(|byte| byte.is_ascii_hexdigit() && byte.is_ascii_lowercase())
+        .map(|index| hash_start + index)
+        .unwrap();
+    unknown[index] = if unknown[index] == b'a' { b'b' } else { b'a' };
+    String::from_utf8(unknown).unwrap()
+}
+
+fn env_name_for_handle(handle: &str) -> String {
+    let inner = handle
+        .strip_prefix("<<")
+        .and_then(|value| value.strip_suffix(">>"))
+        .unwrap();
+    let core = inner
+        .rsplit_once("_length_at_least_")
+        .or_else(|| inner.rsplit_once("_length_"))
+        .or_else(|| inner.rsplit_once("_len"))
+        .map_or(inner, |(core, _)| core);
+    format!("PENTECT_{core}")
+}
+
+fn assert_success(output: &Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context}: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+fn shell_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
+    let mut args = vec!["exec".into()];
+    if live {
+        args.push("--live".into());
+    }
+    args.push(format!(": '{handle}'").into());
+    args
+}
+
+#[cfg(unix)]
+fn referenced_env_args(handle: &str) -> Vec<std::ffi::OsString> {
+    let name = env_name_for_handle(handle);
+    vec![
+        "exec".into(),
+        format!(": '{handle}'; test -n \"${name}\"").into(),
+    ]
+}
+
+#[cfg(windows)]
+fn shell_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
+    let mut args = vec!["exec".into()];
+    if live {
+        args.push("--live".into());
+    }
+    args.push(format!("'{handle}' | Out-Null").into());
+    args
+}
+
+#[cfg(windows)]
+fn referenced_env_args(handle: &str) -> Vec<std::ffi::OsString> {
+    let name = env_name_for_handle(handle);
+    vec![
+        "exec".into(),
+        format!("'{handle}' | Out-Null; if (-not $env:{name}) {{ exit 1 }}").into(),
+    ]
+}
+
+#[cfg(unix)]
+fn secret_stdin_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
+    let mut args = vec!["exec".into()];
+    if live {
+        args.push("--live".into());
+    }
+    args.extend([
+        "--secret-stdin".into(),
+        handle.into(),
+        "--".into(),
+        "sh".into(),
+        "-c".into(),
+        "IFS= read -r value; test -n \"$value\"".into(),
+    ]);
+    args
+}
+
+#[cfg(windows)]
+fn secret_stdin_args(handle: &str, live: bool) -> Vec<std::ffi::OsString> {
+    let mut args = vec!["exec".into()];
+    if live {
+        args.push("--live".into());
+    }
+    args.extend([
+        "--secret-stdin".into(),
+        handle.into(),
+        "--".into(),
+        "powershell.exe".into(),
+        "-NoLogo".into(),
+        "-NoProfile".into(),
+        "-NonInteractive".into(),
+        "-Command".into(),
+        "$value=[Console]::In.ReadToEnd(); if ($value.Length -eq 0) { exit 1 }".into(),
+    ]);
+    args
+}
+
+#[cfg(unix)]
+fn argv_args(handle: &str, exit: i32) -> Vec<std::ffi::OsString> {
+    vec![
+        "exec".into(),
+        "--allow-secret-argv".into(),
+        "--".into(),
+        "sh".into(),
+        "-c".into(),
+        format!("exit {exit}").into(),
+        "pentect-test".into(),
+        handle.into(),
+    ]
+}
+
+#[cfg(windows)]
+fn argv_args(handle: &str, exit: i32) -> Vec<std::ffi::OsString> {
+    vec![
+        "exec".into(),
+        "--allow-secret-argv".into(),
+        "--".into(),
+        "powershell.exe".into(),
+        "-NoLogo".into(),
+        "-NoProfile".into(),
+        "-NonInteractive".into(),
+        "-Command".into(),
+        format!("exit {exit}").into(),
+        handle.into(),
+    ]
+}
+
+fn argv_args_without_opt_in(handle: &str) -> Vec<std::ffi::OsString> {
+    let mut args = argv_args(handle, 0);
+    args.remove(1);
+    args
+}
+
+#[cfg(unix)]
+fn noop_args() -> Vec<std::ffi::OsString> {
+    vec![
+        "exec".into(),
+        "--".into(),
+        "sh".into(),
+        "-c".into(),
+        "exit 0".into(),
+    ]
+}
+
+#[cfg(windows)]
+fn noop_args() -> Vec<std::ffi::OsString> {
+    vec![
+        "exec".into(),
+        "--".into(),
+        "powershell.exe".into(),
+        "-NoLogo".into(),
+        "-NoProfile".into(),
+        "-NonInteractive".into(),
+        "-Command".into(),
+        "exit 0".into(),
+    ]
+}

--- a/crates/pentect-cli/tests/exec_restoration_metrics.rs
+++ b/crates/pentect-cli/tests/exec_restoration_metrics.rs
@@ -131,7 +131,6 @@ impl Fixture {
     fn assert_resolve_count(&self, label: &str, expected: usize) {
         let events = self.resolve_events(label);
         assert_eq!(events.len(), expected, "{label}: {events:?}");
-        let env_name = env_name_for_handle(&self.handle);
         for event in events {
             assert_eq!(event["surface"], "exec", "{label}: {event:?}");
             assert_eq!(event["count"], 1, "{label}: {event:?}");
@@ -143,12 +142,7 @@ impl Fixture {
             );
             assert!(event.get("target").is_none(), "{label}: {event:?}");
             let encoded = serde_json::to_string(&event).unwrap();
-            for private in [
-                SECRET,
-                self.handle.as_str(),
-                self.source.to_str().unwrap(),
-                env_name.as_str(),
-            ] {
+            for private in [SECRET, self.handle.as_str(), self.source.to_str().unwrap()] {
                 assert!(!encoded.contains(private), "{label}: {event:?}");
             }
         }
@@ -179,13 +173,6 @@ fn actual_exec_records_completed_input_restoration_once() {
         assert_success(&output, label);
         fixture.assert_resolve_count(label, 1);
     }
-
-    let output = fixture.run(
-        "referenced-env",
-        referenced_env_args(&fixture.handle, &fixture.source),
-    );
-    assert_success(&output, "referenced-env");
-    fixture.assert_resolve_count("referenced-env", 1);
 
     for (label, live) in [("argv-nonzero", false), ("argv-nonzero-live", true)] {
         let output = fixture.run(
@@ -235,11 +222,12 @@ fn actual_exec_does_not_count_noop_or_failed_input_preparation() {
     assert!(!output.status.success(), "{output:?}");
     fixture.assert_resolve_count("argv-denied", 0);
 
-    let unknown = unknown_handle(&fixture.handle);
+    let foreign_fixture = Fixture::new();
+    assert_ne!(fixture.handle, foreign_fixture.handle);
     for (label, live) in [("late-unknown", false), ("late-unknown-live", true)] {
         let output = fixture.run(
             label,
-            argv_with_late_unknown(&fixture.handle, &unknown, live),
+            argv_with_late_unknown(&fixture.handle, &foreign_fixture.handle, live),
         );
         assert!(!output.status.success(), "{output:?}");
         fixture.assert_resolve_count(label, 0);
@@ -255,33 +243,6 @@ fn first_handle(masked: &str) -> String {
         .map(|offset| start + offset + 2)
         .unwrap_or_else(|| panic!("unterminated handle"));
     masked[start..end].to_string()
-}
-
-fn unknown_handle(handle: &str) -> String {
-    let mut unknown = handle.as_bytes().to_vec();
-    let prefix = b"OPENAI_API_KEY_";
-    let hash_start = unknown
-        .windows(prefix.len())
-        .position(|window| window == prefix)
-        .map(|index| index + prefix.len())
-        .unwrap();
-    let index = hash_start;
-    assert!(unknown[index].is_ascii_hexdigit());
-    unknown[index] = if unknown[index] == b'a' { b'b' } else { b'a' };
-    String::from_utf8(unknown).unwrap()
-}
-
-fn env_name_for_handle(handle: &str) -> String {
-    let inner = handle
-        .strip_prefix("<<")
-        .and_then(|value| value.strip_suffix(">>"))
-        .unwrap();
-    let core = inner
-        .rsplit_once("_length_at_least_")
-        .or_else(|| inner.rsplit_once("_length_"))
-        .or_else(|| inner.rsplit_once("_len"))
-        .map_or(inner, |(core, _)| core);
-    format!("PENTECT_{core}")
 }
 
 fn assert_success(output: &Output, context: &str) {
@@ -337,19 +298,6 @@ fn shell_args(handle: &str, source: &Path, live: bool) -> Vec<std::ffi::OsString
     args
 }
 
-#[cfg(unix)]
-fn referenced_env_args(handle: &str, source: &Path) -> Vec<std::ffi::OsString> {
-    let name = env_name_for_handle(handle);
-    vec![
-        "exec".into(),
-        format!(
-            "expected=$(cut -d= -f2- '{}'); : '{handle}'; test \"${name}\" = \"$expected\"",
-            source.display()
-        )
-        .into(),
-    ]
-}
-
 #[cfg(windows)]
 fn shell_args(handle: &str, source: &Path, live: bool) -> Vec<std::ffi::OsString> {
     let mut args = vec!["exec".into()];
@@ -364,19 +312,6 @@ fn shell_args(handle: &str, source: &Path, live: bool) -> Vec<std::ffi::OsString
         .into(),
     );
     args
-}
-
-#[cfg(windows)]
-fn referenced_env_args(handle: &str, source: &Path) -> Vec<std::ffi::OsString> {
-    let name = env_name_for_handle(handle);
-    vec![
-        "exec".into(),
-        format!(
-            "$expected=(Get-Content -LiteralPath '{}') -replace '^OPENAI_API_KEY=', ''; '{handle}' | Out-Null; if ($env:{name} -ne $expected) {{ exit 1 }}",
-            source.display()
-        )
-        .into(),
-    ]
 }
 
 #[cfg(unix)]

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -1542,19 +1542,22 @@ fn run_resolved_command(
     store: &MemoryStore,
     opts: &ExecOpts,
 ) -> Result<std::process::Output, String> {
-    match &opts.mode {
-        ExecMode::Program(args) => {
-            if args.is_empty() {
-                return Err("exec requires a program after `--`".to_string());
-            }
-            let env = requested_env_bindings(store, &opts.mode)?;
-            let resolved_args = resolve_command_args(store, args, opts.allow_secret_argv)?;
+    let resolved = resolve_exec_inputs(store, opts)?;
+    if resolved.restored() {
+        activity_log::record_resolve("exec", None);
+    }
+    match resolved {
+        ResolvedExecInputs::Program {
+            args: resolved_args,
+            env,
+            secret_stdin,
+            ..
+        } => {
             let program = &resolved_args[0];
             let command_args = &resolved_args[1..];
             let mut command = Command::new(program);
             command.args(command_args);
             apply_child_env_overlays(&mut command, &env, &opts.session);
-            let secret_stdin = resolve_secret_stdin(store, opts)?;
             if let Some(secret) = secret_stdin.as_deref() {
                 run_command_with_stdin(command, secret)
             } else {
@@ -1563,17 +1566,64 @@ fn run_resolved_command(
                     .map_err(|error| command_start_error(&error))
             }
         }
-        ExecMode::Shell(command) => {
-            let command = resolve_command_text(store, command)?;
-            register_local_file_inputs(store, &command)?;
-            let env = requested_env_bindings(store, &opts.mode)?;
-            run_shell_script(&command, &env, &opts.session, opts.script_shell)
-        }
-        ExecMode::Stdin => Err("internal error: exec stdin was not prepared".to_string()),
+        ResolvedExecInputs::Shell {
+            command, script, ..
+        } => run_shell_command(command, &script),
     }
 }
 
 fn run_resolved_command_live(store: &MemoryStore, opts: &ExecOpts) -> Result<ExitStatus, String> {
+    let resolved = resolve_exec_inputs(store, opts)?;
+    if resolved.restored() {
+        activity_log::record_resolve("exec", None);
+    }
+    match resolved {
+        ResolvedExecInputs::Program {
+            args: resolved_args,
+            env,
+            secret_stdin,
+            ..
+        } => {
+            let program = &resolved_args[0];
+            let command_args = &resolved_args[1..];
+            let mut command = Command::new(program);
+            command.args(command_args);
+            apply_child_env_overlays(&mut command, &env, &opts.session);
+            run_live_command(
+                command,
+                secret_stdin.as_ref().map(|value| value.as_str()),
+                store.clone(),
+            )
+        }
+        ResolvedExecInputs::Shell {
+            command, script, ..
+        } => run_live_command(command, Some(&script), store.clone()),
+    }
+}
+
+enum ResolvedExecInputs {
+    Program {
+        args: Vec<String>,
+        env: Vec<(String, String)>,
+        secret_stdin: Option<Zeroizing<String>>,
+        restored: bool,
+    },
+    Shell {
+        command: Command,
+        script: String,
+        restored: bool,
+    },
+}
+
+impl ResolvedExecInputs {
+    fn restored(&self) -> bool {
+        match self {
+            Self::Program { restored, .. } | Self::Shell { restored, .. } => *restored,
+        }
+    }
+}
+
+fn resolve_exec_inputs(store: &MemoryStore, opts: &ExecOpts) -> Result<ResolvedExecInputs, String> {
     match &opts.mode {
         ExecMode::Program(args) => {
             if args.is_empty() {
@@ -1581,26 +1631,27 @@ fn run_resolved_command_live(store: &MemoryStore, opts: &ExecOpts) -> Result<Exi
             }
             let env = requested_env_bindings(store, &opts.mode)?;
             let resolved_args = resolve_command_args(store, args, opts.allow_secret_argv)?;
-            let program = &resolved_args[0];
-            let command_args = &resolved_args[1..];
-            let mut command = Command::new(program);
-            command.args(command_args);
-            apply_child_env_overlays(&mut command, &env, &opts.session);
             let secret_stdin = resolve_secret_stdin(store, opts)?;
-            run_live_command(
-                command,
-                secret_stdin.as_ref().map(|value| value.as_str()),
-                store.clone(),
-            )
+            let restored = !env.is_empty() || resolved_args != *args || secret_stdin.is_some();
+            Ok(ResolvedExecInputs::Program {
+                args: resolved_args,
+                env,
+                secret_stdin,
+                restored,
+            })
         }
         ExecMode::Shell(command) => {
-            let command = resolve_command_text(store, command)?;
-            register_local_file_inputs(store, &command)?;
+            let resolved = resolve_command_text(store, command)?;
+            register_local_file_inputs(store, &resolved)?;
             let env = requested_env_bindings(store, &opts.mode)?;
+            let restored = resolved != *command || !env.is_empty();
             let mut shell = shell_script_command(opts.script_shell)?;
             apply_child_env_overlays(&mut shell, &env, &opts.session);
-            let command = prepare_shell_script(&command, opts.script_shell);
-            run_live_command(shell, Some(&command), store.clone())
+            Ok(ResolvedExecInputs::Shell {
+                command: shell,
+                script: prepare_shell_script(&resolved, opts.script_shell),
+                restored,
+            })
         }
         ExecMode::Stdin => Err("internal error: exec stdin was not prepared".to_string()),
     }
@@ -2017,15 +2068,7 @@ fn command_shell_start_error(error: &std::io::Error) -> String {
     format!("could not start command shell: {reason}")
 }
 
-fn run_shell_script(
-    script: &str,
-    env: &[(String, String)],
-    session: &str,
-    script_shell: ScriptShell,
-) -> Result<std::process::Output, String> {
-    let mut command = shell_script_command(script_shell)?;
-    apply_child_env_overlays(&mut command, env, session);
-    let script = prepare_shell_script(script, script_shell);
+fn run_shell_command(mut command: Command, script: &str) -> Result<std::process::Output, String> {
     let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1604,6 +1604,260 @@ fn exec_auto_binds_masked_env_output_in_running_session() {
 }
 
 #[test]
+fn exec_input_preparation_tracks_selected_recovery_env_without_a_handle_in_command() {
+    let root = temp_root("exec-restored-env-input");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let value = "KGAT_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let masked = mask_tool_output(&session, &format!("KAGGLE_API_TOKEN={value}\n")).unwrap();
+    let env_name =
+        pentect_env_name_for_handle(&masked_handle_from_assignment(&masked, "KAGGLE_API_TOKEN"));
+    let command = if cfg!(windows) {
+        format!("Write-Output $env:{env_name}")
+    } else {
+        format!("printf '%s' \"${env_name}\"")
+    };
+    let opts = ExecOpts {
+        session: DEFAULT_SESSION.to_string(),
+        live: false,
+        allow_secret_argv: false,
+        secret_stdin: None,
+        script_shell: ScriptShell::Native,
+        mode: ExecMode::Shell(command.clone()),
+    };
+
+    let prepared = resolve_exec_inputs(&MemoryStore::for_session(&session), &opts).unwrap();
+    assert!(prepared.restored());
+    match prepared {
+        ResolvedExecInputs::Shell {
+            command: shell,
+            script,
+            ..
+        } => {
+            assert_eq!(script, prepare_shell_script(&command, ScriptShell::Native));
+            assert!(shell.get_envs().any(|(name, configured)| {
+                name == env_name.as_str()
+                    && configured.is_some_and(|configured| configured == value)
+            }));
+        }
+        ResolvedExecInputs::Program { .. } => panic!("expected shell inputs"),
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn exec_input_preparation_aggregates_multiple_restoration_channels() {
+    let root = temp_root("exec-restored-mixed-inputs");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let masked = mask_tool_output(&session, &format!("OPENAI_API_KEY={raw}\n")).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+    let opts = ExecOpts {
+        session: DEFAULT_SESSION.to_string(),
+        live: false,
+        allow_secret_argv: true,
+        secret_stdin: Some(handle.clone()),
+        script_shell: ScriptShell::Native,
+        mode: ExecMode::Program(vec!["program".to_string(), handle]),
+    };
+
+    let prepared = resolve_exec_inputs(&MemoryStore::for_session(&session), &opts).unwrap();
+    assert!(prepared.restored());
+    match prepared {
+        ResolvedExecInputs::Program {
+            args, secret_stdin, ..
+        } => {
+            assert_eq!(args, ["program", raw]);
+            assert_eq!(secret_stdin.as_deref().map(String::as_str), Some(raw));
+        }
+        ResolvedExecInputs::Shell { .. } => panic!("expected program inputs"),
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn exec_input_preparation_does_not_commit_partial_restoration() {
+    let root = temp_root("exec-restored-late-failure");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+    let masked = mask_tool_output(&session, &format!("OPENAI_API_KEY={raw}\n")).unwrap();
+    let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+    let opts = ExecOpts {
+        session: DEFAULT_SESSION.to_string(),
+        live: false,
+        allow_secret_argv: true,
+        secret_stdin: Some("<<UNKNOWN_0123456789abcdef>>".to_string()),
+        script_shell: ScriptShell::Native,
+        mode: ExecMode::Program(vec!["program".to_string(), handle]),
+    };
+
+    let error = match resolve_exec_inputs(&MemoryStore::for_session(&session), &opts) {
+        Ok(_) => panic!("unknown late secret-stdin handle should fail preparation"),
+        Err(error) => error,
+    };
+    assert!(error.contains("unknown masked handle"), "{error}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn exec_input_preparation_leaves_plain_inputs_untracked() {
+    let root = temp_root("exec-unrestored-inputs");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let opts = ExecOpts {
+        session: DEFAULT_SESSION.to_string(),
+        live: false,
+        allow_secret_argv: false,
+        secret_stdin: None,
+        script_shell: ScriptShell::Native,
+        mode: ExecMode::Program(vec!["program".to_string(), "ordinary".to_string()]),
+    };
+
+    let prepared = resolve_exec_inputs(&MemoryStore::for_session(&session), &opts).unwrap();
+    assert!(!prepared.restored());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn exec_input_preparation_emits_only_after_the_whole_operation_is_ready() {
+    const CHILD_CASE_ENV: &str = "PENTECT_TEST_EXEC_METRIC_CASE";
+    const CHILD_ROOT_ENV: &str = "PENTECT_TEST_EXEC_METRIC_ROOT";
+
+    if let (Ok(case), Some(root)) = (
+        std::env::var(CHILD_CASE_ENV),
+        std::env::var_os(CHILD_ROOT_ENV).map(PathBuf::from),
+    ) {
+        let session = Session::open_capability_at(&root, "t").unwrap();
+        let raw = "sk-ABCDEFGHIJKLMNOPQRSTUVWX";
+        let masked = mask_tool_output(&session, &format!("OPENAI_API_KEY={raw}\n")).unwrap();
+        let handle = masked_handle_from_assignment(&masked, "OPENAI_API_KEY");
+        let env_name = pentect_env_name_for_handle(&handle);
+        let store = MemoryStore::for_session(&session);
+        let opts = match case.trim_end_matches("-live") {
+            "env-only" => ExecOpts {
+                session: DEFAULT_SESSION.to_string(),
+                live: case.ends_with("-live"),
+                allow_secret_argv: false,
+                secret_stdin: None,
+                script_shell: ScriptShell::Native,
+                mode: ExecMode::Shell(if cfg!(windows) {
+                    format!("Write-Output $env:{env_name}")
+                } else {
+                    format!("printf '%s' \"${env_name}\"")
+                }),
+            },
+            "unreferenced" => ExecOpts {
+                session: DEFAULT_SESSION.to_string(),
+                live: false,
+                allow_secret_argv: false,
+                secret_stdin: None,
+                script_shell: ScriptShell::Native,
+                mode: ExecMode::Program(vec!["pentect-test-missing-program".to_string()]),
+            },
+            "shell-failure" => ExecOpts {
+                session: DEFAULT_SESSION.to_string(),
+                live: case.ends_with("-live"),
+                allow_secret_argv: false,
+                secret_stdin: None,
+                script_shell: ScriptShell::Bash,
+                mode: ExecMode::Shell(handle),
+            },
+            "late-failure" => ExecOpts {
+                session: DEFAULT_SESSION.to_string(),
+                live: false,
+                allow_secret_argv: true,
+                secret_stdin: Some("<<UNKNOWN_0123456789abcdef>>".to_string()),
+                script_shell: ScriptShell::Native,
+                mode: ExecMode::Program(vec!["program".to_string(), handle]),
+            },
+            _ => panic!("unknown child case"),
+        };
+        let result = if opts.live {
+            run_resolved_command_live(&store, &opts).map(|_| ())
+        } else {
+            run_resolved_command(&store, &opts).map(|_| ())
+        };
+        assert_eq!(
+            result.is_ok(),
+            case.starts_with("env-only"),
+            "{case}: {result:?}"
+        );
+        activity_log::flush_persistent();
+        return;
+    }
+
+    let root = temp_root("exec-restoration-emission");
+    std::fs::create_dir_all(&root).unwrap();
+    for (case, expected) in [
+        ("env-only", 1),
+        ("env-only-live", 1),
+        ("unreferenced", 0),
+        ("shell-failure", 0),
+        ("shell-failure-live", 0),
+        ("late-failure", 0),
+    ] {
+        let child_root = root.join(case);
+        let home = child_root.join("home");
+        let work = child_root.join("work");
+        let log = child_root.join("logs");
+        std::fs::create_dir_all(work.join(".pentect")).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(
+            work.join(".pentect/config.toml"),
+            "[activity]\nshare = false\n[update]\ncheck = false\n",
+        )
+        .unwrap();
+        let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+        command
+            .arg("--exact")
+            .arg("tests::exec_input_preparation_emits_only_after_the_whole_operation_is_ready")
+            .arg("--nocapture")
+            .env_clear()
+            .env(CHILD_CASE_ENV, case)
+            .env(CHILD_ROOT_ENV, &child_root)
+            .env("PENTECT_LOG_DIR", &log)
+            .env("HOME", &home)
+            .env("USERPROFILE", &home)
+            .env("LOCALAPPDATA", child_root.join("local-app-data"))
+            .env("XDG_CONFIG_HOME", home.join(".config"))
+            .env("XDG_DATA_HOME", child_root.join("data"))
+            .env("XDG_CACHE_HOME", child_root.join("cache"))
+            .env("XDG_STATE_HOME", child_root.join("state"))
+            .env("XDG_RUNTIME_DIR", child_root.join("runtime"))
+            .env("TMPDIR", child_root.join("tmp"))
+            .env("TMP", child_root.join("tmp"))
+            .env("TEMP", child_root.join("tmp"))
+            .current_dir(&work);
+        #[cfg(windows)]
+        if let Some(system_root) = std::env::var_os("SystemRoot") {
+            command.env("SystemRoot", system_root);
+        }
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "{case} child failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let payload = std::fs::read_to_string(log.join("pentect.log")).unwrap_or_default();
+        assert!(
+            !payload.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWX"),
+            "{payload}"
+        );
+        let events = payload
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+            .filter(|event| event["action"] == "resolve" && event["surface"] == "exec")
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), expected, "{case}: {payload}");
+        if let Some(event) = events.first() {
+            assert_eq!(event["count"], 1);
+            assert!(event.get("labels").is_none(), "{event}");
+            assert!(event.get("target").is_none(), "{event}");
+        }
+    }
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn handle_core_is_also_a_valid_environment_binding() {
     let root = temp_root("capability-short-env-binding");
     let session = Session::open_capability_at(&root, "t").unwrap();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -174,9 +174,12 @@ logging and rotation continue independently so crashes remain diagnosable.
 The summary includes masked occurrence counts, completed local restoration
 operation counts, blocked restoration attempts, blocked operations, plugin
 failures and timeouts, and warnings grouped by a bounded reason code. Restoration
-operations currently cover changed `pentect resolve` inputs/files and completed
-HTTP tool-call inputs; multiple restored values in one completed tool call count
-as one operation. OpenAI streaming events without a bounded stable call identity,
+operations currently cover changed `pentect resolve` inputs/files, completed
+HTTP tool-call inputs, and successfully prepared `pentect exec` inputs. Multiple
+restored values in one completed tool call or one `pentect exec` invocation count
+as one operation. An exec restoration is counted after all command inputs are
+prepared; it does not assert that the process subsequently started or exited
+successfully. OpenAI streaming events without a bounded stable call identity,
 or after the bounded identity tracker is exhausted, are conservatively omitted
 from metrics without affecting restoration. Other automatic restoration paths
 are not yet included.


### PR DESCRIPTION
## Summary

Closes #1433; follow-up scoped slice of #250.

- Count one fixed resolve/exec operation after every local exec input is prepared successfully, shared by captured and live execution.
- Aggregate shell/script, opted-in argv, secret stdin and selected recovery environment restoration once. No-op, unknown handles, argv-policy rejection and later preparation failure count zero.
- Count local preparation, not execution or delivery: subsequent spawn/stdin I/O failure or child nonzero does not undo a completed restoration.
- Preserve protection and execution behavior; no new metric dimensions or sensitive event payloads. Document scope and bump release manifests to 0.0.80.

## Validation

- Sol-authored implementation and independent CLI regression, reviewed by root and an independent Sol reviewer.
- Full workspace/all-features tests pass: CLI 458, core 487, runtime 348, and integration/doc tests.
- Clippy workspace/all-targets/all-features with warnings denied, formatting and diff checks pass.
- Actual CLI baseline RED / candidate GREEN: restoration succeeds on both, expected resolve/exec event absent only on baseline. Fixture setup uses runtime agent-read with owned file pointers; every tested execution uses public pentect exec.
- New runtime persisted-event tests cover selected-env-only and late shell-preparation failures in buffered/live execution. CLI tests cover repeated handles, stdin, child nonzero and spawn failures, plus zero-count preparation rejection.
- External review followup b161fd77 removes test coupling to opaque-handle encoding; unknown input is copied exactly from a separate isolated project. Final CLI rerun passes 2/2 after scoped invalidation of a stale shared-target runtime artifact; the rebuilt binary contains the new preparation helper. No source change was needed.
- Docs build: 42 pages and 114 internal links pass.

Assistant output, generic hooks/bridge and file repair remain outside this slice. No detector, capability, telemetry, share/export or protection-boundary changes. Final-commit CI Gate, RustSec and Current Client Gate (Linux/macOS/Windows) all pass. External review feedback was fixed and its thread resolved; the final test-only followup was independently reviewed locally (bot followup was rate-limited).