### PR TITLE
chore: prepare v0.0.82

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.81"
+version = "0.0.82"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.81"
+version = "0.0.82"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the Pentect CLI crate version to `0.0.82`
- keep the Cargo lockfile and npm package version synchronized

## Verification

- `cargo metadata --locked --no-deps --format-version 1` reports `pentect-cli` version `0.0.82`
- `package.json` reports version `0.0.82`
- the `pentect-cli` package entry in `Cargo.lock` reports version `0.0.82`
- `git diff --check origin/main...HEAD`

## Release process

After this PR is reviewed and merged, a maintainer can create the matching `v0.0.82` tag from `main`. The release workflow will build and publish the release artifacts; this PR does not create a tag or publish a release.
