### PR TITLE
fix: accept Anthropic client tool-search references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "pentect-cli"
-version = "0.0.82"
+version = "0.0.83"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/crates/pentect-cli/Cargo.toml
+++ b/crates/pentect-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pentect-cli"
-version = "0.0.82"
+version = "0.0.83"
 description = "Pentect CLI"
 edition.workspace = true
 license.workspace = true

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1113,7 +1113,7 @@ fn anthropic_content_unknown_block_kind_at(
         if !known {
             return Some(kind);
         }
-        if kind == "tool_reference" && !block.get("tool_name").is_some_and(Value::is_string) {
+        if kind == "tool_reference" && !valid_tool_reference(block) {
             return Some("<invalid tool reference>");
         }
         if matches!(kind, "tool_result" | "mcp_tool_result") {
@@ -1129,6 +1129,39 @@ fn anthropic_content_unknown_block_kind_at(
         }
         None
     })
+}
+
+fn valid_tool_reference(value: &Value) -> bool {
+    let Some(reference) = value.as_object() else {
+        return false;
+    };
+    if reference
+        .keys()
+        .any(|key| !matches!(key.as_str(), "type" | "tool_name" | "cache_control"))
+        || reference.get("type").and_then(Value::as_str) != Some("tool_reference")
+        || !reference.get("tool_name").is_some_and(Value::is_string)
+    {
+        return false;
+    }
+    let Some(cache_control) = reference.get("cache_control") else {
+        return true;
+    };
+    if cache_control.is_null() {
+        return true;
+    }
+    let Some(cache_control) = cache_control.as_object() else {
+        return false;
+    };
+    if cache_control
+        .keys()
+        .any(|key| !matches!(key.as_str(), "type" | "ttl"))
+        || cache_control.get("type").and_then(Value::as_str) != Some("ephemeral")
+    {
+        return false;
+    }
+    cache_control
+        .get("ttl")
+        .is_none_or(|ttl| matches!(ttl.as_str(), Some("5m" | "1h")))
 }
 
 fn provider_history_unknown_kind<'a>(block: &'a Value, kind: &str) -> Option<&'a str> {
@@ -2186,7 +2219,11 @@ fn mask_content(
                     // A tool reference is protocol metadata returned by the
                     // tool-search feature. In particular, `tool_name` is an
                     // identifier and must remain byte-stable.
-                    "tool_reference" => {}
+                    "tool_reference" => {
+                        if !valid_tool_reference(block) {
+                            return Err(unsupported_provider_history_shape("tool_reference"));
+                        }
+                    }
                     _ => {
                         if !WARNED_UNKNOWN_CONTENT_BLOCK.swap(true, Ordering::Relaxed) {
                             diagnostic("unknown-content-block", "protocol", "messages", false);
@@ -4642,7 +4679,8 @@ mod tests {
         let secret = ["AKIA", "IOSFODNN7", "EXAMPLE"].concat();
         let reference = serde_json::json!({
             "type": "tool_reference",
-            "tool_name": "weather_lookup_20260909"
+            "tool_name": "weather_lookup_20260909",
+            "cache_control": {"type": "ephemeral", "ttl": "1h"}
         });
         let messages = serde_json::json!([
             {"role": "user", "content": "What is the weather?"},
@@ -4747,6 +4785,10 @@ mod tests {
             serde_json::json!([{"type": "tool_result", "content": [
                 {"type": "tool_reference", "tool_name": 7}
             ]}]),
+            serde_json::json!([{"type": "tool_result", "content": [
+                {"type": "tool_reference", "tool_name": "lookup",
+                    "cache_control": {"type": "ephemeral", "ttl": "2h"}}
+            ]}]),
         ] {
             let invalid = serde_json::json!({
                 "messages": [{"role": "user", "content": invalid_content}]
@@ -4765,6 +4807,57 @@ mod tests {
             anthropic_request_unknown_content_kind(&mcp, AnthropicEndpoint::Messages),
             None
         );
+
+        for cache_control in [
+            Value::Null,
+            serde_json::json!({"type": "ephemeral"}),
+            serde_json::json!({"type": "ephemeral", "ttl": "5m"}),
+            serde_json::json!({"type": "ephemeral", "ttl": "1h"}),
+        ] {
+            let valid = serde_json::json!({"messages": [{"role": "user", "content": [{
+                "type": "tool_result", "content": [{
+                    "type": "tool_reference", "tool_name": "lookup",
+                    "cache_control": cache_control
+                }]
+            }]}]});
+            assert_eq!(
+                anthropic_request_unknown_content_kind(&valid, AnthropicEndpoint::Messages),
+                None
+            );
+        }
+
+        for invalid_reference in [
+            serde_json::json!({"type": "tool_reference", "tool_name": "lookup",
+                "payload": secret.clone()}),
+            serde_json::json!({"type": "tool_reference", "tool_name": "lookup",
+                "cache_control": {"type": "ephemeral", "ttl": secret.clone()}}),
+        ] {
+            let body = serde_json::json!({"messages": [{"role": "user", "content": [{
+                "type": "tool_result", "content": [invalid_reference]
+            }]}]});
+            let body = Bytes::from(serde_json::to_vec(&body).unwrap());
+            for block_unknown_formats in [true, false] {
+                let error = protect_anthropic_request_body(
+                    &body,
+                    &masker,
+                    &plugins,
+                    &HashMap::new(),
+                    AnthropicEndpoint::Messages,
+                    block_unknown_formats,
+                )
+                .err()
+                .expect("undocumented tool reference fields must remain blocked");
+                assert!(!error.contains(&secret));
+                if block_unknown_formats {
+                    assert!(error.starts_with("unknown format blocked:"), "{error}");
+                } else {
+                    assert_eq!(
+                        error,
+                        "provider history blocked: tool_reference has an unsupported shape and must remain unchanged"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/pentect-cli/src/claude_http_proxy.rs
+++ b/crates/pentect-cli/src/claude_http_proxy.rs
@@ -1076,6 +1076,13 @@ fn anthropic_request_unknown_content_kind(
 }
 
 fn anthropic_content_unknown_block_kind(value: &Value) -> Option<&str> {
+    anthropic_content_unknown_block_kind_at(value, false)
+}
+
+fn anthropic_content_unknown_block_kind_at(
+    value: &Value,
+    allow_tool_reference: bool,
+) -> Option<&str> {
     let blocks = value.as_array()?;
     blocks.iter().find_map(|block| {
         let Some(kind) = block.get("type").and_then(Value::as_str) else {
@@ -1102,14 +1109,17 @@ fn anthropic_content_unknown_block_kind(value: &Value) -> Option<&str> {
                 | "text_editor_code_execution_tool_result"
                 | "connector_text"
                 | "fallback"
-        );
+        ) || (allow_tool_reference && kind == "tool_reference");
         if !known {
             return Some(kind);
+        }
+        if kind == "tool_reference" && !block.get("tool_name").is_some_and(Value::is_string) {
+            return Some("<invalid tool reference>");
         }
         if matches!(kind, "tool_result" | "mcp_tool_result") {
             return block
                 .get("content")
-                .and_then(anthropic_content_unknown_block_kind);
+                .and_then(|content| anthropic_content_unknown_block_kind_at(content, true));
         }
         if matches!(
             kind,
@@ -2173,6 +2183,10 @@ fn mask_content(
                         inspect_web_search_history_plaintext(block, masker)?
                     }
                     "web_fetch_tool_result" => inspect_web_fetch_history_plaintext(block, masker)?,
+                    // A tool reference is protocol metadata returned by the
+                    // tool-search feature. In particular, `tool_name` is an
+                    // identifier and must remain byte-stable.
+                    "tool_reference" => {}
                     _ => {
                         if !WARNED_UNKNOWN_CONTENT_BLOCK.swap(true, Ordering::Relaxed) {
                             diagnostic("unknown-content-block", "protocol", "messages", false);
@@ -4618,6 +4632,235 @@ mod tests {
             anthropic_request_unknown_content_kind(&value, AnthropicEndpoint::Messages),
             None
         );
+    }
+
+    #[test]
+    fn nested_tool_references_are_preserved_while_adjacent_content_is_masked() {
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        let secret = ["AKIA", "IOSFODNN7", "EXAMPLE"].concat();
+        let reference = serde_json::json!({
+            "type": "tool_reference",
+            "tool_name": "weather_lookup_20260909"
+        });
+        let messages = serde_json::json!([
+            {"role": "user", "content": "What is the weather?"},
+            {"role": "assistant", "content": [{
+                "type": "tool_use", "id": "toolu_search", "name": "tool_search",
+                "input": {"query": "weather"}
+            }]},
+            {"role": "user", "content": [{
+                "type": "tool_result", "tool_use_id": "toolu_search", "content": [
+                    reference.clone(),
+                    {"type": "text", "text": format!("credential={secret}")}
+                ]
+            }]},
+            {"role": "assistant", "content": [{
+                "type": "tool_use", "id": "toolu_lookup", "name": "weather_lookup_20260909",
+                "input": {"token": secret.clone()}
+            }]},
+            {"role": "user", "content": [{
+                "type": "tool_result", "tool_use_id": "toolu_lookup", "content": "sunny"
+            }]}
+        ]);
+        let tools = serde_json::json!([
+            {"name": "tool_search", "description": "Search tools", "input_schema": {
+                "type": "object", "properties": {"query": {"type": "string"}},
+                "required": ["query"]
+            }},
+            {
+                "name": "weather_lookup_20260909",
+                "description": "Look up weather",
+                "defer_loading": true,
+                "input_schema": {"type": "object", "properties": {"token": {"type": "string"}}}
+            }
+        ]);
+        let requests = [
+            (
+                AnthropicEndpoint::Messages,
+                serde_json::json!({"model": "test", "max_tokens": 8,
+                    "messages": messages.clone(), "tools": tools.clone()}),
+            ),
+            (
+                AnthropicEndpoint::CountTokens,
+                serde_json::json!({"model": "test",
+                    "messages": messages.clone(), "tools": tools.clone()}),
+            ),
+            (
+                AnthropicEndpoint::MessageBatches,
+                serde_json::json!({"requests": [{"custom_id": "request-1", "params": {
+                    "model": "test", "max_tokens": 8,
+                    "messages": messages.clone(), "tools": tools.clone()
+                }}]}),
+            ),
+        ];
+        let masker = StdMutex::new(pentect_agent::ActiveToolOutputMasker::new().unwrap());
+        let plugins = StdMutex::new(pentect_agent::PluginMiddleware::from_env().unwrap());
+
+        for (endpoint, request) in requests {
+            let body = Bytes::from(serde_json::to_vec(&request).unwrap());
+            let protected = protect_anthropic_request_body(
+                &body,
+                &masker,
+                &plugins,
+                &HashMap::new(),
+                endpoint,
+                true,
+            )
+            .unwrap();
+            assert_eq!(protected.coverage, crate::http_files::Coverage::Full);
+            let protected: Value = serde_json::from_slice(&protected.body).unwrap();
+            let serialized = protected.to_string();
+            assert!(!serialized.contains(&secret), "{endpoint:?}");
+            assert!(serialized.contains("<<"), "{endpoint:?}");
+            let protected_content = if endpoint == AnthropicEndpoint::MessageBatches {
+                &protected["requests"][0]["params"]["messages"][2]["content"]
+            } else {
+                &protected["messages"][2]["content"]
+            };
+            assert_eq!(protected_content[0]["content"][0], reference);
+        }
+
+        let unknown = serde_json::json!({"messages": [{"role": "user", "content": [{
+            "type": "tool_result", "tool_use_id": "toolu_search", "content": [
+                reference, {"type": "future_reference", "data": "opaque"}
+            ]
+        }]}]});
+        let error = protect_anthropic_request_body(
+            &Bytes::from(serde_json::to_vec(&unknown).unwrap()),
+            &masker,
+            &plugins,
+            &HashMap::new(),
+            AnthropicEndpoint::Messages,
+            true,
+        )
+        .err()
+        .expect("unknown sibling must remain blocked");
+        assert!(error.contains("future_reference"), "{error}");
+
+        for invalid_content in [
+            serde_json::json!([{"type": "tool_reference", "tool_name": "top_level"}]),
+            serde_json::json!([{"type": "tool_result", "content": [
+                {"type": "tool_reference"}
+            ]}]),
+            serde_json::json!([{"type": "tool_result", "content": [
+                {"type": "tool_reference", "tool_name": 7}
+            ]}]),
+        ] {
+            let invalid = serde_json::json!({
+                "messages": [{"role": "user", "content": invalid_content}]
+            });
+            assert!(
+                anthropic_request_unknown_content_kind(&invalid, AnthropicEndpoint::Messages)
+                    .is_some()
+            );
+        }
+        let mcp = serde_json::json!({"messages": [{"role": "user", "content": [{
+            "type": "mcp_tool_result", "tool_use_id": "mcp_1", "content": [
+                {"type": "tool_reference", "tool_name": "mcp_lookup"}
+            ]
+        }]}]});
+        assert_eq!(
+            anthropic_request_unknown_content_kind(&mcp, AnthropicEndpoint::Messages),
+            None
+        );
+    }
+
+    #[test]
+    fn http_proxy_forwards_nested_tool_reference_and_blocks_unknown_sibling() {
+        use std::io::Write;
+
+        let _lock = crate::TEST_PROCESS_ENV_LOCK.lock().unwrap();
+        let store = pentect_agent::start_in_process_memory_store().unwrap();
+        let _env = TestEnv::install(&store);
+        let secret = ["AKIA", "IOSFODNN7", "EXAMPLE"].concat();
+        let reference = serde_json::json!({
+            "type": "tool_reference", "tool_name": "weather_lookup_20260909"
+        });
+        let request = serde_json::json!({
+            "model": "test", "max_tokens": 8,
+            "messages": [
+                {"role": "user", "content": "Weather?"},
+                {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_search",
+                    "name": "tool_search", "input": {"query": "weather"}}]},
+                {"role": "user", "content": [{"type": "tool_result",
+                    "tool_use_id": "toolu_search", "content": [
+                        reference.clone(), {"type": "text", "text": format!("key={secret}")}
+                    ]}]}
+            ],
+            "tools": [
+                {"name": "tool_search", "description": "Search tools", "input_schema": {
+                    "type": "object", "properties": {"query": {"type": "string"}},
+                    "required": ["query"]
+                }},
+                {"name": "weather_lookup_20260909", "description": "Weather",
+                    "defer_loading": true, "input_schema": {"type": "object"}}
+            ]
+        });
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let (body_tx, body_rx) = std::sync::mpsc::channel();
+        let upstream_thread = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(accepted) => break accepted,
+                    Err(error)
+                        if error.kind() == std::io::ErrorKind::WouldBlock
+                            && std::time::Instant::now() < deadline =>
+                    {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("mock upstream accept failed: {error}"),
+                }
+            };
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(10)))
+                .unwrap();
+            let (_, body) = read_http_request(&mut stream);
+            body_tx.send(String::from_utf8(body).unwrap()).unwrap();
+            let response = br#"{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"test","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}"#;
+            write!(stream, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n", response.len()).unwrap();
+            stream.write_all(response).unwrap();
+        });
+        let proxy = ClaudeHttpProxyGuard::start(format!("http://{address}")).unwrap();
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap();
+        let mut unknown = request.clone();
+        unknown["messages"][2]["content"][0]["content"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({"type": "future_reference"}));
+        let blocked = client
+            .post(format!("{}/v1/messages", proxy.base_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(unknown.to_string())
+            .send()
+            .unwrap();
+        assert_eq!(blocked.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+
+        let forwarded = client
+            .post(format!("{}/v1/messages", proxy.base_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(request.to_string())
+            .send()
+            .unwrap();
+        assert_eq!(forwarded.status(), reqwest::StatusCode::OK);
+        let upstream_body = body_rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .unwrap();
+        assert!(!upstream_body.contains(&secret));
+        let upstream: Value = serde_json::from_str(&upstream_body).unwrap();
+        assert_eq!(
+            upstream["messages"][2]["content"][0]["content"][0],
+            reference
+        );
+        drop(proxy);
+        upstream_thread.join().unwrap();
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pentect",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "type": "module",
   "description": "Local secret masking boundary for AI agents",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Fixes #1462.

Anthropic custom tool search returns tool_reference blocks inside tool_result.content. The strict request classifier supported server-side search history but rejected these client-side references, causing HTTP 422 even when the user only entered text.

- Accept references only inside tool_result/mcp_tool_result content; require string tool_name.
- Preserve protocol identifiers while continuing to mask adjacent text and tool inputs.
- Keep unknown siblings, malformed references, and unsupported top-level references blocked. No compatibility setting changes.

## Validation
- Red regression reproduced the exact unsupported tool_reference failure before the fix.
- Messages, count_tokens, and batches regression coverage.
- Real local HTTP proxy with mock upstream: valid reference returns 200, unknown sibling returns 422; upstream gets unchanged reference and no synthetic plaintext secret.
- All 56 claude_http_proxy tests passed, independently rerun during review.
- cargo fmt --all --check and git diff --check passed.

This is local protocol/HTTP regression validation, not a live Anthropic account E2E.

## Protocol source
https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool#custom-tool-search-implementation

Implementation by GPT-5.6 Sol; reviewed by the primary agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of tool references in content validation, including nested references in supported tool-result content.
  - Valid tool references are now preserved correctly when sensitive information is masked.
  - Requests with malformed, misplaced, or incomplete tool-reference content are rejected more consistently.
  - Improved validation across messages, batch requests, and token-count requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->