### PR TITLE
Fix JSON-wrapped handle recovery and verify native file tools

### DIFF
--- a/crates/pentect-cli/src/handle_contract.rs
+++ b/crates/pentect-cli/src/handle_contract.rs
@@ -1,4 +1,4 @@
-pub(crate) const HANDLE_CONTRACT: &str = r#"Pentect replaced local sensitive values with opaque handles such as <<LABEL_HASH>>. A handle in a file or tool result is intentional protected content: it does not mean the file is corrupted, truncated, or invalid. Treat the surrounding content normally and preserve every handle byte-for-byte when reading, reasoning about, or editing it. Do not delete, repair, expand, guess, or reformat a handle. When a local tool needs the represented value, copy the handle unchanged into that tool's input; the local Pentect process can replace a known handle immediately before execution. The original value is not visible to the model and must not be printed or guessed."#;
+pub(crate) const HANDLE_CONTRACT: &str = r#"Pentect replaced local sensitive values with opaque handles such as <<LABEL_HASH>>. A handle in a file or tool result is intentional protected content: it does not mean the file is corrupted, truncated, or invalid. Treat the surrounding content normally and preserve every handle byte-for-byte when reading, reasoning about, or editing it. Do not delete, repair, expand, guess, or reformat a handle. When a local tool needs the represented value, copy the handle unchanged into that tool's input; the local Pentect process can replace a known handle immediately before execution. For native writes or edits, supply the complete desired content with handles intact; a value represented by a handle is not missing or empty. The original value is not visible to the model and must not be printed or guessed."#;
 
 #[cfg(test)]
 mod tests {
@@ -9,5 +9,6 @@ mod tests {
         assert!(HANDLE_CONTRACT.contains("does not mean the file is corrupted"));
         assert!(HANDLE_CONTRACT.contains("preserve every handle byte-for-byte"));
         assert!(HANDLE_CONTRACT.contains("must not be printed or guessed"));
+        assert!(HANDLE_CONTRACT.contains("complete desired content with handles intact"));
     }
 }

--- a/crates/pentect-runtime/src/main.rs
+++ b/crates/pentect-runtime/src/main.rs
@@ -3903,7 +3903,7 @@ fn mask_tool_text_output(
     }
     let store = MemoryStore::for_session(session);
     let mut masker = OutputMasker::new_deferred(store)?;
-    let (updated, changed) = mask_tool_json(&output, &mut masker)?;
+    let (updated, changed) = mask_tool_json(&output, &mut masker, true)?;
     masker.flush()?;
     if changed || image_changed {
         Ok(ToolTextOutput::Updated(updated))
@@ -4164,10 +4164,18 @@ fn empty_json_value(value: &Value) -> bool {
     }
 }
 
-fn mask_tool_json(value: &Value, masker: &mut OutputMasker) -> Result<(Value, bool), String> {
+fn mask_tool_json(
+    value: &Value,
+    masker: &mut OutputMasker,
+    run_plugins: bool,
+) -> Result<(Value, bool), String> {
     let mut scalars = Vec::new();
     collect_tool_json_scalars(value, None, None, &[], &mut scalars);
-    let masked = masker.mask_tool_result_scalars(&scalars)?;
+    let masked = if run_plugins {
+        masker.mask_tool_result_scalars(&scalars)?
+    } else {
+        masker.mask_tool_result_scalars_without_plugins(&scalars)?
+    };
     let mut cursor = 0usize;
     let out = rebuild_masked_tool_json(value, &masked, &mut cursor)?;
     if cursor != masked.len() {

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -137,6 +137,19 @@ impl OutputMasker {
         text: &str,
         run_plugins: bool,
     ) -> Result<String, String> {
+        // Tool adapters commonly wrap command output in JSON. Decode that
+        // envelope before detection so JSON escapes (notably `\\n`) do not
+        // become part of the recovered secret value. Re-encoding after
+        // masking keeps the tool result valid JSON. Malformed JSON follows
+        // the existing text path unchanged.
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(text) {
+            let (updated, changed) = crate::mask_tool_json(&value, self, run_plugins)?;
+            if changed {
+                return serde_json::to_string(&updated)
+                    .map_err(|error| format!("could not encode masked tool output: {error}"));
+            }
+            return Ok(text.to_string());
+        }
         let kind = if looks_like_sensitive_env_output(text) || looks_like_env_output(text) {
             Kind::Env
         } else {
@@ -377,28 +390,34 @@ impl OutputMasker {
             .ok_or_else(|| "text plugin payload requires text".to_string())
     }
 
-    pub(crate) fn mask_tool_result_scalar(
+    fn mask_tool_result_scalar_with_plugins(
         &mut self,
         text: &str,
         region_kind: RegionKind,
         key: Option<&str>,
         path: Option<&str>,
         hints: &[String],
+        run_plugins: bool,
     ) -> Result<String, String> {
         if scalar_is_env_assignment(text) {
-            let protected = self.mask_text(text, Kind::Env)?;
+            let protected = self.mask_text_with_plugins(text, Kind::Env, run_plugins)?;
             if protected != text {
                 return Ok(protected);
             }
         }
-        let protected_assignments = self.mask_embedded_env_assignments(text)?;
+        let protected_assignments =
+            self.mask_embedded_env_assignments_with_plugins(text, run_plugins)?;
         let redacted = redact_env_derivative_lines(&protected_assignments);
         let remasked = self.remask_all(&redacted)?;
-        let remasked = self.run_text_plugins(
-            crate::plugin_middleware::MiddlewareStage::Prepare,
-            remasked,
-            &Kind::ToolResult,
-        )?;
+        let remasked = if run_plugins {
+            self.run_text_plugins(
+                crate::plugin_middleware::MiddlewareStage::Prepare,
+                remasked,
+                &Kind::ToolResult,
+            )?
+        } else {
+            remasked
+        };
         let context = Context {
             path: path.map(str::to_string),
             key: key.map(str::to_string),
@@ -406,7 +425,11 @@ impl OutputMasker {
             kind: region_kind,
             format: Kind::ToolResult,
         };
-        let remasked = self.mask_plugin_input(remasked, Kind::ToolResult, Some(context.clone()))?;
+        let remasked = if run_plugins {
+            self.mask_plugin_input(remasked, Kind::ToolResult, Some(context.clone()))?
+        } else {
+            remasked
+        };
         let cfg = Config {
             disclose_length: false,
             ..Config::new(self.store.session.key).with_identity_key(self.store.session.identity_key)
@@ -415,11 +438,15 @@ impl OutputMasker {
         let mut result = self.engine.mask_context(remasked, context.clone(), &cfg);
         if !masks_only_endpoint_metadata(&result) {
             let initially_masked = std::mem::take(&mut result.masked);
-            let masked = self.run_text_plugins(
-                crate::plugin_middleware::MiddlewareStage::Finalize,
-                initially_masked,
-                &Kind::ToolResult,
-            )?;
+            let masked = if run_plugins {
+                self.run_text_plugins(
+                    crate::plugin_middleware::MiddlewareStage::Finalize,
+                    initially_masked,
+                    &Kind::ToolResult,
+                )?
+            } else {
+                initially_masked
+            };
             let final_result = self.engine.mask_context(masked, context, &cfg);
             merge_final_mask_result(&mut result, final_result);
         }
@@ -430,22 +457,38 @@ impl OutputMasker {
         &mut self,
         scalars: &[ToolScalarInput],
     ) -> Result<Vec<String>, String> {
+        self.mask_tool_result_scalars_with_plugins(scalars, true)
+    }
+
+    pub(crate) fn mask_tool_result_scalars_without_plugins(
+        &mut self,
+        scalars: &[ToolScalarInput],
+    ) -> Result<Vec<String>, String> {
+        self.mask_tool_result_scalars_with_plugins(scalars, false)
+    }
+
+    fn mask_tool_result_scalars_with_plugins(
+        &mut self,
+        scalars: &[ToolScalarInput],
+        run_plugins: bool,
+    ) -> Result<Vec<String>, String> {
         if scalars.is_empty() {
             return Ok(Vec::new());
         }
-        if !self.plugin_middleware.is_empty()
+        if (run_plugins && !self.plugin_middleware.is_empty())
             || scalars
                 .iter()
                 .any(|scalar| contains_sensitive_env_assignment(&scalar.text))
         {
             let mut out = Vec::with_capacity(scalars.len());
             for scalar in scalars {
-                out.push(self.mask_tool_result_scalar(
+                out.push(self.mask_tool_result_scalar_with_plugins(
                     &scalar.text,
                     scalar.region_kind,
                     scalar.key.as_deref(),
                     scalar.path.as_deref(),
                     &scalar.hints,
+                    run_plugins,
                 )?);
             }
             return Ok(out);
@@ -459,12 +502,13 @@ impl OutputMasker {
             return scalars
                 .iter()
                 .map(|scalar| {
-                    self.mask_tool_result_scalar(
+                    self.mask_tool_result_scalar_with_plugins(
                         &scalar.text,
                         scalar.region_kind,
                         scalar.key.as_deref(),
                         scalar.path.as_deref(),
                         &scalar.hints,
+                        run_plugins,
                     )
                 })
                 .collect();
@@ -521,7 +565,16 @@ impl OutputMasker {
         Ok(masked)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn mask_embedded_env_assignments(&mut self, text: &str) -> Result<String, String> {
+        self.mask_embedded_env_assignments_with_plugins(text, true)
+    }
+
+    fn mask_embedded_env_assignments_with_plugins(
+        &mut self,
+        text: &str,
+        run_plugins: bool,
+    ) -> Result<String, String> {
         let mut out = String::with_capacity(text.len());
         let mut changed = false;
         for segment in text.split_inclusive('\n') {
@@ -533,7 +586,8 @@ impl OutputMasker {
                 .map_or((line, false), |line| (line, true));
             if let Some(start) = embedded_sensitive_env_assignment_start(line) {
                 out.push_str(&line[..start]);
-                let protected = self.mask_text(&line[start..], Kind::Env)?;
+                let protected =
+                    self.mask_text_with_plugins(&line[start..], Kind::Env, run_plugins)?;
                 changed |= protected != line[start..];
                 out.push_str(&protected);
             } else {

--- a/crates/pentect-runtime/src/masking.rs
+++ b/crates/pentect-runtime/src/masking.rs
@@ -143,12 +143,17 @@ impl OutputMasker {
         // masking keeps the tool result valid JSON. Malformed JSON follows
         // the existing text path unchanged.
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(text) {
-            let (updated, changed) = crate::mask_tool_json(&value, self, run_plugins)?;
-            if changed {
-                return serde_json::to_string(&updated)
-                    .map_err(|error| format!("could not encode masked tool output: {error}"));
+            // Image payloads use a separate OCR/policy path. Keep those on
+            // the original text path so decoding this envelope cannot skip
+            // image inspection or alter its policy.
+            if !crate::image_ocr::contains_image_result(&value) {
+                let (updated, changed) = crate::mask_tool_json(&value, self, run_plugins)?;
+                if changed {
+                    return serde_json::to_string(&updated)
+                        .map_err(|error| format!("could not encode masked tool output: {error}"));
+                }
+                return Ok(text.to_string());
             }
-            return Ok(text.to_string());
         }
         let kind = if looks_like_sensitive_env_output(text) || looks_like_env_output(text) {
             Kind::Env

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -3568,7 +3568,6 @@ fn env_like_tool_output_masks_all_env_values() {
 
 #[test]
 fn tool_output_masking_roundtrips_plain_envelopes_and_json_escaped_newlines() {
-    let (root, session) = empty_session("tool-output-envelope-roundtrip");
     let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
     let cases = [
         format!("LIVE_KEY={raw}\n"),
@@ -3581,15 +3580,16 @@ fn tool_output_masking_roundtrips_plain_envelopes_and_json_escaped_newlines() {
         serde_json::to_string(&format!("LIVE_KEY={raw}\n")).unwrap(),
     ];
 
-    for output in cases {
+    for (index, output) in cases.into_iter().enumerate() {
+        let (root, session) = empty_session(&format!("tool-output-envelope-roundtrip-{index}"));
         let masked = mask_tool_output(&session, &output).unwrap();
         assert!(!masked.contains(raw), "protected output leaked: {masked}");
         let restored = MemoryStore::for_session(&session)
             .resolve_all(&masked)
             .unwrap();
         assert_eq!(restored, output);
+        let _ = std::fs::remove_dir_all(root);
     }
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1497,7 +1497,7 @@ fn exec_capability_env_does_not_shadow_parent_environment() {
 }
 
 #[test]
-fn diagnostic_recovered_handles_have_exact_raw_bytes_across_output_shapes() {
+fn json_tool_output_recovers_exact_secret_across_output_shapes() {
     let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
     let cases = [
         ("plain", format!("LIVE_KEY={raw}\n")),
@@ -1535,7 +1535,6 @@ fn diagnostic_recovered_handles_have_exact_raw_bytes_across_output_shapes() {
         ),
     ];
 
-    let mut failures = Vec::new();
     for (name, output) in cases {
         let root = temp_root(&format!("diagnostic-recovered-{name}"));
         let session = Session::open_capability_at(&root, "t").unwrap();
@@ -1550,21 +1549,13 @@ fn diagnostic_recovered_handles_have_exact_raw_bytes_across_output_shapes() {
             recovered.contains('\r'),
             recovered.ends_with(r"\n"),
         );
-        let exact = recovered == raw;
-        eprintln!("diagnostic {name}: {shape},exact={exact}");
-        if !exact {
-            failures.push(name);
-        }
+        assert!(recovered == raw, "{name}: recovered shape {shape}");
         let _ = std::fs::remove_dir_all(root);
     }
-    assert!(
-        failures.is_empty(),
-        "non-exact recovered cases: {failures:?}"
-    );
 }
 
 #[test]
-fn diagnostic_json_masking_preserves_literal_backslash_and_metadata() {
+fn json_tool_output_preserves_literal_backslash_and_metadata() {
     let root = temp_root("diagnostic-json-literal-backslash");
     let session = Session::open_capability_at(&root, "t").unwrap();
     let store = MemoryStore::for_session(&session);
@@ -1584,7 +1575,7 @@ fn diagnostic_json_masking_preserves_literal_backslash_and_metadata() {
 }
 
 #[test]
-fn diagnostic_malformed_json_keeps_text_fallback() {
+fn malformed_json_uses_text_masking_fallback() {
     let root = temp_root("diagnostic-json-malformed");
     let session = Session::open_capability_at(&root, "t").unwrap();
     let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
@@ -1596,7 +1587,7 @@ fn diagnostic_malformed_json_keeps_text_fallback() {
 }
 
 #[test]
-fn diagnostic_json_masking_without_plugins_still_decodes_recovery() {
+fn json_tool_output_without_plugins_still_decodes_recovery() {
     let root = temp_root("diagnostic-json-no-plugins");
     let session = Session::open_capability_at(&root, "t").unwrap();
     let store = MemoryStore::for_session(&session);
@@ -1610,6 +1601,25 @@ fn diagnostic_json_masking_without_plugins_still_decodes_recovery() {
         serde_json::from_str::<Value>(&masked).unwrap()["stdout"],
         format!("LIVE_KEY={handle}\n")
     );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn json_tool_output_with_image_payload_uses_text_policy_path() {
+    let root = temp_root("json-tool-image-policy");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let store = MemoryStore::for_session(&session);
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let output = serde_json::json!({
+        "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+        "stdout": format!("LIVE_KEY={raw}")
+    })
+    .to_string();
+    let masked = mask_tool_output(&session, &output).unwrap();
+    let handle = first_masked_handle(&masked);
+    assert_eq!(store.resolve_all(&handle).unwrap(), raw);
+    assert!(masked.contains("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"));
+    assert!(serde_json::from_str::<Value>(&masked).is_ok());
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1557,7 +1557,60 @@ fn diagnostic_recovered_handles_have_exact_raw_bytes_across_output_shapes() {
         }
         let _ = std::fs::remove_dir_all(root);
     }
-    assert!(failures.is_empty(), "non-exact recovered cases: {failures:?}");
+    assert!(
+        failures.is_empty(),
+        "non-exact recovered cases: {failures:?}"
+    );
+}
+
+#[test]
+fn diagnostic_json_masking_preserves_literal_backslash_and_metadata() {
+    let root = temp_root("diagnostic-json-literal-backslash");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let store = MemoryStore::for_session(&session);
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\\n";
+    let output = serde_json::json!({
+        "label": "東京 \"quoted\"",
+        "stdout": format!("LIVE_KEY={raw}")
+    })
+    .to_string();
+    let masked = mask_tool_output(&session, &output).unwrap();
+    let handle = first_masked_handle(&masked);
+    assert_eq!(store.resolve_all(&handle).unwrap(), raw);
+    let parsed: Value = serde_json::from_str(&masked).unwrap();
+    assert_eq!(parsed["label"], "東京 \"quoted\"");
+    assert!(!masked.contains(raw));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn diagnostic_malformed_json_keeps_text_fallback() {
+    let root = temp_root("diagnostic-json-malformed");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let output = format!(r#"{{"stdout":"LIVE_KEY={raw}\\n"}} trailing"#);
+    let masked = mask_tool_output(&session, &output).unwrap();
+    assert!(masked.contains("<<"));
+    assert!(!masked.contains(raw));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn diagnostic_json_masking_without_plugins_still_decodes_recovery() {
+    let root = temp_root("diagnostic-json-no-plugins");
+    let session = Session::open_capability_at(&root, "t").unwrap();
+    let store = MemoryStore::for_session(&session);
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let output = serde_json::json!({"stdout": format!("LIVE_KEY={raw}\n")}).to_string();
+    let mut masker = masking::OutputMasker::new_shared(store.clone()).unwrap();
+    let masked = masker.mask_tool_output_without_plugins(&output).unwrap();
+    let handle = first_masked_handle(&masked);
+    assert_eq!(store.resolve_all(&handle).unwrap(), raw);
+    assert_eq!(
+        serde_json::from_str::<Value>(&masked).unwrap()["stdout"],
+        format!("LIVE_KEY={handle}\n")
+    );
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -3567,6 +3567,32 @@ fn env_like_tool_output_masks_all_env_values() {
 }
 
 #[test]
+fn tool_output_masking_roundtrips_plain_envelopes_and_json_escaped_newlines() {
+    let (root, session) = empty_session("tool-output-envelope-roundtrip");
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let cases = [
+        format!("LIVE_KEY={raw}\n"),
+        serde_json::json!({
+            "stdout": format!("LIVE_KEY={raw}\n"),
+            "exit_code": 0,
+            "status": "completed"
+        })
+        .to_string(),
+        serde_json::to_string(&format!("LIVE_KEY={raw}\n")).unwrap(),
+    ];
+
+    for output in cases {
+        let masked = mask_tool_output(&session, &output).unwrap();
+        assert!(!masked.contains(raw), "protected output leaked: {masked}");
+        let restored = MemoryStore::for_session(&session)
+            .resolve_all(&masked)
+            .unwrap();
+        assert_eq!(restored, output);
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn codex_posttool_does_not_block_already_masked_exec_output() {
     let (root, session) = empty_session("hook-post-codex-already-masked");
     let output = "RUNPOD_API_KEY=rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\nTEST_SECRET=114514810\nNOTE=hello world\n";

--- a/crates/pentect-runtime/src/tests.rs
+++ b/crates/pentect-runtime/src/tests.rs
@@ -1497,6 +1497,70 @@ fn exec_capability_env_does_not_shadow_parent_environment() {
 }
 
 #[test]
+fn diagnostic_recovered_handles_have_exact_raw_bytes_across_output_shapes() {
+    let raw = "rpa_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef";
+    let cases = [
+        ("plain", format!("LIVE_KEY={raw}\n")),
+        (
+            "json-envelope",
+            serde_json::json!({"stdout": format!("LIVE_KEY={raw}\n")}).to_string(),
+        ),
+        (
+            "json-stringified-output",
+            serde_json::to_string(&format!("LIVE_KEY={raw}\n")).unwrap(),
+        ),
+        (
+            "codex-function-output",
+            serde_json::json!({
+                "type": "function_call_output",
+                "output": format!("LIVE_KEY={raw}\n")
+            })
+            .to_string(),
+        ),
+        (
+            "codex-response-output",
+            serde_json::json!({
+                "output": [{
+                    "type": "function_call_output",
+                    "output": format!("LIVE_KEY={raw}\n")
+                }]
+            })
+            .to_string(),
+        ),
+        (
+            "codex-exec-header",
+            format!(
+                "Chunk ID: synthetic\nWall time: 0.1 seconds\nProcess exited with code 0\nFinal output:\nLIVE_KEY={raw}\n"
+            ),
+        ),
+    ];
+
+    let mut failures = Vec::new();
+    for (name, output) in cases {
+        let root = temp_root(&format!("diagnostic-recovered-{name}"));
+        let session = Session::open_capability_at(&root, "t").unwrap();
+        let store = MemoryStore::for_session(&session);
+        let masked = mask_tool_output(&session, &output).unwrap();
+        let handle = first_masked_handle(&masked);
+        let recovered = store.resolve_all(&handle).unwrap();
+        let shape = format!(
+            "len={},actual_lf={},actual_cr={},literal_backslash_n_suffix={}",
+            recovered.len(),
+            recovered.contains('\n'),
+            recovered.contains('\r'),
+            recovered.ends_with(r"\n"),
+        );
+        let exact = recovered == raw;
+        eprintln!("diagnostic {name}: {shape},exact={exact}");
+        if !exact {
+            failures.push(name);
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+    assert!(failures.is_empty(), "non-exact recovered cases: {failures:?}");
+}
+
+#[test]
 fn exec_resolves_masked_handle_in_command_text() {
     let root = temp_root("exec-command-handle");
     let session = Session::open_capability_at(&root, "t").unwrap();

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -2288,6 +2288,9 @@ class Handler(BaseHTTPRequestHandler):
                 payload = tool_response(sequence, source)
             else:
                 handles = list(dict.fromkeys(HANDLE.findall(request)))
+                env_handles = codex_env_handles(request)
+                if len(env_handles) == 2:
+                    handles = env_handles
                 if handles:
                     self.server.state.last_handles = handles
                 elif self.server.state.native_patch:
@@ -2468,6 +2471,16 @@ def anthropic_env_handles(request: dict[str, object]) -> list[str]:
                 continue
             return list(dict.fromkeys(HANDLE.findall(rendered)))[:2]
     return []
+
+
+def codex_env_handles(request: str) -> list[str]:
+    match = re.search(
+        r"FIRST_KEY=(<<[A-Z][A-Z0-9_]*_[0-9a-f]{16}>>).*?"
+        r"SECOND_KEY=(<<[A-Z][A-Z0-9_]*_[0-9a-f]{16}>>)",
+        request,
+        re.DOTALL,
+    )
+    return list(match.groups()) if match else []
 
 
 def client_command(

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -2142,6 +2142,7 @@ class State:
         self.native_patch = native_patch
         self.native_target_path = ""
         self.native_read_sent = False
+        self.native_read_back_sent = False
         self.native_write_sent = False
         self.native_patch_sent = False
         self.native_write_inputs: list[dict[str, str]] = []
@@ -2230,6 +2231,12 @@ class Handler(BaseHTTPRequestHandler):
                 action = "tool:Edit"
                 payload = anthropic_write_response(
                     sequence, handle, self.server.state.native_target_path
+                )
+            elif self.server.state.native_write and not self.server.state.native_read_back_sent:
+                self.server.state.native_read_back_sent = True
+                action = "tool:Read:back"
+                payload = anthropic_read_response(
+                    sequence, self.server.state.native_target_path
                 )
             else:
                 action = "text:done"
@@ -2646,6 +2653,8 @@ else:
                 written = project / "verified-config.json"
                 if len(state.native_write_inputs) != 1 or state.native_write_inputs[0]["name"] != "Edit":
                     raise RuntimeError("native Edit fixture did not emit exactly one Edit call")
+                if not state.native_read_back_sent:
+                    raise RuntimeError("native Edit fixture did not perform the requested readback")
                 if state.native_write_inputs[0]["file_path"] != str(written):
                     raise RuntimeError("native Edit fixture did not use the absolute target path")
                 if not HANDLE.search(state.native_write_inputs[0]["new_string"]):
@@ -2661,9 +2670,8 @@ else:
                         "native Edit did not produce exact verified-config.json content: "
                         + repr(safe_text)
                         + "\nagent output:\n"
-                        + completed.stdout.replace(valid, "<synthetic-key>").replace(
-                            invalid, "<synthetic-key>"
-                        )
+                        + completed.stdout.replace(valid, "<synthetic-key>")
+                        .replace(invalid, "<synthetic-key>")[-4000:]
                         + f"\nfixture actions={state.anthropic_actions!r}"
                         + f"\nmodel requests={len(state.model_requests)}"
                     )
@@ -2702,6 +2710,13 @@ else:
                 f"installed {client} E2E passed: project plugin "
                 "inspect/test/add/setup/update/reinstall/mask/remove, two key handles, "
                 "no model/log plaintext"
+                + (
+                    "; native Read/Edit handle roundtrip with exact disk JSON"
+                    if native_write
+                    else "; native apply_patch handle roundtrip with exact disk JSON"
+                    if native_patch
+                    else ""
+                )
             )
     finally:
         server.shutdown()
@@ -3539,6 +3554,9 @@ def main() -> int:
     # transport. A regression should fail before the slower Codex startup.
     for client in args.clients or ("claude", "codex", "opencode", "pi"):
         run_client(args.pentect, client)
+    if args.clients is None:
+        run_client(args.pentect, "claude", native_write=True)
+        run_client(args.pentect, "codex", native_patch=True)
     if args.clients is None or "codex" in args.clients:
         run_cancellation(args.pentect)
         if not args.skip_image:

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -2275,10 +2275,17 @@ class Handler(BaseHTTPRequestHandler):
                 payload = text_response(sequence, "DONE")
             elif sequence == 1:
                 command = shell_command(["python", "e2e_helper.py", "roundtrip"])
-                payload = tool_response(
-                    sequence,
-                    f"const r = await tools.exec_command({{cmd:{json.dumps(command)}}}); text(r.output);",
-                )
+                if self.server.state.native_patch:
+                    source = (
+                        f"const r = await tools.exec_command({{cmd:{json.dumps(command)}}}); "
+                        "text(r);"
+                    )
+                else:
+                    source = (
+                        f"const r = await tools.exec_command({{cmd:{json.dumps(command)}}}); "
+                        "text(r.output);"
+                    )
+                payload = tool_response(sequence, source)
             else:
                 handles = list(dict.fromkeys(HANDLE.findall(request)))
                 if handles:

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -2415,6 +2415,36 @@ def request_tool_result_summary(requests: list[str]) -> list[str]:
     return summaries[-4:]
 
 
+def tool_output_for_call(requests: list[str], call_id: str) -> object | None:
+    def walk(value: object) -> object | None:
+        if isinstance(value, dict):
+            if (
+                value.get("type") in {"custom_tool_call_output", "function_call_output"}
+                and value.get("call_id") == call_id
+            ):
+                return value.get("output", value.get("content"))
+            for child in value.values():
+                found = walk(child)
+                if found is not None:
+                    return found
+        elif isinstance(value, list):
+            for child in value:
+                found = walk(child)
+                if found is not None:
+                    return found
+        return None
+
+    for request in requests:
+        try:
+            parsed = json.loads(request)
+        except json.JSONDecodeError:
+            continue
+        found = walk(parsed)
+        if found is not None:
+            return found
+    return None
+
+
 def anthropic_env_handles(request: dict[str, object]) -> list[str]:
     messages = request.get("messages", [])
     if not isinstance(messages, list):
@@ -2744,13 +2774,37 @@ else:
                     raise RuntimeError("native apply_patch JSON content or final newline was incorrect")
                 if HANDLE.search(written_bytes.decode("utf-8")):
                     raise RuntimeError("native apply_patch left an opaque handle on disk")
-                if not any(
-                    state.native_patch_read_call_id in request
-                    and HANDLE.search(request)
-                    for request in state.model_requests[4:]
+                readback_output = tool_output_for_call(
+                    state.model_requests, state.native_patch_read_call_id
+                )
+                readback_text = (
+                    readback_output
+                    if isinstance(readback_output, str)
+                    else json.dumps(readback_output, ensure_ascii=True)
+                )
+                if (
+                    readback_output is None
+                    or "api_key" not in readback_text
+                    or not HANDLE.search(readback_text)
                 ):
+                    output_records = []
+                    for request in state.model_requests:
+                        try:
+                            parsed_request = json.loads(request)
+                        except json.JSONDecodeError:
+                            continue
+                        output_records.extend(
+                            (value.get("type"), value.get("call_id"))
+                            for value in parsed_request.get("input", [])
+                            if isinstance(value, dict)
+                            and value.get("type") in {
+                                "custom_tool_call_output",
+                                "function_call_output",
+                            }
+                        )
                     raise RuntimeError(
-                        "native apply_patch readback was not returned protected to the model"
+                        "native apply_patch readback was not returned protected to the model: "
+                        + repr({"expected": state.native_patch_read_call_id, "outputs": output_records})
                     )
             if not unicode_path.is_file() or unicode_path.read_text(encoding="utf-8") != UNICODE_ROUNDTRIP:
                 raise RuntimeError(f"{client} did not complete the Unicode file write/read roundtrip")

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -2143,8 +2143,11 @@ class State:
         self.native_target_path = ""
         self.native_read_sent = False
         self.native_read_back_sent = False
+        self.native_read_back_id: str | None = None
         self.native_write_sent = False
         self.native_patch_sent = False
+        self.native_patch_read_sent = False
+        self.native_patch_read_call_id: str | None = None
         self.native_write_inputs: list[dict[str, str]] = []
         self.native_patch_inputs: list[str] = []
         self.last_handles: list[str] = []
@@ -2234,6 +2237,7 @@ class Handler(BaseHTTPRequestHandler):
                 )
             elif self.server.state.native_write and not self.server.state.native_read_back_sent:
                 self.server.state.native_read_back_sent = True
+                self.server.state.native_read_back_id = f"toolu_e2e_{sequence}"
                 action = "tool:Read:back"
                 payload = anthropic_read_response(
                     sequence, self.server.state.native_target_path
@@ -2299,6 +2303,18 @@ class Handler(BaseHTTPRequestHandler):
                     source = (
                         f"const r = await tools.apply_patch({json.dumps(patch)}); "
                         "text(r);"
+                    )
+                    payload = tool_response(sequence, source)
+                elif self.server.state.native_patch and not self.server.state.native_patch_read_sent:
+                    self.server.state.native_patch_read_sent = True
+                    self.server.state.native_patch_read_call_id = f"call_e2e_{sequence}"
+                    code = (
+                        "from pathlib import Path; "
+                        f"print(Path({json.dumps(self.server.state.native_target_path)}).read_text(), end='')"
+                    )
+                    source = (
+                        f"const r = await tools.exec_command({{cmd:{json.dumps(shell_command(['python', '-c', code]))}}}); "
+                        "text(r.output);"
                     )
                     payload = tool_response(sequence, source)
                 else:
@@ -2535,8 +2551,8 @@ def run_client(
             project.mkdir()
             (project / ".env").write_text(f"FIRST_KEY={invalid}\nSECOND_KEY={valid}\n", encoding="utf-8")
             if native_write or native_patch:
-                (project / "verified-config.json").write_text(
-                    '{"api_key":"PLACEHOLDER"}\n', encoding="utf-8"
+                (project / "verified-config.json").write_bytes(
+                    b'{"api_key":"PLACEHOLDER"}\n'
                 )
             (project / "plugin-input.txt").write_text(
                 PLUGIN_PLAINTEXT + "\n", encoding="utf-8"
@@ -2659,50 +2675,83 @@ else:
                     raise RuntimeError("native Edit fixture did not use the absolute target path")
                 if not HANDLE.search(state.native_write_inputs[0]["new_string"]):
                     raise RuntimeError("native Edit fixture did not carry an opaque handle")
-                written_text = (
-                    written.read_text(encoding="utf-8") if written.is_file() else "<missing>"
-                )
-                if written_text != expected_content:
-                    safe_text = written_text.replace(valid, "<synthetic-key>").replace(
-                        invalid, "<synthetic-key>"
+                written_bytes = written.read_bytes() if written.is_file() else b"<missing>"
+                expected_bytes = expected_content.encode("utf-8")
+                if written_bytes != expected_bytes:
+                    safe_bytes = written_bytes.replace(valid.encode(), b"<synthetic-key>").replace(
+                        invalid.encode(), b"<synthetic-key>"
                     )
                     raise RuntimeError(
                         "native Edit did not produce exact verified-config.json content: "
-                        + repr(safe_text)
+                        + repr(safe_bytes)
                         + "\nagent output:\n"
                         + completed.stdout.replace(valid, "<synthetic-key>")
                         .replace(invalid, "<synthetic-key>")[-4000:]
                         + f"\nfixture actions={state.anthropic_actions!r}"
                         + f"\nmodel requests={len(state.model_requests)}"
                     )
-                if not written_text.endswith("\n") or json.loads(written_text) != {"api_key": valid}:
+                if not written_bytes.endswith(b"\n") or json.loads(written_bytes) != {"api_key": valid}:
                     raise RuntimeError("native Edit JSON content or final newline was incorrect")
-                if HANDLE.search(written_text):
+                if HANDLE.search(written_bytes.decode("utf-8")):
                     raise RuntimeError("native Edit left an opaque handle on disk")
+                readback = None
+                for request in state.model_requests:
+                    try:
+                        parsed_request = json.loads(request)
+                    except json.JSONDecodeError:
+                        continue
+                    for message in parsed_request.get("messages", []):
+                        for block in message.get("content", []) if isinstance(message, dict) else []:
+                            if (
+                                isinstance(block, dict)
+                                and block.get("type") == "tool_result"
+                                and block.get("tool_use_id") == state.native_read_back_id
+                            ):
+                                readback = block
+                readback_content = readback.get("content") if readback else ""
+                readback_text = (
+                    readback_content if isinstance(readback_content, str) else ""
+                )
+                if not state.native_read_back_sent or not readback or readback.get("is_error"):
+                    raise RuntimeError("native Edit readback was not returned successfully")
+                if '"api_key"' not in readback_text or not HANDLE.search(readback_text):
+                    raise RuntimeError(
+                        "native Edit readback was not protected before model delivery: "
+                        + repr(readback_text)
+                    )
             elif native_patch:
                 expected_content = json.dumps(
                     {"api_key": valid}, separators=(",", ":")
                 ) + "\n"
                 written = project / "verified-config.json"
-                written_text = (
-                    written.read_text(encoding="utf-8") if written.is_file() else "<missing>"
-                )
+                written_bytes = written.read_bytes() if written.is_file() else b"<missing>"
+                expected_bytes = expected_content.encode("utf-8")
                 if len(state.native_patch_inputs) != 1:
                     raise RuntimeError("native apply_patch fixture did not emit exactly one patch")
+                if not state.native_patch_read_sent or not state.native_patch_read_call_id:
+                    raise RuntimeError("native apply_patch fixture did not perform readback")
                 if not HANDLE.search(state.native_patch_inputs[0]):
                     raise RuntimeError("fixture patch did not carry an opaque handle")
-                if written_text != expected_content:
-                    safe_text = written_text.replace(valid, "<synthetic-key>").replace(
-                        invalid, "<synthetic-key>"
+                if written_bytes != expected_bytes:
+                    safe_bytes = written_bytes.replace(valid.encode(), b"<synthetic-key>").replace(
+                        invalid.encode(), b"<synthetic-key>"
                     )
                     raise RuntimeError(
                         "native apply_patch did not produce exact file content: "
-                        + repr(safe_text)
+                        + repr(safe_bytes)
                     )
-                if not written_text.endswith("\n") or json.loads(written_text) != {"api_key": valid}:
+                if not written_bytes.endswith(b"\n") or json.loads(written_bytes) != {"api_key": valid}:
                     raise RuntimeError("native apply_patch JSON content or final newline was incorrect")
-                if HANDLE.search(written_text):
+                if HANDLE.search(written_bytes.decode("utf-8")):
                     raise RuntimeError("native apply_patch left an opaque handle on disk")
+                if not any(
+                    state.native_patch_read_call_id in request
+                    and HANDLE.search(request)
+                    for request in state.model_requests[4:]
+                ):
+                    raise RuntimeError(
+                        "native apply_patch readback was not returned protected to the model"
+                    )
             if not unicode_path.is_file() or unicode_path.read_text(encoding="utf-8") != UNICODE_ROUNDTRIP:
                 raise RuntimeError(f"{client} did not complete the Unicode file write/read roundtrip")
             remove_detector_plugin(pentect, project, environment)
@@ -3514,12 +3563,13 @@ def main() -> int:
     parser.add_argument("--claude-parent-kill", action="store_true")
     parser.add_argument("--tmux-cancellation", action="store_true")
     parser.add_argument("--plugin-lifecycle-only", action="store_true")
-    parser.add_argument(
+    native_mode = parser.add_mutually_exclusive_group()
+    native_mode.add_argument(
         "--native-handle-write",
         action="store_true",
         help="run the deterministic Claude native Edit handle roundtrip only",
     )
-    parser.add_argument(
+    native_mode.add_argument(
         "--native-handle-patch",
         action="store_true",
         help="run the deterministic Codex native apply_patch handle roundtrip only",

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -2318,12 +2318,8 @@ class Handler(BaseHTTPRequestHandler):
                 elif self.server.state.native_patch and not self.server.state.native_patch_read_sent:
                     self.server.state.native_patch_read_sent = True
                     self.server.state.native_patch_read_call_id = f"call_e2e_{sequence}"
-                    code = (
-                        "from pathlib import Path; "
-                        f"print(Path({json.dumps(self.server.state.native_target_path)}).read_text(), end='')"
-                    )
                     source = (
-                        f"const r = await tools.exec_command({{cmd:{json.dumps(shell_command(['python', '-c', code]))}}}); "
+                        f"const r = await tools.exec_command({{cmd:{json.dumps(shell_command(['python', 'e2e_helper.py', 'read_file', 'verified-config.json']))}}}); "
                         "text(r.output);"
                     )
                     payload = tool_response(sequence, source)
@@ -2616,6 +2612,8 @@ import urllib.request
 if sys.argv[1] == "read":
     print(Path(".env").read_text(encoding="utf-8"))
     print(Path("plugin-input.txt").read_text(encoding="utf-8"))
+elif sys.argv[1] == "read_file":
+    sys.stdout.write(Path(sys.argv[2]).read_text(encoding="utf-8"))
 elif sys.argv[1] == "roundtrip":
     path = Path("unicode 東京 path.txt")
     path.write_text("write/read ✓ 東京 — multiline\\nsecond line\\n", encoding="utf-8")

--- a/tools/installed_agent_e2e.py
+++ b/tools/installed_agent_e2e.py
@@ -2031,6 +2031,77 @@ def anthropic_tool_response(sequence: int, command: str) -> bytes:
     ])
 
 
+def anthropic_write_response(sequence: int, handle: str, file_path: str) -> bytes:
+    return anthropic_sse([
+        {"type": "message_start", "message": anthropic_message(sequence)},
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": f"toolu_e2e_{sequence}",
+                "name": "Edit",
+                "input": {},
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": json.dumps(
+                    {
+                        "file_path": file_path,
+                        "old_string": "PLACEHOLDER",
+                        "new_string": handle,
+                    },
+                    separators=(",", ":"),
+                ),
+            },
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+            "usage": {"output_tokens": 1},
+        },
+        {"type": "message_stop"},
+    ])
+
+
+def anthropic_read_response(sequence: int, file_path: str) -> bytes:
+    return anthropic_sse([
+        {"type": "message_start", "message": anthropic_message(sequence)},
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": f"toolu_e2e_{sequence}",
+                "name": "Read",
+                "input": {},
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": json.dumps(
+                    {"file_path": file_path}, separators=(",", ":")
+                ),
+            },
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+            "usage": {"output_tokens": 1},
+        },
+        {"type": "message_stop"},
+    ])
+
+
 def anthropic_text_response(sequence: int, text: str) -> bytes:
     return anthropic_sse([
         {"type": "message_start", "message": anthropic_message(sequence)},
@@ -2055,10 +2126,27 @@ def anthropic_text_response(sequence: int, text: str) -> bytes:
 
 
 class State:
-    def __init__(self, valid: str, invalid: str, *, hold_model: bool = False) -> None:
+    def __init__(
+        self,
+        valid: str,
+        invalid: str,
+        *,
+        hold_model: bool = False,
+        native_write: bool = False,
+        native_patch: bool = False,
+    ) -> None:
         self.valid = valid
         self.invalid = invalid
         self.hold_model = hold_model
+        self.native_write = native_write
+        self.native_patch = native_patch
+        self.native_target_path = ""
+        self.native_read_sent = False
+        self.native_write_sent = False
+        self.native_patch_sent = False
+        self.native_write_inputs: list[dict[str, str]] = []
+        self.native_patch_inputs: list[str] = []
+        self.last_handles: list[str] = []
         self.model_request_seen = threading.Event()
         self.release_model_request = threading.Event()
         self.model_requests: list[str] = []
@@ -2102,6 +2190,10 @@ class Handler(BaseHTTPRequestHandler):
                 for tool in parsed.get("tools", [])
             )
             handles = anthropic_env_handles(parsed)
+            if handles:
+                self.server.state.last_handles = handles
+            elif self.server.state.native_write:
+                handles = self.server.state.last_handles
             attempts = len(self.server.state.service_attempts)
             if not bash_enabled:
                 action = "text:no-bash"
@@ -2119,6 +2211,25 @@ class Handler(BaseHTTPRequestHandler):
                 action = f"tool:probe:{attempts}"
                 payload = anthropic_tool_response(
                     sequence, self._probe_command(handles[attempts], posix_shell=True)
+                )
+            elif self.server.state.native_write and not self.server.state.native_read_sent:
+                self.server.state.native_read_sent = True
+                action = "tool:Read"
+                payload = anthropic_read_response(
+                    sequence, self.server.state.native_target_path
+                )
+            elif self.server.state.native_write and not self.server.state.native_write_sent:
+                handle = handles[1]
+                self.server.state.native_write_sent = True
+                self.server.state.native_write_inputs.append({
+                    "name": "Edit",
+                    "file_path": self.server.state.native_target_path,
+                    "old_string": "PLACEHOLDER",
+                    "new_string": handle,
+                })
+                action = "tool:Edit"
+                payload = anthropic_write_response(
+                    sequence, handle, self.server.state.native_target_path
                 )
             else:
                 action = "text:done"
@@ -2159,10 +2270,30 @@ class Handler(BaseHTTPRequestHandler):
                 )
             else:
                 handles = list(dict.fromkeys(HANDLE.findall(request)))
+                if handles:
+                    self.server.state.last_handles = handles
+                elif self.server.state.native_patch:
+                    handles = self.server.state.last_handles
                 if sequence == 2 and len(handles) >= 2:
                     payload = tool_response(sequence, self._probe_source(handles[0]))
                 elif sequence == 3 and len(handles) >= 2:
                     payload = tool_response(sequence, self._probe_source(handles[1]))
+                elif self.server.state.native_patch and not self.server.state.native_patch_sent and len(handles) >= 2:
+                    self.server.state.native_patch_sent = True
+                    patch = (
+                        "*** Begin Patch\n"
+                        f"*** Update File: {self.server.state.native_target_path}\n"
+                        "@@\n"
+                        '-{"api_key":"PLACEHOLDER"}\n'
+                        f'+{{"api_key":"{handles[1]}"}}\n'
+                        "*** End Patch\n"
+                    )
+                    self.server.state.native_patch_inputs.append(patch)
+                    source = (
+                        f"const r = await tools.apply_patch({json.dumps(patch)}); "
+                        "text(r);"
+                    )
+                    payload = tool_response(sequence, source)
                 else:
                     payload = text_response(sequence, "DONE")
             self.send_response(200)
@@ -2280,9 +2411,32 @@ def anthropic_env_handles(request: dict[str, object]) -> list[str]:
 
 
 def client_command(
-    pentect: str, client: str, project: Path, upstream: str
+    pentect: str,
+    client: str,
+    project: Path,
+    upstream: str,
+    *,
+    native_write: bool = False,
+    native_patch: bool = False,
 ) -> list[str]:
-    prompt = "Read .env, write/read a Unicode path roundtrip, try each key against the local service, and finish after one succeeds."
+    prompt = (
+        "Read .env, write/read a Unicode path roundtrip, try each key against the local "
+        "service, and finish after one succeeds."
+    )
+    tools = "Read,Bash,Edit" if native_write else "Bash"
+    if native_write:
+        prompt = (
+            "Read .env, try each key against the local service, then use the native Edit "
+            "tool exactly once to update verified-config.json with the successful key in an "
+            "api_key JSON field, including a final newline. Read that file back and finish. "
+            "Do not use Bash, cp, shell redirection, or a helper script for the file edit."
+        )
+    if native_patch:
+        prompt = (
+            "Read .env, try each key against the local service, then use the native apply_patch "
+            "tool exactly once to update verified-config.json with the successful key. Read "
+            "that file back and finish. Do not use shell redirection, cp, or a helper script."
+        )
     if client == "codex":
         return [
             pentect,
@@ -2326,7 +2480,7 @@ def client_command(
             "--no-session-persistence",
             "--dangerously-skip-permissions",
             "--tools",
-            "Bash",
+            tools,
             "--model",
             "claude-sonnet-4-5",
             prompt,
@@ -2350,10 +2504,16 @@ def client_command(
     ]
 
 
-def run_client(pentect: str, client: str) -> None:
+def run_client(
+    pentect: str,
+    client: str,
+    *,
+    native_write: bool = False,
+    native_patch: bool = False,
+) -> None:
     valid = "".join(("rpa_", "PENTECT_VALID_", "0123456789abcdef"))
     invalid = "".join(("rpa_", "PENTECT_INVALID_", "fedcba9876543210"))
-    state = State(valid, invalid)
+    state = State(valid, invalid, native_write=native_write, native_patch=native_patch)
     server = FixtureServer(state)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -2367,6 +2527,10 @@ def run_client(pentect: str, client: str) -> None:
             home.mkdir()
             project.mkdir()
             (project / ".env").write_text(f"FIRST_KEY={invalid}\nSECOND_KEY={valid}\n", encoding="utf-8")
+            if native_write or native_patch:
+                (project / "verified-config.json").write_text(
+                    '{"api_key":"PLACEHOLDER"}\n', encoding="utf-8"
+                )
             (project / "plugin-input.txt").write_text(
                 PLUGIN_PLAINTEXT + "\n", encoding="utf-8"
             )
@@ -2396,6 +2560,7 @@ else:
                 encoding="utf-8",
             )
             environment = isolated_environment(home, root / "logs")
+            state.native_target_path = str(project / "verified-config.json")
             environment.update({
                 "OPENAI_API_KEY": "local-fixture",
                 "ANTHROPIC_API_KEY": "local-fixture",
@@ -2414,6 +2579,8 @@ else:
                 client,
                 project,
                 f"http://127.0.0.1:{server.server_port}/v1",
+                native_write=native_write,
+                native_patch=native_patch,
             )
             if os.name == "nt" and pentect.lower().endswith((".cmd", ".bat")):
                 command = [os.environ.get("COMSPEC", "cmd.exe"), "/d", "/s", "/c", *command]
@@ -2472,6 +2639,62 @@ else:
                 raise RuntimeError(
                     f"{client} did not record a completed HTTP tool-input restoration"
                 )
+            if native_write:
+                expected_content = json.dumps(
+                    {"api_key": valid}, separators=(",", ":")
+                ) + "\n"
+                written = project / "verified-config.json"
+                if len(state.native_write_inputs) != 1 or state.native_write_inputs[0]["name"] != "Edit":
+                    raise RuntimeError("native Edit fixture did not emit exactly one Edit call")
+                if state.native_write_inputs[0]["file_path"] != str(written):
+                    raise RuntimeError("native Edit fixture did not use the absolute target path")
+                if not HANDLE.search(state.native_write_inputs[0]["new_string"]):
+                    raise RuntimeError("native Edit fixture did not carry an opaque handle")
+                written_text = (
+                    written.read_text(encoding="utf-8") if written.is_file() else "<missing>"
+                )
+                if written_text != expected_content:
+                    safe_text = written_text.replace(valid, "<synthetic-key>").replace(
+                        invalid, "<synthetic-key>"
+                    )
+                    raise RuntimeError(
+                        "native Edit did not produce exact verified-config.json content: "
+                        + repr(safe_text)
+                        + "\nagent output:\n"
+                        + completed.stdout.replace(valid, "<synthetic-key>").replace(
+                            invalid, "<synthetic-key>"
+                        )
+                        + f"\nfixture actions={state.anthropic_actions!r}"
+                        + f"\nmodel requests={len(state.model_requests)}"
+                    )
+                if not written_text.endswith("\n") or json.loads(written_text) != {"api_key": valid}:
+                    raise RuntimeError("native Edit JSON content or final newline was incorrect")
+                if HANDLE.search(written_text):
+                    raise RuntimeError("native Edit left an opaque handle on disk")
+            elif native_patch:
+                expected_content = json.dumps(
+                    {"api_key": valid}, separators=(",", ":")
+                ) + "\n"
+                written = project / "verified-config.json"
+                written_text = (
+                    written.read_text(encoding="utf-8") if written.is_file() else "<missing>"
+                )
+                if len(state.native_patch_inputs) != 1:
+                    raise RuntimeError("native apply_patch fixture did not emit exactly one patch")
+                if not HANDLE.search(state.native_patch_inputs[0]):
+                    raise RuntimeError("fixture patch did not carry an opaque handle")
+                if written_text != expected_content:
+                    safe_text = written_text.replace(valid, "<synthetic-key>").replace(
+                        invalid, "<synthetic-key>"
+                    )
+                    raise RuntimeError(
+                        "native apply_patch did not produce exact file content: "
+                        + repr(safe_text)
+                    )
+                if not written_text.endswith("\n") or json.loads(written_text) != {"api_key": valid}:
+                    raise RuntimeError("native apply_patch JSON content or final newline was incorrect")
+                if HANDLE.search(written_text):
+                    raise RuntimeError("native apply_patch left an opaque handle on disk")
             if not unicode_path.is_file() or unicode_path.read_text(encoding="utf-8") != UNICODE_ROUNDTRIP:
                 raise RuntimeError(f"{client} did not complete the Unicode file write/read roundtrip")
             remove_detector_plugin(pentect, project, environment)
@@ -3276,6 +3499,16 @@ def main() -> int:
     parser.add_argument("--claude-parent-kill", action="store_true")
     parser.add_argument("--tmux-cancellation", action="store_true")
     parser.add_argument("--plugin-lifecycle-only", action="store_true")
+    parser.add_argument(
+        "--native-handle-write",
+        action="store_true",
+        help="run the deterministic Claude native Edit handle roundtrip only",
+    )
+    parser.add_argument(
+        "--native-handle-patch",
+        action="store_true",
+        help="run the deterministic Codex native apply_patch handle roundtrip only",
+    )
     args = parser.parse_args()
     candidate = Path(args.pentect)
     if candidate.is_file():
@@ -3291,6 +3524,16 @@ def main() -> int:
         return 0
     if args.tmux_cancellation:
         run_cancellation(args.pentect, tmux_pty=True)
+        return 0
+    if args.native_handle_write:
+        if args.clients and args.clients != ["claude"]:
+            parser.error("--native-handle-write only supports --client claude")
+        run_client(args.pentect, "claude", native_write=True)
+        return 0
+    if args.native_handle_patch:
+        if args.clients and args.clients != ["codex"]:
+            parser.error("--native-handle-patch only supports --client codex")
+        run_client(args.pentect, "codex", native_patch=True)
         return 0
     # Run Claude first because it has the strictest native Windows tool
     # transport. A regression should fail before the slower Codex startup.


### PR DESCRIPTION
## Summary

Fix JSON-wrapped tool output capturing serialization escapes in secret handles. Previously, a 46-byte synthetic key followed by an encoded newline recovered as 48 bytes, including literal backslash + `n`. Decode the JSON container before masking its scalar values, preserving key/path context and plugin-disabled gateway behavior, then encode valid masked JSON. This uses the existing structured masking adapter, not a new detector or a heuristic that trims secrets.

Clarify that native writes/edits must receive complete content with opaque handles intact: a protected value is not an empty or missing value. This does not prohibit normal rereads/copies or change the protection boundary.

Add installed-client regression coverage for Claude Read/Edit and Codex code-mode `tools.apply_patch`. The fixture supplies handles, the actual client executes native tools, and the test checks exact JSON bytes on disk with no remaining handle or unwanted newline in the key. These cases now run in the default installed-client E2E. Add a runtime roundtrip regression for plain output and JSON-escaped output envelopes.

## Validation

- Full `cargo test --locked -p pentect-cli` passed locally (including 464 unit tests and applicable Linux integration tests).
- `cargo fmt --all --check`, Python compilation, and `git diff --check` passed.
- New runtime envelope regression passed independently (1 test).
- Exact-handle regressions use independent stores: plain output and JSON-wrapped output must recover the original key alone, including legitimate backslashes, rather than merely roundtrip the entire output.
- Actual installed Codex with serialized `text(r)` output: baseline fails (one combined handle, no successful service attempt); the fixed binary passes native patching, exact disk bytes, and call-correlated masked readback.
- Full installed-client E2E on the fixed binary passed: Claude, Codex, OpenCode, Pi, both native file cases, cancellation, and image redaction.
- Final integrated head `beb5ce4d`: root independently ran the full runtime suite (361 passed). The rebuilt immutable binary `837c1cecb7a3aed652e1f6262bff5638f071050edfdf35dcf64be443113a8ba3` passed the entire installed-client E2E again, including image-policy preservation. The same final harness still fails against the baseline; conflicting native-only flags reject with exit 2.
- Independently ran installed Codex native apply_patch and Claude native Edit fixtures against the previously reviewed baseline: both passed. These tests are regression coverage, not proof of a previously broken native transport.
- Live OpenCode, same `openrouter/google/gemini-2.5-flash-lite` model and task, one run each: baseline wrote an empty file; contract candidate used native write with complete content, localhost Bearer verification returned 200, and the saved file matched the source byte-for-byte. A single A/B pair does not establish reliability or causality.
  The live candidate SHA-256 was `20b72f971092eee0bb6f9dcd724cc12de50947d9f0509623822ae4b3c89f79c1`; its binary contains the added contract sentence, but the exact build invocation was not retained, so source-to-binary provenance is incomplete. This result is supporting evidence, not a reproducible-build certification.

## Limits

Strict live Codex retry on the immutable integrated binary `506dfe5639fb8808765a65445338003275b65e4ff566c7b2cc9971fb1d58231e`, built by root from production source `0bd17077`: passed in 97.3s. The unchanged task read `.env` once, sent the observed value in a literal Bearer header (200), created the JSON using a native file tool, then authenticated again using the saved file (200). The saved `api_key` exactly matched the synthetic source value. Root inspected the redacted client trace and confirmed the native file-change event and both 200 results. This is a single live success, not a reliability guarantee.

Related investigation: #1443. The confirmed serialization defect is fixed here; the original model-side patch was not retained, so we do not claim every detail of that original failure is explained. The speculative direct-patch multiline transformation remains excluded. Mock-provider installed-client tests are not live-model tests. Live Claude remains blocked by expired OAuth credentials.

Fixes #1443, with the deterministic recovery regression and unchanged strict live task both verified. The final image-policy guard retains the original text path for image-bearing JSON, avoiding changes to image inspection behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of secrets in tool outputs, including JSON, escaped content, and outputs containing images.
  * Added support for reliable native tool read/write workflows across supported coding agents.
  * Preserved complete file content when using native edits and handles.

* **Bug Fixes**
  * Improved recovery of masked values across plain-text, structured, and malformed tool output formats.
  * Preserved unrelated JSON metadata and literal backslash sequences during masking.

* **Documentation**
  * Clarified that native writes and edits must provide complete content with handles intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->